### PR TITLE
fix: nodemon watch to legacy mode for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Note: If you're on Windows and having issues with MongoDB, install mongosh for c
 docker-compose up
 ```
 
-:warning: If you make changes to a UI server, you'll need to do a build with `docker-compose up --build`. Hot reloading will be in place shortly.
-
 Several services are built:
 
 | Service | URL |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - REFERENCE_DATA_PROXY_URL=http://reference-data-proxy:5002
       - MONGO_INITDB_DATABASE=dtfs-submissions
       - MONGODB_URI=mongodb://root:r00t@dtfs-submissions-data:27017/?authMechanism=DEFAULT
-    entrypoint: npx nodemon src/index.js
+    entrypoint: npx nodemon src/index.js -L
 
   trade-finance-manager-ui:
     build: ./trade-finance-manager-ui
@@ -49,7 +49,7 @@ services:
       - REFERENCE_DATA_PROXY_URL=http://reference-data-proxy:5002
       - UKEF_TFM_API_SYSTEM_KEY
       - ESTORE_URL
-    command: node dist/server.js
+    command: node dist/server.js -L
   
   trade-finance-manager-api:
     build: ./trade-finance-manager-api
@@ -73,7 +73,7 @@ services:
       - UKEF_TFM_API_SYSTEM_KEY
       - UKEF_TFM_API_REPORTS_KEY
       - TFM_URI=http://localhost:5003
-    entrypoint: npx nodemon src/index.js
+    entrypoint: npx nodemon src/index.js -L
   
   portal:
     build: ./portal
@@ -95,7 +95,7 @@ services:
       - REFERENCE_DATA_PROXY_URL=http://reference-data-proxy:5002
       - SESSION_SECRET
       - REDIS_HOSTNAME=redis
-    command: npx nodemon server/index.js
+    command: npx nodemon server/index.js -L
 
   portal-api:
     build: ./portal-api
@@ -133,7 +133,7 @@ services:
       - DTFS_CENTRAL_API=http://dtfs-central-api:5005
       - TFM_API=http://trade-finance-manager-api:5004
 
-    entrypoint: npx nodemon src/index.js
+    entrypoint: npx nodemon src/index.js -L
   
   reference-data-proxy:
     build: ./reference-data-proxy
@@ -169,7 +169,7 @@ services:
       - MULESOFT_API_UKEF_ESTORE_EA_SECRET
       - AZURE_ACBS_FUNCTION_URL=http://host.docker.internal:7071
       - GOV_NOTIFY_API_KEY
-    entrypoint: npx nodemon src/index.js
+    entrypoint: npx nodemon src/index.js -L
 
   gef-ui:
     build: ./gef-ui
@@ -191,7 +191,7 @@ services:
       - REFERENCE_DATA_PROXY_URL=http://reference-data-proxy:5002
       - SESSION_SECRET
       - REDIS_HOSTNAME=redis
-    command: npx nodemon server/index.js
+    command: npx nodemon server/index.js -L
   
   # ACBS function is causing an out of memory error on github actions. disable for now
   # acbs-function:
@@ -253,4 +253,4 @@ services:
       - GOV_NOTIFY_API_KEY
       - GOV_NOTIFY_EMAIL_RECIPIENT
 
-    entrypoint: npx nodemon src/index.js
+    entrypoint: npx nodemon src/index.js -L


### PR DESCRIPTION
Changes nodemon watch to legacy mode to make it work for windows users. Works as normal for others. Common problem with containers and mounted drives (https://github.com/remy/nodemon#application-isnt-restarting)