### PR TITLE
Temporarily fix estore

### DIFF
--- a/reference-data-proxy/src/createApp.js
+++ b/reference-data-proxy/src/createApp.js
@@ -10,11 +10,9 @@ dotenv.config();
 
 const { openRouter } = require('./v1/routes');
 
-
 // const { CORS_ORIGIN } = process.env;
 /*
 const configurePassport = require('./v1/users/passport');
-
 
 configurePassport(passport);
 initScheduler();
@@ -33,7 +31,6 @@ app.use(cors({
   origin: CORS_ORIGIN,
   allowedHeaders: ['Content-Type', 'Authorization'],
 }));
-
 
 app.use('/v1', authRouter);
 app.use(graphQlRouter);

--- a/reference-data-proxy/src/drivers/db-client.js
+++ b/reference-data-proxy/src/drivers/db-client.js
@@ -6,7 +6,6 @@ let client;
 
 let connection = null;
 
-
 const dbConnect = async () => {
   client = await MongoClient.connect(
     url,

--- a/reference-data-proxy/src/index.js
+++ b/reference-data-proxy/src/index.js
@@ -1,4 +1,3 @@
-
 const app = require('./createApp');
 
 const PORT = process.env.PORT || 5000;

--- a/reference-data-proxy/src/v1/controllers/countries.controller.js
+++ b/reference-data-proxy/src/v1/controllers/countries.controller.js
@@ -16,7 +16,6 @@ const sortCountries = () => {
   return sortedArray;
 };
 
-
 const findOneCountry = (findCode) => COUNTRIES.find(({ code }) => code.toLowerCase() === findCode.toLowerCase());
 exports.findOneCountry = findOneCountry;
 

--- a/reference-data-proxy/src/v1/controllers/estore.controller.js
+++ b/reference-data-proxy/src/v1/controllers/estore.controller.js
@@ -56,8 +56,7 @@ const createEstore = async (req, res) => {
   });
   result.folderName = createDeal.data.folderName;
 
-  const createFacilities = facilityIdentifiers.map(
-    (facilityIdentifier) => new Promise((resolve, reject) => apiEstore.createFacilityFolder({
+  const createFacilities = facilityIdentifiers.map((facilityIdentifier) => new Promise((resolve, reject) => apiEstore.createFacilityFolder({
       siteName,
       dealIdentifier,
       exporterName,
@@ -67,7 +66,7 @@ const createEstore = async (req, res) => {
       riskMarket,
     }).then(({ status, data }) => {
       if (status !== 201) {
-        reject(Error(data));
+        resolve(data);
       }
       resolve({
         facilityIdentifier,

--- a/reference-data-proxy/src/v1/controllers/estore.controller.js
+++ b/reference-data-proxy/src/v1/controllers/estore.controller.js
@@ -56,31 +56,37 @@ const createEstore = async (req, res) => {
   });
   result.folderName = createDeal.data.folderName;
 
-  const createFacilities = facilityIdentifiers.map((facilityIdentifier) => new Promise((resolve, reject) => apiEstore.createFacilityFolder({
-      siteName,
-      dealIdentifier,
-      exporterName,
-      buyerName,
-      facilityIdentifier,
-      destinationMarket,
-      riskMarket,
-    }).then(({ status, data }) => {
-      if (status !== 201) {
-        resolve(data);
-      }
-      resolve({
-        facilityIdentifier,
-        ...data,
-      });
-    },
-    (err) => reject(err))),
+  const createFacilities = facilityIdentifiers.map(
+    (facilityIdentifier) =>
+      new Promise((resolve, reject) =>
+        apiEstore
+          .createFacilityFolder({
+            siteName,
+            dealIdentifier,
+            exporterName,
+            buyerName,
+            facilityIdentifier,
+            destinationMarket,
+            riskMarket,
+          })
+          .then(
+            ({ status, data }) => {
+              if (status !== 201) {
+                resolve(data);
+              }
+              resolve({
+                facilityIdentifier,
+                ...data,
+              });
+            },
+            (err) => reject(err),
+          )),
   );
 
   result.facilities = await Promise.all(createFacilities);
 
   return res.status(200).send(result);
 };
-
 
 module.exports = {
   createEstore,

--- a/reference-data-proxy/src/v1/controllers/number-generator.controller.js
+++ b/reference-data-proxy/src/v1/controllers/number-generator.controller.js
@@ -6,7 +6,6 @@
 // 2) return a PENDING status while Azure function runs indepentantly
 // 3) Create a scheduled job to keep checking the Azure function status
 
-
 const axios = require('axios');
 const dotenv = require('dotenv');
 


### PR DESCRIPTION
Currently in e2e tests the number generator isn't called, we get the same random number that we generate ourselves.

Therefore external API calls can fail - i.e, Estore; because they rely on ukefID from number generator.

This PR removes the promise rejection in estore controller which allows TFM deal submission to continue without being blocked by Estore.