### PR TITLE
Improve TFM GraphQL queries

### DIFF
--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -32,7 +32,7 @@ type DealDetails {
   status: String
   bankSupplyContractID: String
   bankSupplyContractName: String
-  ukefDealId: String!
+  ukefDealId: String
   submissionType: String
   maker: Maker
   checker: Checker

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -137,7 +137,7 @@ type FacilityUkefExposure {
 
 type FacilitySnapshot {
   _id: String!
-  ukefFacilityID: String!
+  ukefFacilityID: String
   associatedDealId: String!
   facilityProduct: FacilityProduct!
   facilityType: String
@@ -153,12 +153,12 @@ type FacilitySnapshot {
   bondBeneficiary: String
   ukefExposure: String
   firstDrawdownAmountInExportCurrency: String
-  feeType: String,
-  feeFrequency: String,
-  dayCountBasis: String,
-  dates: FacilityDates,
-  providedOn: [String],
-  providedOnOther: String,
+  feeType: String
+  feeFrequency: String
+  dayCountBasis: String
+  dates: FacilityDates
+  providedOn: [String]
+  providedOnOther: String
 }
 
 type Facility {

--- a/trade-finance-manager-api/src/v1/controllers/deal.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.controller.js
@@ -23,12 +23,18 @@ const findOneTfmDeal = async (dealId) => {
 };
 exports.findOneTfmDeal = findOneTfmDeal;
 
-const findTfmDealsLight = async (queryParams) => {
-  const { deals } = await api.queryDeals({ queryParams });
+const queryDeals = async (queryParams) => {
+  const { deals } = await api.queryDeals({ ...queryParams });
 
   if (!deals) {
     return false;
   }
+
+  return deals;
+};
+
+const findTfmDealsLight = async (queryParams) => {
+  const deals = await queryDeals(queryParams);
 
   return {
     deals,
@@ -37,11 +43,7 @@ const findTfmDealsLight = async (queryParams) => {
 exports.findTfmDealsLight = findTfmDealsLight;
 
 const findTfmDeals = async (queryParams) => {
-  const { deals } = await findTfmDealsLight(queryParams);
-
-  if (!deals) {
-    return false;
-  }
+  const deals = await queryDeals(queryParams);
 
   const mapped = await mapDeals(deals);
 

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import apollo from './graphql/apollo';
 import dealQuery from './graphql/queries/deal-query';
-import dealsQuery from './graphql/queries/deals-query';
+import dealsLightQuery from './graphql/queries/deals-query-light';
 import facilityQuery from './graphql/queries/facility-query';
 import teamMembersQuery from './graphql/queries/team-members-query';
 import userQuery from './graphql/queries/user-query';
@@ -35,16 +35,16 @@ const getDeal = async (id, tasksFilters) => {
 };
 
 const getDeals = async (queryParams) => {
-  const response = await apollo('GET', dealsQuery, queryParams);
+  const response = await apollo('GET', dealsLightQuery, queryParams);
 
   if (response.errors) {
     console.error('TFM UI - GraphQL error querying deals ', response.errors);
   }
 
-  if (response.data && response.data.deals) {
+  if (response.data && response.data.dealsLight) {
     return {
-      deals: response.data.deals,
-      count: response.data.count,
+      deals: response.data.dealsLight.deals,
+      count: response.data.dealsLight.count,
     };
   }
 

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -26,22 +26,40 @@ const getDeal = async (id, tasksFilters) => {
   };
 
   const response = await apollo('GET', dealQuery, queryParams);
+
+  if (response.errors) {
+    console.error('TFM UI - GraphQL error querying deal ', response.errors);
+  }
+
   return response.data.deal;
 };
 
 const getDeals = async (queryParams) => {
   const response = await apollo('GET', dealsQuery, queryParams);
 
-  const { deals: dealsObj } = response.data;
+  if (response.errors) {
+    console.error('TFM UI - GraphQL error querying deals ', response.errors);
+  }
+
+  if (response.data && response.data.deals) {
+    return {
+      deals: response.data.deals,
+      count: response.data.count,
+    };
+  }
 
   return {
-    deals: dealsObj.deals,
-    count: dealsObj.count,
+    deals: [],
+    count: 0,
   };
 };
 
 const getFacility = async (id) => {
   const response = await apollo('GET', facilityQuery, { id });
+
+  if (response.errors) {
+    console.error('TFM UI - GraphQL error querying facility ', response.errors);
+  }
 
   return response.data.facility;
 };

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query-light.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query-light.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
 import gql from 'graphql-tag';
 
-const dealQuery = gql`
+const dealsLightQuery = gql`
 query DealsLight($searchString: String, $sortBy: DealsSortBy, $start: Int, $pagesize: Int){
   dealsLight(params: {searchString: $searchString, sortBy: $sortBy, start: $start, pagesize: $pagesize}) {
     count
@@ -30,4 +30,4 @@ query DealsLight($searchString: String, $sortBy: DealsSortBy, $start: Int, $page
 }
 `;
 
-export default dealQuery;
+export default dealsLightQuery;

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query.js
@@ -2,9 +2,8 @@
 import gql from 'graphql-tag';
 
 // NOTE: this is not actually used by TFM UI.
-// kept in place as an example.
-// This returns more data than the dealsLight query
-// and will be used be external systems.
+// This returns more data than the dealsLight query that TFM UI does not need.
+// This query is used by external systems.
 
 const dealsQuery = gql`
 query Deals($searchString: String, $sortBy: DealsSortBy, $start: Int, $pagesize: Int){

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query.js
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 // This returns more data than the dealsLight query
 // and will be used be external systems.
 
-const dealQuery = gql`
+const dealsQuery = gql`
 query Deals($searchString: String, $sortBy: DealsSortBy, $start: Int, $pagesize: Int){
   deals(params: {searchString: $searchString, sortBy: $sortBy, start: $start, pagesize: $pagesize}) {
     count
@@ -150,4 +150,4 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $start: Int, $pagesize:
 }
 `;
 
-export default dealQuery;
+export default dealsQuery;


### PR DESCRIPTION
Previously if for some reason, TFM API deals/facilities query doesn't get returned, the UI just hangs and says eg. "cannot read deals of undefined". Very unhelpful.

### Small tweaks to improve debugging and TFM experience when UKEF IDs are unavailable

- Make deal and facility UKEF IDs optional in TFM GraphQL schema. This way, some things display in the UI rather than erroring when Number Generator doesn't work and the ID doesn't exist.
- Add logs to deal, deals and facility queries so that if the API returns GraphQL errors, they are logged out.
- Fix issue where "all deals" was not using the light query version. My fault for missing this. The non-light version does additional API calls that TFM UI does not need. The light version only returns what TFM UI needs (e.g no facilities data or eligibility)
- Fix some typos