### PR TITLE
DTFS2-4525 - GEF/BSS - Add facilitiesUpdated timestamp to deal

### DIFF
--- a/portal-api/README.md
+++ b/portal-api/README.md
@@ -66,3 +66,4 @@ Over time the differences between this and central API have become murkier. It i
 If the team like working with GraphQL, it is worth embracing it and planning to move to a complete schema, this eliminating the need for REST endpoints except for things like healthcheck etc. With other APIs doing the same, it is worth investigating [Apollo Federation](https://www.apollographql.com/docs/federation/) to simplify working with a range of services.
 
 There is area for the GraphQL Schema to be simplified. Possible options are making use of GraphQL files, or by modularising the Schema currently in use.
+

--- a/portal-api/api-tests/fixtures/gef/application.js
+++ b/portal-api/api-tests/fixtures/gef/application.js
@@ -11,6 +11,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -24,6 +25,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -37,6 +39,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -50,6 +53,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -63,6 +67,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -76,6 +81,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -89,6 +95,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -102,6 +109,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -115,6 +123,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -128,6 +137,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -141,6 +151,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -154,6 +165,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -167,6 +179,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -180,6 +193,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }, {
   dealType: 'GEF',
   userId: null,
@@ -193,6 +207,7 @@ const APPLICATION = [{
   updatedAt: null,
   submissionCount: 0,
   editedBy: [null],
+  facilitiesUpdated: null,
 }];
 
 module.exports = APPLICATION;

--- a/portal-api/api-tests/v1/bonds/bonds.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bonds.api-test.js
@@ -687,6 +687,26 @@ describe('/v1/deals/:id/bond', () => {
       expect(status).toEqual(200);
       expect(body.lastEdited).toEqual(expect.any(String));
     });
+
+    it('should update the associated deal\'s facilitiesUpdated timestamp', () => {
+      // create deal
+      const deal = await as(aBarclaysMaker).post(newDeal).to('/v1/deals/');
+      const dealId = deal.body._id;
+
+      // create bond facility
+      const { body: createdBond } = await as(aBarclaysMaker).put({}).to(`/v1/deals/${dealId}/bond/create`);
+      const { bondId } = createdBond;
+
+      const bondUpdate = { test: true };
+
+      // update bond facility
+      await as(aBarclaysMaker).put(bondUpdate).to(`/v1/deals/${dealId}/bond/${bondId}`);
+
+      // get the deal, check facilities timestamp
+      const { body: dealAfterFirstUpdate } = await as(aBarclaysMaker).get(`/v1/deals/${dealId}`);
+      const originalFacilitiesUpdated = dealAfterFirstUpdate.deal.facilitiesUpdated;
+      expect(originalFacilitiesUpdated).toEqual(expect.any(String));
+    });
   });
 
   describe('DELETE /v1/deals/:id/bond/:id', () => {

--- a/portal-api/api-tests/v1/bonds/bonds.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bonds.api-test.js
@@ -703,9 +703,8 @@ describe('/v1/deals/:id/bond', () => {
       await as(aBarclaysMaker).put(bondUpdate).to(`/v1/deals/${dealId}/bond/${bondId}`);
 
       // get the deal, check facilities timestamp
-      const { body: dealAfterFirstUpdate } = await as(aBarclaysMaker).get(`/v1/deals/${dealId}`);
-      const originalFacilitiesUpdated = dealAfterFirstUpdate.deal.facilitiesUpdated;
-      expect(originalFacilitiesUpdated).toEqual(expect.any(String));
+      const { body: dealAfterUpdate } = await as(aBarclaysMaker).get(`/v1/deals/${dealId}`);
+      expect(dealAfterUpdate.deal.facilitiesUpdated).toEqual(expect.any(Number));
     });
   });
 

--- a/portal-api/api-tests/v1/bonds/bonds.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bonds.api-test.js
@@ -688,7 +688,7 @@ describe('/v1/deals/:id/bond', () => {
       expect(body.lastEdited).toEqual(expect.any(String));
     });
 
-    it('should update the associated deal\'s facilitiesUpdated timestamp', () => {
+    it('should update the associated deal\'s facilitiesUpdated timestamp', async () => {
       // create deal
       const deal = await as(aBarclaysMaker).post(newDeal).to('/v1/deals/');
       const dealId = deal.body._id;

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -392,7 +392,7 @@ describe(baseUrl, () => {
 
       const { body } = await as(aMaker).get(`${applicationBaseUrl}/${facility.body.details.applicationId}`);
 
-      expect(body.facilitiesUpdated).toEqual(expect.any(Number);
+      expect(body.facilitiesUpdated).toEqual(expect.any(Number));
     });
 
     it('returns a 204 - "No Content" if there are no records', async () => {

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -359,7 +359,7 @@ describe(baseUrl, () => {
       expect(status).toEqual(200);
     });
 
-    it('completely update a facility ', async () => {
+    it('completely updates a facility', async () => {
       const { details } = newFacility;
       const item = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
       const { status, body } = await as(aMaker).put(completeUpdate).to(`${baseUrl}/${item.body.details._id}`);
@@ -381,6 +381,18 @@ describe(baseUrl, () => {
 
       expect(body).toEqual(expected);
       expect(status).toEqual(200);
+    });
+
+    it('updates the associated deal\'s facilitiesUpdated timestamp', () => {
+      const { details } = newFacility;
+      const facility = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+
+      const update = { hasBeenIssued : true };
+      await as(aMaker).put(update).to(`${baseUrl}/${facility.body.details._id}`);
+
+      const { body } = await as(aMaker).get(`${applicationBaseUrl}/${facility.body.details.applicationId}`);
+
+      expect(body.facilitiesUpdated).toEqual(expect.any(Number);
     });
 
     it('returns a 204 - "No Content" if there are no records', async () => {

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -383,7 +383,7 @@ describe(baseUrl, () => {
       expect(status).toEqual(200);
     });
 
-    it('updates the associated deal\'s facilitiesUpdated timestamp', () => {
+    it('updates the associated deal\'s facilitiesUpdated timestamp', async () => {
       const { details } = newFacility;
       const facility = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
 

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -384,13 +384,18 @@ describe(baseUrl, () => {
     });
 
     it('updates the associated deal\'s facilitiesUpdated timestamp', async () => {
+      // create deal
+      const { body: createdDeal } = await as(aMaker).post(mockApplications[0]).to(applicationBaseUrl);
+
+      // create and update facility
       const { details } = newFacility;
-      const facility = await as(aMaker).post({ applicationId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
+      const facility = await as(aMaker).post({ applicationId: createdDeal._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
 
       const update = { hasBeenIssued : true };
       await as(aMaker).put(update).to(`${baseUrl}/${facility.body.details._id}`);
 
-      const { body } = await as(aMaker).get(`${applicationBaseUrl}/${facility.body.details.applicationId}`);
+      // check the deal
+      const { body } = await as(aMaker).get(`${applicationBaseUrl}/${createdDeal._id}`);
 
       expect(body.facilitiesUpdated).toEqual(expect.any(Number));
     });

--- a/portal-api/api-tests/v1/loan/loan.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan.api-test.js
@@ -497,9 +497,8 @@ describe('/v1/deals/:id/loan', () => {
       await as(aBarclaysMaker).put(loanUpdate).to(`/v1/deals/${dealId}/loan/${loanId}`);
 
       // get the deal, check facilities timestamp
-      const { body: dealAfterFirstUpdate } = await as(aBarclaysMaker).get(`/v1/deals/${dealId}`);
-      const originalFacilitiesUpdated = dealAfterFirstUpdate.deal.facilitiesUpdated;
-      expect(originalFacilitiesUpdated).toEqual(expect.any(String));
+      const { body: dealAfterUpdate } = await as(aBarclaysMaker).get(`/v1/deals/${dealId}`);
+      expect(dealAfterUpdate.deal.facilitiesUpdated).toEqual(expect.any(Number));
     });
   });
 

--- a/portal-api/api-tests/v1/loan/loan.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan.api-test.js
@@ -481,6 +481,26 @@ describe('/v1/deals/:id/loan', () => {
       expect(status).toEqual(200);
       expect(body.loan.lastEdited).toEqual(expect.any(String));
     });
+
+    it('should update the associated deal\'s facilitiesUpdated timestamp', () => {
+      // create deal
+      const deal = await as(aBarclaysMaker).post(newDeal).to('/v1/deals/');
+      const dealId = deal.body._id;
+
+      // create loan facility
+      const { body: createdLoan } = await as(aBarclaysMaker).put({}).to(`/v1/deals/${dealId}/loan/create`);
+      const { loanId } = createdLoan;
+
+      const loanUpdate = { test: true };
+
+      // update loan facility
+      await as(aBarclaysMaker).put(loanUpdate).to(`/v1/deals/${dealId}/loan/${loanId}`);
+
+      // get the deal, check facilities timestamp
+      const { body: dealAfterFirstUpdate } = await as(aBarclaysMaker).get(`/v1/deals/${dealId}`);
+      const originalFacilitiesUpdated = dealAfterFirstUpdate.deal.facilitiesUpdated;
+      expect(originalFacilitiesUpdated).toEqual(expect.any(String));
+    });
   });
 
   describe('PUT /v1/deals/:id/loan/create', () => {

--- a/portal-api/api-tests/v1/loan/loan.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan.api-test.js
@@ -482,7 +482,7 @@ describe('/v1/deals/:id/loan', () => {
       expect(body.loan.lastEdited).toEqual(expect.any(String));
     });
 
-    it('should update the associated deal\'s facilitiesUpdated timestamp', () => {
+    it('should update the associated deal\'s facilitiesUpdated timestamp', async () => {
       // create deal
       const deal = await as(aBarclaysMaker).post(newDeal).to('/v1/deals/');
       const dealId = deal.body._id;

--- a/portal-api/src/v1/controllers/bond-change-cover-start-date.controller.js
+++ b/portal-api/src/v1/controllers/bond-change-cover-start-date.controller.js
@@ -10,10 +10,11 @@ const facilitiesController = require('./facilities.controller');
 
 exports.updateBondCoverStartDate = async (req, res) => {
   const {
+    id: dealId,
     bondId,
   } = req.params;
 
-  await findOneDeal(req.params.id, async (deal) => {
+  await findOneDeal(dealId, async (deal) => {
     if (deal) {
       if (!userHasAccessTo(req.user, deal)) {
         return res.status(401).send();
@@ -51,7 +52,12 @@ exports.updateBondCoverStartDate = async (req, res) => {
         });
       }
 
-      const { status, data } = await facilitiesController.update(bondId, modifiedBond, req.user);
+      const { status, data } = await facilitiesController.update(
+        dealId,
+        bondId,
+        modifiedBond,
+        req.user,
+      );
 
       return res.status(status).send(data);
     }

--- a/portal-api/src/v1/controllers/bond-issue-facility.controller.js
+++ b/portal-api/src/v1/controllers/bond-issue-facility.controller.js
@@ -13,10 +13,11 @@ const facilitiesController = require('./facilities.controller');
 
 exports.updateBondIssueFacility = async (req, res) => {
   const {
+    id: dealId,
     bondId,
   } = req.params;
 
-  await findOneDeal(req.params.id, async (deal) => {
+  await findOneDeal(dealId, async (deal) => {
     if (deal) {
       if (!userHasAccessTo(req.user, deal)) {
         return res.status(401).send();
@@ -74,7 +75,12 @@ exports.updateBondIssueFacility = async (req, res) => {
         modifiedBond.issueFacilityDetailsProvided = false;
       }
 
-      const { status, data } = await facilitiesController.update(bondId, modifiedBond, req.user);
+      const { status, data } = await facilitiesController.update(
+        dealId,
+        bondId,
+        modifiedBond,
+        req.user,
+      );
 
       if (validationErrors.count !== 0) {
         return res.status(400).send({

--- a/portal-api/src/v1/controllers/bonds.controller.js
+++ b/portal-api/src/v1/controllers/bonds.controller.js
@@ -106,10 +106,11 @@ const feeTypeFields = (bond) => {
 
 exports.updateBond = async (req, res) => {
   const {
+    id: dealId,
     bondId,
   } = req.params;
 
-  await findOneDeal(req.params.id, async (deal) => {
+  await findOneDeal(dealId, async (deal) => {
     if (deal) {
       if (!userHasAccessTo(req.user, deal)) {
         res.status(401).send();
@@ -151,7 +152,12 @@ exports.updateBond = async (req, res) => {
         modifiedBond.requestedCoverStartDate = null;
       }
 
-      const { status, data } = await facilitiesController.update(bondId, modifiedBond, req.user);
+      const { status, data } = await facilitiesController.update(
+        dealId,
+        bondId,
+        modifiedBond,
+        req.user,
+      );
 
       const validationErrors = bondValidationErrors(data, deal);
 

--- a/portal-api/src/v1/controllers/deal-status/create-ukef-ids.js
+++ b/portal-api/src/v1/controllers/deal-status/create-ukef-ids.js
@@ -67,7 +67,7 @@ const createUkefIds = async (entityId, deal, user) => {
 
     facilitiesUpdatePromises.push(
       facilitiesController.update(
-        deal._id
+        deal._id,
         facilityId,
         modifiedFacility,
         user,

--- a/portal-api/src/v1/controllers/deal-status/create-ukef-ids.js
+++ b/portal-api/src/v1/controllers/deal-status/create-ukef-ids.js
@@ -66,7 +66,12 @@ const createUkefIds = async (entityId, deal, user) => {
     };
 
     facilitiesUpdatePromises.push(
-      facilitiesController.update(facilityId, modifiedFacility, user),
+      facilitiesController.update(
+        deal._id
+        facilityId,
+        modifiedFacility,
+        user,
+      ),
     );
 
     return facilityId;

--- a/portal-api/src/v1/controllers/deal-status/update-facility-cover-start-dates.js
+++ b/portal-api/src/v1/controllers/deal-status/update-facility-cover-start-dates.js
@@ -24,7 +24,12 @@ const updateFacilityCoverStartDates = async (user, deal) => {
         facility['requestedCoverStartDate-month'] = today.getMonth() + 1;
         facility['requestedCoverStartDate-year'] = today.getFullYear();
 
-        const { data } = await facilitiesController.update(facilityId, facility, user);
+        const { data } = await facilitiesController.update(
+          deal._id,
+          facilityId,
+          facility,
+          user,
+        );
         return data;
       }
       return facility;

--- a/portal-api/src/v1/controllers/deal-status/update-issued-facilities.js
+++ b/portal-api/src/v1/controllers/deal-status/update-issued-facilities.js
@@ -137,7 +137,12 @@ const updateIssuedFacilities = async (
             }
           }
 
-          await facilitiesController.update(facilityId, facility, user);
+          await facilitiesController.update(
+            deal._id,
+            facilityId,
+            facility,
+            user,
+          );
 
           updatedCount += 1;
         }

--- a/portal-api/src/v1/controllers/deal-status/update-submitted-issued-facilities.js
+++ b/portal-api/src/v1/controllers/deal-status/update-submitted-issued-facilities.js
@@ -51,7 +51,12 @@ const updateSubmittedIssuedFacilities = async (user, deal) => {
       facility.status = CONSTANTS.FACILITIES.STATUS.SUBMITTED;
     }
 
-    const { data } = await facilitiesController.update(facilityId, facility, user);
+    const { data } = await facilitiesController.update(
+      deal._id,
+      facilityId,
+      facility,
+      user,
+    );
 
     return data;
   });

--- a/portal-api/src/v1/controllers/facilities.controller.js
+++ b/portal-api/src/v1/controllers/facilities.controller.js
@@ -1,4 +1,5 @@
 const api = require('../api');
+const { updateDeal } = require('./deal.controller');
 
 exports.create = async (facilityBody, user) => {
   const createdFacility = await api.createFacility(facilityBody, user);
@@ -17,8 +18,21 @@ exports.create = async (facilityBody, user) => {
 exports.findOne = async (facilityId) =>
   api.findOneFacility(facilityId);
 
-exports.update = async (facilityId, facilityBody, user) =>
-  api.updateFacility(facilityId, facilityBody, user);
+exports.update = async (dealId, facilityId, facilityBody, user) => {
+  const updatedFacility = await api.updateFacility(facilityId, facilityBody, user);
+
+  const dealUpdate = {
+    facilitiesUpdated: new Date().valueOf(),
+  };
+
+  await updateDeal(
+    dealId,
+    dealUpdate,
+    user,
+  );
+
+  return updatedFacility;
+};
 
 exports.delete = async (facilityId, user) =>
   api.deleteFacility(facilityId, user);

--- a/portal-api/src/v1/controllers/facilities.controller.js
+++ b/portal-api/src/v1/controllers/facilities.controller.js
@@ -22,7 +22,7 @@ exports.update = async (dealId, facilityId, facilityBody, user) => {
   const updatedFacility = await api.updateFacility(facilityId, facilityBody, user);
 
   const dealUpdate = {
-    facilitiesUpdated: new Date().valueOf(),
+    facilitiesUpdated: Date.now(),
   };
 
   await updateDeal(

--- a/portal-api/src/v1/controllers/facilities.controller.js
+++ b/portal-api/src/v1/controllers/facilities.controller.js
@@ -22,7 +22,7 @@ exports.update = async (dealId, facilityId, facilityBody, user) => {
   const updatedFacility = await api.updateFacility(facilityId, facilityBody, user);
 
   const dealUpdate = {
-    facilitiesUpdated: Date.now(),
+    facilitiesUpdated: new Date().valueOf(),
   };
 
   await updateDeal(

--- a/portal-api/src/v1/controllers/integration/type-b-helpers/update-facilities.js
+++ b/portal-api/src/v1/controllers/integration/type-b-helpers/update-facilities.js
@@ -117,7 +117,12 @@ const updateBond = async (bond, dealId, workflowDeal, interfaceUser, checkIssueF
     modifiedBond.status = changeBondStatus(bond, workflowBond, workflowActionCode);
   }
 
-  const { data } = await facilitiesController.update(bondId, modifiedBond, interfaceUser);
+  const { data } = await facilitiesController.update(
+    dealId,
+    bondId,
+    modifiedBond,
+    interfaceUser,
+  );
 
   return data;
 };

--- a/portal-api/src/v1/controllers/loan-change-cover-start-date.controller.js
+++ b/portal-api/src/v1/controllers/loan-change-cover-start-date.controller.js
@@ -10,10 +10,11 @@ const facilitiesController = require('./facilities.controller');
 
 exports.updateLoanCoverStartDate = async (req, res) => {
   const {
+    id: dealId,
     loanId,
   } = req.params;
 
-  await findOneDeal(req.params.id, async (deal) => {
+  await findOneDeal(dealId, async (deal) => {
     if (deal) {
       if (!userHasAccessTo(req.user, deal)) {
         return res.status(401).send();
@@ -51,7 +52,12 @@ exports.updateLoanCoverStartDate = async (req, res) => {
         });
       }
 
-      const { status, data } = await facilitiesController.update(loanId, modifiedLoan, req.user);
+      const { status, data } = await facilitiesController.update(
+        dealId,
+        loanId,
+        modifiedLoan,
+        req.user,
+      );
 
       return res.status(status).send(data);
     }

--- a/portal-api/src/v1/controllers/loan-issue-facility.controller.js
+++ b/portal-api/src/v1/controllers/loan-issue-facility.controller.js
@@ -13,10 +13,11 @@ const facilitiesController = require('./facilities.controller');
 
 exports.updateLoanIssueFacility = async (req, res) => {
   const {
+    id: dealId,
     loanId,
   } = req.params;
 
-  await findOneDeal(req.params.id, async (deal) => {
+  await findOneDeal(dealId, async (deal) => {
     if (deal) {
       if (!userHasAccessTo(req.user, deal)) {
         return res.status(401).send();
@@ -74,7 +75,12 @@ exports.updateLoanIssueFacility = async (req, res) => {
         modifiedLoan.issueFacilityDetailsProvided = false;
       }
 
-      const { status, data } = await facilitiesController.update(loanId, modifiedLoan, req.user);
+      const { status, data } = await facilitiesController.update(
+        dealId,
+        loanId,
+        modifiedLoan,
+        req.user,
+      );
 
       if (validationErrors.count !== 0) {
         return res.status(400).send({

--- a/portal-api/src/v1/controllers/loans.controller.js
+++ b/portal-api/src/v1/controllers/loans.controller.js
@@ -105,10 +105,11 @@ const premiumTypeFields = (loan) => {
 
 exports.updateLoan = async (req, res) => {
   const {
+    id: dealId,
     loanId,
   } = req.params;
 
-  await findOneDeal(req.params.id, async (deal) => {
+  await findOneDeal(dealId, async (deal) => {
     if (deal) {
       if (!userHasAccessTo(req.user, deal)) {
         res.status(401).send();
@@ -156,7 +157,12 @@ exports.updateLoan = async (req, res) => {
         modifiedLoan.requestedCoverStartDate = null;
       }
 
-      const { status, data } = await facilitiesController.update(loanId, modifiedLoan, req.user);
+      const { status, data } = await facilitiesController.update(
+        dealId,
+        loanId,
+        modifiedLoan,
+        req.user,
+      );
 
       const validationErrors = loanValidationErrors(data, deal);
 

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -113,7 +113,7 @@ const update = async (id, updateBody) => {
 
   // update facilitiesUpdated timestamp in the deal
   const dealUpdate = {
-    facilitiesUpdated: Date.now(),
+    facilitiesUpdated: new Date().valueOf(),
   };
   const update = new Application(dealUpdate);
 

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -111,17 +111,19 @@ const update = async (id, updateBody) => {
     { _id: { $eq: facilityId } }, { $set: facilityUpdate }, { returnOriginal: false },
   );
 
-  // update facilitiesUpdated timestamp in the deal
-  const dealUpdate = {
-    facilitiesUpdated: new Date().valueOf(),
-  };
-  const update = new Application(dealUpdate);
+  if (existingFacility) {
+    // update facilitiesUpdated timestamp in the deal
+    const dealUpdate = {
+      facilitiesUpdated: new Date().valueOf(),
+    };
+    const update = new Application(dealUpdate);
 
-  await dealsCollection.findOneAndUpdate(
-    { _id: { $eq: ObjectID(existingFacility.applicationId) } },
-    { $set: dealUpdate },
-    { returnOriginal: false },
-  );
+    await dealsCollection.findOneAndUpdate(
+      { _id: { $eq: ObjectID(existingFacility.applicationId) } },
+      { $set: dealUpdate },
+      { returnOriginal: false },
+    );
+  }
 
   return updatedFacility;
 };

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -5,6 +5,7 @@ const {
   facilitiesValidation, facilitiesStatus, facilitiesOverallStatus, facilitiesCheckEnums,
 } = require('./validation/facilities');
 const { Facility } = require('../models/facilities');
+const { Application } = require('../models/application');
 const { isSuperUser } = require('../../users/checks');
 const {
   calculateUkefExposure,
@@ -12,6 +13,7 @@ const {
 } = require('../calculations/facility-calculations');
 
 const collectionName = 'gef-facilities';
+const dealsCollectionName = 'gef-application';
 
 exports.create = async (req, res) => {
   const enumValidationErr = facilitiesCheckEnums(req.body);
@@ -93,6 +95,8 @@ exports.getById = async (req, res) => {
 
 const update = async (id, updateBody) => {
   const collection = await db.getCollection(collectionName);
+  const dealsCollection = await db.getCollection(dealsCollectionName);
+
   const facilityId = ObjectID(String(id));
 
   const existingFacility = await collection.findOne({ _id: facilityId });
@@ -103,11 +107,23 @@ const update = async (id, updateBody) => {
     guaranteeFee: calculateGuaranteeFee(updateBody, existingFacility),
   });
 
-  const result = await collection.findOneAndUpdate(
+  const updatedFacility = await collection.findOneAndUpdate(
     { _id: { $eq: facilityId } }, { $set: facilityUpdate }, { returnOriginal: false },
   );
 
-  return result;
+  // update facilitiesUpdated timestamp in the deal
+  const dealUpdate = {
+    facilitiesUpdated: Date.now(),
+  };
+  const update = new Application(dealUpdate);
+
+  await dealsCollection.findOneAndUpdate(
+    { _id: { $eq: ObjectID(existingFacility.applicationId) } },
+    { $set: dealUpdate },
+    { returnOriginal: false },
+  );
+
+  return updatedFacility;
 };
 exports.update = update;
 

--- a/portal-api/src/v1/gef/models/application.js
+++ b/portal-api/src/v1/gef/models/application.js
@@ -33,6 +33,7 @@ class Application {
       editedBy.push(this.userId);
       this.editedBy = editedBy;
       this.additionalRefName = req.additionalRefName ? String(req.additionalRefName) : null;
+      this.facilitiesUpdated = null;
     } else {
       // Update
       this.updatedAt = Date.now();
@@ -50,6 +51,7 @@ class Application {
         'bankInternalRefName',
         'additionalRefName',
         'eligibility',
+        'facilitiesUpdated',
       ];
 
       if (req.eligibility) {

--- a/portal-api/src/v1/gef/models/facilities.js
+++ b/portal-api/src/v1/gef/models/facilities.js
@@ -38,7 +38,7 @@ function checkPaymentType(paymentType) {
 class Facility {
   constructor(req) {
     if (req.applicationId) {
-      // new application
+      // new facility
       this.applicationId = req.applicationId ? new ObjectID(req.applicationId) : null;
       this.type = checkType(req.type);
       this.hasBeenIssued = null;
@@ -67,7 +67,7 @@ class Facility {
       this.feeFrequency = null;
       this.dayCountBasis = null;
     } else {
-      // update application
+      // update facility
       if (req.hasBeenIssued != null) {
         this.hasBeenIssued = Boolean(req.hasBeenIssued);
       }


### PR DESCRIPTION
When a GEF/BSS facility is updated, update the `facilitiesUpdated` timestamp in the associated deal.

This is required for Cedar reporting (external system that will query our data)