### PR TITLE
DTFS2-4525 - Fix/improve TFM API deals query for external teams. Query timestamp fields by date string

### DIFF
--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get.api-test.js
@@ -28,6 +28,7 @@ const newDeal = (dealOverrides) => ({
   eligibility: {
     status: 'Not started',
     criteria: [{ }],
+    ...dealOverrides.eligibility,
   },
   bondTransactions: dealOverrides.bondTransactions,
   loanTransactions: dealOverrides.loanTransactions,

--- a/dtfs-central-api/src/v1/controllers/portal/facility/create-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/create-facility.controller.js
@@ -56,4 +56,6 @@ exports.createFacilityPost = async (req, res) => {
 
     return res.status(404).send('Deal not found');
   });
+
+  return res.status(404).send();
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.api-test.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.api-test.js
@@ -1,4 +1,9 @@
-const { parse, getTime, startOfDay, endOfDay } = require('date-fns');
+const {
+  parse,
+  getTime,
+  startOfDay,
+  endOfDay,
+} = require('date-fns');
 const {
   TIMESTAMP_FIELDS,
   isTimestampField,

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.api-test.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.api-test.js
@@ -1,0 +1,79 @@
+const { parse, getTime, startOfDay, endOfDay } = require('date-fns');
+const {
+  TIMESTAMP_FIELDS,
+  isTimestampField,
+  DATE_INPUT_FORMAT,
+  dayStartAndEndTimestamps,
+} = require('./tfm-get-deals-date-helpers');
+
+describe('tfm get deals controller - date helpers', () => {
+  describe('DATE_INPUT_FORMAT', () => {
+    it('should be defined', () => {
+      expect(DATE_INPUT_FORMAT).toEqual('dd-MM-yyyy');
+    });
+  });
+
+  describe('TIMESTAMP_FIELDS', () => {
+    it('should be defined', () => {
+      const expected = [
+        'dealSnapshot.eligibility.lastUpdated',
+        'dealSnapshot.details.submissionDate',
+        'dealSnapshot.facilitiesUpdated',
+      ];
+
+      expect(TIMESTAMP_FIELDS).toEqual(expected);
+    });
+  });
+
+  describe('isTimestampField', () => {
+    it('should return true when the provided field name is in TIMESTAMP_FIELDS', () => {
+      const result = isTimestampField('dealSnapshot.eligibility.lastUpdated');
+      expect(result).toEqual(true);
+    });
+
+    it('should return false when the provided field name is NOT in TIMESTAMP_FIELDS', () => {
+      const result = isTimestampField('some-invalid-field');
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('dayStartAndEndTimestamps', () => {
+    it('should return start and end of day timestamps from a provided date string', () => {
+      const mockDate = '31-10-2021';
+
+      const result = dayStartAndEndTimestamps(mockDate);
+
+      const generateTimeStamp = (dateStr, timeOfDay) => {
+        let timestamp;
+
+        const day = parse(dateStr, DATE_INPUT_FORMAT, new Date());
+
+        if (timeOfDay === 'start') {
+          const dayStart = startOfDay(new Date(day));
+          timestamp = getTime(dayStart);
+
+          return timestamp;
+        }
+
+        if (timeOfDay === 'end') {
+          const dayEnd = endOfDay(new Date(day));
+          timestamp = getTime(dayEnd);
+
+          return timestamp;
+        }
+
+        return timestamp;
+      };
+
+      const expectedDayStartTimestamp = generateTimeStamp(mockDate, 'start');
+      const expectedDayEndTimestamp = generateTimeStamp(mockDate, 'end');
+
+      const expected = {
+        dayStartTimestamp: expectedDayStartTimestamp,
+        dayEndTimestamp: expectedDayEndTimestamp,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.js
@@ -1,0 +1,43 @@
+const { parse, getTime, startOfDay, endOfDay } = require('date-fns');
+
+// date format that the endpoint will receive
+const DATE_INPUT_FORMAT = 'dd-MM-yyyy';
+
+// Timestamp fields that other systems consume.
+// These fields require special date generation/comparison for MongoDB query.
+const TIMESTAMP_FIELDS = [
+  'dealSnapshot.eligibility.lastUpdated',
+  'dealSnapshot.details.submissionDate',
+  'dealSnapshot.facilitiesUpdated',
+];
+
+const isTimestampField = (fieldName) =>
+  TIMESTAMP_FIELDS.includes(fieldName);
+
+const dayStartAndEndTimestamps = (dateString) => {
+  // generate date from provided string
+  const day = parse(dateString, DATE_INPUT_FORMAT, new Date());
+
+  // generate start of the day timestamp
+  const dayStart = startOfDay(new Date(day));
+  const dayStartTimestamp = getTime(dayStart);
+
+  // generate end of the day timestamp
+  const dayEnd = endOfDay(new Date(day));
+  const dayEndTimestamp = getTime(dayEnd);
+  
+  const dates = {
+    dayStartTimestamp,
+    dayEndTimestamp,
+  };
+
+  return dates;
+};
+
+
+module.exports = {
+  TIMESTAMP_FIELDS,
+  isTimestampField,
+  DATE_INPUT_FORMAT,
+  dayStartAndEndTimestamps,
+};

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.js
@@ -1,4 +1,9 @@
-const { parse, getTime, startOfDay, endOfDay } = require('date-fns');
+const {
+  parse,
+  getTime,
+  startOfDay,
+  endOfDay,
+} = require('date-fns');
 
 // date format that the endpoint will receive
 const DATE_INPUT_FORMAT = 'dd-MM-yyyy';
@@ -25,7 +30,7 @@ const dayStartAndEndTimestamps = (dateString) => {
   // generate end of the day timestamp
   const dayEnd = endOfDay(new Date(day));
   const dayEndTimestamp = getTime(dayEnd);
-  
+
   const dates = {
     dayStartTimestamp,
     dayEndTimestamp,
@@ -33,7 +38,6 @@ const dayStartAndEndTimestamps = (dateString) => {
 
   return dates;
 };
-
 
 module.exports = {
   TIMESTAMP_FIELDS,

--- a/dtfs-central-api/src/v1/routes/bank-routes.js
+++ b/dtfs-central-api/src/v1/routes/bank-routes.js
@@ -66,5 +66,4 @@ bankRouter.route('/:id')
     getBankController.findOneBankGet,
   );
 
-
 module.exports = bankRouter;

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.api-test.js
@@ -21,6 +21,8 @@ describe('mapGefDealDetails', () => {
       submissionType: mockDeal.dealSnapshot.submissionType,
       owningBank: {
         name: mockDeal.dealSnapshot.bank.name,
+        emails: mockDeal.dealSnapshot.bank.emails,
+        partyUrn: mockDeal.dealSnapshot.bank.partyUrn,
       },
     };
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.js
@@ -5,6 +5,8 @@ const mapGefDealDetails = (dealSnapshot) => ({
   submissionType: dealSnapshot.submissionType,
   owningBank: {
     name: dealSnapshot.bank.name,
+    emails: dealSnapshot.bank.emails,
+    partyUrn: dealSnapshot.bank.partyUrn,
   },
 });
 

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -39,6 +39,7 @@ type DealDetails {
   checkerMIN: Checker
   dateOfLastAction: String
   submissionDate: String
+  manualInclusionNoticeSubmissionDate: String
   approvalDate: String
   created: String
   workflowStatus: String

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -117,7 +117,7 @@ type DealEligibility {
   agentAddressTown: String
   agentName: String
   agentAlias: String
-  lastUpdated: Int
+  lastUpdated: Float
 }
 
 type FacilityProduct {

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -342,7 +342,7 @@ type DealSnapshot {
   isFinanceIncreasing: Boolean
   eligibility: DealEligibility
   dealFiles: DealFiles
-  facilitiesUpdated: Int
+  facilitiesUpdated: Float
 }
 
 type Deal {

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -13,6 +13,7 @@ type Country {
 type OwningBank {
   name: String
   emails: [String]
+  partyUrn: String
 }
 
 type Maker {

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -255,7 +255,11 @@ const updateFacility = async (facilityId, facilityUpdate) => {
   }
 };
 
-const queryDeals = async ({ queryParams, start = 0, pagesize = 0 }) => {
+const queryDeals = async ({
+  byField,
+  start = 0,
+  pagesize = 0,
+}) => {
   try {
     const response = await axios({
       method: 'get',
@@ -264,7 +268,9 @@ const queryDeals = async ({ queryParams, start = 0, pagesize = 0 }) => {
         'Content-Type': 'application/json',
       },
       data: {
-        queryParams,
+        queryParams: {
+          byField,
+        },
         start,
         pagesize,
       },

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query.js
@@ -40,10 +40,13 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
           }
           dateOfLastAction
           submissionDate
+          manualInclusionNoticeSubmissionDate
           approvalDate
           created
-          owningBank{
+          owningBank {
             name
+            emails
+            partyUrn
           }
         }
         submissionDetails {

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query.js
@@ -8,33 +8,19 @@ const dealsQuery = gql`
 query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField], $start: Int, $pagesize: Int){
   deals(params: {searchString: $searchString, sortBy: $sortBy, byField: $byField, start: $start, pagesize: $pagesize}) {
     count
-    deals{
-      _id
-      tfm {
-        dateReceived
-        product
-        stage
-        history {
-          tasks {
-            timestamp
-          }
-        }
-      }
+    deals {
       dealSnapshot {
-        _id
         details {
           status
-          bankSupplyContractID
-          bankSupplyContractName
           ukefDealId
           submissionType
+          submissionDate
           maker {
-            username
             firstname
             surname
+            email
           }
           checker {
-            username
             firstname
             surname
           }
@@ -48,12 +34,29 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
             emails
             partyUrn
           }
+          bankSupplyContractID
+          bankSupplyContractName
         }
         submissionDetails {
+          supplierType
+          supplierCompaniesHouseRegistrationNumber
           supplierName
+          supplierCountry
+          supplierAddressLine1
+          supplierAddressLine2
+          supplierAddressLine3
+          supplierAddressPostcode
+          supplierAddressTown
+          industrySector
+          industryClass
           supplyContractDescription
-          destinationCountry
-          supplyContractValue
+          indemnifierCompaniesHouseRegistrationNumber
+          indemnifierCorrespondenceAddressCountry
+          indemnifierCorrespondenceAddressLine1
+          indemnifierCorrespondenceAddressLine2
+          indemnifierCorrespondenceAddressLine3
+          indemnifierCorrespondenceAddressPostcode
+          indemnifierCorrespondenceAddressTown
           buyerName
           buyerAddressCountry
           buyerAddressLine1
@@ -61,36 +64,8 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
           buyerAddressLine3
           buyerAddressPostcode
           buyerAddressTown
-          indemnifierAddressCountry
-          indemnifierAddressLine1
-          indemnifierAddressLine2
-          indemnifierAddressLine3
-          indemnifierAddressPostcode
-          indemnifierAddressTown
-          indemnifierCorrespondenceAddressCountry
-          indemnifierCorrespondenceAddressLine1
-          indemnifierCorrespondenceAddressLine2
-          indemnifierCorrespondenceAddressLine3
-          indemnifierCorrespondenceAddressPostcode
-          indemnifierCorrespondenceAddressTown
-          indemnifierName
-          industryClass
-          industrySector
-          supplierAddressCountry
-          supplierCountry
-          supplierAddressLine1
-          supplierAddressLine2
-          supplierAddressLine3
-          supplierAddressPostcode
-          supplierAddressTown
-          supplierCompaniesHouseRegistrationNumber
-          supplierCorrespondenceAddressCountry
-          supplierCorrespondenceAddressLine1
-          supplierCorrespondenceAddressLine2
-          supplierCorrespondenceAddressLine3
-          supplierCorrespondenceAddressPostcode
-          supplierCorrespondenceAddressTown
-          smeType
+          supplyContractValue
+          supplyContractCurrency
         }
         eligibility {
           criteria {
@@ -108,6 +83,8 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
           agentAddressLine3
           agentAddressPostcode
           agentAddressTown
+          agentName
+          agentAlias
           lastUpdated
         }
         dealFiles {
@@ -119,6 +96,7 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
         }
         facilities {
           facilitySnapshot {
+            _id,
             ukefFacilityID
             bankFacilityReference
             facilityValue
@@ -149,9 +127,25 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
         }
         facilitiesUpdated
       }
+      tfm {
+        dateReceived
+        product
+        stage
+        underwriterManagersDecision {
+          decision
+          comments
+          internalComments
+          userFullName
+          timestamp
+        }
+        exporterCreditRating
+        probabilityOfDefault
+        lossGivenDefault
+      }
     }
   }
 }
+
 `;
 
 module.exports = dealsQuery;


### PR DESCRIPTION
## Summary

### Why?

- Without this change, only deals with specific timestamps would get returned if they are passed into the `byField` request body. 
- Now, a date format can be passed in, e.g '01-12-2021' and any timestamp that's within this day will be returned in the response.
- How? We generate start-of-day and end-of-day timestamps with `date-fns` and then use these in the MongoDB query, with `$gte`/`$lte` operators.

### Central API

- Create `get-deals-date-helpers` function for API call:
  - keeps date input format and supported timestamp fields in one place.
  - main function: `dayStartAndEndTimestamps`: given a date in '01-12-2021' format, this will return 2 timestamps of the start and end of this day.
  - all of these functions are then used in the "get deals" endpoint/MongoDB query, if an appropriate field is passed into `byField` request body.


### TFM API

- Add `bank.emails` and `bank.partyUrn` to GEF GraphQL reducer mapping.
- Update GraphQL schema with missing fields and incorrect timestamp types (Float instead of Int).
- Fix issue where api.queryDeals function was not correctly passing `byField` param.
- Update example `deals-query` that external teams use.

### Other

- Various lint fixes.