### PR TITLE
fix/update GEF statusLabel nunjuck filter used in Deals page

### DIFF
--- a/gef-ui/server/nunjucks-configuration/filter-getStatusLabel.js
+++ b/gef-ui/server/nunjucks-configuration/filter-getStatusLabel.js
@@ -6,9 +6,9 @@ const statusLabelMap = {
   SUBMITTED_TO_UKEF: 'Submitted',
   UKEF_ACKNOWLEDGED: 'Acknowledged by UKEF',
   UKEF_IN_PROGRESS: 'In progress by UKEF',
-  UKEF_APPROVED_WITH_CONDITIONS: 'Accepted (with conditions)',
-  UKEF_APPROVED_WITHOUT_CONDITIONS: 'Accepted (without conditions)',
-  UKEF_REFUSED: 'Rejected by UKEF',
+  UKEF_ACCEPTED_CONDITIONAL: 'Accepted by UKEF (with conditions)',
+  UKEF_ACCEPTED_UNCONDITIONAL: 'Accepted by UKEF (without conditions)',
+  UKEF_DECLINED: 'Rejected by UKEF',
   EXPIRED: 'Expired',
   WITHDRAWN: 'Withdrawn',
 };

--- a/portal/server/nunjucks-configuration/filter-getStatusLabel.test.js
+++ b/portal/server/nunjucks-configuration/filter-getStatusLabel.test.js
@@ -1,8 +1,52 @@
 import getStatusLabel from './filter-getStatusLabel';
 
 describe('getStatusLabel filter', () => {
-  it('returns the expected label for a give application status', () => {
+  it('returns label for DRAFT', () => {
+    expect(getStatusLabel('DRAFT')).toEqual('Draft');
+  });
+
+  it('returns label for BANK_CHECK', () => {
     expect(getStatusLabel('BANK_CHECK')).toEqual('Ready for Checker\'s approval');
+  });
+
+  it('returns label for CHANGES_REQUIRED', () => {
+    expect(getStatusLabel('CHANGES_REQUIRED')).toEqual('Further Maker\'s input required');
+  });
+
+  it('returns label for ABANDONED', () => {
+    expect(getStatusLabel('ABANDONED')).toEqual('Abandoned');
+  });
+
+  it('returns label for SUBMITTED_TO_UKEF', () => {
+    expect(getStatusLabel('SUBMITTED_TO_UKEF')).toEqual('Submitted');
+  });
+
+  it('returns label for UKEF_ACKNOWLEDGED', () => {
+    expect(getStatusLabel('UKEF_ACKNOWLEDGED')).toEqual('Acknowledged by UKEF');
+  });
+
+  it('returns label for UKEF_IN_PROGRESS', () => {
+    expect(getStatusLabel('UKEF_IN_PROGRESS')).toEqual('In progress by UKEF');
+  });
+
+  it('returns label for UKEF_ACCEPTED_CONDITIONAL', () => {
+    expect(getStatusLabel('UKEF_ACCEPTED_CONDITIONAL')).toEqual('Accepted by UKEF (with conditions)');
+  });
+
+  it('returns label for UKEF_ACCEPTED_UNCONDITIONAL', () => {
+    expect(getStatusLabel('UKEF_ACCEPTED_UNCONDITIONAL')).toEqual('Accepted by UKEF (without conditions)');
+  });
+
+  it('returns label for UKEF_DECLINED', () => {
+    expect(getStatusLabel('UKEF_DECLINED')).toEqual('Rejected by UKEF');
+  });
+
+  it('returns label for EXPIRED', () => {
+    expect(getStatusLabel('EXPIRED')).toEqual('Expired');
+  });
+
+  it('returns label for WITHDRAWN', () => {
+    expect(getStatusLabel('WITHDRAWN')).toEqual('Withdrawn');
   });
 
   it('returns the status passed if no matching status is found', () => {


### PR DESCRIPTION
There are two `getStatusLabel` functions used for GEF in Portal. One for Deal page, the other for GEF Deals table.

This one, for the Deals table, was missed in previous PR.