### PR TITLE
DTFS2-3549 - TFM tasks creation based on list of additional tasks (depending on deal data)

### DIFF
--- a/trade-finance-manager-api/src/constants/tasks.js
+++ b/trade-finance-manager-api/src/constants/tasks.js
@@ -1,5 +1,12 @@
 const TEAMS = require('./teams');
 
+/**
+ * NOTE:
+ * Tasks that have isConditional flag are tasks that can either be:
+ * - added (depending on deal data)
+ * - excluded (depending on deal data)
+ * */
+
 const AIN_AND_MIA = {
   GROUP_1: {
     GROUP_TITLE: 'Set up deal',
@@ -15,6 +22,7 @@ const AIN = {
       {
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
         team: TEAMS.BUSINESS_SUPPORT,
+        isConditional: true,
       },
       {
         title: AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE,
@@ -28,6 +36,7 @@ const MIA_GROUP_1_TASKS = {
   FILE_ALL_DEAL_EMAILS: 'File all deal emails in this deal',
   CREATE_CREDIT_ANALYSIS_DOCUMENT: 'Create a credit analysis document',
   ASSIGN_AN_UNDERWRITER: 'Assign an underwriter for this deal',
+  COMPLETE_AGENT_CHECK: 'Complete an agent check',
 };
 
 const MIA_GROUP_2_TASKS = {
@@ -38,6 +47,7 @@ const MIA_GROUP_3_TASKS = {
   CHECK_EXPOSURE: 'Check exposure',
   GIVE_EXPORTER_A_CREDIT_RATING: 'Give the exporter a credit rating',
   COMPLETE_CREDIT_ANALYSIS: 'Complete the credit analysis',
+  
 };
 
 const MIA_GROUP_4_TASKS = {
@@ -53,6 +63,7 @@ const MIA = {
       {
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
         team: TEAMS.BUSINESS_SUPPORT,
+        isConditional: true,
       },
       {
         title: AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE,
@@ -69,6 +80,11 @@ const MIA = {
       {
         title: MIA_GROUP_1_TASKS.ASSIGN_AN_UNDERWRITER,
         team: TEAMS.UNDERWRITER_MANAGERS,
+      },
+      {
+        title: MIA_GROUP_1_TASKS.COMPLETE_AGENT_CHECK,
+        team: TEAMS.UNDERWRITERS,
+        isConditional: true,
       },
     ],
   },

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
@@ -1,0 +1,144 @@
+const {
+  listExcludedTasks,
+  listAdditionalTasks,
+  createDealTasks,
+} = require('./deal.tasks');
+const externalApis = require('../../../src/v1/api');
+const CONSTANTS = require('../../constants');
+const MOCK_DEAL_MIA = require('../../../src/v1/__mocks__/mock-deal-MIA-submitted');
+const { createTasks } = require('../helpers/create-tasks');
+const mapSubmittedDeal = require('../mappings/map-submitted-deal');
+
+describe('createDealTasks', () => {
+  const updateDealSpy = jest.fn((dealUpdate) => Promise.resolve(dealUpdate));
+  const mockSubmittedDeal = mapSubmittedDeal({
+    dealSnapshot: MOCK_DEAL_MIA,
+    tfm: {
+      parties: { exporter: {} },
+    },
+  });
+
+  beforeEach(() => {
+    externalApis.updateDeal = updateDealSpy;
+  });
+
+  describe('listExcludedTasks', () => {
+    describe('when a deal has tfm.parties.exporter.partyUrn', () => {
+      it('should return array with MATCH_OR_CREATE_PARTIES task title', () => {
+        const mockDeal = {
+          ...mockSubmittedDeal,
+          tfm: {
+            parties: {
+              exporter: {
+                partyUrn: 'mock',
+              },
+            },
+          },
+        };
+
+        const result = listExcludedTasks(mockDeal);
+
+        const expected = [
+          CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when a deal does NOT have tfm.parties.exporter.partyUrn', () => {
+      it('should return empty array', () => {
+        const mockDeal = {
+          ...mockSubmittedDeal,
+          tfm: {
+            parties: {
+              exporter: {
+                partyUrn: '',
+              },
+            },
+          },
+        };
+
+        const result = listExcludedTasks(mockDeal);
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe('listAdditionalTasks', () => {
+    describe('when a BSS deal has eligibility criteria 11 answer as false', () => {
+      it('should return array with COMPLETE_AGENT_CHECK task title', () => {
+        const mockDeal = {
+          ...mockSubmittedDeal,
+          eligibility: {
+            criteria: [
+              { id: 11, answer: false },
+            ],
+          },
+        };
+
+        const result = listAdditionalTasks(mockDeal);
+
+        const expected = [
+          CONSTANTS.TASKS.MIA_GROUP_1_TASKS.COMPLETE_AGENT_CHECK,
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when a deal does NOT have eligibility criteria 11 answer as false', () => {
+      it('should return empty array', () => {
+        const mockDeal = {
+          ...mockSubmittedDeal,
+          eligibility: {
+            criteria: [
+              { id: 11, answer: true },
+            ],
+          },
+        };
+
+        const result = listAdditionalTasks(mockDeal);
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe('createDealTasks', () => {
+    it('should return false when there is no deal', async () => {
+      const result = await createDealTasks();
+
+      expect(result).toEqual(false);
+    });
+
+    it('should call api.updateDeal and return updated deal', async () => {
+      await createDealTasks(mockSubmittedDeal);
+
+      const expectedTasks = createTasks(
+        mockSubmittedDeal.submissionType,
+        listExcludedTasks(mockSubmittedDeal),
+        listAdditionalTasks(mockSubmittedDeal),
+      );
+
+
+      const expectedDealTfm = {
+        ...mockSubmittedDeal.tfm,
+        tasks: expectedTasks,
+      };
+
+      expect(updateDealSpy).toHaveBeenCalledWith(
+        mockSubmittedDeal._id,
+        { tfm: expectedDealTfm },
+      );
+
+      const expectedDealReturn = {
+        ...mockSubmittedDeal,
+        tfm: expectedDealTfm,
+      };
+
+      expect(result).toEqual(expectedDealReturn);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/helpers/create-tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/create-tasks.api-test.js
@@ -24,7 +24,7 @@ describe('defaults - tasks creation', () => {
   });
 
   describe('createGroupTasks', () => {
-    const mockTasks = [
+    const mockGroupTasks = [
       {
         title: 'Title A',
         team: 'Team A',
@@ -36,7 +36,7 @@ describe('defaults - tasks creation', () => {
     ];
 
     it('should return array of tasks with incremented task id', () => {
-      const result = createGroupTasks(mockTasks, 2);
+      const result = createGroupTasks(mockGroupTasks, 2);
 
       const expected = [
         {
@@ -60,7 +60,7 @@ describe('defaults - tasks creation', () => {
 
     describe('when the given groupId is 1', () => {
       it('should add `canEdit` to the first task in group 1', () => {
-        const result = createGroupTasks(mockTasks, 1);
+        const result = createGroupTasks(mockGroupTasks, 1);
 
         const expected = [
           {
@@ -101,7 +101,11 @@ describe('defaults - tasks creation', () => {
           'Task C',
         ];
 
-        const result = createGroupTasks(mockGroupTasks, mockGroupId, mockExcludedTasks);
+        const result = createGroupTasks(
+          mockGroupTasks,
+          mockGroupId,
+          mockExcludedTasks,
+        );
 
         const expected = [
           {
@@ -120,6 +124,77 @@ describe('defaults - tasks creation', () => {
             team: 'Test team',
             ...NEW_TASK,
           },
+        ];
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when no additionalTasks are passed and a task has isConditional flag', () => {
+      it('should NOT isConditional tasks', () => {
+        const mockGroupTasks = [
+          { title: 'Task A', team: 'Test team' },
+          { title: 'Task B', team: 'Test team', isConditional: true },
+          { title: 'Task C', team: 'Test team' },
+          { title: 'Task D', team: 'Test team', isConditional: true },
+        ];
+
+        const mockGroupId = 1;
+
+        const result = createGroupTasks(
+          mockGroupTasks,
+          mockGroupId,
+        );
+
+        const conditionalTasks = mockGroupTasks.filter((task) => task.isConditional === true);
+
+        const conditionalTask1 = conditionalTasks[0];
+        const conditionalTask2 = conditionalTasks[1];
+
+        const conditionalTask1InResult = result.find((task) => task.title === conditionalTask1.title);
+        expect(conditionalTask1InResult).toBeUndefined();
+
+        const conditionalTask2InResult = result.find((task) => task.title === conditionalTask2.title);
+        expect(conditionalTask2InResult).toBeUndefined();
+      });
+    });
+
+    describe('when additionalTasks array of strings is passed', () => {
+      it('should return any additional tasks (with isConditional flag) in a group that match a title in additionalTasks, retaining incremental task ids', () => {
+        const mockGroupTasks = [
+          { title: 'Task A', team: 'Test team' },
+          { title: 'Task B', team: 'Test team', isConditional: true },
+          { title: 'Task C', team: 'Test team' },
+          { title: 'Task D', team: 'Test team', isConditional: true },
+        ];
+
+        const mockGroupId = 1;
+
+        const mockExcludedTasks = [];
+        const mockAdditionalTasks = [
+          'Task B',
+          'Task D',
+        ];
+
+        const result = createGroupTasks(
+          mockGroupTasks,
+          mockGroupId,
+          mockExcludedTasks,
+          mockAdditionalTasks,
+        );
+
+        const expected = [
+          {
+            id: '1',
+            groupId: mockGroupId,
+            ...mockGroupTasks[0],
+            ...NEW_TASK,
+            status: 'To do',
+            canEdit: true,
+          },
+          { id: '2', groupId: mockGroupId, ...mockGroupTasks[1], ...NEW_TASK },
+          { id: '3', groupId: mockGroupId, ...mockGroupTasks[2], ...NEW_TASK },
+          { id: '4', groupId: mockGroupId, ...mockGroupTasks[3], ...NEW_TASK },
         ];
 
         expect(result).toEqual(expected);

--- a/trade-finance-manager-api/src/v1/helpers/create-tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/create-tasks.api-test.js
@@ -35,6 +35,13 @@ describe('defaults - tasks creation', () => {
       },
     ];
 
+    const mockGroupTasksWithConditionalFlags = [
+      { title: 'Task A', team: 'Test team' },
+      { title: 'Task B', team: 'Test team', isConditional: true },
+      { title: 'Task C', team: 'Test team' },
+      { title: 'Task D', team: 'Test team', isConditional: true },
+    ];
+
     it('should return array of tasks with incremented task id', () => {
       const result = createGroupTasks(mockGroupTasks, 2);
 
@@ -87,21 +94,14 @@ describe('defaults - tasks creation', () => {
 
     describe('when no additionalTasks are passed and a task has isConditional flag', () => {
       it('should NOT add isConditional tasks', () => {
-        const mockGroupTasks = [
-          { title: 'Task A', team: 'Test team' },
-          { title: 'Task B', team: 'Test team', isConditional: true },
-          { title: 'Task C', team: 'Test team' },
-          { title: 'Task D', team: 'Test team', isConditional: true },
-        ];
-
         const mockGroupId = 1;
 
         const result = createGroupTasks(
-          mockGroupTasks,
+          mockGroupTasksWithConditionalFlags,
           mockGroupId,
         );
 
-        const conditionalTasks = mockGroupTasks.filter((task) => task.isConditional === true);
+        const conditionalTasks = mockGroupTasksWithConditionalFlags.filter((task) => task.isConditional === true);
 
         const conditionalTask1 = conditionalTasks[0];
         const conditionalTask2 = conditionalTasks[1];
@@ -116,13 +116,6 @@ describe('defaults - tasks creation', () => {
 
     describe('when additionalTasks array of strings is passed', () => {
       it('should return any additional tasks (with isConditional flag) in a group that match a title in additionalTasks, retaining incremental task ids', () => {
-        const mockGroupTasks = [
-          { title: 'Task A', team: 'Test team' },
-          { title: 'Task B', team: 'Test team', isConditional: true },
-          { title: 'Task C', team: 'Test team' },
-          { title: 'Task D', team: 'Test team', isConditional: true },
-        ];
-
         const mockGroupId = 1;
 
         const mockAdditionalTasks = [
@@ -131,7 +124,7 @@ describe('defaults - tasks creation', () => {
         ];
 
         const result = createGroupTasks(
-          mockGroupTasks,
+          mockGroupTasksWithConditionalFlags,
           mockGroupId,
           mockAdditionalTasks,
         );
@@ -140,14 +133,14 @@ describe('defaults - tasks creation', () => {
           {
             id: '1',
             groupId: mockGroupId,
-            ...mockGroupTasks[0],
+            ...mockGroupTasksWithConditionalFlags[0],
             ...NEW_TASK,
             status: 'To do',
             canEdit: true,
           },
-          { id: '2', groupId: mockGroupId, ...mockGroupTasks[1], ...NEW_TASK },
-          { id: '3', groupId: mockGroupId, ...mockGroupTasks[2], ...NEW_TASK },
-          { id: '4', groupId: mockGroupId, ...mockGroupTasks[3], ...NEW_TASK },
+          { id: '2', groupId: mockGroupId, ...mockGroupTasksWithConditionalFlags[1], ...NEW_TASK },
+          { id: '3', groupId: mockGroupId, ...mockGroupTasksWithConditionalFlags[2], ...NEW_TASK },
+          { id: '4', groupId: mockGroupId, ...mockGroupTasksWithConditionalFlags[3], ...NEW_TASK },
         ];
 
         expect(result).toEqual(expected);

--- a/trade-finance-manager-api/src/v1/helpers/create-tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/create-tasks.api-test.js
@@ -85,53 +85,8 @@ describe('defaults - tasks creation', () => {
       });
     });
 
-    describe('when excludedTasks array of strings is passed', () => {
-      it('should NOT return any tasks in a group that match a title in excludedTasks, retaining incremental task ids', () => {
-        const mockGroupTasks = [
-          { title: 'Task A', team: 'Test team' },
-          { title: 'Task B', team: 'Test team' },
-          { title: 'Task C', team: 'Test team' },
-          { title: 'Task D', team: 'Test team' },
-        ];
-
-        const mockGroupId = 1;
-
-        const mockExcludedTasks = [
-          'Task B',
-          'Task C',
-        ];
-
-        const result = createGroupTasks(
-          mockGroupTasks,
-          mockGroupId,
-          mockExcludedTasks,
-        );
-
-        const expected = [
-          {
-            id: '1',
-            groupId: 1,
-            title: 'Task A',
-            team: 'Test team',
-            ...NEW_TASK,
-            status: 'To do',
-            canEdit: true,
-          },
-          {
-            id: '2',
-            groupId: 1,
-            title: 'Task D',
-            team: 'Test team',
-            ...NEW_TASK,
-          },
-        ];
-
-        expect(result).toEqual(expected);
-      });
-    });
-
     describe('when no additionalTasks are passed and a task has isConditional flag', () => {
-      it('should NOT isConditional tasks', () => {
+      it('should NOT add isConditional tasks', () => {
         const mockGroupTasks = [
           { title: 'Task A', team: 'Test team' },
           { title: 'Task B', team: 'Test team', isConditional: true },
@@ -170,7 +125,6 @@ describe('defaults - tasks creation', () => {
 
         const mockGroupId = 1;
 
-        const mockExcludedTasks = [];
         const mockAdditionalTasks = [
           'Task B',
           'Task D',
@@ -179,7 +133,6 @@ describe('defaults - tasks creation', () => {
         const result = createGroupTasks(
           mockGroupTasks,
           mockGroupId,
-          mockExcludedTasks,
           mockAdditionalTasks,
         );
 
@@ -217,18 +170,18 @@ describe('defaults - tasks creation', () => {
       expect(result).toEqual(expected);
     });
 
-    it('should return AIN tasks array with createGroupTasks and excludedTasks', () => {
-      const mockExcludedTasks = [
+    it('should return AIN tasks array with createGroupTasks and additionalTasks', () => {
+      const mockAdditionalTasks = [
         CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE
       ];
 
-      const result = createTasksAIN(mockExcludedTasks);
+      const result = createTasksAIN(mockAdditionalTasks);
 
       const expected = [
         {
           groupTitle: CONSTANTS.TASKS.AIN.GROUP_1.GROUP_TITLE,
           id: 1,
-          groupTasks: createGroupTasks(CONSTANTS.TASKS.AIN.GROUP_1.TASKS, 1, mockExcludedTasks),
+          groupTasks: createGroupTasks(CONSTANTS.TASKS.AIN.GROUP_1.TASKS, 1, mockAdditionalTasks),
         },
       ];
 
@@ -266,33 +219,33 @@ describe('defaults - tasks creation', () => {
       expect(result).toEqual(expected);
     });
 
-    it('should return MIA tasks array with createGroupTasks and excludedTasks', () => {
-      const mockExcludedTasks = [
+    it('should return MIA tasks array with createGroupTasks and additionalTasks', () => {
+      const mockAdditionalTasks = [
         CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES
       ];
 
-      const result = createTasksMIA(mockExcludedTasks);
+      const result = createTasksMIA(mockAdditionalTasks);
 
       const expected = [
         {
           groupTitle: CONSTANTS.TASKS.MIA.GROUP_1.GROUP_TITLE,
           id: 1,
-          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_1.TASKS, 1, mockExcludedTasks),
+          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_1.TASKS, 1, mockAdditionalTasks),
         },
         {
           groupTitle: CONSTANTS.TASKS.MIA.GROUP_2.GROUP_TITLE,
           id: 2,
-          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_2.TASKS, 2, mockExcludedTasks),
+          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_2.TASKS, 2, mockAdditionalTasks),
         },
         {
           groupTitle: CONSTANTS.TASKS.MIA.GROUP_3.GROUP_TITLE,
           id: 3,
-          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_3.TASKS, 3, mockExcludedTasks),
+          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_3.TASKS, 3, mockAdditionalTasks),
         },
         {
           groupTitle: CONSTANTS.TASKS.MIA.GROUP_4.GROUP_TITLE,
           id: 4,
-          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_4.TASKS, 4, mockExcludedTasks),
+          groupTasks: createGroupTasks(CONSTANTS.TASKS.MIA.GROUP_4.TASKS, 4, mockAdditionalTasks),
         },
       ];
 

--- a/trade-finance-manager-api/src/v1/helpers/create-tasks.js
+++ b/trade-finance-manager-api/src/v1/helpers/create-tasks.js
@@ -9,15 +9,29 @@ const NEW_TASK = ({
   canEdit: false,
 });
 
-const createGroupTasks = (tasks, groupId, excludedTasks = []) => {
+const createGroupTasks = (
+  tasks,
+  groupId,
+  excludedTasks = [],
+  additionalTasks = [],
+) => {
   const mappedTasks = [];
   let taskIdCount = 0;
 
   tasks.forEach((t) => {
     let task = t;
 
-    // only add the task if the title is in excludedTasks array
-    if (!excludedTasks.includes(task.title)) {
+    /**
+     * Only create the task if:
+     * - task title is NOT in the excludedTasks array
+     * - task is NOT a conditional task
+     * - OR is a conditional task and title is listed in the additionalTasks array
+     * */
+    const shouldCreateTask = (
+      (!excludedTasks.includes(task.title) && !task.isConditional)
+      || (task.isConditional && additionalTasks.includes(task.title)));
+
+    if (shouldCreateTask) {
       // do not rely on index - otherwise if a task is excluded,
       // we can end up with e.g id 1 then skipping to id 3
       taskIdCount += 1;
@@ -42,7 +56,7 @@ const createGroupTasks = (tasks, groupId, excludedTasks = []) => {
   return mappedTasks;
 };
 
-const createTasksAIN = (excludedTasks) => [
+const createTasksAIN = (excludedTasks, additionalTasks) => [
   {
     groupTitle: CONSTANTS.TASKS.AIN.GROUP_1.GROUP_TITLE,
     id: 1,
@@ -50,11 +64,12 @@ const createTasksAIN = (excludedTasks) => [
       CONSTANTS.TASKS.AIN.GROUP_1.TASKS,
       1,
       excludedTasks,
+      additionalTasks,
     ),
   },
 ];
 
-const createTasksMIA = (excludedTasks) => [
+const createTasksMIA = (excludedTasks, additionalTasks) => [
   {
     groupTitle: CONSTANTS.TASKS.MIA.GROUP_1.GROUP_TITLE,
     id: 1,
@@ -62,6 +77,7 @@ const createTasksMIA = (excludedTasks) => [
       CONSTANTS.TASKS.MIA.GROUP_1.TASKS,
       1,
       excludedTasks,
+      additionalTasks,
     ),
   },
   {
@@ -71,6 +87,7 @@ const createTasksMIA = (excludedTasks) => [
       CONSTANTS.TASKS.MIA.GROUP_2.TASKS,
       2,
       excludedTasks,
+      additionalTasks,
     ),
   },
   {
@@ -80,6 +97,7 @@ const createTasksMIA = (excludedTasks) => [
       CONSTANTS.TASKS.MIA.GROUP_3.TASKS,
       3,
       excludedTasks,
+      additionalTasks,
     ),
   },
   {
@@ -89,6 +107,7 @@ const createTasksMIA = (excludedTasks) => [
       CONSTANTS.TASKS.MIA.GROUP_4.TASKS,
       4,
       excludedTasks,
+      additionalTasks,
     ),
   },
 ];
@@ -96,15 +115,16 @@ const createTasksMIA = (excludedTasks) => [
 const createTasks = (
   submissionType,
   excludedTasks,
+  additionalTasks,
 ) => {
   let tasks = [];
 
   if (submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN) {
-    tasks = createTasksAIN(excludedTasks);
+    tasks = createTasksAIN(excludedTasks, additionalTasks);
   }
 
   if (submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {
-    tasks = createTasksMIA(excludedTasks);
+    tasks = createTasksMIA(excludedTasks, additionalTasks);
   }
 
   return tasks;

--- a/trade-finance-manager-api/src/v1/helpers/create-tasks.js
+++ b/trade-finance-manager-api/src/v1/helpers/create-tasks.js
@@ -12,7 +12,6 @@ const NEW_TASK = ({
 const createGroupTasks = (
   tasks,
   groupId,
-  excludedTasks = [],
   additionalTasks = [],
 ) => {
   const mappedTasks = [];
@@ -23,16 +22,15 @@ const createGroupTasks = (
 
     /**
      * Only create the task if:
-     * - task title is NOT in the excludedTasks array
-     * - task is NOT a conditional task
-     * - OR is a conditional task and title is listed in the additionalTasks array
+     * - task title is NOT conditional and always applies.
+     * - OR the task is conditional and the task title is listed in additionalTasks array
      * */
     const shouldCreateTask = (
-      (!excludedTasks.includes(task.title) && !task.isConditional)
+      !task.isConditional
       || (task.isConditional && additionalTasks.includes(task.title)));
 
     if (shouldCreateTask) {
-      // do not rely on index - otherwise if a task is excluded,
+      // do not rely on index - otherwise if a task is conditional,
       // we can end up with e.g id 1 then skipping to id 3
       taskIdCount += 1;
 
@@ -56,27 +54,25 @@ const createGroupTasks = (
   return mappedTasks;
 };
 
-const createTasksAIN = (excludedTasks, additionalTasks) => [
+const createTasksAIN = (additionalTasks) => [
   {
     groupTitle: CONSTANTS.TASKS.AIN.GROUP_1.GROUP_TITLE,
     id: 1,
     groupTasks: createGroupTasks(
       CONSTANTS.TASKS.AIN.GROUP_1.TASKS,
       1,
-      excludedTasks,
       additionalTasks,
     ),
   },
 ];
 
-const createTasksMIA = (excludedTasks, additionalTasks) => [
+const createTasksMIA = (additionalTasks) => [
   {
     groupTitle: CONSTANTS.TASKS.MIA.GROUP_1.GROUP_TITLE,
     id: 1,
     groupTasks: createGroupTasks(
       CONSTANTS.TASKS.MIA.GROUP_1.TASKS,
       1,
-      excludedTasks,
       additionalTasks,
     ),
   },
@@ -86,7 +82,6 @@ const createTasksMIA = (excludedTasks, additionalTasks) => [
     groupTasks: createGroupTasks(
       CONSTANTS.TASKS.MIA.GROUP_2.TASKS,
       2,
-      excludedTasks,
       additionalTasks,
     ),
   },
@@ -96,7 +91,6 @@ const createTasksMIA = (excludedTasks, additionalTasks) => [
     groupTasks: createGroupTasks(
       CONSTANTS.TASKS.MIA.GROUP_3.TASKS,
       3,
-      excludedTasks,
       additionalTasks,
     ),
   },
@@ -106,7 +100,6 @@ const createTasksMIA = (excludedTasks, additionalTasks) => [
     groupTasks: createGroupTasks(
       CONSTANTS.TASKS.MIA.GROUP_4.TASKS,
       4,
-      excludedTasks,
       additionalTasks,
     ),
   },
@@ -114,17 +107,16 @@ const createTasksMIA = (excludedTasks, additionalTasks) => [
 
 const createTasks = (
   submissionType,
-  excludedTasks,
   additionalTasks,
 ) => {
   let tasks = [];
 
   if (submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN) {
-    tasks = createTasksAIN(excludedTasks, additionalTasks);
+    tasks = createTasksAIN(additionalTasks);
   }
 
   if (submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {
-    tasks = createTasksMIA(excludedTasks, additionalTasks);
+    tasks = createTasksMIA(additionalTasks);
   }
 
   return tasks;


### PR DESCRIPTION
## Business requirement
- Add a task creation rule for a BSS MIA deal that has eligibility criteria answer 11 as false (additional task gets added)

## How
- Add `isConditional` flag to tasks that can be included or not included (on deal submission), depending on deal data
- Remove ability to pass a list of 'excluded tasks' to task creation function


## How / clean up / scalability
- Instead of having a list of 'exluded tasks', we now only specifically define a list of 'additional tasks' that will be added, depending on the deal data
- Make `deal.tasks.js` more functional - each task rule in it's own function
- Add logic to 'create group tasks' function so that a task will only be added to a group if:
  - the task is *not*  a conditional task (therefore always applies)
  - or the task is a conditional task and is included in the list of additional tasks to add

## Why 
- This approach saves logic/conditions and potentially hard to read or confusing code
- Specifically creating 'additional tasks' to add (depending on the deal data), is clearer and more scalable than having a list of 'excluded tasks'
- Splitting out each task creation condition ("if X in deal, add this task") ...into their own functions is nice and clean; can be easily removed, expanded and tested
