### PR TITLE
DTFS2-4973 - TFM - GEF facility/fee record fixes

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.facilities.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.facilities.api-test.js
@@ -11,6 +11,7 @@ const MOCK_DEAL_ISSUED_FACILITIES = require('../../../src/v1/__mocks__/mock-deal
 const MOCK_CURRENCY_EXCHANGE_RATE = require('../../../src/v1/__mocks__/mock-currency-exchange-rate');
 const MOCK_NOTIFY_EMAIL_RESPONSE = require('../../../src/v1/__mocks__/mock-notify-email-response');
 const MOCK_GEF_DEAL = require('../../../src/v1/__mocks__/mock-gef-deal');
+const MOCK_GEF_DEAL_MIA = require('../../../src/v1/__mocks__/mock-gef-deal-MIA');
 
 const sendEmailApiSpy = jest.fn(() => Promise.resolve(
   MOCK_NOTIFY_EMAIL_RESPONSE,
@@ -247,6 +248,18 @@ describe('/v1/deals', () => {
             expect(unissuedFacility.tfm.feeRecord).toEqual(null);
           });
         });
+
+        it('does NOT add fee record when deal is MIA', async () => {
+          const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIA));
+
+          expect(status).toEqual(200);
+
+          const issuedFacility = body.facilities.find((facility) =>
+            facility.hasBeenIssued);
+
+          expect(issuedFacility.tfm.feeRecord).toBeUndefined();
+        });
+
 
         describe('when facility/dealType is BSS', () => {
           it('does NOT add fee record to any unissued facilities', async () => {

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -15,6 +15,7 @@ const MOCK_NOTIFY_EMAIL_RESPONSE = require('../../../src/v1/__mocks__/mock-notif
 const MOCK_PREMIUM_SCHEUDLE_RESPONSE = require('../../../src/v1/__mocks__/mock-premium-schedule-response');
 const MOCK_FACILITIES = require('../../../src/v1/__mocks__/mock-facilities');
 const MOCK_GEF_DEAL = require('../../../src/v1/__mocks__/mock-gef-deal');
+const MOCK_GEF_DEAL_MIA = require('../../../src/v1/__mocks__/mock-gef-deal-MIA');
 const submitDeal = require('../utils/submitDeal');
 
 const sendEmailApiSpy = jest.fn(() => Promise.resolve(
@@ -557,6 +558,17 @@ describe('/v1/deals', () => {
           !facility.hasBeenIssued);
 
         expect(unissuedFacility.tfm.feeRecord).toEqual(null);
+      });
+
+      it('does NOT add fee record when deal is MIA', async () => {
+        const { status, body } = await submitDeal(createSubmitBody(MOCK_GEF_DEAL_MIA));
+
+        expect(status).toEqual(200);
+
+        const issuedFacility = body.facilities.find((facility) =>
+          facility.hasBeenIssued);
+
+        expect(issuedFacility.tfm.feeRecord).toBeUndefined();
       });
     });
   });

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityFeeType.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityFeeType.api-test.js
@@ -20,6 +20,15 @@ describe('mapGefFacilityFeeType', () => {
     });
   });
 
+  describe('when feeType is `AT_MATURITY`', () => {
+    it('should return AT_MATURITY', () => {
+      const result = mapGefFacilityFeeType('AT_MATURITY');
+
+      const expected = CONSTANTS.FACILITIES.FACILITY_FEE_TYPE.AT_MATURITY;
+      expect(result).toEqual(expected);
+    });
+  });
+
   it('should return null', () => {
     const result = mapGefFacilityFeeType();
     expect(result).toEqual(null);

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityFeeType.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityFeeType.js
@@ -9,6 +9,10 @@ const mapGefFacilityFeeType = (paymentType) => {
     return CONSTANTS.FACILITIES.FACILITY_FEE_TYPE.IN_ADVANCE;
   }
 
+  if (paymentType === CONSTANTS.FACILITIES.FACILITY_FEE_TYPE_GEF.AT_MATURITY) {
+    return CONSTANTS.FACILITIES.FACILITY_FEE_TYPE.AT_MATURITY;
+  }
+
   return null;
 };
 

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal-MIA.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal-MIA.js
@@ -4,6 +4,7 @@ const MOCK_GEF_DEAL_MIA = {
   ...MOCK_GEF_DEAL,
   _id: 'MOCK_GEF_DEAL_MIA',
   submissionType: 'Manual Inclusion Application',
+  submissionCount: 1,
 };
 
 module.exports = MOCK_GEF_DEAL_MIA;

--- a/trade-finance-manager-api/src/v1/controllers/update-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-facilities.js
@@ -12,8 +12,9 @@ const updateFacilities = async (deal) => {
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
 
   const {
-    submissionDate: dealSubmissionDate,
     dealType,
+    submissionDate: dealSubmissionDate,
+    submissionType,
   } = modifiedDeal;
 
   modifiedDeal.facilities = await Promise.all(modifiedDeal.facilities.map(async (f) => {
@@ -36,7 +37,11 @@ const updateFacilities = async (deal) => {
     }
 
     let feeRecord;
-    if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
+
+    const shouldCalculateFeeRecord = (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF
+      && submissionType !== CONSTANTS.DEALS.SUBMISSION_TYPE.MIA);
+
+    if (shouldCalculateFeeRecord) {
       feeRecord = calculateGefFacilityFeeRecord(facility);
     }
 

--- a/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
@@ -11,8 +11,9 @@ const updatedIssuedFacilities = async (deal) => {
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
 
   const {
-    submissionDate: dealSubmissionDate,
     dealType,
+    submissionDate: dealSubmissionDate,
+    submissionType,
   } = deal;
 
   const updatedFacilities = [];
@@ -55,7 +56,11 @@ const updatedIssuedFacilities = async (deal) => {
       }
 
       let feeRecord;
-      if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
+
+      const shouldCalculateFeeRecord = (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF
+        && submissionType !== CONSTANTS.DEALS.SUBMISSION_TYPE.MIA);
+
+      if (shouldCalculateFeeRecord) {
         feeRecord = calculateGefFacilityFeeRecord(facility);
       }
 

--- a/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.api-test.js
@@ -75,7 +75,7 @@ describe('calculate-gef-facility-fee-record', () => {
 
       const drawnAmountAndDays = (drawnAmount * daysOfCover);
 
-      const expected = (drawnAmountAndDays * daysOfCover * 0.1 / mockDayBasis);
+      const expected = (drawnAmountAndDays * daysOfCover * (0.1 / mockDayBasis));
 
       expect(result).toEqual(expected);
     });

--- a/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.js
+++ b/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.js
@@ -19,10 +19,10 @@ const calculateDaysOfCover = (
   coverStartDate,
   coverEndDate,
 ) =>
-  /* Business logic:
-   * Number of days covered.
-   * I.e, date from when the cover starts until the date when the cover ends
-  */
+/* Business logic:
+ * Number of days covered.
+ * I.e, date from when the cover starts until the date when the cover ends
+ */
 
   // NOTE: if the start date is passed first, we get a minus result.
   differenceInDays(
@@ -38,7 +38,7 @@ const calculateFeeAmount = (
   /* Business logic:
    * (Drawn Amount * Days Of Cover) * 10 percent, divided by day basis
   */
-  (drawnAmount * daysOfCover * 0.1 / dayBasis);
+  (drawnAmount * daysOfCover * (0.1 / dayBasis));
 
 const calculateGefFacilityFeeRecord = (facility) => {
   if (facility.hasBeenIssued) {

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.api-test.js
@@ -11,18 +11,7 @@ const MOCK_CASH_CONTINGENT_FACILITIES = require('../../__mocks__/mock-cash-conti
 
 describe('mappings - map submitted deal - mapCashContingentFacility', () => {
   describe('mapCoverStartDate', () => {
-    it('should return facility.submittedAsIssuedDate when facility.hasBeenIssued is true', () => {
-      const mockFacility = {
-        hasBeenIssued: true,
-        submittedAsIssuedDate: '1628770126495',
-      };
-
-      const result = mapCoverStartDate(mockFacility);
-
-      expect(result).toEqual(mockFacility.submittedAsIssuedDate);
-    });
-
-    it('should return coverStartDate as a timestamp when facility.hasBeenIssued is NOT true', () => {
+    it('should return coverStartDate as a timestamp', () => {
       const mockFacility = {
         hasBeenIssued: null,
         coverStartDate: '2021-12-12 00:00:00.000Z',

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-cash-contingent-facility.js
@@ -4,15 +4,7 @@ const mapGefFacilityFeeType = require('../../../graphql/reducers/mappings/gef-fa
 const CONSTANTS = require('../../../constants');
 
 const mapCoverStartDate = (facility) => {
-  const {
-    hasBeenIssued,
-    submittedAsIssuedDate,
-    coverStartDate,
-  } = facility;
-
-  if (hasBeenIssued && submittedAsIssuedDate) {
-    return submittedAsIssuedDate;
-  }
+  const { coverStartDate } = facility;
 
   if (coverStartDate && isValid(new Date(coverStartDate))) {
     return convertDateToTimestamp(coverStartDate);


### PR DESCRIPTION
- do not calculate GEF facility fee record if the deal type is MIA
- do not use `submittedAsIssuedDate` in facility `coverStartDate` mapping, just use the `coverStartDate`.
- add missing facility feeType mapping for "At Maturity" value
- lint fixes