### PR TITLE
TFM graphQL deals query patches for Cedar/external integration

### DIFF
--- a/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
@@ -136,6 +136,7 @@ query Deal($_id: String! $tasksFilters: TasksFilters $activityFilters: ActivityF
         facilitiesValueInGBP,
         facilitiesUkefExposure
       }
+      facilitiesUpdated
       facilities {
         _id,
         facilitySnapshot {

--- a/trade-finance-manager-api/src/graphql/reducers/deals.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deals.api-test.js
@@ -5,6 +5,7 @@ const {
   dealsReducer,
 } = require('./deals');
 const mapSubmissionDetails = require('./mappings/deal/mapSubmissionDetails');
+const mapEligibility = require('./mappings/deal/mapEligibility');
 const mapFacilities = require('./mappings/facilities/mapFacilities');
 const mapTotals = require('./mappings/deal/mapTotals');
 const mapDealTfm = require('./mappings/deal/dealTfm/mapDealTfm');
@@ -64,7 +65,7 @@ describe('reducer - deals', () => {
             mockBssDeal.tfm,
           ),
           dealFiles: mockBssDeal.dealSnapshot.dealFiles,
-          eligibilityCriteria: mockBssDeal.dealSnapshot.eligibility.criteria,
+          eligibility: mapEligibility(mockBssDeal.dealSnapshot.eligibility),
           totals: mapTotals(mockBssDeal.dealSnapshot.facilities),
         },
         tfm: mapDealTfm(mockBssDeal),
@@ -81,6 +82,9 @@ describe('reducer - deals', () => {
         _id: mockGefDeal._id,
         dealSnapshot: {
           _id: mockGefDeal._id,
+          dealType: mockGefDeal.dealSnapshot.dealType,
+          facilitiesUpdated: mockGefDeal.dealSnapshot.facilitiesUpdated,
+          eligibility: mockGefDeal.dealSnapshot.eligibility,
           details: mapGefDealDetails(mockGefDeal.dealSnapshot),
           submissionDetails: mapGefSubmissionDetails(mockGefDeal.dealSnapshot),
           facilities: mapGefFacilities(mockGefDeal.dealSnapshot, mockGefDeal.tfm),

--- a/trade-finance-manager-api/src/graphql/reducers/deals.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deals.js
@@ -1,4 +1,5 @@
 const mapSubmissionDetails = require('./mappings/deal/mapSubmissionDetails');
+const mapEligibility = require('./mappings/deal/mapEligibility');
 const mapFacilities = require('./mappings/facilities/mapFacilities');
 const mapTotals = require('./mappings/deal/mapTotals');
 const mapDealTfm = require('./mappings/deal/dealTfm/mapDealTfm');
@@ -17,7 +18,7 @@ const mapBssDeal = (deal) => {
       submissionDetails: mapSubmissionDetails(dealSnapshot.submissionDetails),
       facilities: mapFacilities(dealSnapshot.facilities, dealSnapshot.details, deal.tfm),
       dealFiles: dealSnapshot.dealFiles,
-      eligibilityCriteria: dealSnapshot.eligibility.criteria,
+      eligibility: mapEligibility(dealSnapshot.eligibility),
       totals: mapTotals(dealSnapshot.facilities),
     },
     tfm: mapDealTfm(deal),
@@ -33,6 +34,9 @@ const mapGefDeal = (deal) => {
     _id,
     dealSnapshot: {
       _id,
+      dealType: dealSnapshot.dealType,
+      facilitiesUpdated: dealSnapshot.facilitiesUpdated,
+      eligibility: dealSnapshot.eligibility,
       details: mapGefDealDetails(dealSnapshot),
       submissionDetails: mapGefSubmissionDetails(dealSnapshot),
       facilities: mapGefFacilities(dealSnapshot, deal.tfm),

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.api-test.js
@@ -19,6 +19,7 @@ describe('mapGefDealDetails', () => {
       bankSupplyContractID: mockDeal.dealSnapshot.bankInternalRefName,
       bankSupplyContractName: mockDeal.dealSnapshot.additionalRefName,
       submissionType: mockDeal.dealSnapshot.submissionType,
+      dateOfLastAction: mockDeal.dealSnapshot.updatedAt,
       owningBank: {
         name: mockDeal.dealSnapshot.bank.name,
         emails: mockDeal.dealSnapshot.bank.emails,

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealDetails.js
@@ -3,6 +3,7 @@ const mapGefDealDetails = (dealSnapshot) => ({
   bankSupplyContractID: dealSnapshot.bankInternalRefName,
   bankSupplyContractName: dealSnapshot.additionalRefName,
   submissionType: dealSnapshot.submissionType,
+  dateOfLastAction: dealSnapshot.updatedAt,
   owningBank: {
     name: dealSnapshot.bank.name,
     emails: dealSnapshot.bank.emails,

--- a/trade-finance-manager-ui/server/graphql/queries/deal-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deal-query.js
@@ -100,6 +100,7 @@ const dealQuery = gql`
           facilitiesValueInGBP,
           facilitiesUkefExposure
         }
+        facilitiesUpdated
         facilities {
           _id,
           facilitySnapshot {


### PR DESCRIPTION
- add `dealType`, `facilitiesUpdated` and `eligibility` mappings to deals query reducer, for GEF deals
- add `dateOfLastAction` to GEF deal details reducer mapping