### PR TITLE
Rename TFM task group title constants

### DIFF
--- a/trade-finance-manager-api/src/constants/tasks.js
+++ b/trade-finance-manager-api/src/constants/tasks.js
@@ -7,9 +7,16 @@ const TEAMS = require('./teams');
  * - excluded (depending on deal data)
  * */
 
+const GROUP_TITLES = {
+  SETUP_DEAL: 'Set up deal',
+  ADVERSE_HISTORY: 'Adverse history check',
+  UNDERWRITING: 'Underwriting',
+  APPROVALS: 'Approvals',
+};
+
 const AIN_AND_MIA = {
   GROUP_1: {
-    GROUP_TITLE: 'Set up deal',
+    GROUP_TITLE: GROUP_TITLES.SETUP_DEAL,
     MATCH_OR_CREATE_PARTIES: 'Match or create the parties in this deal',
     CREATE_OR_LINK_SALESFORCE: 'Create or link this opportunity in Salesforce',
   },
@@ -17,7 +24,7 @@ const AIN_AND_MIA = {
 
 const AIN = {
   GROUP_1: {
-    GROUP_TITLE: AIN_AND_MIA.GROUP_1.GROUP_TITLE,
+    GROUP_TITLE: GROUP_TITLES.SETUP_DEAL,
     TASKS: [
       {
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
@@ -55,15 +62,10 @@ const MIA_GROUP_4_TASKS = {
   APPROVE_OR_DECLINE_THE_DEAL: 'Approve or decline the deal',
 };
 
-const GROUP_TITLES = {
-  ADVERSE_HISTORY: 'Adverse history check',
-  UNDERWRITING: 'Underwriting',
-};
-
 const MIA = {
   GROUP_1: {
     id: 1,
-    GROUP_TITLE: AIN_AND_MIA.GROUP_1.GROUP_TITLE,
+    GROUP_TITLE: GROUP_TITLES.SETUP_DEAL,
     TASKS: [
       {
         groupId: 1,
@@ -132,7 +134,7 @@ const MIA = {
   },
   GROUP_4: {
     id: 4,
-    GROUP_TITLE: 'Approvals',
+    GROUP_TITLE: GROUP_TITLES.APPROVALS,
     TASKS: [
       {
         groupId: 4,

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-MIA-tasks-populated.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-MIA-tasks-populated.js
@@ -2,7 +2,7 @@ const CONSTANTS = require('../../constants');
 
 const MOCK_MIA_TASKS_POPULATED = [
   {
-    groupTitle: CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.GROUP_TITLE,
+    groupTitle: CONSTANTS.TASKS.GROUP_TITLES.SETUP_DEAL,
     id: 1,
     groupTasks: [
       {
@@ -42,7 +42,7 @@ const MOCK_MIA_TASKS_POPULATED = [
     ],
   },
   {
-    groupTitle: CONSTANTS.TASKS.MIA.GROUP_2.GROUP_TITLE,
+    groupTitle: CONSTANTS.TASKS.GROUP_TITLES.ADVERSE_HISTORY,
     id: 2,
     groupTasks: [
       {
@@ -98,7 +98,7 @@ const MOCK_MIA_TASKS_POPULATED = [
     ],
   },
   {
-    groupTitle: CONSTANTS.TASKS.MIA.GROUP_4.GROUP_TITLE,
+    groupTitle: CONSTANTS.TASKS.GROUP_TITLES.APPROVALS,
     id: 4,
     groupTasks: [
       {

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-MIA-tasks.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-MIA-tasks.js
@@ -2,7 +2,7 @@ const CONSTANTS = require('../../constants');
 
 const MOCK_MIA_TASKS = [
   {
-    groupTitle: CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.GROUP_TITLE,
+    groupTitle: CONSTANTS.TASKS.GROUP_TITLES.SETUP_DEAL,
     id: 1,
     groupTasks: [
       {
@@ -38,7 +38,7 @@ const MOCK_MIA_TASKS = [
     ],
   },
   {
-    groupTitle: CONSTANTS.TASKS.MIA.GROUP_2.GROUP_TITLE,
+    groupTitle: CONSTANTS.TASKS.GROUP_TITLES.ADVERSE_HISTORY,
     id: 2,
     groupTasks: [
       {
@@ -74,7 +74,7 @@ const MOCK_MIA_TASKS = [
     ],
   },
   {
-    groupTitle: CONSTANTS.TASKS.MIA.GROUP_4.GROUP_TITLE,
+    groupTitle: CONSTANTS.TASKS.GROUP_TITLES.APPROVALS,
     id: 4,
     groupTasks: [
       {


### PR DESCRIPTION
Don't rely on e.g. "group_1.group_title", just name the group title constant as to what the group/title actually is.