### PR TITLE
DTFS2-5078 - Maker from same bank can re-submit

### DIFF
--- a/gef-ui/server/utils/helpers.js
+++ b/gef-ui/server/utils/helpers.js
@@ -308,7 +308,7 @@ const makerCanReSubmit = (maker, application) => {
     CONSTANTS.DEAL_STATUS.UKEF_APPROVED_WITH_CONDITIONS,
   ];
   const coverDateConfirmed = coverDatesConfirmed(application.facilities);
-  const makerAuthorised = (maker._id === application.maker._id);
+  const makerAuthorised = (maker.roles.includes('maker') && maker.bank.id === application.bankId);
 
   return (coverDateConfirmed && acceptableStatus.includes(application.status) && makerAuthorised);
 };

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -724,4 +724,16 @@ describe('makerCanReSubmit', () => {
     MOCK_DEAL.status = 'UKEF_APPROVED_WITH_CONDITIONS';
     expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(true);
   });
+  it('Should return FALSE as the Maker is from a different Bank', () => {
+    MOCK_REQUEST.bank.id = 10;
+    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(false);
+  });
+  it('Should return FALSE as the user does not have `maker` role', () => {
+    MOCK_REQUEST.roles = ['checker'];
+    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(false);
+  });
+  it('Should return FALSE as the Application maker is from a different current logged-in maker', () => {
+    MOCK_DEAL.bankId = 1;
+    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(false);
+  });
 });


### PR DESCRIPTION
This patch allows maker from the same bank to re-submit the application to the checker provided the user role is `Maker`.