### PR TITLE
Add exporter.companyName to BSS deals ('supplier-name')

### DIFF
--- a/azure-functions/acbs-function/mappings/deal/deal.js
+++ b/azure-functions/acbs-function/mappings/deal/deal.js
@@ -36,9 +36,7 @@ const initialDeal = (deal, obligorPartyIdentifier, acbsReference) => ({
   dealValue: to2Decimals(getDealValue(deal)),
   guaranteeCommencementDate: getDealEffectiveDate(deal),
   obligorPartyIdentifier,
-  obligorName: deal.dealSnapshot.dealType === CONSTANTS.PRODUCT.TYPE.GEF
-    ? deal.dealSnapshot.exporter.companyName.substring(0, 35)
-    : deal.dealSnapshot.submissionDetails['supplier-name'].substring(0, 35),
+  obligorName: deal.dealSnapshot.exporter.companyName.substring(0, 35),
   obligorIndustryClassification: acbsReference.supplierAcbsIndustryCode,
   creditReviewRiskDate: formatTimestamp(getDealSubmissionDate(deal)),
 });

--- a/azure-functions/acbs-function/mappings/facility/facility-master.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-master.js
@@ -88,10 +88,7 @@ const facilityMaster = (deal, facility, acbsData, acbsReference) => {
     description: helpers.getDescription(facility, deal.dealSnapshot.dealType),
     agentBankIdentifier: CONSTANTS.FACILITY.BANK_IDENTIFIER.DEFAULT,
     obligorPartyIdentifier: acbsData.parties.exporter.partyIdentifier,
-    obligorName:
-      deal.dealSnapshot.dealType === CONSTANTS.PRODUCT.TYPE.GEF
-        ? deal.dealSnapshot.exporter.companyName.substring(0, 35)
-        : deal.dealSnapshot.submissionDetails['supplier-name'].substring(0, 35),
+    obligorName: deal.dealSnapshot.exporter.companyName.substring(0, 35),
     obligorIndustryClassification: acbsReference.supplierAcbsIndustryCode,
   };
 };

--- a/azure-functions/acbs-function/mappings/party/exporter.js
+++ b/azure-functions/acbs-function/mappings/party/exporter.js
@@ -33,11 +33,7 @@ const exporter = ({ deal, acbsReference }) => {
     ? CONSTANTS.PARTY.CITIZENSHIP_CLASS.UNITED_KINGDOM
     : CONSTANTS.PARTY.CITIZENSHIP_CLASS.ROW;
 
-  const partyNames = getPartyNames(
-    product === CONSTANTS.PRODUCT.TYPE.GEF
-      ? submissionDetails.exporter.companyName
-      : submissionDetails['supplier-name'],
-  );
+  const partyNames = getPartyNames(deal.dealSnapshot.exporter.companyName);
 
   return {
     alternateIdentifier: deal.tfm.parties.exporter.partyUrn.substring(0, 20),

--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -183,7 +183,7 @@ const queryAllDeals = async (filters = {}, sort = {}, start = 0, pagesize = 0) =
         status: '$details.status',
         product: 'BSS/EWCS',
         type: '$details.submissionType',
-        exporter: '$submissionDetails.supplier-name',
+        exporter: '$exporter.companyName',
         lastUpdate: { $convert: { input: '$details.dateOfLastAction', to: 'double' } },
         userId: '$details.maker._id',
       },

--- a/e2e-tests/trade-finance-manager/cypress/fixtures/deal-AIN.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/deal-AIN.js
@@ -161,6 +161,9 @@ const MOCK_DEAL = {
     agentAddressPostcode: 'CF64 5SH',
     agentAddressTown: 'City',
   },
+  exporter: {
+    companyName: 'Mock company',
+  },
   mockFacilities: [
     {
       facilityType: 'bond',

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/facility/facility.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/facility/facility.spec.js
@@ -46,9 +46,9 @@ context('Facility page', () => {
       expect(text.trim()).equal(MOCK_DEAL_AIN.details.ukefDealId);
     });
 
-    partials.caseSummary.supplierName().should('be.visible');
-    partials.caseSummary.supplierName().invoke('text').then((text) => {
-      expect(text.trim()).equal(MOCK_DEAL_AIN.submissionDetails['supplier-name']);
+    partials.caseSummary.exporterName().should('be.visible');
+    partials.caseSummary.exporterName().invoke('text').then((text) => {
+      expect(text.trim()).equal(MOCK_DEAL_AIN.exporter.companyName);
     });
   });
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/partials/caseSummary.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/partials/caseSummary.js
@@ -1,6 +1,6 @@
 const partial = {
   ukefDealId: () => cy.get('[data-cy="ukef-deal-id"]'),
-  supplierName: () => cy.get('[data-cy="supplier-name"]'),
+  exporterName: () => cy.get('[data-cy="exporter-name"]'),
   contractValue: () => cy.get('[data-cy="contract-value"]'),
   contractValueInGBP: () => cy.get('[data-cy="contract-value-in-gbp"]'),
   ukefProduct: () => cy.get('[data-cy="ukef-product"]'),

--- a/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
@@ -289,5 +289,24 @@ describe('/v1/deals/:id/submission-details', () => {
 
       expect(body.deal.details.dateOfLastAction).not.toEqual(dealInOriginalShape.deal.details.dateOfLastAction);
     });
+
+    it('updates deal.exporter.companyName with the provided `supplier-name` field', async () => {
+      const postResult = await as(anHSBCMaker).post(newDeal).to('/v1/deals');
+      const createdDeal = postResult.body;
+
+      const { body: dealInOriginalShape } = await as(anHSBCMaker).get(`/v1/deals/${createdDeal._id}`);
+
+      const submissionDetails = {
+        'supplier-name': 'Mock supplier name',
+      };
+
+      await as(anHSBCMaker).put(submissionDetails).to(`/v1/deals/${createdDeal._id}/submission-details`);
+
+      const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${createdDeal._id}`);
+
+      expect(status).toEqual(200);
+
+      expect(body.deal.exporter.companyName).toEqual(submissionDetails['supplier-name']);
+    });
   });
 });

--- a/portal-api/api-tests/v1/deals/expectAddedFields.js
+++ b/portal-api/api-tests/v1/deals/expectAddedFields.js
@@ -36,6 +36,7 @@ const expectAddedFields = (obj) => {
       status: 'Draft',
     },
     editedBy: [],
+    exporter: {},
   });
 
   return expectation;

--- a/portal-api/src/v1/controllers/deal-submission-details.controller.js
+++ b/portal-api/src/v1/controllers/deal-submission-details.controller.js
@@ -30,6 +30,19 @@ const updateSubmissionDetails = async (dealId, submissionDetails, user) => {
     },
   };
 
+  /**
+   * Portal BSS UI gives us a field name called supplier-name.
+   * This maybe eventually changed to 'exporter name'.
+   * Every other service (TFM, ABCS), uses this value
+   * as the 'exporter name'.
+   * Therefore, we add this value to the deal object under exporter.
+   * */
+  if (submissionDetails['supplier-name']) {
+    update.exporter = {
+      companyName: submissionDetails['supplier-name'],
+    };
+  }
+
   const updateDealResponse = await updateDeal(
     dealId,
     update,
@@ -141,6 +154,7 @@ exports.update = (req, res) => {
         submissionDetails.supplyContractCurrency,
       );
     }
+
     const dealAfterAllUpdates = await updateSubmissionDetails(req.params.id, submissionDetails, user);
 
     const validationErrors = validateSubmissionDetails({ ...dealAfterAllUpdates.submissionDetails, ...req.body });

--- a/portal-api/src/v1/defaults/index.js
+++ b/portal-api/src/v1/defaults/index.js
@@ -22,6 +22,7 @@ const DEFAULTS = {
     comments: [],
     editedBy: [],
     facilities: [],
+    exporter: {},
   },
 };
 

--- a/trade-finance-manager-api/README.md
+++ b/trade-finance-manager-api/README.md
@@ -153,9 +153,7 @@ Therefore in TFM, we currently need to deal with 2 different data structures for
   details: {
     submissionType: 'Automatic Inclusion Notice',
     submissionDate: '1606900616651',
-  },
-  submissionDetails: {
-    'supplier-name': 'Test'
+    dateOfLastAction: '1639589760162'
   },
   facilities: [ '1', '2' ],
   ...
@@ -170,9 +168,7 @@ Therefore in TFM, we currently need to deal with 2 different data structures for
   dealType: 'GEF',
   submissionType: 'Automatic Inclusion Notice',
   submissionDate: '1606900616651',
-  exporter: {
-    companyName: 'Test'
-  },
+  updatedAt: 1639580324306.0
   ...
 }
 ```

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -276,7 +276,7 @@ describe('/v1/deals', () => {
           templateId: CONSTANTS.EMAIL_TEMPLATE_IDS.ISSUED_FACILITY_RECEIVED,
           sendToEmailAddress: mockDeal.details.maker.email,
           emailVariables: {
-            exporterName: mockDeal.submissionDetails['supplier-name'],
+            exporterName: mockDeal.exporter.companyName,
             recipientName: mockDeal.details.maker.firstname,
             bankReferenceNumber: mockDeal.details.bankSupplyContractID,
             ukefDealID: mockDeal.details.ukefDealId,
@@ -506,7 +506,7 @@ describe('/v1/deals', () => {
           templateId: CONSTANTS.EMAIL_TEMPLATE_IDS.ISSUED_FACILITY_RECEIVED,
           sendToEmailAddress: mockDeal.details.maker.email,
           emailVariables: {
-            exporterName: mockDeal.submissionDetails['supplier-name'],
+            exporterName: mockDeal.exporter.companyName,
             recipientName: mockDeal.details.maker.firstname,
             bankReferenceNumber: mockDeal.details.bankSupplyContractID,
             ukefDealID: mockDeal.details.ukefDealId,

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
@@ -77,7 +77,7 @@ describe('/v1/deals', () => {
               'mock-origin-url',
               firstTask,
               dealId,
-              body.dealSnapshot.submissionDetails['supplier-name'],
+              body.dealSnapshot.exporter.companyName,
               body.dealSnapshot.details.ukefDealId,
             ),
           };
@@ -118,7 +118,7 @@ describe('/v1/deals', () => {
             emailVariables: generateTaskEmailVariables(
               'mock-origin-url',
               firstTask,
-              body.dealSnapshot.submissionDetails['supplier-name'],
+              body.dealSnapshot.exporter.companyName,
               body.dealSnapshot.details.submissionType,
               moment(formattedTimestamp(body.dealSnapshot.details.submissionDate)).format('Do MMMM YYYY'),
               body.dealSnapshot.details.owningBank.name,

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-update-underwriter-managers-decision.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-update-underwriter-managers-decision.api-test.js
@@ -56,7 +56,7 @@ describe('update tfm underwriter managers decision', () => {
         sendToEmailAddress: MOCK_DEAL_BSS_MIA.details.maker.email,
         emailVariables: {
           recipientName: MOCK_DEAL_BSS_MIA.details.maker.firstname,
-          exporterName: MOCK_DEAL_BSS_MIA.submissionDetails['supplier-name'],
+          exporterName: MOCK_DEAL_BSS_MIA.exporterName.companyName,
           bankReferenceNumber: MOCK_DEAL_BSS_MIA.details.bankSupplyContractID,
           ukefDealId: MOCK_DEAL_BSS_MIA.details.ukefDealId,
           conditions: comments,
@@ -89,7 +89,7 @@ describe('update tfm underwriter managers decision', () => {
         sendToEmailAddress: MOCK_DEAL_BSS_MIA.details.maker.email,
         emailVariables: {
           recipientName: MOCK_DEAL_BSS_MIA.details.maker.firstname,
-          exporterName: MOCK_DEAL_BSS_MIA.submissionDetails['supplier-name'],
+          exporterName: MOCK_DEAL_BSS_MIA.exporterName.companyName,
           bankReferenceNumber: MOCK_DEAL_BSS_MIA.details.bankSupplyContractID,
           ukefDealId: MOCK_DEAL_BSS_MIA.details.ukefDealId,
         },
@@ -121,7 +121,7 @@ describe('update tfm underwriter managers decision', () => {
         sendToEmailAddress: MOCK_DEAL_BSS_MIA.details.maker.email,
         emailVariables: {
           recipientName: MOCK_DEAL_BSS_MIA.details.maker.firstname,
-          exporterName: MOCK_DEAL_BSS_MIA.submissionDetails['supplier-name'],
+          exporterName: MOCK_DEAL_BSS_MIA.exporterName.companyName,
           bankReferenceNumber: MOCK_DEAL_BSS_MIA.details.bankSupplyContractID,
           ukefDealId: MOCK_DEAL_BSS_MIA.details.ukefDealId,
           reasonForRejection: comments,

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-update-underwriter-managers-decision.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-update-underwriter-managers-decision.api-test.js
@@ -56,7 +56,7 @@ describe('update tfm underwriter managers decision', () => {
         sendToEmailAddress: MOCK_DEAL_BSS_MIA.details.maker.email,
         emailVariables: {
           recipientName: MOCK_DEAL_BSS_MIA.details.maker.firstname,
-          exporterName: MOCK_DEAL_BSS_MIA.exporterName.companyName,
+          exporterName: MOCK_DEAL_BSS_MIA.exporter.companyName,
           bankReferenceNumber: MOCK_DEAL_BSS_MIA.details.bankSupplyContractID,
           ukefDealId: MOCK_DEAL_BSS_MIA.details.ukefDealId,
           conditions: comments,
@@ -89,7 +89,7 @@ describe('update tfm underwriter managers decision', () => {
         sendToEmailAddress: MOCK_DEAL_BSS_MIA.details.maker.email,
         emailVariables: {
           recipientName: MOCK_DEAL_BSS_MIA.details.maker.firstname,
-          exporterName: MOCK_DEAL_BSS_MIA.exporterName.companyName,
+          exporterName: MOCK_DEAL_BSS_MIA.exporter.companyName,
           bankReferenceNumber: MOCK_DEAL_BSS_MIA.details.bankSupplyContractID,
           ukefDealId: MOCK_DEAL_BSS_MIA.details.ukefDealId,
         },
@@ -121,7 +121,7 @@ describe('update tfm underwriter managers decision', () => {
         sendToEmailAddress: MOCK_DEAL_BSS_MIA.details.maker.email,
         emailVariables: {
           recipientName: MOCK_DEAL_BSS_MIA.details.maker.firstname,
-          exporterName: MOCK_DEAL_BSS_MIA.exporterName.companyName,
+          exporterName: MOCK_DEAL_BSS_MIA.exporter.companyName,
           bankReferenceNumber: MOCK_DEAL_BSS_MIA.details.bankSupplyContractID,
           ukefDealId: MOCK_DEAL_BSS_MIA.details.ukefDealId,
           reasonForRejection: comments,

--- a/trade-finance-manager-api/graphql-query-tests/mock-deal.js
+++ b/trade-finance-manager-api/graphql-query-tests/mock-deal.js
@@ -233,6 +233,9 @@ const MOCK_DEAL = {
         },
       ],
     },
+    exporter: {
+      companyName: 'test',
+    },
   },
   tfm: {
     submissionDetails: {

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -100,6 +100,10 @@ type DealFiles {
   security: String
 }
 
+type DealExporter {
+  companyName: String
+}
+
 type DealEligibilityCriterion {
   id: Int
   text: String
@@ -362,6 +366,7 @@ type DealSnapshot {
   isFinanceIncreasing: Boolean
   eligibility: DealEligibility
   dealFiles: DealFiles
+  exporter: DealExporter
   facilitiesUpdated: Float
 }
 

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-second-submit-facilities-unissued-to-issued.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-second-submit-facilities-unissued-to-issued.js
@@ -236,6 +236,9 @@ const MOCK_DEAL_AIN_SUBMITTED_FACILITIES_UNISSUED_TO_ISSUED = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_AIN_SUBMITTED_FACILITIES_UNISSUED_TO_ISSUED;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted-non-gbp-contract-value.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted-non-gbp-contract-value.js
@@ -233,6 +233,9 @@ const MOCK_DEAL_AIN_SUBMITTED_NON_GBP_CONTRACT_VALUE = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_AIN_SUBMITTED_NON_GBP_CONTRACT_VALUE;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted.js
@@ -233,6 +233,9 @@ const MOCK_DEAL_AIN_SUBMITTED = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_AIN_SUBMITTED;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-not-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-not-submitted.js
@@ -234,6 +234,9 @@ const MOCK_DEAL = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit-facilities-unissued-to-issued.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit-facilities-unissued-to-issued.js
@@ -235,6 +235,9 @@ const MOCK_DEAL_MIA_SUBMITTED_FACILITIES_UNISSUED_TO_ISSUED = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_MIA_SUBMITTED_FACILITIES_UNISSUED_TO_ISSUED;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit.js
@@ -234,6 +234,9 @@ const MOCK_DEAL = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-submitted.js
@@ -235,6 +235,9 @@ const MOCK_DEAL = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN-second-submit-facilities-unissued-to-issued.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN-second-submit-facilities-unissued-to-issued.js
@@ -234,6 +234,9 @@ const MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN.js
@@ -235,6 +235,9 @@ const MOCK_DEAL = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-acbs.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-acbs.js
@@ -170,6 +170,9 @@ const MOCK_DEAL = {
   loanTransactions: {
     items: [],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-facilities-USD-currency.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-facilities-USD-currency.js
@@ -179,6 +179,9 @@ const MOCK_DEAL = {
       { ...MOCK_FACILITIES_USD_CURRENCY[1] },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-issued-facilities.js
@@ -235,6 +235,9 @@ const MOCK_DEAL_ISSUED_FACILITIES = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_ISSUED_FACILITIES;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-companies-house.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-companies-house.js
@@ -233,6 +233,9 @@ const MOCK_DEAL_NO_COMPANIES_HOUSE = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_NO_COMPANIES_HOUSE;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-party-db.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-party-db.js
@@ -233,6 +233,9 @@ const MOCK_DEAL_NO_PARTY_DB = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL_NO_PARTY_DB;

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal.js
@@ -235,6 +235,9 @@ const MOCK_DEAL = {
       },
     ],
   },
+  exporter: {
+    companyName: 'test',
+  },
 };
 
 module.exports = MOCK_DEAL;

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-bss.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-bss.api-test.js
@@ -31,7 +31,7 @@ describe('send-deal-submit-emails - BSS', () => {
       bankReferenceNumber: mockDealMia.dealSnapshot.details.bankSupplyContractID,
       maker: mockDealMia.dealSnapshot.details.maker,
       exporter: {
-        companyName: mockDealMia.dealSnapshot.submissionDetails['supplier-name'],
+        companyName: mockDealMia.dealSnapshot.exporter.companyName,
       },
       facilities: [
         ...mockDealMia.dealSnapshot.bondTransactions.items,
@@ -70,7 +70,7 @@ describe('send-deal-submit-emails - BSS', () => {
           bankReferenceNumber: mockDealMin.dealSnapshot.details.bankSupplyContractID,
           maker: mockDealMin.dealSnapshot.details.maker,
           exporter: {
-            companyName: mockDealMin.dealSnapshot.submissionDetails['supplier-name'],
+            companyName: mockDealMin.dealSnapshot.exporter.companyName,
           },
           facilities: [
             {
@@ -131,7 +131,7 @@ describe('send-deal-submit-emails - BSS', () => {
           bankReferenceNumber: mockDealMin.dealSnapshot.details.bankSupplyContractID,
           maker: mockDealMin.dealSnapshot.details.maker,
           exporter: {
-            companyName: mockDealMin.dealSnapshot.submissionDetails['supplier-name'],
+            companyName: mockDealMin.dealSnapshot.exporter.companyName,
           },
           facilities: [
             {
@@ -189,7 +189,7 @@ describe('send-deal-submit-emails - BSS', () => {
           bankReferenceNumber: mockDealAin.dealSnapshot.details.bankSupplyContractID,
           maker: mockDealAin.dealSnapshot.details.maker,
           exporter: {
-            companyName: mockDealAin.dealSnapshot.submissionDetails['supplier-name'],
+            companyName: mockDealAin.dealSnapshot.exporter.companyName,
           },
           facilities: [
             {
@@ -250,7 +250,7 @@ describe('send-deal-submit-emails - BSS', () => {
           bankReferenceNumber: mockDealAin.dealSnapshot.details.bankSupplyContractID,
           maker: mockDealAin.dealSnapshot.details.maker,
           exporter: {
-            companyName: mockDealAin.dealSnapshot.submissionDetails['supplier-name'],
+            companyName: mockDealAin.dealSnapshot.exporter.companyName,
           },
           facilities: [
             {

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-tfm-tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-tfm-tasks.api-test.js
@@ -30,7 +30,7 @@ describe('send-deal-submit-emails - TFM tasks', () => {
       bankReferenceNumber: mockDealMia.dealSnapshot.details.bankSupplyContractID,
       maker: mockDealMia.dealSnapshot.details.maker,
       exporter: {
-        companyName: mockDealMia.dealSnapshot.submissionDetails['supplier-name'],
+        companyName: mockDealMia.dealSnapshot.exporter.companyName,
       },
       facilities: [
         ...mockDealMia.dealSnapshot.bondTransactions.items,

--- a/trade-finance-manager-api/src/v1/controllers/task-emails.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/task-emails.api-test.js
@@ -16,7 +16,7 @@ describe('task emails functions', () => {
     _id: MOCK_DEAL_MIA_SUBMITTED._id,
     ukefDealId: MOCK_DEAL_MIA_SUBMITTED.ukefDealId,
     exporter: {
-      companyName: MOCK_DEAL_MIA_SUBMITTED.submissionDetails['supplier-name'],
+      companyName: MOCK_DEAL_MIA_SUBMITTED.exporter.companyName,
     },
     tfm: {
       history: { emails: [] },

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.api-test.js
@@ -19,6 +19,7 @@ describe('mappings - map submitted deal - mapBssEwcsDeal', () => {
       bondTransactions,
       loanTransactions,
       eligibility,
+      exporter,
     } = mockDeal.dealSnapshot;
 
     const {
@@ -44,7 +45,7 @@ describe('mappings - map submitted deal - mapBssEwcsDeal', () => {
       ukefDealId,
       maker,
       exporter: {
-        companyName: submissionDetails['supplier-name'],
+        companyName: exporter.companyName,
         companiesHouseRegistrationNumber: submissionDetails['supplier-companies-house-registration-number'],
       },
       buyer: {

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.js
@@ -11,6 +11,7 @@ const mapBssEwcsDeal = (deal) => {
     bondTransactions,
     loanTransactions,
     eligibility,
+    exporter,
   } = dealSnapshot;
 
   const {
@@ -39,7 +40,7 @@ const mapBssEwcsDeal = (deal) => {
     ukefDealId,
     maker,
     exporter: {
-      companyName: submissionDetails['supplier-name'],
+      companyName: exporter.companyName,
       companiesHouseRegistrationNumber: submissionDetails['supplier-companies-house-registration-number'],
     },
     buyer: {

--- a/trade-finance-manager-ui/server/graphql/queries/deal-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deal-query.js
@@ -208,6 +208,9 @@ const dealQuery = gql`
           supplierType,
           smeType
         }
+        exporter {
+          companyName
+        }
         isFinanceIncreasing
       }
     }

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query-light.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query-light.js
@@ -20,8 +20,10 @@ query DealsLight($searchString: String, $sortBy: DealsSortBy, $start: Int, $page
           }
         }
         submissionDetails {
-          supplierName
           buyerName
+        }
+        exporter {
+          companyName
         }
       }
     }

--- a/trade-finance-manager-ui/templates/case/_macros/case-summary.component-test.js
+++ b/trade-finance-manager-ui/templates/case/_macros/case-summary.component-test.js
@@ -7,10 +7,11 @@ const formatDateString = require('../../../server/nunjucks-configuration/filter-
 
 const render = componentRenderer(component);
 
-const rawdata = fs.readFileSync('templates/case/mock_data/deal.json');
+const rawData = fs.readFileSync('templates/case/mock_data/deal.json');
+
 let params = {
   deal: {
-    ...JSON.parse(rawdata),
+    ...JSON.parse(rawData),
     totals: {
       facilitiesValueInGBP: 'GBP 2,740.41',
       facilitiesUkefExposure: 'GBP 123,456.12',
@@ -43,8 +44,8 @@ describe(component, () => {
   });
 
 
-  it('should render supplier name', () => {
-    wrapper.expectText('[data-cy="supplier-name"]').toRead(params.deal.submissionDetails.supplierName);
+  it('should render exporter (supplier) name', () => {
+    wrapper.expectText('[data-cy="exporter-name"]').toRead(params.deal.exporter.companyName);
   });
 
   it('should render buyer name', () => {

--- a/trade-finance-manager-ui/templates/case/_macros/case-summary.njk
+++ b/trade-finance-manager-ui/templates/case/_macros/case-summary.njk
@@ -24,7 +24,7 @@
         <div class="label">
           {{ supplierType.render(deal.submissionDetails.supplierType) }}
         </div>
-        <div class="ukef-heading-l" data-cy="supplier-name">{{ deal.submissionDetails.supplierName | dashIfEmpty }}</div>
+        <div class="ukef-heading-l" data-cy="exporter-name">{{ deal.exporter.companyName | dashIfEmpty }}</div>
       </div>
 
       {% if deal.submissionDetails.buyerName %}

--- a/trade-finance-manager-ui/templates/case/mock_data/deal.json
+++ b/trade-finance-manager-ui/templates/case/mock_data/deal.json
@@ -152,5 +152,8 @@
     "smeType": "Small",
     "__typename": "DealSubmissionDetails"
   },
+  "exporter": {
+    "companyName": "test"
+  },
   "__typename": "DealSnapshot"
 }

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.component-test.js
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.component-test.js
@@ -23,7 +23,7 @@ describe(page, () => {
         },
       },
       submissionDetails: {
-        supplierName: 'The Supplier name',
+        supplierName: 'The company name',
         buyerName: 'The Buyer name',
         supplyContractDescription: 'supplyContractDescription',
         destinationCountry: 'United Kingdom',
@@ -75,6 +75,9 @@ describe(page, () => {
         agentAddressTown: 'City',
         agentName: 'AGENT NAME',
       },
+      exporter: {
+        companyName: 'The company name'
+      },
     },
   };
 
@@ -89,7 +92,7 @@ describe(page, () => {
   it('should render exporter name', () => {
     wrapper
       .expectText('[data-cy="exporter-name"]')
-      .toRead(params.deal.submissionDetails.supplierName);
+      .toRead(params.deal.exporter.companyName);
   });
   it('should render industry class', () => {
     wrapper

--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-exporter-area.njk
@@ -39,7 +39,7 @@
     <div class="govuk-grid-column-one-half">
       {{ keyValueGridRow.render({
         key: 'Name',
-        value: deal.submissionDetails.supplierName,
+        value: deal.exporter.companyName,
         dataCy: 'exporter-name'
       }) }}
 

--- a/utils/mock-data-loader/bss/deals/1.js
+++ b/utils/mock-data-loader/bss/deals/1.js
@@ -625,5 +625,8 @@ module.exports = {
 			}
 		},
 		"security" : "TEST"
+	},
+	"exporter": {
+		"companyName": "Auto Test 1"
 	}
 }

--- a/utils/mock-data-loader/bss/deals/10.js
+++ b/utils/mock-data-loader/bss/deals/10.js
@@ -389,5 +389,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/11.js
+++ b/utils/mock-data-loader/bss/deals/11.js
@@ -389,5 +389,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/2.js
+++ b/utils/mock-data-loader/bss/deals/2.js
@@ -673,5 +673,8 @@ module.exports = {
 		"security" : "TEST"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Auto Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/3.js
+++ b/utils/mock-data-loader/bss/deals/3.js
@@ -627,5 +627,8 @@ module.exports = {
 			}
 		},
 		"security" : "Test"
+	},
+	"exporter": {
+		"companyName": "Manual Test 1"
 	}
 }

--- a/utils/mock-data-loader/bss/deals/4.js
+++ b/utils/mock-data-loader/bss/deals/4.js
@@ -404,5 +404,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/5.js
+++ b/utils/mock-data-loader/bss/deals/5.js
@@ -404,5 +404,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/6.js
+++ b/utils/mock-data-loader/bss/deals/6.js
@@ -389,5 +389,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/7.js
+++ b/utils/mock-data-loader/bss/deals/7.js
@@ -389,5 +389,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/8.js
+++ b/utils/mock-data-loader/bss/deals/8.js
@@ -404,5 +404,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }

--- a/utils/mock-data-loader/bss/deals/9.js
+++ b/utils/mock-data-loader/bss/deals/9.js
@@ -389,5 +389,8 @@ module.exports = {
 		"security" : "Test"
 	},
 	"ukefComments" : [ ],
-	"specialConditions" : [ ]
+	"specialConditions" : [ ],
+	"exporter": {
+		"companyName": "Manual Test 2"
+	}
 }


### PR DESCRIPTION
When a BSS deal is created, there is a section called "About Supply Contract" - in the DB, all this data lives under `deal.submissionDetails`. One field is called `supplier-name`. In other parts of the system - ACBS, TFM, `supplier-name` is used as the exporter name.

This PR adds a new object to a BSS deal - `exporter`, with `companyName` set to the `supplier-name`. This happens when the `deal.submissionDetails` is updated.

In the future, the BSS design might change so that "Supplier name" is called "Exporter name". 

## Summary of changes
- BSS deals: on creation, add empty exporter object.
- BSS deals: when submissionDetails are updated, add `exporter.companyName` as `supplier-name`.
- TFM: consume `exporter.companyName` instead of mapping with `submissionDetails['supplier-name']`
- ACBS: consume `exporter.companyName` instead of mapping with `submissionDetails['supplier-name']`
- TFM: Update mappings, mock data, tests, deal summary template, GraphQL queries, schema