### PR TITLE
Convert the facilityIdentifier to string

### DIFF
--- a/reference-data-proxy/src/v1/controllers/estore.controller.js
+++ b/reference-data-proxy/src/v1/controllers/estore.controller.js
@@ -65,7 +65,7 @@ const createEstore = async (req, res) => {
             dealIdentifier,
             exporterName,
             buyerName,
-            facilityIdentifier,
+            facilityIdentifier: facilityIdentifier.toString(),
             destinationMarket,
             riskMarket,
           })


### PR DESCRIPTION
- currently the facilityIdentifer is a number and this throws an error with eStore as it only accepts strings