### PR TITLE
BSS deal status on the top level

### DIFF
--- a/dtfs-central-api/api-tests/v1/deals/deal.api-test.js
+++ b/dtfs-central-api/api-tests/v1/deals/deal.api-test.js
@@ -369,10 +369,8 @@ describe('/v1/portal/deals', () => {
     it('returns the updated deal with updated statuses', async () => {
       const dealWithSubmittedStatus = {
         ...newDeal,
-        details: {
-          status: 'Submitted',
-          previousStatus: 'Checker\'s approval',
-        },
+        status: 'Submitted',
+        previousStatus: 'Checker\'s approval',
       };
 
       const postResult = await api.post({ deal: dealWithSubmittedStatus, user: mockUser }).to('/v1/portal/deals');
@@ -383,8 +381,8 @@ describe('/v1/portal/deals', () => {
 
       expect(status).toEqual(200);
 
-      expect(body.details.status).toEqual('Acknowledged by UKEF');
-      expect(body.details.previousStatus).toEqual('Submitted');
+      expect(body.status).toEqual('Acknowledged by UKEF');
+      expect(body.previousStatus).toEqual('Submitted');
       expect(typeof body.updatedAt).toEqual('number');
     });
   });

--- a/dtfs-central-api/api-tests/v1/deals/expectAddedFields.js
+++ b/dtfs-central-api/api-tests/v1/deals/expectAddedFields.js
@@ -7,6 +7,7 @@ const expectAddedFields = (obj) => {
   }
 
   const expectation = expectMongoId({
+    status: 'Draft',
     updatedAt: expect.any(Number),
     eligibility: {
       status: 'Not started',
@@ -24,7 +25,6 @@ const expectAddedFields = (obj) => {
       created: expect.any(String),
       maker: expect.any(Object),
       owningBank: expect.any(Object),
-      status: 'Draft',
     },
     facilities: [],
     editedBy: [],

--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-search-string.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-search-string.api-test.js
@@ -211,17 +211,17 @@ describe('/v1/tfm/deals', () => {
         // NOTE: tfm.stage is generated on deal submission.
 
         const ainDealWithConfirmedStage = newDeal({
+          status: 'Submitted',
           details: {
             ukefDealId: 'DEAL-WITH-CONFIRMED-STAGE',
-            status: 'Submitted',
           },
         });
 
         const miaDealWithApplicationStage = newDeal({
           submissionType: 'Manual Inclusion Application',
+          status: 'Submitted',
           details: {
             ukefDealId: 'DEAL-WITH-APPLICATION-STAGE',
-            status: 'Submitted',
           },
         });
 
@@ -364,17 +364,17 @@ describe('/v1/tfm/deals', () => {
         const yesterday = sub(today, { days: 1 });
 
         const dealSubmittedYesterday = newDeal({
+          status: 'Submitted',
           details: {
             ukefDealId: 'DEAL-SUBMITTED-YESTERDAY',
-            status: 'Submitted',
             submissionDate: yesterday,
           },
         });
 
         const dealSubmittedToday = newDeal({
+          status: 'Submitted',
           details: {
             ukefDealId: 'DEAL-SUBMITTED-TODAY',
-            status: 'Submitted',
             submissionDate: todayTimestamp,
           },
         });
@@ -436,17 +436,17 @@ describe('/v1/tfm/deals', () => {
         const yesterdayTimestamp = sub(today, { days: 1 }).valueOf().toString();
 
         const dealSubmittedYesterday = newDeal({
+          status: 'Submitted',
           details: {
             ukefDealId: 'DEAL-SUBMITTED-YESTERDAY',
-            status: 'Submitted',
             submissionDate: yesterdayTimestamp,
           },
         });
 
         const dealSubmittedToday = newDeal({
+          status: 'Submitted',
           details: {
             ukefDealId: 'DEAL-SUBMITTED-TODAY',
-            status: 'Submitted',
             submissionDate: todayTimestamp,
           },
         });

--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -182,7 +182,7 @@ const queryAllDeals = async (filters = {}, sort = {}, start = 0, pagesize = 0) =
         _id: 1,
         bankId: '$details.owningBank.id',
         bankRef: '$additionalRefName',
-        status: '$details.status',
+        status: '$status',
         product: 'BSS/EWCS',
         submissionType: '$submissionType',
         exporter: '$exporter.companyName',

--- a/dtfs-central-api/src/v1/controllers/portal/deal/update-deal-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/update-deal-status.controller.js
@@ -11,7 +11,7 @@ const withoutId = (obj) => {
 const updateDealStatus = async (dealId, status, existingDeal) => {
   const collection = await db.getCollection('deals');
 
-  const previousStatus = existingDeal.details.status;
+  const previousStatus = existingDeal.status;
 
   const modifiedDeal = {
     ...existingDeal,

--- a/dtfs-central-api/src/v1/controllers/portal/deal/update-deal-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/update-deal-status.controller.js
@@ -16,11 +16,8 @@ const updateDealStatus = async (dealId, status, existingDeal) => {
   const modifiedDeal = {
     ...existingDeal,
     updatedAt: Date.now(),
-    details: {
-      ...existingDeal.details,
-      status,
-      previousStatus,
-    },
+    status,
+    previousStatus,
   };
 
   const findAndUpdateResponse = await collection.findOneAndUpdate(

--- a/dtfs-central-api/src/v1/defaults/index.js
+++ b/dtfs-central-api/src/v1/defaults/index.js
@@ -1,8 +1,7 @@
 const DEFAULTS = {
   DEAL: {
-    details: {
-      status: 'Draft',
-    },
+    status: 'Draft',
+    details: {},
     eligibility: {
       status: 'Not started',
       criteria: [],

--- a/dtfs-central-api/src/v1/routes/portal-routes.js
+++ b/dtfs-central-api/src/v1/routes/portal-routes.js
@@ -638,9 +638,9 @@ portalRouter.route('/gef/deals/:id')
  *                 - type: object
  *                   properties:
  *                     previousStatus:
- *                       example: SUBMITTED_TO_UKEF
+ *                       example: Submitted
  *                     status:
- *                       example: UKEF_ACKNOWLEDGED
+ *                       example: Acknowledged by UKEF
  *       404:
  *         description: Not found
  */

--- a/dtfs-central-api/src/v1/swagger-definitions/portal/deal-bss.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/portal/deal-bss.js
@@ -22,12 +22,15 @@
  *       additionalRefName:
  *         type: string
  *         example: Test
+ *       status:
+ *         type: string
+ *         example: Submitted
+ *       previousStatus:
+ *         type: string
+ *         example: Ready for Checker's approval
  *       details:
  *         type: object
  *         properties:
- *           status:
- *             type: string
- *             example: Submitted
  *           owningBank:
  *             $ref: '#/definitions/Bank'
  *           maker:
@@ -35,9 +38,6 @@
  *           created:
  *             type: string
  *             example: '1632389070727'
- *           previousStatus:
- *             type: string
- *             example: Ready for Checker's approval
  *           submissionCount:
  *             type: integer
  *             emample: 1

--- a/e2e-tests/portal/cypress/fixtures/aDealForTestingFreeTextSearch.js
+++ b/e2e-tests/portal/cypress/fixtures/aDealForTestingFreeTextSearch.js
@@ -3,8 +3,8 @@ module.exports = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'abc-1-def',
   additionalRefName: 'Tibettan submarine acquisition scheme',
+  status: 'Draft',
   details: {
-    status: 'Draft',
     owningBank: {
       id: '9',
       name: 'UKEF test bank (Delegated)',

--- a/e2e-tests/portal/cypress/fixtures/deal-dashboard-data.js
+++ b/e2e-tests/portal/cypress/fixtures/deal-dashboard-data.js
@@ -9,8 +9,8 @@ module.exports = [
     submissionType: 'Automatic Inclusion Notice',
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Draft',
     details: {
-      status: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -30,8 +30,8 @@ module.exports = [
     submissionType: 'Automatic Inclusion Notice',
     bankInternalRefName: 'abc-2-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Draft',
     details: {
-      status: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -48,8 +48,8 @@ module.exports = [
     submissionType: 'Automatic Inclusion Notice',
     bankInternalRefName: 'abc-3-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Draft',
     details: {
-      status: 'Draft',
       submissionDate: now,
       owningBank: {
         id: '9',
@@ -67,9 +67,9 @@ module.exports = [
     submissionType: 'Manual Inclusion Notice',
     bankInternalRefName: 'abc-4-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: "Ready for Checker's approval",
+    previousStatus: 'Draft',
     details: {
-      status: "Ready for Checker's approval",
-      previousStatus: 'Draft',
       submissionDate: now,
       owningBank: {
         id: '9',
@@ -95,9 +95,9 @@ module.exports = [
     submissionType: 'Manual Inclusion Application',
     bankInternalRefName: 'abc-5-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: "Further Maker's input required",
+    previousStatus: "Ready for Checker's approval",
     details: {
-      status: "Further Maker's input required",
-      previousStatus: "Ready for Checker's approval",
       submissionDate: now,
       owningBank: {
         id: '9',
@@ -122,9 +122,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-6-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Abandoned',
+    previousStatus: 'Draft',
     details: {
-      status: 'Abandoned',
-      previousStatus: 'Draft',
       submissionDate: now,
       owningBank: {
         id: '9',
@@ -141,9 +141,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-7-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Submitted',
+    previousStatus: "Ready for Checker's approval",
     details: {
-      status: 'Submitted',
-      previousStatus: "Ready for Checker's approval",
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -167,9 +167,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-8-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Submitted',
+    previousStatus: "Ready for Checker's approval",
     details: {
-      status: 'Submitted',
-      previousStatus: "Ready for Checker's approval",
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -193,9 +193,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-9-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: "Ready for Checker's approval",
+    previousStatus: 'Draft',
     details: {
-      status: "Ready for Checker's approval",
-      previousStatus: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -219,9 +219,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Acknowledged by UKEF',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Acknowledged by UKEF',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -237,8 +237,8 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Draft',
     details: {
-      status: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -254,8 +254,8 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Draft',
     details: {
-      status: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -271,8 +271,8 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Draft',
     details: {
-      status: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -288,9 +288,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Acknowledged by UKEF',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Acknowledged by UKEF',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -306,9 +306,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Accepted by UKEF (without conditions)',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Accepted by UKEF (without conditions)',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -324,9 +324,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Rejected by UKEF',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Rejected by UKEF',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -342,9 +342,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Rejected by UKEF',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Rejected by UKEF',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -360,9 +360,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: "Further Maker's input required",
+    previousStatus: "Ready for Checker's approval",
     details: {
-      status: "Further Maker's input required",
-      previousStatus: "Ready for Checker's approval",
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -378,9 +378,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Accepted by UKEF (without conditions)',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Accepted by UKEF (without conditions)',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -396,9 +396,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc 2 def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Accepted by UKEF (with conditions)',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Accepted by UKEF (with conditions)',
-      previousStatus: 'Submitted',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',
@@ -414,9 +414,9 @@ module.exports = [
   }, {
     bankInternalRefName: 'abc 2 def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
+    status: 'Abandoned',
+    previousStatus: 'Draft',
     details: {
-      status: 'Abandoned',
-      previousStatus: 'Draft',
       owningBank: {
         id: '9',
         name: 'UKEF test bank (Delegated)',

--- a/e2e-tests/portal/cypress/fixtures/templates/aDealWithOneBond.json
+++ b/e2e-tests/portal/cypress/fixtures/templates/aDealWithOneBond.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "aDealWithOneBond",
   "additionalRefName": "aDealWithOneBond",
+  "status": "Draft",
   "details": {
     "ukefDealId": "ukef:aDealWithOneBond",
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/fixtures/templates/aDealWithOneLoan.json
+++ b/e2e-tests/portal/cypress/fixtures/templates/aDealWithOneLoan.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "aDealWithOneLoan",
   "additionalRefName": "aDealWithOneLoan",
+  "status": "Draft",
   "details": {
     "ukefDealId": "ukef:aDealWithOneLoan",
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/fixtures/templates/aDealWithOneLoanAndOneBond.json
+++ b/e2e-tests/portal/cypress/fixtures/templates/aDealWithOneLoanAndOneBond.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "aDealWithOneLoanAndOneBond",
   "additionalRefName": "aDealWithOneLoanAndOneBond",
+  "status": "Draft",
   "details": {
     "ukefDealId": "ukef:aDealWithOneLoanAndOneBond",
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/fixtures/templates/aDealWithTenBonds.json
+++ b/e2e-tests/portal/cypress/fixtures/templates/aDealWithTenBonds.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "aDealWithTenBonds",
   "additionalRefName": "aDealWithTenBonds",
+  "status": "Draft",
   "details": {
     "ukefDealId": "ukef:aDealWithTenBonds",
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/fixtures/templates/aDealWithTenLoans.json
+++ b/e2e-tests/portal/cypress/fixtures/templates/aDealWithTenLoans.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "aDealWithTenLoans",
   "additionalRefName": "aDealWithTenLoans",
+  "status": "Draft",
   "details": {
     "ukefDealId": "ukef:aDealWithTenLoans",
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/fixtures/templates/aDealWithTenLoansAndTenBonds.json
+++ b/e2e-tests/portal/cypress/fixtures/templates/aDealWithTenLoansAndTenBonds.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "aDealWithTenLoansAndTenBonds",
   "additionalRefName": "aDealWithTenLoansAndTenBonds",
+  "status": "Draft",
   "details": {
     "ukefDealId": "ukef:aDealWithTenLoansAndTenBonds",
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-UKEF-supply-contract-id.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-UKEF-supply-contract-id.spec.js
@@ -21,9 +21,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneBond, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-01'),
-            status: 'Submitted',
           },
         };
         cy.updateDeal(inserted._id, update, MAKER_LOGIN);
@@ -32,9 +32,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoan, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-03'),
-            status: 'Submitted',
           },
         };
 
@@ -44,9 +44,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoanAndOneBond, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-05'),
-            status: 'Submitted',
           },
         };
 
@@ -56,9 +56,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenBonds, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-07'),
-            status: 'Submitted',
           },
         };
 
@@ -68,9 +68,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenLoans, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-09'),
-            status: 'Submitted',
           },
         };
 
@@ -80,9 +80,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenLoansAndTenBonds, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-11'),
-            status: 'Submitted',
           },
         };
 

--- a/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-bank-supply-contract-id.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-bank-supply-contract-id.spec.js
@@ -21,9 +21,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneBond, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-01'),
-            status: 'Submitted',
           },
         };
         cy.updateDeal(inserted._id, update, MAKER_LOGIN);
@@ -32,9 +32,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoan, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-03'),
-            status: 'Submitted',
           },
         };
 
@@ -44,9 +44,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoanAndOneBond, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-05'),
-            status: 'Submitted',
           },
         };
 
@@ -56,9 +56,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenBonds, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-07'),
-            status: 'Submitted',
           },
         };
 
@@ -68,9 +68,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenLoans, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-09'),
-            status: 'Submitted',
           },
         };
 
@@ -80,9 +80,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenLoansAndTenBonds, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-11'),
-            status: 'Submitted',
           },
         };
 

--- a/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-bank.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-bank.spec.js
@@ -25,9 +25,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneBond, BANK1_MAKER)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-01'),
-            status: 'Submitted',
           },
         };
         cy.updateDeal(inserted._id, update, BANK1_MAKER);
@@ -36,9 +36,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoan, BANK1_MAKER)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-03'),
-            status: 'Submitted',
           },
         };
 
@@ -48,9 +48,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoanAndOneBond, BANK1_MAKER)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-05'),
-            status: 'Submitted',
           },
         };
 
@@ -60,9 +60,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenBonds, BANK2_MAKER)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-07'),
-            status: 'Submitted',
           },
         };
 
@@ -72,9 +72,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenLoans, BANK2_MAKER)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-09'),
-            status: 'Submitted',
           },
         };
 
@@ -84,9 +84,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithTenLoansAndTenBonds, BANK2_MAKER)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-11'),
-            status: 'Submitted',
           },
         };
 

--- a/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-submission-date.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-filter-by-submission-date.spec.js
@@ -18,9 +18,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneBond, BANK1_MAKER)
       .then((inserted) => {
         cy.updateDeal(inserted._id, {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-01'),
-            status: 'Submitted',
           },
         }, BANK1_MAKER)
           .then((updated) => { aDealWithOneBond = updated; });
@@ -29,9 +29,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoan, BANK1_MAKER)
       .then((inserted) => {
         cy.updateDeal(inserted._id, {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-03'),
-            status: 'Submitted',
           },
         }, BANK1_MAKER)
           .then((updated) => { aDealWithOneLoan = updated; });
@@ -40,9 +40,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoanAndOneBond, BANK1_MAKER)
       .then((inserted) => {
         cy.updateDeal(inserted._id, {
+          status: 'Submitted',
           details: {
             submissionDate: toBigNumber('2020-01-05'),
-            status: 'Submitted',
           },
         }, BANK1_MAKER)
           .then((updated) => { aDealWithOneLoanAndOneBond = updated; });

--- a/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-should-not-show-deals-submitted-within-last-2-hours.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/admin/reports/reconciliation-report/report-should-not-show-deals-submitted-within-last-2-hours.spec.js
@@ -22,9 +22,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneBond, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: nowMinus(100),
-            status: 'Submitted',
           },
         };
         cy.updateDeal(inserted._id, update, MAKER_LOGIN);
@@ -33,9 +33,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoan, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: nowMinus(118),
-            status: 'Submitted',
           },
         };
 
@@ -45,9 +45,9 @@ context('reconciliation report', () => {
     cy.insertOneDeal(aDealWithOneLoanAndOneBond, MAKER_LOGIN)
       .then((inserted) => {
         const update = {
+          status: 'Submitted',
           details: {
             submissionDate: nowMinus(121),
-            status: 'Submitted',
           },
         };
 

--- a/e2e-tests/portal/cypress/integration/journeys/checker/cannot-submit-a-deal-with-newly-issued-facilities-that-have-cover-start-dates-before-today/deal.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/cannot-submit-a-deal-with-newly-issued-facilities-that-have-cover-start-dates-before-today/deal.js
@@ -4,8 +4,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'DTFS2-2815 MIN - pre submit',
   additionalRefName: 'DTFS2-2815 MIN - pre submit',
+  status: "Ready for Checker's approval",
+  previousStatus: 'Acknowledged by UKEF',
   details: {
-    status: "Ready for Checker's approval",
     maker: {
       _id: '5f3ab3f705e6630007dcfb25',
       username: 'maker1@ukexportfinance.gov.uk',
@@ -36,7 +37,6 @@ const deal = {
       ],
     },
     created: '1606900241023',
-    previousStatus: 'Acknowledged by UKEF',
     submissionDate: '1606900616651',
     checker: {
       _id: '5f3ab3f705e6630007dcfb29',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/dashboard/bss-dashboard.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/dashboard/bss-dashboard.spec.js
@@ -16,10 +16,8 @@ context('View a deal with checker role', () => {
     submissionType: 'Manual Inclusion Notice',
     bankInternalRefName: 'abc-1-def',
     additionalRefName: 'Tibettan submarine acquisition scheme',
-    details: {
-      status: "Ready for Checker's approval",
-      previousStatus: 'Draft',
-    },
+    status: "Ready for Checker's approval",
+    previousStatus: 'Draft',
   };
   const draftDealData = {
     dealType: 'BSS/EWCS',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/MIA-deal-with-unissued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/MIA-deal-with-unissued-facilities.js
@@ -3,8 +3,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test',
   additionalRefName: 'testing',
+  status: "Ready for Checker's approval",
+  previousStatus: 'Draft',
   details: {
-    status: "Ready for Checker's approval",
     maker: {
       username: 'MAKER',
       roles: [
@@ -34,7 +35,6 @@ const deal = {
       ],
     },
     created: new Date().valueOf(),
-    previousStatus: 'Draft',
   },
   eligibility: {
     status: 'Completed',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/submit-MIN-deal-with-issued-facility/MIN-deal-accepted-status-with-unissued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/submit-MIN-deal-with-issued-facility/MIN-deal-accepted-status-with-unissued-facilities.js
@@ -4,8 +4,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test',
   additionalRefName: 'testing',
+  status: 'Accepted by UKEF (with conditions)',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Accepted by UKEF (with conditions)',
     created: new Date().valueOf(),
     maker: {
       username: 'MAKER',
@@ -35,7 +36,6 @@ const deal = {
         'checker@ukexportfinance.gov.uk',
       ],
     },
-    previousStatus: 'Submitted',
     checker: {
       bank: {
         id: '9',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/return-a-deal-to-maker/dealWithSomeIssuedFacilitiesReadyForReview.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/return-a-deal-to-maker/dealWithSomeIssuedFacilitiesReadyForReview.js
@@ -9,12 +9,12 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'mock id',
   additionalRefName: 'mock name',
+  status: "Ready for Checker's approval",
+  previousStatus: 'Acknowledged by UKEF',
   details: {
-    status: "Ready for Checker's approval",
     created: date.valueOf(),
     previousWorkflowStatus: 'confirmation_acknowledged',
     submissionDate: date.valueOf(),
-    previousStatus: 'Acknowledged by UKEF',
     owningBank: {
       id: '9',
       name: 'UKEF test bank (Delegated)',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/return-a-deal-to-maker/return-deal-to-maker.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/return-a-deal-to-maker/return-deal-to-maker.spec.js
@@ -14,7 +14,7 @@ context('A checker selects to return a deal to maker from the view-contract page
   let deal;
 
   before(() => {
-    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.details.status)[0];
+    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.status)[0];
 
     cy.deleteDeals(MAKER_LOGIN);
     cy.insertOneDeal(aDealInStatus("Ready for Checker's approval"), MAKER_LOGIN)

--- a/e2e-tests/portal/cypress/integration/journeys/checker/submit-a-deal/test-data/template.json
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/submit-a-deal/test-data/template.json
@@ -2,9 +2,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Ready for Checker's approval",
+  "previousStatus": "Draft",
   "details": {
-    "status": "Ready for Checker's approval",
-    "previousStatus": "Draft",
     "previousWorkflowStatus": "Draft"
   },
   "submissionDetails" : {

--- a/e2e-tests/portal/cypress/integration/journeys/maker/abandon-a-deal.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/abandon-a-deal.spec.js
@@ -12,7 +12,7 @@ context('A maker selects to abandon a contract from the view-contract page', () 
   let deal;
 
   before(() => {
-    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.details.status)[0];
+    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.status)[0];
 
     cy.deleteDeals(MAKER_LOGIN);
     cy.insertOneDeal(aDealInStatus('Draft'), MAKER_LOGIN)

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-happy-path.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-happy-path.spec.js
@@ -15,8 +15,8 @@ context('about-supply-contract', () => {
   before(() => {
     const aDealWithAboutSupplyContractInStatus = (status) => {
       const candidates = twentyOneDeals
-        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionDetails.status)
-          && (aDeal.details && aDeal.details.status === 'Draft')
+        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionstatus)
+          && (aDeal.details && aDeal.status === 'Draft')
           && (aDeal.details && !aDeal.details.submissionDate));
 
       const aDeal = candidates[0];

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-happy-path.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-happy-path.spec.js
@@ -15,7 +15,7 @@ context('about-supply-contract', () => {
   before(() => {
     const aDealWithAboutSupplyContractInStatus = (status) => {
       const candidates = twentyOneDeals
-        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionstatus)
+        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionDetails.status)
           && (aDeal.details && aDeal.status === 'Draft')
           && (aDeal.details && !aDeal.details.submissionDate));
 

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-unhappy-path.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-unhappy-path.spec.js
@@ -12,8 +12,8 @@ context('about-supply-contract', () => {
   before(() => {
     const aDealWithAboutSupplyContractInStatus = (status) => {
       const candidates = twentyOneDeals
-        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionDetails.status)
-        && (aDeal.details && aDeal.details.status === 'Draft')
+        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionstatus)
+        && (aDeal.details && aDeal.status === 'Draft')
         && (aDeal.details && !aDeal.details.submissionDate));
 
       const aDeal = candidates[0];

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-unhappy-path.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-unhappy-path.spec.js
@@ -12,7 +12,7 @@ context('about-supply-contract', () => {
   before(() => {
     const aDealWithAboutSupplyContractInStatus = (status) => {
       const candidates = twentyOneDeals
-        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionstatus)
+        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionDetails.status)
         && (aDeal.details && aDeal.status === 'Draft')
         && (aDeal.details && !aDeal.details.submissionDate));
 

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-validation.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-validation.spec.js
@@ -18,8 +18,8 @@ context('about-supply-contract', () => {
 
     const aDealWithAboutSupplyContractInStatus = (status) => {
       const candidates = twentyOneDeals
-        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionDetails.status)
-        && (aDeal.details && aDeal.details.status === 'Draft'));
+        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionstatus)
+        && (aDeal.details && aDeal.status === 'Draft'));
 
       const aDeal = candidates[0];
       if (!aDeal) {

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-validation.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/fill-in-about-supply-contract-validation.spec.js
@@ -18,7 +18,7 @@ context('about-supply-contract', () => {
 
     const aDealWithAboutSupplyContractInStatus = (status) => {
       const candidates = twentyOneDeals
-        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionstatus)
+        .filter((aDeal) => (aDeal.submissionDetails && status === aDeal.submissionDetails.status)
         && (aDeal.details && aDeal.status === 'Draft'));
 
       const aDeal = candidates[0];

--- a/e2e-tests/portal/cypress/integration/journeys/maker/bond/delete-a-bond.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/bond/delete-a-bond.spec.js
@@ -11,9 +11,7 @@ const now = new Date().valueOf();
 const MOCK_DEAL = {
   bankInternalRefName: 'someDealId',
   additionalRefName: 'someDealName',
-  details: {
-    status: 'Draft',
-  },
+  status: 'Draft',
   submissionDetails: {
     supplyContractCurrency: {
       id: 'GBP',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/check-deal-details/check-deal-details.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/check-deal-details/check-deal-details.spec.js
@@ -8,10 +8,7 @@ const MAKER_LOGIN = mockUsers.find((user) => (user.roles.includes('maker')));
 
 const dealInDraft = {
   ...fullyCompletedDeal,
-  details: {
-    ...fullyCompletedDeal.details,
-    status: 'Draft',
-  },
+  status: 'Draft',
 };
 
 context('Check deal details', () => {

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/MIA-accepted-deal-status-maker-cannot-resubmit-until-confirmed-all-issued-facilities-cover-start-date/MIA-deal-with-accepted-status-issued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/MIA-accepted-deal-status-maker-cannot-resubmit-until-confirmed-all-issued-facilities-cover-start-date/MIA-deal-with-accepted-status-issued-facilities.js
@@ -8,8 +8,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test',
   additionalRefName: 'testing',
+  status: 'Accepted by UKEF (with conditions)',
+  previousStatus: "Ready for Checker's approval",
   details: {
-    status: 'Accepted by UKEF (with conditions)',
     createdDate: now,
     maker: {
       username: 'MAKER',
@@ -39,7 +40,6 @@ const deal = {
         'checker@ukexportfinance.gov.uk',
       ],
     },
-    previousStatus: "Ready for Checker's approval",
     checker: {
       bank: {
         id: '9',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/fixtures/MIA-deal-with-accepted-status-issued-facilities-cover-start-date-in-past.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/fixtures/MIA-deal-with-accepted-status-issued-facilities-cover-start-date-in-past.js
@@ -10,8 +10,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test',
   additionalRefName: 'testing',
+  status: 'Accepted by UKEF (with conditions)',
+  previousStatus: "Ready for Checker's approval",
   details: {
-    status: 'Accepted by UKEF (with conditions)',
     createdDate: now,
     maker: {
       username: 'MAKER',
@@ -41,7 +42,6 @@ const deal = {
         'checker@ukexportfinance.gov.uk',
       ],
     },
-    previousStatus: "Ready for Checker's approval",
     checker: {
       bank: {
         id: '9',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/fixtures/MIA-draft-deal-with-issued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/fixtures/MIA-draft-deal-with-issued-facilities.js
@@ -8,8 +8,8 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'TEST-DEAL',
   additionalRefName: 'TEST-DEAL',
+  status: 'Draft',
   details: {
-    status: 'Draft',
     created: now,
     maker: {
       username: 'MAKER',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-can-edit-issued-facilities-after-checker-returns-to-maker-after-submit-to-ukef/MIA-deal-submitted-to-ukef-with-issued-facilities-after-checker-returned-to-maker.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-can-edit-issued-facilities-after-checker-returns-to-maker-after-submit-to-ukef/MIA-deal-submitted-to-ukef-with-issued-facilities-after-checker-returned-to-maker.js
@@ -10,8 +10,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test',
   additionalRefName: 'testing',
+  status: 'Further Maker\'s input required',
+  previousStatus: 'Ready for Checker's approval',
   details: {
-    status: "Further Maker's input required",
     maker: {
       username: 'MAKER',
       roles: [
@@ -41,7 +42,6 @@ const deal = {
       ],
     },
     created: '1599048723110',
-    previousStatus: "Ready for Checker's approval",
     checker: {
       bank: {
         id: '9',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-can-edit-issued-facilities-after-checker-returns-to-maker-after-submit-to-ukef/MIA-deal-submitted-to-ukef-with-issued-facilities-after-checker-returned-to-maker.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-can-edit-issued-facilities-after-checker-returns-to-maker-after-submit-to-ukef/MIA-deal-submitted-to-ukef-with-issued-facilities-after-checker-returned-to-maker.js
@@ -11,7 +11,7 @@ const deal = {
   bankInternalRefName: 'test',
   additionalRefName: 'testing',
   status: 'Further Maker\'s input required',
-  previousStatus: 'Ready for Checker's approval',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
     maker: {
       username: 'MAKER',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-cannot-edit-issued-facilities-after-submit-to-ukef/deal-multiple-facility-types-ready-to-submit-to-ukef.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-cannot-edit-issued-facilities-after-submit-to-ukef/deal-multiple-facility-types-ready-to-submit-to-ukef.js
@@ -7,8 +7,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test',
   additionalRefName: 'test',
+  status: "Ready for Checker's approval",
+  previousStatus: 'Draft',
   details: {
-    status: "Ready for Checker's approval",
     created: '1598021253917',
     maker: {
       username: 'MAKER',
@@ -38,7 +39,6 @@ const deal = {
         'checker@ukexportfinance.gov.uk',
       ],
     },
-    previousStatus: 'Draft',
   },
   eligibility: {
     status: 'Completed',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/fixtures/dealFullyCompleted.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/fixtures/dealFullyCompleted.js
@@ -9,10 +9,8 @@ const deal = {
   updatedAt: Date.now(),
   additionalRefName: 'mock name',
   bankInternalRefName: 'mock id',
-  details: {
-    status: 'Ready for Checker\'s approval',
-    previousStatus: 'Draft',
-  },
+  status: 'Ready for Checker\'s approval',
+  previousStatus: 'Draft',
   comments: [{
     username: 'bananaman',
     timestamp: '1984/12/25 00:00:00:001',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/loan/delete-a-loan.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/loan/delete-a-loan.spec.js
@@ -11,9 +11,8 @@ const now = new Date().valueOf();
 const MOCK_DEAL = {
   bankInternalRefName: 'someDealId',
   additionalRefName: 'someDealName',
-  details: {
-    status: 'Draft',
-  },
+  status: 'Draft',
+  details: {},
   submissionDetails: {
     supplyContractCurrency: {
       id: 'GBP',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
@@ -8,8 +8,8 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'mock id',
   additionalRefName: 'mock name',
+  status: 'Draft',
   details: {
-    status: 'Draft',
     created: now,
     owningBank: {
       id: '9',

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealThatJustNeedsConversionDate.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealThatJustNeedsConversionDate.json
@@ -2,8 +2,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteAbout.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteAbout.json
@@ -2,8 +2,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
     "details": {
-      "status": "Draft",
       "owningBank": {
         "id": "9",
         "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteBonds.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteBonds.json
@@ -2,8 +2,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-3-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
     "details": {
-      "status": "Draft",
       "owningBank": {
         "id": "9",
         "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteEligibility.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteEligibility.json
@@ -2,8 +2,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteLoans.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteLoans.json
@@ -2,8 +2,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-3-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "9",
       "name": "UKEF test bank (Delegated)",

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/dealWithNotStartedFacilityStatuses.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/dealWithNotStartedFacilityStatuses.js
@@ -5,8 +5,8 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'mock id',
   additionalRefName: 'mock name',
+  status: 'Acknowledged by UKEF',
   details: {
-    status: 'Acknowledged by UKEF',
     created: now,
     previousWorkflowStatus: 'Draft',
     submissionDate: now,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-MIN-deal-with-issued-facilities-for-review-without-cover-start-dates/MINDealWithNotStartedFacilityStatuses.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-MIN-deal-with-issued-facilities-for-review-without-cover-start-dates/MINDealWithNotStartedFacilityStatuses.js
@@ -5,8 +5,8 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'mock id',
   additionalRefName: 'mock name',
+  status: 'Acknowledged by UKEF',
   details: {
-    status: 'Acknowledged by UKEF',
     created: now,
     previousWorkflowStatus: 'Draft',
     submissionDate: now,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-issued-facilities-for-review-deal-status-approved-with-conditions.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-issued-facilities-for-review-deal-status-approved-with-conditions.spec.js
@@ -9,10 +9,7 @@ const MAKER_LOGIN = mockUsers.find((user) => (user.roles.includes('maker') && us
 
 const dealWithStatus = {
   ...dealWithNotStartedFacilityStatuses,
-  details: {
-    ...dealWithNotStartedFacilityStatuses.details,
-    status: 'Accepted by UKEF (with conditions)',
-  },
+  status: 'Accepted by UKEF (with conditions)',
 };
 
 context('A maker can issue and submit issued bond & loan facilities with a deal in `Accepted by UKEF (with conditions)` status', () => {

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-issued-facilities-for-review-deal-status-approved-without-conditions.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-issued-facilities-for-review-deal-status-approved-without-conditions.spec.js
@@ -9,10 +9,7 @@ const MAKER_LOGIN = mockUsers.find((user) => (user.roles.includes('maker') && us
 
 const dealWithStatus = {
   ...dealWithNotStartedFacilityStatuses,
-  details: {
-    ...dealWithNotStartedFacilityStatuses.details,
-    status: 'Accepted by UKEF (without conditions)',
-  },
+  status: 'Accepted by UKEF (without conditions)',
 };
 
 context('A maker can issue and submit issued bond & loan facilities with a deal in `Accepted by UKEF (without conditions)` status', () => {

--- a/e2e-tests/portal/cypress/integration/journeys/maker/xss.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/xss.spec.js
@@ -11,7 +11,7 @@ context('Input is cleaned to avoid Cross Site Scripting', () => {
   let deal;
 
   before(() => {
-    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.details.status)[0];
+    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.status)[0];
 
     cy.deleteDeals(MAKER_LOGIN);
     cy.insertOneDeal(aDealInStatus('Draft'), MAKER_LOGIN)

--- a/e2e-tests/portal/cypress/integration/journeys/number-generator/test-data/MIA-deal-ready-to-submit-with-already-submitted-issued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/number-generator/test-data/MIA-deal-ready-to-submit-with-already-submitted-issued-facilities.js
@@ -6,8 +6,9 @@ const deal = {
   updatedAt: Date.now(),
   bankInternalRefName: 'test-deal',
   additionalRefName: 'test-deal',
+  status: 'Ready for Checker\'s approval',
+  previousStatus: 'Draft',
   details: {
-    status: "Ready for Checker's approval",
     created: now,
     maker: {
       username: 'MAKER',
@@ -37,7 +38,6 @@ const deal = {
         'checker@ukexportfinance.gov.uk',
       ],
     },
-    previousStatus: 'Draft',
   },
   eligibility: {
     status: 'Completed',

--- a/e2e-tests/portal/cypress/integration/journeys/number-generator/test-data/template.json
+++ b/e2e-tests/portal/cypress/integration/journeys/number-generator/test-data/template.json
@@ -2,9 +2,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Ready for Checker's approval",
+  "previousStatus": "Draft",
   "details": {
-    "status": "Ready for Checker's approval",
-    "previousStatus": "Draft",
     "previousWorkflowStatus": "Draft",
     "owningBank": {
       "id": "9",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/fixtures/deal.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/fixtures/deal.js
@@ -3,10 +3,10 @@ const MOCK_DEAL = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/test-data/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/test-data/dealThatJustNeedsDates.json
@@ -3,8 +3,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-non-gbp-facilities/test-data/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-non-gbp-facilities/test-data/dealThatJustNeedsDates.json
@@ -3,8 +3,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-unissued-facilities-and-resubmit-as-issued/submit-deal-with-unissued-bond-and-resubmit-as-issued/test-data/dealThatJustNeedsConversionDate.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-unissued-facilities-and-resubmit-as-issued/submit-deal-with-unissued-bond-and-resubmit-as-issued/test-data/dealThatJustNeedsConversionDate.json
@@ -3,8 +3,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-unissued-facilities-and-resubmit-as-issued/submit-deal-with-unissued-loan-and-resubmit-as-issued/test-data/dealThatJustNeedsConversionDate.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-unissued-facilities-and-resubmit-as-issued/submit-deal-with-unissued-loan-and-resubmit-as-issued/test-data/dealThatJustNeedsConversionDate.json
@@ -3,8 +3,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/AIN-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/AIN-deal/dealThatJustNeedsDates.json
@@ -3,8 +3,8 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIA-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIA-deal/dealThatJustNeedsDates.json
@@ -3,8 +3,8 @@
   "submissionType": "Manual Inclusion Application",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal-unissued-facilities/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal-unissued-facilities/dealThatJustNeedsDates.json
@@ -3,8 +3,8 @@
   "submissionType": "Manual Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal/dealThatJustNeedsDates.json
@@ -3,8 +3,8 @@
   "submissionType": "Manual Inclusion Notice",
   "bankInternalRefName": "abc-1-def",
   "additionalRefName": "Tibettan submarine acquisition scheme",
+  "status": "Draft",
   "details": {
-    "status": "Draft",
     "owningBank": {
       "id": "956",
       "name": "Barclays Bank",

--- a/e2e-tests/trade-finance-manager/cypress/fixtures/create-mock-deal.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/create-mock-deal.js
@@ -10,7 +10,7 @@ const createMockDeal = (overrides) => {
     facilities = overrides.mockFacilities;
   }
 
-  if (overrides.details.submissionDate) {
+  if (overrides?.details?.submissionDate) {
     submissionDate = overrides.details.submissionDate;
   }
 

--- a/e2e-tests/trade-finance-manager/cypress/fixtures/deal-AIN.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/deal-AIN.js
@@ -3,10 +3,10 @@ const MOCK_DEAL = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/e2e-tests/trade-finance-manager/cypress/fixtures/deal-MIA.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/deal-MIA.js
@@ -3,10 +3,10 @@ const MOCK_DEAL = {
   submissionType: 'Manual Inclusion Application',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s Approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
-    previousStatus: 'Ready for Checker\'s Approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -14,25 +14,24 @@ context('User can view and filter multiple deals', () => {
   let ALL_FACILITIES = [];
 
   const DEAL_WITH_TEST_SUPPLIER_NAME = createMockDeal({
-    'Submitted',
+    status: 'Submitted',
     submissionDetails: { 'supplier-name': 'MY-SUPPLIER' },
   });
 
   const DEAL_WITH_TEST_MIN_SUBMISSION_TYPE = createMockDeal({
     submissionType: 'Manual Inclusion Notice',
     status: 'Submitted',
-    },
   });
 
   const DEAL_WITH_TEST_BUYER_NAME = createMockDeal({
-    'Submitted',
+    status: 'Submitted',
     submissionDetails: { 'buyer-name': 'MY-BUYER' },
   });
 
   const DEAL_WITH_TEST_MIA_SUBMISSION_TYPE = createMockDeal({
+    status: 'Submitted',
     submissionType: 'Manual Inclusion Application',
     testId: 'DEAL_WITH_TEST_MIA_SUBMISSION_TYPE',
-    status: 'Submitted',
   });
 
   const DEAL_WITH_ONLY_1_FACILITY_BOND = createMockDeal({

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -50,9 +50,17 @@ context('User can view and filter multiple deals', () => {
 
   const yesterday = nowPlusDays(-1);
 
+  // NOTE: searching by date queries multiple fields.
+  // Therefore we need to set all of these fields to yesterday.
   const DEAL_SUBMITTED_YESTERDAY = createMockDeal({
     testId: 'DEAL_SUBMITTED_YESTERDAY',
-    submissionDate: yesterday.valueOf().toString(),
+    details: {
+      submissionDate: yesterday.valueOf().toString(),
+    },
+    eligibility: {
+      lastUpdated: yesterday.valueOf().toString(),
+    },
+    facilitiesUpdated: yesterday.valueOf().toString(),
   });
 
   const MOCK_DEALS = [

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -14,43 +14,36 @@ context('User can view and filter multiple deals', () => {
   let ALL_FACILITIES = [];
 
   const DEAL_WITH_TEST_SUPPLIER_NAME = createMockDeal({
-    details: { status: 'Submitted' },
+    'Submitted',
     submissionDetails: { 'supplier-name': 'MY-SUPPLIER' },
   });
 
   const DEAL_WITH_TEST_MIN_SUBMISSION_TYPE = createMockDeal({
     submissionType: 'Manual Inclusion Notice',
-    details: {
-      status: 'Submitted',
+    status: 'Submitted',
     },
   });
 
   const DEAL_WITH_TEST_BUYER_NAME = createMockDeal({
-    details: { status: 'Submitted' },
+    'Submitted',
     submissionDetails: { 'buyer-name': 'MY-BUYER' },
   });
 
   const DEAL_WITH_TEST_MIA_SUBMISSION_TYPE = createMockDeal({
     submissionType: 'Manual Inclusion Application',
-    details: {
-      testId: 'DEAL_WITH_TEST_MIA_SUBMISSION_TYPE',
-      status: 'Submitted',
-    },
+    testId: 'DEAL_WITH_TEST_MIA_SUBMISSION_TYPE',
+    status: 'Submitted',
   });
 
   const DEAL_WITH_ONLY_1_FACILITY_BOND = createMockDeal({
-    details: {
-      testId: 'DEAL_WITH_ONLY_1_FACILITY_BOND',
-    },
+    testId: 'DEAL_WITH_ONLY_1_FACILITY_BOND',
     mockFacilities: [
       MOCK_DEAL_AIN.mockFacilities.find((f) => f.facilityType === 'bond'),
     ],
   });
 
   const DEAL_WITH_ONLY_1_FACILITY_LOAN = createMockDeal({
-    details: {
-      testId: 'DEAL_WITH_ONLY_1_FACILITY_LOAN',
-    },
+    testId: 'DEAL_WITH_ONLY_1_FACILITY_LOAN',
     mockFacilities: [
       MOCK_DEAL_AIN.mockFacilities.find((f) => f.facilityType === 'loan'),
     ],
@@ -59,10 +52,8 @@ context('User can view and filter multiple deals', () => {
   const yesterday = nowPlusDays(-1);
 
   const DEAL_SUBMITTED_YESTERDAY = createMockDeal({
-    details: {
-      testId: 'DEAL_SUBMITTED_YESTERDAY',
-      submissionDate: yesterday.valueOf().toString(),
-    },
+    testId: 'DEAL_SUBMITTED_YESTERDAY',
+    submissionDate: yesterday.valueOf().toString(),
   });
 
   const MOCK_DEALS = [
@@ -207,7 +198,7 @@ context('User can view and filter multiple deals', () => {
     // all other deals used in this e2e spec are either AIN or MIN deals.
 
     const submittedMiaDeal = ALL_SUBMITTED_DEALS.find((deal) =>
-      deal.dealSnapshot.details.testId === 'DEAL_WITH_TEST_MIA_SUBMISSION_TYPE'
+      deal.dealSnapshot.testId === 'DEAL_WITH_TEST_MIA_SUBMISSION_TYPE'
       && deal.tfm.stage === 'Application');
 
     const searchString = submittedMiaDeal.tfm.stage;
@@ -264,7 +255,7 @@ context('User can view and filter multiple deals', () => {
 
     const searchString = todayFormatted;
 
-    const ALL_DEALS_SUBMITTED_TODAY = MOCK_DEALS.filter((deal) => deal.details.testId !== 'DEAL_SUBMITTED_YESTERDAY');
+    const ALL_DEALS_SUBMITTED_TODAY = MOCK_DEALS.filter((deal) => deal.testId !== 'DEAL_SUBMITTED_YESTERDAY');
 
     const expectedResultsLength = ALL_DEALS_SUBMITTED_TODAY.length;
 
@@ -284,7 +275,7 @@ context('User can view and filter multiple deals', () => {
     const searchString = todayFormatted;
 
     const ALL_DEALS_SUBMITTED_TODAY = MOCK_DEALS.filter((deal) =>
-      deal.details.testId !== 'DEAL_SUBMITTED_YESTERDAY');
+      deal.testId !== 'DEAL_SUBMITTED_YESTERDAY');
 
     const expectedResultsLength = ALL_DEALS_SUBMITTED_TODAY.length;
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-buyer.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-buyer.spec.js
@@ -11,18 +11,14 @@ context('User can view and sort deals by buyer', () => {
   let dealBuyerB;
 
   const DEAL_BUYER_A = createMockDeal({
-    details: {
-      testId: 'DEAL_BUYER_A',
-    },
+    testId: 'DEAL_BUYER_A',
     submissionDetails: {
       'buyer-name': 'BUYER A',
     },
   });
 
   const DEAL_BUYER_B = createMockDeal({
-    details: {
-      testId: 'DEAL_BUYER_B',
-    },
+    testId: 'DEAL_BUYER_B',
     submissionDetails: {
       'buyer-name': 'BUYER B',
     },
@@ -56,10 +52,10 @@ context('User can view and sort deals by buyer', () => {
           ALL_SUBMITTED_DEALS = submittedDeals;
 
           dealBuyerA = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_BUYER_A.details.testId);
+            deal.dealSnapshot.testId === DEAL_BUYER_A.testId);
 
           dealBuyerB = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_BUYER_B.details.testId);
+            deal.dealSnapshot.testId === DEAL_BUYER_B.testId);
         });
       });
   });

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-exporter.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-exporter.spec.js
@@ -14,15 +14,11 @@ context('User can view and sort deals by exporter', () => {
 
   // Exporter (called supplier-name in a BSS deal), is generated automatically with mock data and deal ID.
   const DEAL_A_SUPPLIER = createMockDeal({
-    details: {
-      testId: 'DEAL_A_SUPPLIER',
-    },
+    testId: 'DEAL_A_SUPPLIER',
   });
 
   const DEAL_B_SUPPLIER = createMockDeal({
-    details: {
-      testId: 'DEAL_B_SUPPLIER',
-    },
+    testId: 'DEAL_B_SUPPLIER',
   });
 
   const MOCK_DEALS = [

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-product.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-product.spec.js
@@ -13,27 +13,21 @@ context('User can view and sort deals by product', () => {
   let dealWith1LoanAndBondFacilities;
 
   const DEAL_WITH_ONLY_1_FACILITY_BOND = createMockDeal({
-    details: {
-      testId: 'DEAL_WITH_ONLY_1_FACILITY_BOND',
-    },
+    testId: 'DEAL_WITH_ONLY_1_FACILITY_BOND',
     mockFacilities: [
       MOCK_DEAL_AIN.mockFacilities.find((f) => f.facilityType === 'bond'),
     ],
   });
 
   const DEAL_WITH_ONLY_1_FACILITY_LOAN = createMockDeal({
-    details: {
-      testId: 'DEAL_WITH_ONLY_1_FACILITY_LOAN',
-    },
+    testId: 'DEAL_WITH_ONLY_1_FACILITY_LOAN',
     mockFacilities: [
       MOCK_DEAL_AIN.mockFacilities.find((f) => f.facilityType === 'loan'),
     ],
   });
 
   const DEAL_WITH_1_LOAN_AND_BOND_FACILITIES = createMockDeal({
-    details: {
-      testId: 'DEAL_WITH_1_LOAN_AND_BOND_FACILITIES',
-    },
+    testId: 'DEAL_WITH_1_LOAN_AND_BOND_FACILITIES',
     mockFacilities: MOCK_DEAL_AIN.mockFacilities,
   });
 
@@ -66,13 +60,13 @@ context('User can view and sort deals by product', () => {
           ALL_SUBMITTED_DEALS = submittedDeals;
 
           dealWith1FacilityBond = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_WITH_ONLY_1_FACILITY_BOND.details.testId);
+            deal.dealSnapshot.testId === DEAL_WITH_ONLY_1_FACILITY_BOND.testId);
 
           dealWith1FacilityLoan = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_WITH_ONLY_1_FACILITY_LOAN.details.testId);
+            deal.dealSnapshot.testId === DEAL_WITH_ONLY_1_FACILITY_LOAN.testId);
 
           dealWith1LoanAndBondFacilities = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_WITH_1_LOAN_AND_BOND_FACILITIES.details.testId);
+            deal.dealSnapshot.testId === DEAL_WITH_1_LOAN_AND_BOND_FACILITIES.testId);
         });
       });
   });

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-stage.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-stage.spec.js
@@ -12,17 +12,13 @@ context('User can view and sort deals by stage', () => {
   let dealApplication;
 
   const DEAL_CONFIRMED = createMockDeal({
-    details: {
-      testId: 'DEAL_CONFIRMED',
-    },
+    testId: 'DEAL_CONFIRMED',
     mockFacilities: MOCK_DEAL_AIN.mockFacilities,
   });
 
   const DEAL_APPLICATION = createMockDeal({
     submissionType: 'Manual Inclusion Application',
-    details: {
-      testId: 'DEAL_APPLICATION',
-    },
+    testId: 'DEAL_APPLICATION',
     mockFacilities: MOCK_DEAL_AIN.mockFacilities,
   });
 
@@ -54,10 +50,10 @@ context('User can view and sort deals by stage', () => {
           ALL_SUBMITTED_DEALS = submittedDeals;
 
           dealConfirmed = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_CONFIRMED.details.testId);
+            deal.dealSnapshot.testId === DEAL_CONFIRMED.testId);
 
           dealApplication = ALL_SUBMITTED_DEALS.find((deal) =>
-            deal.dealSnapshot.details.testId === DEAL_APPLICATION.details.testId);
+            deal.dealSnapshot.testId === DEAL_APPLICATION.testId);
         });
       });
   });

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-ukefDealId.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-sort-by-ukefDealId.spec.js
@@ -18,15 +18,11 @@ context('User can view and sort deals by ukefDealId', () => {
   const yesterday = nowPlusDays(-1);
 
   const DEAL_1 = createMockDeal({
-    details: {
-      submissionDate: twoDaysAgo.valueOf().toString(),
-    },
+    submissionDate: twoDaysAgo.valueOf().toString(),
   });
 
   const DEAL_2 = createMockDeal({
-    details: {
-      submissionDate: yesterday.valueOf().toString(),
-    },
+    submissionDate: yesterday.valueOf().toString(),
   });
 
   const MOCK_DEALS = [

--- a/gef-ui/server/controllers/companies-house/index.js
+++ b/gef-ui/server/controllers/companies-house/index.js
@@ -43,7 +43,7 @@ const validateCompaniesHouse = async (req, res) => {
       companiesHouseDetails = await api.getCompaniesHouseDetails(regNumber);
     }
 
-    if (companiesHouseDetails && companiesHouseDetails.status === 422) {
+    if (companiesHouseDetails && companiesHousestatus === 422) {
       companiesHouseDetails.data.forEach((error) => {
         companiesHouseErrors.push(error);
       });

--- a/gef-ui/server/controllers/companies-house/index.js
+++ b/gef-ui/server/controllers/companies-house/index.js
@@ -43,7 +43,7 @@ const validateCompaniesHouse = async (req, res) => {
       companiesHouseDetails = await api.getCompaniesHouseDetails(regNumber);
     }
 
-    if (companiesHouseDetails && companiesHousestatus === 422) {
+    if (companiesHouseDetails && companiesHouseDetails.status === 422) {
       companiesHouseDetails.data.forEach((error) => {
         companiesHouseErrors.push(error);
       });

--- a/portal-api/api-tests/fixtures/deal-fully-completed.js
+++ b/portal-api/api-tests/fixtures/deal-fully-completed.js
@@ -5,9 +5,9 @@ const deal = {
   updatedAt: Date.now(),
   additionalRefName: 'mock name',
   bankInternalRefName: 'mock id',
+  status: 'Ready for Checker\'s approval',
+  previousStatus: 'Draft',
   details: {
-    status: "Ready for Checker's approval",
-    previousStatus: 'Draft',
     previousWorkflowStatus: 'Draft',
     checker: {
       username: 'test1',

--- a/portal-api/api-tests/graphql/queries/query-all-deals.api-test.js
+++ b/portal-api/api-tests/graphql/queries/query-all-deals.api-test.js
@@ -285,14 +285,14 @@ describe('/graphql query deals', () => {
   describe('/graphql list deals filters', () => {
     it('returns a list of deals, ordered by "updated", filtered by equal filters', async () => {
       const deals = [
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Submitted' },  additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Submitted',  additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
       ];
 
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');
@@ -323,14 +323,14 @@ describe('/graphql query deals', () => {
 
     it('returns a list of deals, ordered by "updated", paginated and filtered by equal filters', async () => {
       const deals = [
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Submitted' }, additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Submitted', additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
       ];
 
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');
@@ -357,14 +357,14 @@ describe('/graphql query deals', () => {
 
     it('returns a list of deals, ordered by "updated", filtered by not equal filter', async () => {
       const deals = [
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Submitted' }, additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Submitted', additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
       ];
 
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');

--- a/portal-api/api-tests/graphql/queries/query-deals.api-test.js
+++ b/portal-api/api-tests/graphql/queries/query-deals.api-test.js
@@ -66,9 +66,7 @@ query {
       updatedAt
       additionalRefName
       bankInternalRefName
-      details {
-        status
-      }
+      status
     }
   }
 }`;
@@ -85,9 +83,7 @@ query {
       updatedAt
       additionalRefName
       bankInternalRefName
-      details {
-        status
-      }
+      status
     }
   }
 }`;
@@ -104,9 +100,7 @@ query {
       updatedAt
       additionalRefName
       bankInternalRefName
-      details {
-        status
-      }
+      status
     }
   }
 }`;
@@ -348,8 +342,8 @@ describe('/graphql query deals', () => {
       expect(body.data.deals.status.code).toEqual(200);
 
       // expect deals of 2nd page in reverse order; most recent first..
-      expect(body.data.deals.deals[0].details).toMatchObject(deals[3].details);
-      expect(body.data.deals.deals[1].details).toMatchObject(deals[2].details);
+      expect(body.data.deals.deals[0]).toMatchObject(deals[3]);
+      expect(body.data.deals.deals[1]).toMatchObject(deals[2]);
 
       expect(body.data.deals.count).toEqual(5);
     });

--- a/portal-api/api-tests/graphql/queries/query-deals.api-test.js
+++ b/portal-api/api-tests/graphql/queries/query-deals.api-test.js
@@ -287,14 +287,14 @@ describe('/graphql query deals', () => {
   describe('/graphql list deals filters', () => {
     it('returns a list of deals, ordered by "updated", filtered by equal filters', async () => {
       const deals = [
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Submitted' }, additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Submitted', additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
       ];
 
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');
@@ -323,14 +323,14 @@ describe('/graphql query deals', () => {
 
     it('returns a list of deals, ordered by "updated", paginated and filtered by equal filters', async () => {
       const deals = [
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Submitted' }, additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Submitted', additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
       ];
 
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');
@@ -356,14 +356,14 @@ describe('/graphql query deals', () => {
 
     it('returns a list of deals, ordered by "updated", filtered by not equal filter', async () => {
       const deals = [
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Submitted' }, additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Draft' }, additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
-        aDeal({ details: { status: 'Acknowledged by UKEF' }, additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-2', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-3', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Submitted', additionalRefName: 'bank1-4', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Draft', additionalRefName: 'bank1-5', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-0', bankInternalRefName: 'mockSupplyContractId' }),
+        aDeal({ status: 'Acknowledged by UKEF', additionalRefName: 'bank2-1', bankInternalRefName: 'mockSupplyContractId' }),
       ];
 
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');

--- a/portal-api/api-tests/graphql/queries/query-deals.api-test.js
+++ b/portal-api/api-tests/graphql/queries/query-deals.api-test.js
@@ -56,7 +56,7 @@ query {
 
 const dealsFilterStatusQuery = `
 query {
-  deals(params: { filters: [{ field: "details.status", value: "Draft"}]}) {
+  deals(params: { filters: [{ field: "status", value: "Draft"}]}) {
     status {
       code
     }
@@ -75,7 +75,7 @@ query {
 
 const dealsFilterStatusPaginatedQuery = `
 query {
-  deals(params: {  start:1, pagesize: 2, filters: [{ field: "details.status", value: "Draft"}]}) {
+  deals(params: {  start:1, pagesize: 2, filters: [{ field: "status", value: "Draft"}]}) {
     status {
       code
     }
@@ -94,7 +94,7 @@ query {
 
 const dealsFilterNotStatusQuery = `
 query {
-  deals(params: { filters: [{ field: "details.status", value: "Draft", operator: "ne"}]}) {
+  deals(params: { filters: [{ field: "status", value: "Draft", operator: "ne"}]}) {
     status {
       code
     }

--- a/portal-api/api-tests/v1/bonds/bond-change-cover-start-date-validation.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bond-change-cover-start-date-validation.api-test.js
@@ -12,8 +12,8 @@ describe('/v1/deals/:id/bond/:bondId/change-cover-start-date', () => {
     submissionType: 'Manual Inclusion Notice',
     additionalRefName: 'mock name',
     bankInternalRefName: 'mock id',
+    status: 'Acknowledged by UKEF',
     details: {
-      status: 'Acknowledged by UKEF',
       submissionDate: moment().utc().valueOf(),
     },
     submissionDetails: {
@@ -182,12 +182,12 @@ describe('/v1/deals/:id/bond/:bondId/change-cover-start-date', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Application',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
               manualInclusionApplicationSubmissionDate: moment().subtract(3, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 
@@ -272,11 +272,11 @@ describe('/v1/deals/:id/bond/:bondId/change-cover-start-date', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Notice',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 

--- a/portal-api/api-tests/v1/bonds/bond-issue-facility-validation.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bond-issue-facility-validation.api-test.js
@@ -14,8 +14,8 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
     submissionType: 'Manual Inclusion Notice',
     additionalRefName: 'mock name',
     bankInternalRefName: 'mock id',
+    status: 'Acknowledged by UKEF',
     details: {
-      status: 'Acknowledged by UKEF',
       submissionDate: moment(submissionDate).utc().valueOf(),
     },
     submissionDetails: {
@@ -268,11 +268,11 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Application',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 
@@ -357,11 +357,11 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Notice',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 

--- a/portal-api/api-tests/v1/bonds/bond-issue-facility.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bond-issue-facility.api-test.js
@@ -10,9 +10,9 @@ describe('/v1/deals/:id/bond/:id/issue-facility', () => {
     submissionType: 'Manual Inclusion Notice',
     additionalRefName: 'mock name',
     bankInternalRefName: 'mock id',
+    status: 'Ready for Checker\'s approval',
     details: {
       submissionDate: moment().subtract(1, 'day').utc().valueOf(),
-      status: 'Ready for Checker\'s approval',
     },
     submissionDetails: {
       supplyContractCurrency: {

--- a/portal-api/api-tests/v1/deals/deal-clone.api-test.js
+++ b/portal-api/api-tests/v1/deals/deal-clone.api-test.js
@@ -126,7 +126,7 @@ describe('/v1/deals/:id/clone', () => {
         expect(cloned.deal.details.maker._id).toEqual(aBarclaysMaker._id);
 
         expect(cloned.deal.details.owningBank).toEqual(aBarclaysMaker.bank);
-        expect(cloned.deal.details.status).toEqual('Draft');
+        expect(cloned.deal.status).toEqual('Draft');
         expect(cloned.deal.editedBy).toEqual([]);
         expect(cloned.deal.comments).toEqual([]);
         expect(cloned.deal.ukefComments).toEqual([]);

--- a/portal-api/api-tests/v1/deals/deal-name.api-test.js
+++ b/portal-api/api-tests/v1/deals/deal-name.api-test.js
@@ -10,9 +10,7 @@ const newDeal = aDeal({
   updatedAt: Date.now(),
   additionalRefName: 'mock name',
   bankInternalRefName: 'mock id',
-  details: {
-    status: 'Draft',
-  },
+  status: 'Draft',
   comments: [{
     username: 'bananaman',
     timestamp: '1984/12/25 00:00:00:001',

--- a/portal-api/api-tests/v1/deals/deal-status-accepted.api-test.js
+++ b/portal-api/api-tests/v1/deals/deal-status-accepted.api-test.js
@@ -33,7 +33,7 @@ describe('PUT /v1/deals/:id/status - to `Accepted by UKEF`', () => {
     beforeEach(async () => {
       const minDeal = completedDeal;
       minDeal.details.manualInclusionNoticeSubmissionDate = moment().utc().valueOf();
-      minDeal.details.status = 'Acknowledged';
+      minDeal.status = 'Acknowledged';
 
       const postResult = await as(aBarclaysMaker).post(JSON.parse(JSON.stringify(minDeal))).to('/v1/deals');
 
@@ -63,7 +63,7 @@ describe('PUT /v1/deals/:id/status - to `Accepted by UKEF`', () => {
     beforeEach(async () => {
       const minDeal = completedDeal;
       minDeal.details.manualInclusionNoticeSubmissionDate = moment().utc().valueOf();
-      minDeal.details.status = 'Acknowledged';
+      minDeal.status = 'Acknowledged';
 
       const postResult = await as(aBarclaysMaker).post(JSON.parse(JSON.stringify(minDeal))).to('/v1/deals');
 

--- a/portal-api/api-tests/v1/deals/deals-status-accepted-facilities-cover-start-date.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status-accepted-facilities-cover-start-date.api-test.js
@@ -45,7 +45,7 @@ describe('PUT /v1/deals/:id/status - from `Accepted by UKEF` - facility cover st
     beforeEach(async () => {
       const minDeal = completedDeal;
       minDeal.details.manualInclusionNoticeSubmissionDate = moment().utc().valueOf();
-      minDeal.details.status = 'Accepted by UKEF (without conditions)';
+      minDeal.status = 'Accepted by UKEF (without conditions)';
 
       const postResult = await as(aBarclaysMaker).post(JSON.parse(JSON.stringify(minDeal))).to('/v1/deals');
 
@@ -122,7 +122,7 @@ describe('PUT /v1/deals/:id/status - from `Accepted by UKEF` - facility cover st
     beforeEach(async () => {
       const minDeal = completedDeal;
       minDeal.details.manualInclusionNoticeSubmissionDate = moment().utc().valueOf();
-      minDeal.details.status = 'Accepted by UKEF (with conditions)';
+      minDeal.status = 'Accepted by UKEF (with conditions)';
 
       const postResult = await as(aBarclaysMaker).post(JSON.parse(JSON.stringify(minDeal))).to('/v1/deals');
 

--- a/portal-api/api-tests/v1/deals/deals-status-facilities.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status-facilities.api-test.js
@@ -49,7 +49,7 @@ describe('/v1/deals/:id/status - facilities', () => {
       let createdFacilities;
 
       beforeEach(async () => {
-        completedDeal.details.status = 'Further Maker\'s input required';
+        completedDeal.status = 'Further Maker\'s input required';
         completedDeal.details.submissionDate = moment().utc().valueOf();
 
         const submittedDeal = JSON.parse(JSON.stringify(completedDeal));
@@ -499,7 +499,7 @@ describe('/v1/deals/:id/status - facilities', () => {
 
       beforeEach(async () => {
         const dealInDraftStatus = completedDeal;
-        dealInDraftStatus.details.status = 'Draft';
+        dealInDraftStatus.status = 'Draft';
 
         const deal = JSON.parse(JSON.stringify(dealInDraftStatus));
 

--- a/portal-api/api-tests/v1/deals/deals-status.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status.api-test.js
@@ -370,10 +370,7 @@ describe('/v1/deals/:id/status', () => {
     it("rejects 'Ready for Checker's approval' updates if no comment provided.", async () => {
       const draftDeal = {
         ...completedDeal,
-        details: {
-          ...completedDeal.details,
-          status: 'Draft',
-        },
+        status: 'Draft',
       };
 
       const postResult = await as(anHSBCMaker).post(draftDeal).to('/v1/deals');

--- a/portal-api/api-tests/v1/deals/deals-status.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status.api-test.js
@@ -150,7 +150,7 @@ describe('/v1/deals/:id/status', () => {
       const { status, body } = await as(anHSBCMaker).put(statusUpdate).to(`/v1/deals/${createdDeal._id}/status`);
 
       expect(status).toEqual(200);
-      expect(body.details.status).toEqual('Abandoned');
+      expect(body.status).toEqual('Abandoned');
     });
 
     it('updates the deal', async () => {
@@ -166,7 +166,7 @@ describe('/v1/deals/:id/status', () => {
       const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${createdDeal._id}`);
 
       expect(status).toEqual(200);
-      expect(body.deal.details.status).toEqual('Abandoned');
+      expect(body.deal.status).toEqual('Abandoned');
     });
 
     it('updates the deals updatedAt field', async () => {
@@ -185,7 +185,7 @@ describe('/v1/deals/:id/status', () => {
       expect(body.deal.updatedAt).not.toEqual(completedDeal.updatedAt);
     });
 
-    it('updates the deals.details.previousStatus field', async () => {
+    it('updates the deals.previousStatus field', async () => {
       const postResult = await as(anHSBCMaker).post(completedDeal).to('/v1/deals');
       const { body: createdDealBody } = await as(anHSBCMaker).get(`/v1/deals/${postResult.body._id}`);
       const createdDeal = createdDealBody.deal;
@@ -200,8 +200,8 @@ describe('/v1/deals/:id/status', () => {
       const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${createdDeal._id}`);
 
       expect(status).toEqual(200);
-      expect(body.deal.details.previousStatus).toEqual(createdDeal.details.status);
-      expect(body.deal.details.status).toEqual('Abandoned');
+      expect(body.deal.previousStatus).toEqual(createdDeal.status);
+      expect(body.deal.status).toEqual('Abandoned');
     });
 
     it('updates details.previousWorkflowStatus only when relevant workflow status changed', async () => {
@@ -227,17 +227,17 @@ describe('/v1/deals/:id/status', () => {
 
       const statusUpdate = {
         comments: 'Flee!',
-        status: completedDeal.details.status,
+        status: completedDeal.status,
       };
 
-      const expectedPreviousStatus = completedDeal.details.previousStatus;
+      const expectedPreviousStatus = completedDeal.previousStatus;
 
       await as(anHSBCMaker).put(statusUpdate).to(`/v1/deals/${dealId}/status`);
 
       const { body } = await as(anHSBCMaker).get(`/v1/deals/${dealId}`);
 
-      expect(body.deal.details.previousStatus).toEqual(expectedPreviousStatus);
-      expect(body.deal.details.status).toEqual(completedDeal.details.status);
+      expect(body.deal.previousStatus).toEqual(expectedPreviousStatus);
+      expect(body.deal.status).toEqual(completedDeal.status);
     });
 
     it('adds the comment to the existing comments', async () => {
@@ -310,7 +310,7 @@ describe('/v1/deals/:id/status', () => {
       const postResult = await as(anHSBCMaker).post(completedDeal).to('/v1/deals');
       const createdDeal = postResult.body;
       const statusUpdate = {
-        status: completedDeal.details.status,
+        status: completedDeal.status,
       };
 
       await as(anHSBCMaker).put(statusUpdate).to(`/v1/deals/${createdDeal._id}/status`);

--- a/portal-api/api-tests/v1/deals/deals-submission-details-validation.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details-validation.api-test.js
@@ -13,9 +13,7 @@ const newDeal = aDeal({
   updatedAt: Date.now(),
   additionalRefName: 'mock name',
   bankInternalRefName: 'mock id',
-  details: {
-    status: 'Draft',
-  },
+  status: 'Draft',
   comments: [{
     username: 'bananaman',
     timestamp: '1984/12/25 00:00:00:001',

--- a/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
@@ -230,7 +230,7 @@ describe('/v1/deals/:id/submission-details', () => {
         };
 
         const updatedSubmissionDetails = await as(anHSBCMaker).put(updateBody).to(`/v1/deals/${createdDeal._id}/submission-details`);
-        expect(updatedsubmissionDetails.status).toEqual(200);
+        expect(updatedSubmissionDetails.status).toEqual(200);
 
         const expectedCurrencyObj = { currencyId: 5, id: 'CAD', text: 'CAD - Canadian Dollars' };
 

--- a/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
@@ -198,7 +198,7 @@ describe('/v1/deals/:id/submission-details', () => {
         };
 
         const updatedSubmissionDetails = await as(anHSBCMaker).put(body).to(`/v1/deals/${createdDeal._id}/submission-details`);
-        expect(updatedSubmissionDetails.status).toEqual(200);
+        expect(updatedSubmissionstatus).toEqual(200);
 
         const expectedCountryObj = { name: 'Canada', code: 'CAN' };
 
@@ -232,7 +232,7 @@ describe('/v1/deals/:id/submission-details', () => {
         };
 
         const updatedSubmissionDetails = await as(anHSBCMaker).put(updateBody).to(`/v1/deals/${createdDeal._id}/submission-details`);
-        expect(updatedSubmissionDetails.status).toEqual(200);
+        expect(updatedSubmissionstatus).toEqual(200);
 
         const expectedCurrencyObj = { currencyId: 5, id: 'CAD', text: 'CAD - Canadian Dollars' };
 

--- a/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
@@ -196,7 +196,7 @@ describe('/v1/deals/:id/submission-details', () => {
         };
 
         const updatedSubmissionDetails = await as(anHSBCMaker).put(body).to(`/v1/deals/${createdDeal._id}/submission-details`);
-        expect(updatedSubmissionstatus).toEqual(200);
+        expect(updatedsubmissionDetails.status).toEqual(200);
 
         const expectedCountryObj = { name: 'Canada', code: 'CAN' };
 
@@ -230,7 +230,7 @@ describe('/v1/deals/:id/submission-details', () => {
         };
 
         const updatedSubmissionDetails = await as(anHSBCMaker).put(updateBody).to(`/v1/deals/${createdDeal._id}/submission-details`);
-        expect(updatedSubmissionstatus).toEqual(200);
+        expect(updatedsubmissionDetails.status).toEqual(200);
 
         const expectedCurrencyObj = { currencyId: 5, id: 'CAD', text: 'CAD - Canadian Dollars' };
 

--- a/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
@@ -196,7 +196,7 @@ describe('/v1/deals/:id/submission-details', () => {
         };
 
         const updatedSubmissionDetails = await as(anHSBCMaker).put(body).to(`/v1/deals/${createdDeal._id}/submission-details`);
-        expect(updatedsubmissionDetails.status).toEqual(200);
+        expect(updatedSubmissionDetails.status).toEqual(200);
 
         const expectedCountryObj = { name: 'Canada', code: 'CAN' };
 

--- a/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-submission-details.api-test.js
@@ -11,9 +11,7 @@ const newDeal = aDeal({
   updatedAt: Date.now(),
   additionalRefName: 'mock name',
   bankInternalRefName: 'mock id',
-  details: {
-    status: 'Draft',
-  },
+  status: 'Draft',
   comments: [{
     username: 'bananaman',
     timestamp: '1984/12/25 00:00:00:001',

--- a/portal-api/api-tests/v1/deals/deals.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals.api-test.js
@@ -106,24 +106,24 @@ describe('/v1/deals', () => {
       expect(body.deal).toEqual(expectAddedFields(newDeal));
     });
 
-    it('calculates deal.submissionDetails.status = Incomplete if there are validation failures', async () => {
+    it('calculates deal.submissionstatus = Incomplete if there are validation failures', async () => {
       const postResult = await as(anHSBCMaker).post(dealWithAboutIncomplete).to('/v1/deals');
       const newId = postResult.body._id;
 
       const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${newId}`);
 
       expect(status).toEqual(200);
-      expect(body.deal.submissionDetails.status).toEqual('Incomplete');
+      expect(body.deal.submissionstatus).toEqual('Incomplete');
     });
 
-    it('calculates deal.submissionDetails.status = Completed if there are no validation failures', async () => {
+    it('calculates deal.submissionstatus = Completed if there are no validation failures', async () => {
       const postResult = await as(anHSBCMaker).post(dealWithAboutComplete).to('/v1/deals');
       const newId = postResult.body._id;
 
       const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${newId}`);
 
       expect(status).toEqual(200);
-      expect(body.deal.submissionDetails.status).toEqual('Completed');
+      expect(body.deal.submissionstatus).toEqual('Completed');
     });
 
     it('returns a deal with calculated summary/totals object', async () => {

--- a/portal-api/api-tests/v1/deals/deals.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals.api-test.js
@@ -106,24 +106,24 @@ describe('/v1/deals', () => {
       expect(body.deal).toEqual(expectAddedFields(newDeal));
     });
 
-    it('calculates deal.submissionstatus = Incomplete if there are validation failures', async () => {
+    it('calculates deal.submissionDetails.status = Incomplete if there are validation failures', async () => {
       const postResult = await as(anHSBCMaker).post(dealWithAboutIncomplete).to('/v1/deals');
       const newId = postResult.body._id;
 
       const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${newId}`);
 
       expect(status).toEqual(200);
-      expect(body.deal.submissionstatus).toEqual('Incomplete');
+      expect(body.deal.submissionDetails.status).toEqual('Incomplete');
     });
 
-    it('calculates deal.submissionstatus = Completed if there are no validation failures', async () => {
+    it('calculates deal.submissionDetails.status = Completed if there are no validation failures', async () => {
       const postResult = await as(anHSBCMaker).post(dealWithAboutComplete).to('/v1/deals');
       const newId = postResult.body._id;
 
       const { status, body } = await as(anHSBCMaker).get(`/v1/deals/${newId}`);
 
       expect(status).toEqual(200);
-      expect(body.deal.submissionstatus).toEqual('Completed');
+      expect(body.deal.submissionDetails.status).toEqual('Completed');
     });
 
     it('returns a deal with calculated summary/totals object', async () => {

--- a/portal-api/api-tests/v1/deals/expectAddedFields.js
+++ b/portal-api/api-tests/v1/deals/expectAddedFields.js
@@ -9,6 +9,7 @@ const expectAddedFields = (obj) => {
 
   const expectation = expectMongoId({
     dealType: CONSTANTS.DEAL.DEAL_TYPE.BSS_EWCS,
+    status: 'Draft',
     eligibility: {
       status: 'Not started',
       criteria: expect.any(Array),
@@ -32,7 +33,6 @@ const expectAddedFields = (obj) => {
       created: expect.any(String),
       maker: expect.any(Object),
       owningBank: expect.any(Object),
-      status: 'Draft',
     },
     editedBy: [],
     exporter: {},

--- a/portal-api/api-tests/v1/loan/loan-change-cover-start-date-validation.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan-change-cover-start-date-validation.api-test.js
@@ -12,8 +12,8 @@ describe('/v1/deals/:id/loan/:loanId', () => {
     submissionType: 'Manual Inclusion Notice',
     additionalRefName: 'mock name',
     bankInternalRefName: 'mock id',
+    status: 'Acknowledged by UKEF',
     details: {
-      status: 'Acknowledged by UKEF',
       submissionDate: moment().utc().valueOf(),
     },
     submissionDetails: {
@@ -182,11 +182,11 @@ describe('/v1/deals/:id/loan/:loanId', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Application',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 
@@ -271,11 +271,11 @@ describe('/v1/deals/:id/loan/:loanId', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Notice',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 

--- a/portal-api/api-tests/v1/loan/loan-issue-facility-validation.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan-issue-facility-validation.api-test.js
@@ -14,8 +14,8 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
     submissionType: 'Manual Inclusion Notice',
     additionalRefName: 'mock name',
     bankInternalRefName: 'mock id',
+    status: 'Acknowledged by UKEF',
     details: {
-      status: 'Acknowledged by UKEF',
       submissionDate: moment(submissionDate).utc().valueOf(),
     },
     submissionDetails: {
@@ -272,11 +272,11 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Application',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 
@@ -361,11 +361,11 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
           updatedDeal = {
             ...newDeal,
             submissionType: 'Manual Inclusion Notice',
+            status: 'Accepted by UKEF (without conditions)',
             details: {
               ...newDeal.details,
               submissionDate: moment().subtract(1, 'week').utc().valueOf(),
               manualInclusionNoticeSubmissionDate: moment().subtract(2, 'day').utc().valueOf(),
-              status: 'Accepted by UKEF (without conditions)',
             },
           };
 

--- a/portal-api/api-tests/v1/loan/loan-issue-facility.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan-issue-facility.api-test.js
@@ -10,9 +10,9 @@ describe('/v1/deals/:id/loan/:id/issue-facility', () => {
     submissionType: 'Manual Inclusion Notice',
     additionalRefName: 'mock name',
     bankInternalRefName: 'mock id',
+    status: 'Ready for Checker\'s approval',
     details: {
       submissionDate: moment().subtract(1, 'day').utc().valueOf(),
-      status: 'Ready for Checker\'s approval',
     },
     submissionDetails: {
       supplyContractCurrency: {

--- a/portal-api/api-tests/v1/section-status/bonds.api-test.js
+++ b/portal-api/api-tests/v1/section-status/bonds.api-test.js
@@ -118,10 +118,8 @@ describe('section-status - bond', () => {
         ];
 
         const mockDeal = (submissionType) => ({
-          details: {
-            status: 'Further Maker\'s input required',
-            submissionType,
-          },
+          status: 'Further Maker\'s input required',
+          submissionType,
           bondTransactions: {
             items: mockBonds,
           },

--- a/portal-api/api-tests/v1/section-status/loans.api-test.js
+++ b/portal-api/api-tests/v1/section-status/loans.api-test.js
@@ -118,10 +118,8 @@ describe('section-status - loan', () => {
         ];
 
         const mockDeal = (submissionType)  => ({
-          details: {
-            status: 'Further Maker\'s input required',
-            submissionType,
-          },
+          status: 'Further Maker\'s input required',
+          submissionType,
           loanTransactions: {
             items: mockLoans,
           },

--- a/portal-api/src/graphql/schemas/index.js
+++ b/portal-api/src/graphql/schemas/index.js
@@ -33,7 +33,6 @@ type ErrorListItem {
 }
 
 type DealDetails {
-  status: String
   ukefDealId: String
   maker: Maker
   checker: Checker
@@ -52,6 +51,7 @@ type Deal {
   bankInternalRefName: String
   additionalRefName: String
   updatedAt: Float
+  status: String
   details: DealDetails
 }
 

--- a/portal-api/src/v1/controllers/deal-clone.controller.js
+++ b/portal-api/src/v1/controllers/deal-clone.controller.js
@@ -73,6 +73,7 @@ exports.clone = async (req, res) => {
 
     const modifiedDeal = {
       ...existingDealWithoutId,
+      status: DEFAULTS.DEAL.status,
       submissionType: existingDeal.submissionType,
       updatedAt: existingDeal.updatedAt,
       bankInternalRefName,

--- a/portal-api/src/v1/controllers/deal-status.controller.js
+++ b/portal-api/src/v1/controllers/deal-status.controller.js
@@ -32,7 +32,7 @@ exports.findOne = (req, res) => {
     } else if (!userHasAccessTo(req.user, deal)) {
       res.status(401).send();
     } else {
-      res.status(200).send(deal.details.status);
+      res.status(200).send(deal.status);
     }
   });
 };
@@ -44,7 +44,7 @@ exports.update = (req, res) => {
     if (!deal) return res.status(404).send();
     if (!userHasAccessTo(req.user, deal)) return res.status(401).send();
 
-    const fromStatus = deal.details.status;
+    const fromStatus = deal.status;
     const toStatus = req.body.status;
 
     if (toStatus !== 'Ready for Checker\'s approval'
@@ -65,7 +65,7 @@ exports.update = (req, res) => {
 
     const updatedDeal = await updateStatus(req.params.id, fromStatus, toStatus, user);
 
-    const updatedDealStatus = updatedDeal.details.status;
+    const updatedDealStatus = updatedDeal.status;
 
     const shouldCheckFacilityDates = (fromStatus === 'Draft' && updatedDealStatus === 'Ready for Checker\'s approval');
 

--- a/portal-api/src/v1/controllers/deal-status/update-status.js
+++ b/portal-api/src/v1/controllers/deal-status/update-status.js
@@ -3,13 +3,11 @@ const { updateDeal } = require('../deal.controller');
 const updateStatus = async (dealId, from, to) => {
   const modifiedDeal = {
     updatedAt: Date.now(),
-    details: {
-      status: to,
-    },
+    status: to,
   };
 
   if (from !== to) {
-    modifiedDeal.details.previousStatus = from;
+    modifiedDeal.previousStatus = from;
   }
 
   const updatedDeal = await updateDeal(

--- a/portal-api/src/v1/controllers/integration/type-b-helpers/generate-status.js
+++ b/portal-api/src/v1/controllers/integration/type-b-helpers/generate-status.js
@@ -4,7 +4,7 @@ const generateStatus = (portalDeal, workflowDeal) => {
   let workflowStatus = workflowDeal.Deal_status[0];
   const actionCode = workflowDeal.$.Action_Code;
 
-  const portalStatus = portalDeal.details.status;
+  const portalStatus = portalDeal.status;
 
   if (workflowStatus && portalStatus !== workflowStatus && actionCode === '004') {
     workflowStatus = 'in_progress_by_ukef';

--- a/portal-api/src/v1/controllers/transactions/bondFixer.js
+++ b/portal-api/src/v1/controllers/transactions/bondFixer.js
@@ -94,7 +94,7 @@ const constructor = (listOfFilters) => {
       // map whatever's still left into the generic schema that graphQL is expecting..
 
       deal_id: deal._id,
-      deal_status: deal.details.status,
+      deal_status: deal.status,
       deal_supplierName: deal.submissionDetails['supplier-name'],
       deal_bankInternalRefName: deal.bankInternalRefName,
       deal_ukefDealId: deal.details.ukefDealId,

--- a/portal-api/src/v1/controllers/transactions/loanFixer.js
+++ b/portal-api/src/v1/controllers/transactions/loanFixer.js
@@ -93,7 +93,7 @@ const constructor = (listOfFilters) => {
     }).map((loan) => ({
       // map whatever's still left into the generic schema that graphQL is expecting..
       deal_id: deal._id,
-      deal_status: deal.details.status,
+      deal_status: deal.status,
       deal_supplierName: deal.submissionDetails['supplier-name'],
       deal_bankInternalRefName: deal.bankInternalRefName,
       deal_ukefDealId: deal.details.ukefDealId,

--- a/portal-api/src/v1/controllers/transactions/transactionFixer.js
+++ b/portal-api/src/v1/controllers/transactions/transactionFixer.js
@@ -6,7 +6,7 @@ const bankInternalRefName = 'bankInternalRefName';
 const TRANSACTION_STAGE = 'transaction.transactionStage';
 const TRANSACTION_DEAL_CREATED = 'details.created';
 const DEAL_ID = '_id';
-const DEAL_STATUS = 'details.status';
+const DEAL_STATUS = 'status';
 const DEAL_PREVIOUS_STATUS = 'details.previousStatus';
 const TRANSACTION_PREVIOUS_COVER_START_DATE = 'transaction.previousCoverStartDate';
 const DEAL_BANK = 'details.owningBank.id';
@@ -66,12 +66,12 @@ const constructor = (user, filters) => {
         return listSoFar.concat([deal]);
       }
       if (DEAL_STATUS === filterField) {
-        const dealwithStatus = { 'details.status': filter[filterField] };
+        const dealwithStatus = { status: filter[filterField] };
 
         return listSoFar.concat([dealwithStatus]);
       }
       if (DEAL_PREVIOUS_STATUS === filterField) {
-        const dealwithStatus = { 'details.previousStatus': filter[filterField] };
+        const dealwithStatus = { previousStatus: filter[filterField] };
 
         return listSoFar.concat([dealwithStatus]);
       }

--- a/portal-api/src/v1/defaults/index.js
+++ b/portal-api/src/v1/defaults/index.js
@@ -3,9 +3,7 @@ const CONSTANTS = require('../../constants');
 const DEFAULTS = {
   DEAL: {
     dealType: CONSTANTS.DEAL.DEAL_TYPE.BSS_EWCS,
-    details: {
-      status: 'Draft',
-    },
+    status: 'Draft',
     eligibility: {
       status: 'Not started',
     },

--- a/portal-api/src/v1/facility-issuance/index.js
+++ b/portal-api/src/v1/facility-issuance/index.js
@@ -3,11 +3,8 @@ const CONSTANTS = require('../../constants');
 const canIssueFacility = (userRoles, deal, facility) => {
   const isMaker = userRoles.includes('maker');
 
-  const { submissionType, details } = deal;
-  const {
-    status,
-    submissionDate,
-  } = details;
+  const { submissionType, status, details } = deal;
+  const { submissionDate } = details;
 
   const dealHasBeenSubmitted = submissionDate;
 

--- a/portal-api/src/v1/section-status/aboutSupplyContractStatus.js
+++ b/portal-api/src/v1/section-status/aboutSupplyContractStatus.js
@@ -1,7 +1,7 @@
 module.exports = (submissionDetails, validationErrors) => {
   // some of the validation is time-sensitive so we have to be able to
   // recalculate this stuff on the fly.
-  if (submissionDetails === 'Not started') {
+  if (submissionDetails.status === 'Not started') {
     return 'Not started';
   }
 

--- a/portal-api/src/v1/section-status/aboutSupplyContractStatus.js
+++ b/portal-api/src/v1/section-status/aboutSupplyContractStatus.js
@@ -1,7 +1,7 @@
 module.exports = (submissionDetails, validationErrors) => {
   // some of the validation is time-sensitive so we have to be able to
   // recalculate this stuff on the fly.
-  if (submissionDetails.status === 'Not started') {
+  if (submissionDetails === 'Not started') {
     return 'Not started';
   }
 

--- a/portal-api/src/v1/section-status/bonds.js
+++ b/portal-api/src/v1/section-status/bonds.js
@@ -50,7 +50,7 @@ const addAccurateStatusesToBonds = (
   const {
     status: dealStatus,
     previousStatus: previousDealStatus,
-  } = deal.details;
+  } = deal;
 
   if (deal.bondTransactions.items.length) {
     deal.bondTransactions.items.forEach((b) => {

--- a/portal-api/src/v1/section-status/index.js
+++ b/portal-api/src/v1/section-status/index.js
@@ -4,8 +4,8 @@ const { aboutSupplyContractStatus } = require('./about');
 
 exports.dealSectionStatuses = (deal) => ({
   ...deal,
-  bondTransactions: addAccurateStatusesToBonds(deal.details.status, deal.submissionType, deal.bondTransactions),
-  loanTransactions: addAccurateStatusesToLoans(deal.details.status, deal.submissionType, deal.loanTransactions),
+  bondTransactions: addAccurateStatusesToBonds(deal.status, deal.submissionType, deal.bondTransactions),
+  loanTransactions: addAccurateStatusesToLoans(deal.status, deal.submissionType, deal.loanTransactions),
   submissionDetails: {
     ...deal.submissionDetails,
     status: aboutSupplyContractStatus(deal.submissionDetails),

--- a/portal-api/src/v1/section-status/loans.js
+++ b/portal-api/src/v1/section-status/loans.js
@@ -49,7 +49,7 @@ const addAccurateStatusesToLoans = (
   const {
     status: dealStatus,
     previousStatus: previousDealStatus,
-  } = deal.details;
+  } = deal;
 
   if (deal.loanTransactions.items.length) {
     deal.loanTransactions.items.forEach((l) => {

--- a/portal-api/src/v1/validation/is-validation-required.js
+++ b/portal-api/src/v1/validation/is-validation-required.js
@@ -11,5 +11,5 @@ module.exports = (deal) => {
   if (deal.dataMigrationInfo) {
     return false;
   }
-  return statusToValidate.includes(deal.details.status);
+  return statusToValidate.includes(deal.status);
 };

--- a/portal/component-tests/contract/components/abandon-deal-link.component-test.js
+++ b/portal/component-tests/contract/components/abandon-deal-link.component-test.js
@@ -8,8 +8,20 @@ describe(component, () => {
     it("should be enabled for deals in status=Draft and status=Further Maker's input required", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Draft", maker:{_id:123}}},
-        {_id: 2, details:{status:"Further Maker's input required", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: 'Draft',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status: 'Further Maker\'s input required',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -22,13 +34,55 @@ describe(component, () => {
     it("should not render at all for deals in any other status", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted", maker:{_id:123}}},
-        {_id: 2, details:{status:"Rejected by UKEF", maker:{_id:123}}},
-        {_id: 3, details:{status:"Abandoned", maker:{_id:123}}},
-        {_id: 4, details:{status:"Acknowledged by UKEF", maker:{_id:123}}},
-        {_id: 5, details:{status:"Accepted by UKEF (without conditions)", maker:{_id:123}}},
-        {_id: 6, details:{status:"Accepted by UKEF (with conditions)", maker:{_id:123}}},
-        {_id: 7, details:{status:"Ready for Checker's approval", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: 'Submitted',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status: 'Rejected by UKEF',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 3,
+          status: 'Abandoned',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 4,
+          status: 'Acknowledged by UKEF',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 5,
+          status: 'Accepted by UKEF (without conditions)',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 6,
+          status: 'Accepted by UKEF (with conditions)',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 7,
+          status: 'Ready for Checker\'s approval',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -44,15 +98,15 @@ describe(component, () => {
     it("should not render at all", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Draft"}},
-        {_id: 2, details:{status:"Further Maker's input required"}},
-        {_id: 3, details:{status:"Submitted"}},
-        {_id: 4, details:{status:"Rejected by UKEF"}},
-        {_id: 5, details:{status:"Abandoned"}},
-        {_id: 6, details:{status:"Acknowledged by UKEF"}},
-        {_id: 7, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 8, details:{status:"Accepted by UKEF (with conditions)"}},
-        {_id: 9, details:{status:"Ready for Checker's approval"}},
+        {_id: 1, status: 'Draft'},
+        {_id: 2, status: 'Further Maker\'s input required'},
+        {_id: 3, status: 'Submitted'},
+        {_id: 4, status: 'Rejected by UKEF'},
+        {_id: 5, status: 'Abandoned'},
+        {_id: 6, status: 'Acknowledged by UKEF'},
+        {_id: 7, status: 'Accepted by UKEF (without conditions)'},
+        {_id: 8, status: 'Accepted by UKEF (with conditions)'},
+        {_id: 9, status: 'Ready for Checker\'s approval'},
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/bond-transactions-table.component-test.js
+++ b/portal/component-tests/contract/components/bond-transactions-table.component-test.js
@@ -86,7 +86,7 @@ describe(component, () => {
     describe('when a bond Cover Date can be modified', () => {
       it('should render `change start date` link and NOT `issue facility link', () => {
         const dealWithBondsThatCanChangeCoverDate = deal;
-        dealWithBondsThatCanChangeCoverDate.details.status = 'Acknowledged by UKEF';
+        dealWithBondsThatCanChangeCoverDate.status = 'Acknowledged by UKEF';
         dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].facilityStage = 'Issued';
         dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].issueFacilityDetailsSubmitted = true;
 
@@ -113,7 +113,7 @@ describe(component, () => {
 
         it('should render `change start date` link', () => {
           const dealWithBondsThatCanChangeCoverDate = deal;
-          dealWithBondsThatCanChangeCoverDate.details.status = 'Acknowledged by UKEF';
+          dealWithBondsThatCanChangeCoverDate.status = 'Acknowledged by UKEF';
           dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].facilityStage = 'Issued';
           dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].issueFacilityDetailsSubmitted = true;
 

--- a/portal/component-tests/contract/components/bond-transactions-table.component-test.js
+++ b/portal/component-tests/contract/components/bond-transactions-table.component-test.js
@@ -10,9 +10,7 @@ describe(component, () => {
 
   const deal = {
     submissionType: 'Manual Inclusion Application',
-    details: {
-      status: 'Ready for Checker\'s approval',
-    },
+    status: 'Ready for Checker\'s approval',
     bondTransactions: {
       items: [
         {

--- a/portal/component-tests/contract/components/clone-deal-link.component-test.js
+++ b/portal/component-tests/contract/components/clone-deal-link.component-test.js
@@ -8,15 +8,15 @@ describe(component, () => {
     it('should be enabled', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
-        { _id: 3, details: { status: 'Submitted' } },
-        { _id: 4, details: { status: 'Rejected by UKEF' } },
-        { _id: 5, details: { status: 'Abandoned' } },
-        { _id: 6, details: { status: 'Acknowledged by UKEF' } },
-        { _id: 7, details: { status: 'Accepted by UKEF (without conditions)' } },
-        { _id: 8, details: { status: 'Accepted by UKEF (with conditions)' } },
-        { _id: 9, details: { status: "Ready for Checker's approval" } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: "Further Maker's input required" },
+        { _id: 3, status: 'Submitted' },
+        { _id: 4, status: 'Rejected by UKEF' },
+        { _id: 5, status: 'Abandoned' },
+        { _id: 6, status: 'Acknowledged by UKEF' },
+        { _id: 7, status: 'Accepted by UKEF (without conditions)' },
+        { _id: 8, status: 'Accepted by UKEF (with conditions)' },
+        { _id: 9, status: "Ready for Checker's approval" },
       ];
 
       for (const deal of deals) {
@@ -31,15 +31,15 @@ describe(component, () => {
     it('should not render at all', () => {
       const user = { roles: ['checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
-        { _id: 3, details: { status: 'Submitted' } },
-        { _id: 4, details: { status: 'Rejected by UKEF' } },
-        { _id: 5, details: { status: 'Abandoned' } },
-        { _id: 6, details: { status: 'Acknowledged by UKEF' } },
-        { _id: 7, details: { status: 'Accepted by UKEF (without conditions)' } },
-        { _id: 8, details: { status: 'Accepted by UKEF (with conditions)' } },
-        { _id: 9, details: { status: "Ready for Checker's approval" } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: "Further Maker's input required" },
+        { _id: 3, status: 'Submitted' },
+        { _id: 4, status: 'Rejected by UKEF' },
+        { _id: 5, status: 'Abandoned' },
+        { _id: 6, status: 'Acknowledged by UKEF' },
+        { _id: 7, status: 'Accepted by UKEF (without conditions)' },
+        { _id: 8, status: 'Accepted by UKEF (with conditions)' },
+        { _id: 9, status: "Ready for Checker's approval" },
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/contract-actions/abandon-deal-button.component-test.js
+++ b/portal/component-tests/contract/components/contract-actions/abandon-deal-button.component-test.js
@@ -8,8 +8,22 @@ describe(component, () => {
     it("should be enabled for deals in status=Draft and status=Further Maker's input required", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Draft", maker:{_id:123}}},
-        {_id: 2, details:{status:"Further Maker's input required", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: "Draft",
+          details: {
+            maker: {
+              _id:123,
+            },
+          },
+        },
+        {
+          _id: 2,
+          status: "Further Maker's input required",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -22,8 +36,20 @@ describe(component, () => {
     it("should not render at all for deals in status=Submitted and status=Rejected by UKEF", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted", maker:{_id:123}}},
-        {_id: 2, details:{status:"Rejected by UKEF", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: "Submitted",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status:"Rejected by UKEF",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -36,11 +62,41 @@ describe(component, () => {
     it("should be disabled for deals in all other states", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Abandoned", maker:{_id:123}}},
-        {_id: 2, details:{status:"Acknowledged by UKEF", maker:{_id:123}}},
-        {_id: 3, details:{status:"Accepted by UKEF (without conditions)", maker:{_id:123}}},
-        {_id: 4, details:{status:"Accepted by UKEF (with conditions)", maker:{_id:123}}},
-        {_id: 5, details:{status:"Ready for Checker's approval", maker:{_id:123}}},
+        {
+          _id: 1,
+          status:"Abandoned",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status: "Acknowledged by UKEF",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 3,
+          status: "Accepted by UKEF (without conditions)",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 4,
+          status: "Accepted by UKEF (with conditions)",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 5,
+          status: "Ready for Checker's approval",
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -56,8 +112,8 @@ describe(component, () => {
     it("should not render at all", () => {
       const user = { _id: 123, roles: ['checker'] };
       const deals = [
-        { _id: 1, details: { status: "Draft", maker: { _id: 123 } } },
-        { _id: 2, details: { status: "Further Maker's input required", maker: { _id: 123 } } },
+        { _id: 1, status: "Draft", details: { maker: { _id: 123 } } },
+        { _id: 2, status: "Further Maker's input required", details: { maker: { _id: 123 } } },
       ];
 
       for (const deal of deals) {
@@ -72,8 +128,8 @@ describe(component, () => {
     it("should render", () => {
       const user = { _id: 123, roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: "Draft", maker: { _id: 123 } } },
-        { _id: 2, details: { status: "Further Maker's input required", maker: { _id: 123 } } },
+        { _id: 1, status: "Draft", details: { maker: { _id: 123 } } },
+        { _id: 2, status: "Further Maker's input required", details: { maker: { _id: 123 } } },
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/contract-actions/proceed-to-review-button.component-test.js
+++ b/portal/component-tests/contract/components/contract-actions/proceed-to-review-button.component-test.js
@@ -166,7 +166,7 @@ describe(component, () => {
   describe('when viewed by a maker checker', () => {
     it('should not render at all for deals in status=Ready for Checker\'s approval with dealFormsCompleted flag set to true', () => {
       const user = { roles: ['maker', 'checker'] };
-      const deal = { _id: 4, status: "Ready for Checker's approval" },
+      const deal = { _id: 4, status: "Ready for Checker's approval" };
       const dealFormsCompleted = true;
 
       const wrapper = render({ user, deal, dealFormsCompleted });

--- a/portal/component-tests/contract/components/contract-actions/proceed-to-review-button.component-test.js
+++ b/portal/component-tests/contract/components/contract-actions/proceed-to-review-button.component-test.js
@@ -8,8 +8,8 @@ describe(component, () => {
     it("should be enabled for deals in status=Draft and status=Further Maker's input required and when dealFormsCompleted flag is true", () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: "Further Maker's input required" },
       ];
 
       const dealFormsCompleted = true;
@@ -24,7 +24,7 @@ describe(component, () => {
     it('should be enabled for deals in status=Acknowledged by UKEF with dealHasIssuedFacilitiesToSubmit flag set to true', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Acknowledged by UKEF' } },
+        { _id: 1, status: 'Acknowledged by UKEF' },
       ];
 
       const dealFormsCompleted = true;
@@ -42,8 +42,8 @@ describe(component, () => {
     it('should be enabled for deals in status=`Acknowledged by UKEF`, `Ready for Checker\'s approval`, `Further Maker\'s input required` when dealHasIssuedFacilitiesToSubmit flag set to true and dealFormsCompleted flag set to false', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Acknowledged by UKEF' } },
-        { _id: 4, details: { status: 'Ready for Checker\'s approval' } },
+        { _id: 1, status: 'Acknowledged by UKEF' },
+        { _id: 4, status: 'Ready for Checker\'s approval' },
       ];
 
       const dealHasIssuedFacilitiesToSubmit = true;
@@ -60,8 +60,8 @@ describe(component, () => {
     it('should not be enabled for deals in status=`Accepted by UKEF (with conditions)`, `Accepted by UKEF (without conditions)`, until facility start dates confirmed', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Accepted by UKEF (with conditions)' } },
-        { _id: 2, details: { status: 'Accepted by UKEF (without conditions)' } },
+        { _id: 1, status: 'Accepted by UKEF (with conditions)' },
+        { _id: 2, status: 'Accepted by UKEF (without conditions)' },
       ];
 
       for (const deal of deals) {
@@ -75,8 +75,8 @@ describe(component, () => {
     it('should be enabled for deals in status=`Accepted by UKEF (with conditions)`, `Accepted by UKEF (without conditions)`,and all facility start dates confirmed', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Accepted by UKEF (with conditions)' } },
-        { _id: 2, details: { status: 'Accepted by UKEF (without conditions)' } },
+        { _id: 1, status: 'Accepted by UKEF (with conditions)' },
+        { _id: 2, status: 'Accepted by UKEF (without conditions)' },
       ];
 
       for (const deal of deals) {
@@ -91,8 +91,8 @@ describe(component, () => {
     it('should not render at all for deals in status=Submitted and status=Rejected by UKEF', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Submitted' } },
-        { _id: 2, details: { status: 'Rejected by UKEF' } },
+        { _id: 1, status: 'Submitted' },
+        { _id: 2, status: 'Rejected by UKEF' },
       ];
 
       for (const deal of deals) {
@@ -105,10 +105,10 @@ describe(component, () => {
     it('should be disabled when dealFormsCompleted and dealHasIssuedFacilitiesToSubmit flags are false', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
-        { _id: 3, details: { status: 'Abandoned' } },
-        { _id: 4, details: { status: 'Acknowledged by UKEF' } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: "Further Maker's input required" },
+        { _id: 3, status: 'Abandoned' },
+        { _id: 4, status: 'Acknowledged by UKEF' },
       ];
 
       const dealFormsCompleted = false;
@@ -126,10 +126,10 @@ describe(component, () => {
     it('should be disabled for deals in all other states', () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: 'Further Maker\'s input required' } },
-        { _id: 3, details: { status: 'Abandoned' } },
-        { _id: 4, details: { status: 'Acknowledged by UKEF' } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: 'Further Maker\'s input required' },
+        { _id: 3, status: 'Abandoned' },
+        { _id: 4, status: 'Acknowledged by UKEF' },
       ];
 
       for (const deal of deals) {
@@ -144,15 +144,15 @@ describe(component, () => {
     it('should not render at all', () => {
       const user = { roles: ['checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
-        { _id: 3, details: { status: 'Submitted' } },
-        { _id: 4, details: { status: 'Rejected by UKEF' } },
-        { _id: 5, details: { status: 'Abandoned' } },
-        { _id: 6, details: { status: 'Acknowledged by UKEF' } },
-        { _id: 7, details: { status: 'Accepted by UKEF (without conditions)' } },
-        { _id: 8, details: { status: 'Accepted by UKEF (with conditions)' } },
-        { _id: 9, details: { status: "Ready for Checker's approval" } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: "Further Maker's input required" },
+        { _id: 3, status: 'Submitted' },
+        { _id: 4, status: 'Rejected by UKEF' },
+        { _id: 5, status: 'Abandoned' },
+        { _id: 6, status: 'Acknowledged by UKEF' },
+        { _id: 7, status: 'Accepted by UKEF (without conditions)' },
+        { _id: 8, status: 'Accepted by UKEF (with conditions)' },
+        { _id: 9, status: "Ready for Checker's approval" },
       ];
 
       for (const deal of deals) {
@@ -166,7 +166,7 @@ describe(component, () => {
   describe('when viewed by a maker checker', () => {
     it('should not render at all for deals in status=Ready for Checker\'s approval with dealFormsCompleted flag set to true', () => {
       const user = { roles: ['maker', 'checker'] };
-      const deal = { _id: 4, details: { status: "Ready for Checker's approval" } };
+      const deal = { _id: 4, status: "Ready for Checker's approval" },
       const dealFormsCompleted = true;
 
       const wrapper = render({ user, deal, dealFormsCompleted });

--- a/portal/component-tests/contract/components/contract-actions/proceed-to-submit-button.component-test.js
+++ b/portal/component-tests/contract/components/contract-actions/proceed-to-submit-button.component-test.js
@@ -9,7 +9,7 @@ describe(component, () => {
     it("should be enabled for deals in status=Ready for Checker's approval", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Ready for Checker's approval"}},
+        {_id: 1, status: "Ready for Checker's approval"},
       ];
       const userCanSubmit = true;
 
@@ -23,8 +23,8 @@ describe(component, () => {
     it("should not render at all for deals in status=Submitted and status=Rejected by UKEF", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted"}},
-        {_id: 2, details:{status:"Rejected by UKEF"}},
+        {_id: 1, status: "Submitted"},
+        {_id: 2, status: "Rejected by UKEF"},
       ];
       const userCanSubmit = true;
 
@@ -38,12 +38,12 @@ describe(component, () => {
     it("should be disabled for deals in all other states", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Draft"}},
-        {_id: 2, details:{status:"Abandoned"}},
-        {_id: 3, details:{status:"Acknowledged by UKEF"}},
-        {_id: 4, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 5, details:{status:"Accepted by UKEF (with conditions)"}},
-        {_id: 6, details:{status:"In progress by UKEF"}},
+        {_id: 1, status: "Draft"},
+        {_id: 2, status: "Abandoned"},
+        {_id: 3, status: "Acknowledged by UKEF"},
+        {_id: 4, status: "Accepted by UKEF (without conditions)"},
+        {_id: 5, status: "Accepted by UKEF (with conditions)"},
+        {_id: 6, status: "In progress by UKEF"},
       ];
       const userCanSubmit = true;
 
@@ -60,8 +60,8 @@ describe(component, () => {
     it('should be enabled', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Submitted' } },
-        { _id: 2, details: { status: 'Rejected by UKEF' } },
+        { _id: 1, status: 'Submitted' },
+        { _id: 2, status: 'Rejected by UKEF' },
       ];
       const userCanSubmit = true;
 
@@ -75,7 +75,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Draft`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
+        { _id: 1, status: 'Draft' },
       ];
       const userCanSubmit = true;
 
@@ -88,7 +88,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Further Maker\'s input required`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Further Maker\'s input required' } },
+        { _id: 1, status: 'Further Maker\'s input required' },
       ];
       const userCanSubmit = true;
 
@@ -101,7 +101,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Acknowledged by UKEF`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Further Maker\'s input required' } },
+        { _id: 1, status: 'Further Maker\'s input required' },
       ];
       const userCanSubmit = true;
 
@@ -114,7 +114,7 @@ describe(component, () => {
     it('should NOT render when deal status is `In progress by UKEF`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'In progress by UKEF' } },
+        { _id: 1, status: 'In progress by UKEF' },
       ];
       const userCanSubmit = true;
 
@@ -127,7 +127,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Accepted by UKEF (without conditions)`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Accepted by UKEF (without conditions)' } },
+        { _id: 1, status: 'Accepted by UKEF (without conditions)' },
       ];
       const userCanSubmit = true;
 
@@ -140,7 +140,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Accepted by UKEF (with conditions)`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Accepted by UKEF (with conditions)' } },
+        { _id: 1, status: 'Accepted by UKEF (with conditions)' },
       ];
       const userCanSubmit = true;
 
@@ -156,15 +156,15 @@ describe(component, () => {
     it('should not render at all', () => {
       const user = { roles: ['checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Ready for Checker\'s approval' } },
-        { _id: 2, details: { status: 'Submitted' } },
-        { _id: 3, details: { status: 'Rejected by UKEF' } },
-        { _id: 4, details: { status: 'Draft' } },
-        { _id: 5, details: { status: 'Further Maker\'s input required' } },
-        { _id: 6, details: { status: 'Abandoned' } },
-        { _id: 7, details: { status: 'Acknowledged by UKEF' } },
-        { _id: 8, details: { status: 'Accepted by UKEF (without conditions)' } },
-        { _id: 9, details: { status: 'Accepted by UKEF (with conditions)' } },
+        { _id: 1, status: 'Ready for Checker\'s approval' },
+        { _id: 2, status: 'Submitted' },
+        { _id: 3, status: 'Rejected by UKEF' },
+        { _id: 4, status: 'Draft' },
+        { _id: 5, status: 'Further Maker\'s input required' },
+        { _id: 6, status: 'Abandoned' },
+        { _id: 7, status: 'Acknowledged by UKEF' },
+        { _id: 8, status: 'Accepted by UKEF (without conditions)' },
+        { _id: 9, status: 'Accepted by UKEF (with conditions)' },
       ];
       const userCanSubmit = false;
 
@@ -179,15 +179,15 @@ describe(component, () => {
     it("should not render at all", () =>{
       const user = {roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted"}},
-        {_id: 2, details:{status:"Rejected by UKEF"}},
-        {_id: 3, details:{status:"Abandoned"}},
-        {_id: 4, details:{status:"Acknowledged by UKEF"}},
-        {_id: 5, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 6, details:{status:"Accepted by UKEF (with conditions)"}},
-        {_id: 7, details:{status:"Ready for Checker's approval"}},
-        {_id: 8, details:{status:"Submitted"}},
-        {_id: 9, details:{status:"Rejected by UKEF"}},
+        {_id: 1, status: "Submitted"},
+        {_id: 2, status: "Rejected by UKEF"},
+        {_id: 3, status: "Abandoned"},
+        {_id: 4, status: "Acknowledged by UKEF"},
+        {_id: 5, status: "Accepted by UKEF (without conditions)"},
+        {_id: 6, status: "Accepted by UKEF (with conditions)"},
+        {_id: 7, status: "Ready for Checker's approval"},
+        {_id: 8, status: "Submitted"},
+        {_id: 9, status: "Rejected by UKEF"},
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/contract-actions/return-to-maker-button.component-test.js
+++ b/portal/component-tests/contract/components/contract-actions/return-to-maker-button.component-test.js
@@ -9,7 +9,7 @@ describe(component, () => {
     it("should be enabled for deals in status=Ready for Checker's approval", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Ready for Checker's approval"}},
+        {_id: 1, status: "Ready for Checker's approval" },
       ];
       const userCanSubmit = true;
 
@@ -23,8 +23,8 @@ describe(component, () => {
     it("should not render at all for deals in status=Submitted and status=Rejected by UKEF", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted"}},
-        {_id: 2, details:{status:"Rejected by UKEF"}},
+        {_id: 1, status: "Submitted" },
+        {_id: 2, status: "Rejected by UKEF" },
       ];
       const userCanSubmit = true;
 
@@ -38,12 +38,12 @@ describe(component, () => {
     it("should be disabled for deals in all other states", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Draft"}},
-        {_id: 2, details:{status:"Abandoned"}},
-        {_id: 3, details:{status:"Acknowledged by UKEF"}},
-        {_id: 4, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 5, details:{status:"Accepted by UKEF (with conditions)"}},
-        {_id: 6, details:{status:"In progress by UKEF"}},
+        {_id: 1, status: "Draft" },
+        {_id: 2, status: "Abandoned" },
+        {_id: 3, status: "Acknowledged by UKEF" },
+        {_id: 4, status: "Accepted by UKEF (without conditions)" },
+        {_id: 5, status: "Accepted by UKEF (with conditions)" },
+        {_id: 6, status: "In progress by UKEF" },
       ];
       const userCanSubmit = true;
 
@@ -59,8 +59,8 @@ describe(component, () => {
     it('should be enabled', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Submitted' } },
-        { _id: 2, details: { status: 'Rejected by UKEF' } },
+        { _id: 1, status: 'Submitted' },
+        { _id: 2, status: 'Rejected by UKEF' },
       ];
       const userCanSubmit = true;
 
@@ -74,7 +74,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Draft`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
+        { _id: 1, status: 'Draft' },
       ];
       const userCanSubmit = true;
 
@@ -87,7 +87,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Further Maker\'s input required`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Further Maker\'s input required' } },
+        { _id: 1, status: 'Further Maker\'s input required' },
       ];
       const userCanSubmit = true;
 
@@ -100,7 +100,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Acknowledged by UKEF`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Further Maker\'s input required' } },
+        { _id: 1, status: 'Further Maker\'s input required' },
       ];
       const userCanSubmit = true;
 
@@ -113,7 +113,7 @@ describe(component, () => {
     it('should NOT render when deal status is `In progress by UKEF`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'In progress by UKEF' } },
+        { _id: 1, status: 'In progress by UKEF' },
       ];
       const userCanSubmit = true;
 
@@ -126,7 +126,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Accepted by UKEF (without conditions)`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Accepted by UKEF (without conditions)' } },
+        { _id: 1, status: 'Accepted by UKEF (without conditions)' },
       ];
       const userCanSubmit = true;
 
@@ -139,7 +139,7 @@ describe(component, () => {
     it('should NOT render when deal status is `Accepted by UKEF (out conditions)`', () => {
       const user = { roles: ['maker', 'checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Accepted by UKEF (with conditions)' } },
+        { _id: 1, status: 'Accepted by UKEF (with conditions)' },
       ];
       const userCanSubmit = true;
 
@@ -155,15 +155,15 @@ describe(component, () => {
     it('should not render at all', () => {
       const user = { roles: ['checker'] };
       const deals = [
-        { _id: 1, details: { status: 'Ready for Checker\'s approval' } },
-        { _id: 2, details: { status: 'Submitted' } },
-        { _id: 3, details: { status: 'Rejected by UKEF' } },
-        { _id: 4, details: { status: 'Draft' } },
-        { _id: 5, details: { status: 'Further Maker\'s input required' } },
-        { _id: 6, details: { status: 'Abandoned' } },
-        { _id: 7, details: { status: 'Acknowledged by UKEF' } },
-        { _id: 8, details: { status: 'Accepted by UKEF (without conditions)' } },
-        { _id: 9, details: { status: 'Accepted by UKEF (with conditions)' } },
+        { _id: 1, status: 'Ready for Checker\'s approval' },
+        { _id: 2, status: 'Submitted' },
+        { _id: 3, status: 'Rejected by UKEF' },
+        { _id: 4, status: 'Draft' },
+        { _id: 5, status: 'Further Maker\'s input required' },
+        { _id: 6, status: 'Abandoned' },
+        { _id: 7, status: 'Acknowledged by UKEF' },
+        { _id: 8, status: 'Accepted by UKEF (without conditions)' },
+        { _id: 9, status: 'Accepted by UKEF (with conditions)' },
       ];
       const userCanSubmit = false;
 
@@ -178,15 +178,15 @@ describe(component, () => {
     it("should not render at all", () =>{
       const user = {roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted"}},
-        {_id: 2, details:{status:"Rejected by UKEF"}},
-        {_id: 3, details:{status:"Abandoned"}},
-        {_id: 4, details:{status:"Acknowledged by UKEF"}},
-        {_id: 5, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 6, details:{status:"Accepted by UKEF (with conditions)"}},
-        {_id: 7, details:{status:"Ready for Checker's approval"}},
-        {_id: 8, details:{status:"Submitted"}},
-        {_id: 9, details:{status:"Rejected by UKEF"}},
+        {_id: 1, status: "Submitted" },
+        {_id: 2, status: "Rejected by UKEF" },
+        {_id: 3, status: "Abandoned" },
+        {_id: 4, status: "Acknowledged by UKEF" },
+        {_id: 5, status: "Accepted by UKEF (without conditions)" },
+        {_id: 6, status: "Accepted by UKEF (with conditions)" },
+        {_id: 7, status: "Ready for Checker's approval" },
+        {_id: 8, status: "Submitted" },
+        {_id: 9, status: "Rejected by UKEF" },
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/contract-actions/review-eligibility-checklist-link.component-test.js
+++ b/portal/component-tests/contract/components/contract-actions/review-eligibility-checklist-link.component-test.js
@@ -9,7 +9,7 @@ describe(component, () => {
     it("should display for deals in status=Ready for Checker's approval", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Ready for Checker's approval"}},
+        {_id: 1, status: "Ready for Checker's approval" },
       ];
 
       for (const deal of deals) {
@@ -22,14 +22,14 @@ describe(component, () => {
     it("should not render at all for deals in any other status", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Draft"}},
-        {_id: 2, details:{status:"Further Maker's input required"}},
-        {_id: 3, details:{status:"Submitted"}},
-        {_id: 4, details:{status:"Rejected by UKEF"}},
-        {_id: 5, details:{status:"Abandoned"}},
-        {_id: 6, details:{status:"Acknowledged by UKEF"}},
-        {_id: 7, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 8, details:{status:"Accepted by UKEF (with conditions)"}},
+        {_id: 1, status: "Draft" },
+        {_id: 2, status: "Further Maker's input required" },
+        {_id: 3, status: "Submitted" },
+        {_id: 4, status: "Rejected by UKEF" },
+        {_id: 5, status: "Abandoned" },
+        {_id: 6, status: "Acknowledged by UKEF" },
+        {_id: 7, status: "Accepted by UKEF (without conditions)" },
+        {_id: 8, status: "Accepted by UKEF (with conditions)" },
       ];
 
       for (const deal of deals) {
@@ -46,7 +46,7 @@ describe(component, () => {
     it("should display for deals in status=Ready for Checker's approval", () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: "Ready for Checker's approval" } },
+        { _id: 1, status: "Ready for Checker's approval" },
       ];
 
       for (const deal of deals) {
@@ -59,14 +59,14 @@ describe(component, () => {
     it("should not render at all for deals in any other status", () => {
       const user = { roles: ['checker'] };
       const deals = [
-        { _id: 1, details: { status: "Draft" } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
-        { _id: 3, details: { status: "Submitted" } },
-        { _id: 4, details: { status: "Rejected by UKEF" } },
-        { _id: 5, details: { status: "Abandoned" } },
-        { _id: 6, details: { status: "Acknowledged by UKEF" } },
-        { _id: 7, details: { status: "Accepted by UKEF (without conditions)" } },
-        { _id: 8, details: { status: "Accepted by UKEF (with conditions)" } },
+        { _id: 1, status: "Draft" },
+        { _id: 2, status: "Further Maker's input required" },
+        { _id: 3, status: "Submitted" },
+        { _id: 4, status: "Rejected by UKEF" },
+        { _id: 5, status: "Abandoned" },
+        { _id: 6, status: "Acknowledged by UKEF" },
+        { _id: 7, status: "Accepted by UKEF (without conditions)" },
+        { _id: 8, status: "Accepted by UKEF (with conditions)" },
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/contract-overview-table.component-test.js
+++ b/portal/component-tests/contract/components/contract-overview-table.component-test.js
@@ -119,10 +119,10 @@ describe(component, () => {
 
     const deal = {
       updatedAt: null,
+      status: '',
       details: {
         bankInternalRefName: '',
         ukefDealId: ' ',
-        status: '   ',
         previousStatus: '',
         maker: {},
         checker: {},

--- a/portal/component-tests/contract/components/contract-overview-table.component-test.js
+++ b/portal/component-tests/contract/components/contract-overview-table.component-test.js
@@ -12,10 +12,10 @@ describe(component, () => {
   const deal = {
     updatedAt: Date.now(),
     bankInternalRefName: 'bankInternalRefName',
+    status: 'status',
+    previousStatus: 'previousStatus',
     details: {
       ukefDealId: 'ukefDealId',
-      status: 'status',
-      previousStatus: 'previousStatus',
       maker: {
         firstname: 'Robert',
         surname: 'Bruce',
@@ -55,14 +55,14 @@ describe(component, () => {
                     .toRead(deal.details.ukefDealId);
     });
 
-    it("displays deal.details.status", () =>{
+    it("displays deal.status", () =>{
       return wrapper.expectText('[data-cy="status"]')
-                    .toRead(deal.details.status);
+                    .toRead(deal.status);
     });
 
-    it("displays deal.details.previousStatus", () =>{
+    it("displays deal.previousStatus", () =>{
       return wrapper.expectText('[data-cy="previousStatus"]')
-                    .toRead(deal.details.previousStatus);
+                    .toRead(deal.previousStatus);
     });
 
     it("displays deal.details.maker.username", () =>{
@@ -145,12 +145,12 @@ describe(component, () => {
                     .toRead("-");
     });
 
-    it("displays deal.details.status", () =>{
+    it("displays deal.status", () =>{
       return wrapper.expectText('[data-cy="status"]')
                     .toRead("-");
     });
 
-    it("displays deal.details.previousStatus", () =>{
+    it("displays deal.previousStatus", () =>{
       return wrapper.expectText('[data-cy="previousStatus"]')
                     .toRead("-");
     });

--- a/portal/component-tests/contract/components/edit-deal-name-link.component-test.js
+++ b/portal/component-tests/contract/components/edit-deal-name-link.component-test.js
@@ -8,8 +8,20 @@ describe(component, () => {
     it("should be enabled for deals in status=Draft and status=Further Maker's input required", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Draft", maker:{_id:123}}},
-        {_id: 2, details:{status:"Further Maker's input required", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: 'Draft',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status: 'Further Maker\'s input required',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -22,13 +34,55 @@ describe(component, () => {
     it("should not render at all for deals in any other status", () =>{
       const user = {_id: 123, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Submitted", maker:{_id:123}}},
-        {_id: 2, details:{status:"Rejected by UKEF", maker:{_id:123}}},
-        {_id: 3, details:{status:"Abandoned", maker:{_id:123}}},
-        {_id: 4, details:{status:"Acknowledged by UKEF", maker:{_id:123}}},
-        {_id: 5, details:{status:"Accepted by UKEF (without conditions)", maker:{_id:123}}},
-        {_id: 6, details:{status:"Accepted by UKEF (with conditions)", maker:{_id:123}}},
-        {_id: 7, details:{status:"Ready for Checker's approval", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: 'Submitted',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status: 'Rejected by UKEF',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 3,
+          status: 'Abandoned',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 4,
+          status: 'Acknowledged by UKEF',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 5,
+          status: 'Accepted by UKEF (without conditions)',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 6,
+          status: 'Accepted by UKEF (with conditions)',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 7,
+          status: 'Ready for Checker\'s approval',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -37,23 +91,75 @@ describe(component, () => {
           .notToExist();
       }
     });
-
   });
 
   describe("when viewed by a maker who did not create the deal", () => {
-
     it("should not render at all", () =>{
       const user = {_id: 666, roles: ['maker']};
       const deals = [
-        {_id: 1, details:{status:"Draft", maker:{_id:123}}},
-        {_id: 2, details:{status:"Further Maker's input required", maker:{_id:123}}},
-        {_id: 3, details:{status:"Submitted", maker:{_id:123}}},
-        {_id: 4, details:{status:"Rejected by UKEF", maker:{_id:123}}},
-        {_id: 5, details:{status:"Abandoned", maker:{_id:123}}},
-        {_id: 6, details:{status:"Acknowledged by UKEF", maker:{_id:123}}},
-        {_id: 7, details:{status:"Accepted by UKEF (without conditions)", maker:{_id:123}}},
-        {_id: 8, details:{status:"Accepted by UKEF (with conditions)", maker:{_id:123}}},
-        {_id: 9, details:{status:"Ready for Checker's approval", maker:{_id:123}}},
+        {
+          _id: 1,
+          status: 'Draft',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 2,
+          status: 'Further Maker\'s input required',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 3,
+          status: 'Submitted',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 4,
+          status: 'Rejected by UKEF',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 5,
+          status: 'Abandoned',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 6,
+          status: 'Acknowledged by UKEF',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 7,
+          status: 'Accepted by UKEF (without conditions)',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 8,
+          status: 'Accepted by UKEF (with conditions)',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
+        {
+          _id: 9,
+          status: 'Ready for Checker\'s approval',
+          details: {
+            maker: { _id: 123 },
+          },
+        },
       ];
 
       for (const deal of deals) {
@@ -62,22 +168,21 @@ describe(component, () => {
           .notToExist();
       }
     });
-
   });
 
   describe("when viewed by a checker", () => {
     it("should not render at all", () =>{
       const user = {roles: ['checker']};
       const deals = [
-        {_id: 1, details:{status:"Draft"}},
-        {_id: 2, details:{status:"Further Maker's input required"}},
-        {_id: 3, details:{status:"Submitted"}},
-        {_id: 4, details:{status:"Rejected by UKEF"}},
-        {_id: 5, details:{status:"Abandoned"}},
-        {_id: 6, details:{status:"Acknowledged by UKEF"}},
-        {_id: 7, details:{status:"Accepted by UKEF (without conditions)"}},
-        {_id: 8, details:{status:"Accepted by UKEF (with conditions)"}},
-        {_id: 9, details:{status:"Ready for Checker's approval"}},
+        {_id: 1, status: 'Draft' },
+        {_id: 2, status: 'Further Maker\'s input required' },
+        {_id: 3, status: 'Submitted' },
+        {_id: 4, status: 'Rejected by UKEF' },
+        {_id: 5, status: 'Abandoned' },
+        {_id: 6, status: 'Acknowledged by UKEF' },
+        {_id: 7, status: 'Accepted by UKEF (without conditions)' },
+        {_id: 8, status: 'Accepted by UKEF (with conditions)' },
+        {_id: 9, status: 'Ready for Checker\'s approval' },
       ];
 
       for (const deal of deals) {

--- a/portal/component-tests/contract/components/forms-incomplete-text.component-test.js
+++ b/portal/component-tests/contract/components/forms-incomplete-text.component-test.js
@@ -9,8 +9,8 @@ describe(component, () => {
     it("should display when deal status=Draft and status=Further Maker's input required and canFullyCalculateDealSummary flag is false", () => {
       const user = { roles: ['maker'] };
       const deals = [
-        { _id: 1, details: { status: 'Draft' } },
-        { _id: 2, details: { status: "Further Maker's input required" } },
+        { _id: 1, status: 'Draft' },
+        { _id: 2, status: "Further Maker's input required" },
       ];
 
       const canFullyCalculateDealSummary = false;

--- a/portal/component-tests/contract/components/issue-or-delete-facility-link.component-test.js
+++ b/portal/component-tests/contract/components/issue-or-delete-facility-link.component-test.js
@@ -42,7 +42,7 @@ describe(component, () => {
         const facilityName = 'loan';
 
         const deals = [
-          { _id: '1', details: { status: 'Ready for Checker\'s approval' }},
+          { _id: '1', status: 'Ready for Checker\'s approval' },
         ];
 
         deals.forEach((deal) => {
@@ -75,8 +75,8 @@ describe(component, () => {
         const facilityTableIndex = 1;
 
         const deals = [
-          { _id: '1', details: { status: 'Draft' } },
-          { _id: '2', details: { status: 'Further Maker\'s input required' } },
+          { _id: '1', status: 'Draft' },
+          { _id: '2', status: 'Further Maker\'s input required' },
         ];
 
         deals.forEach((deal) => {

--- a/portal/component-tests/contract/components/loan-transactions-table.component-test.js
+++ b/portal/component-tests/contract/components/loan-transactions-table.component-test.js
@@ -10,9 +10,7 @@ describe(component, () => {
 
   const deal = {
     submissionType: 'Manual Inclusion Application',
-    details: {
-      status: 'Ready for Checker\'s approval',
-    },
+    status: 'Ready for Checker\'s approval',
     loanTransactions: {
       items: [
         {

--- a/portal/component-tests/contract/components/loan-transactions-table.component-test.js
+++ b/portal/component-tests/contract/components/loan-transactions-table.component-test.js
@@ -86,7 +86,7 @@ describe(component, () => {
     describe('when a loan Cover Date can be modified', () => {
       it('should render `change start date` link and NOT `issue facility link', () => {
         const dealWithLoansThatCanChangeCoverDate = deal;
-        dealWithLoansThatCanChangeCoverDate.details.status = 'Acknowledged by UKEF';
+        dealWithLoansThatCanChangeCoverDate.status = 'Acknowledged by UKEF';
         dealWithLoansThatCanChangeCoverDate.loanTransactions.items[0].facilityStage = 'Unconditional';
         dealWithLoansThatCanChangeCoverDate.loanTransactions.items[0].issueFacilityDetailsSubmitted = true;
 
@@ -114,7 +114,7 @@ describe(component, () => {
 
       it('should render `change start date` link', () => {
         const dealWithLoansThatCanChangeCoverDate = deal;
-        dealWithLoansThatCanChangeCoverDate.details.status = 'Acknowledged by UKEF';
+        dealWithLoansThatCanChangeCoverDate.status = 'Acknowledged by UKEF';
         dealWithLoansThatCanChangeCoverDate.loanTransactions.items[0].facilityStage = 'Unconditional';
         dealWithLoansThatCanChangeCoverDate.loanTransactions.items[0].issueFacilityDetailsSubmitted = true;
 

--- a/portal/component-tests/contract/contract-view.component-test.js
+++ b/portal/component-tests/contract/contract-view.component-test.js
@@ -8,10 +8,7 @@ const deal = require('../fixtures/deal-fully-completed');
 
 const aDealInStatus = (status) => ({
   ...deal,
-  details: {
-    ...deal.details,
-    status,
-  },
+  status,
 });
 
 const oneDealInEachStatus = () => [

--- a/portal/component-tests/fixtures/deal-fully-completed.js
+++ b/portal/component-tests/fixtures/deal-fully-completed.js
@@ -7,9 +7,9 @@ const deal = {
   updatedAt: Date.now(),
   additionalRefName: 'mock name',
   bankInternalRefName: 'mock id',
+  status: 'Ready for Checker\'s approval',
+  previousStatus: 'Draft',
   details: {
-    status: 'Ready for Checker\'s approval',
-    previousStatus: 'Draft',
     maker: { username: 'some.user@client.com' },
     submissionDate: 1594296776916.0,
   },

--- a/portal/server/controllers/dashboard/facilities.js
+++ b/portal/server/controllers/dashboard/facilities.js
@@ -17,7 +17,7 @@ exports.bssFacilities = async (req, res) => {
   const { user } = req.session;
   const facilityFilters = [];
 
-  if (user.roles.every((role) => role === 'checker')) facilityFilters.push({ field: 'details.status', value: STATUS.readyForApproval, operator: 'eq' });
+  if (user.roles.every((role) => role === 'checker')) facilityFilters.push({ field: 'status', value: STATUS.readyForApproval, operator: 'eq' });
 
   const filters = [...facilityFilters];
 

--- a/portal/server/controllers/dashboard/facilities.test.js
+++ b/portal/server/controllers/dashboard/facilities.test.js
@@ -82,7 +82,7 @@ describe('controllers/facilities', () => {
     it('passes the expected filter for checker', async () => {
       await bssFacilities(checkerReq, res);
 
-      expect(api.transactions).toHaveBeenCalledWith(20, 20, [{ field: 'details.status', operator: 'eq', value: STATUS.readyForApproval }], 'mock-token');
+      expect(api.transactions).toHaveBeenCalledWith(20, 20, [{ field: 'status', operator: 'eq', value: STATUS.readyForApproval }], 'mock-token');
     });
 
     it('renders the correct template', async () => {

--- a/portal/server/graphql/queries/deals-query.js
+++ b/portal/server/graphql/queries/deals-query.js
@@ -7,11 +7,11 @@ query Deals($start: Int, $pagesize: Int, $filters:[DashboardFilters]){
     deals {
       _id
       submissionType
-      updatedAt
       bankInternalRefName
       additionalRefName
+      updatedAt
+      status
       details {
-        status
         ukefDealId
         maker {
           username

--- a/portal/server/helpers/dealFormsCompleted.js
+++ b/portal/server/helpers/dealFormsCompleted.js
@@ -27,7 +27,7 @@ const hasIncompleteLoans = (deal) => {
 const hasAtLeastOneLoanOrBond = (deal) => deal.loanTransactions.items.length > 0
                                        || deal.bondTransactions.items.length > 0;
 
-const submissionDetailsComplete = (deal) => deal.submissionDetails && deal.submissionDetails.status === 'Completed';
+const submissionDetailsComplete = (deal) => deal.submissionDetails && deal.submissionstatus === 'Completed';
 
 const eligibilityComplete = (deal) => deal.eligibility && deal.eligibility.status === 'Completed';
 

--- a/portal/server/helpers/dealFormsCompleted.js
+++ b/portal/server/helpers/dealFormsCompleted.js
@@ -27,7 +27,7 @@ const hasIncompleteLoans = (deal) => {
 const hasAtLeastOneLoanOrBond = (deal) => deal.loanTransactions.items.length > 0
                                        || deal.bondTransactions.items.length > 0;
 
-const submissionDetailsComplete = (deal) => deal.submissionDetails && deal.submissionstatus === 'Completed';
+const submissionDetailsComplete = (deal) => deal.submissionDetails && deal.submissionDetails.status === 'Completed';
 
 const eligibilityComplete = (deal) => deal.eligibility && deal.eligibility.status === 'Completed';
 

--- a/portal/server/helpers/dealFormsCompleted.test.js
+++ b/portal/server/helpers/dealFormsCompleted.test.js
@@ -84,7 +84,7 @@ describe('dealFormsCompleted', () => {
     expect(dealFormsCompleted(deal)).toEqual(false);
   });
 
-  it('should return false when a deal\'s submissionstatus is NOT `Completed`', () => {
+  it('should return false when a deal\'s submissionDetails.status is NOT `Completed`', () => {
     const deal = {
       submissionDetails: incompleteSubmissionDetails,
       bondTransactions: completeBonds,

--- a/portal/server/helpers/dealFormsCompleted.test.js
+++ b/portal/server/helpers/dealFormsCompleted.test.js
@@ -84,7 +84,7 @@ describe('dealFormsCompleted', () => {
     expect(dealFormsCompleted(deal)).toEqual(false);
   });
 
-  it('should return false when a deal\'s submissionDetails.status is NOT `Completed`', () => {
+  it('should return false when a deal\'s submissionstatus is NOT `Completed`', () => {
     const deal = {
       submissionDetails: incompleteSubmissionDetails,
       bondTransactions: completeBonds,

--- a/portal/server/routes/buildDashboardFilters.js
+++ b/portal/server/routes/buildDashboardFilters.js
@@ -52,7 +52,7 @@ const buildDashboardFilters = (params, user) => {
     isUsingAdvancedFilter = true;
     filters.push(
       {
-        field: 'details.status',
+        field: 'status',
         value: STATUS[params.filterByStatus],
       },
     );
@@ -60,7 +60,7 @@ const buildDashboardFilters = (params, user) => {
 
   if (params.filterByShowAbandonedDeals === false || params.filterByShowAbandonedDeals === 'false') {
     filters.push({
-      field: 'details.status',
+      field: 'status',
       value: STATUS.abandoned,
       operator: 'ne',
     });

--- a/portal/server/routes/buildReportFilters.js
+++ b/portal/server/routes/buildReportFilters.js
@@ -48,7 +48,7 @@ const buildReportFilters = (params, user) => {
   if (STATUS[params.filterByStatus]) {
     filters.push(
       {
-        field: 'details.status',
+        field: 'status',
         value: STATUS[params.filterByStatus],
       },
     );

--- a/portal/server/routes/contract/canIssueOrEditIssueFacility.js
+++ b/portal/server/routes/contract/canIssueOrEditIssueFacility.js
@@ -1,10 +1,13 @@
 const canIssueOrEditIssueFacility = (userRoles, deal, facility) => {
   const isMaker = userRoles.includes('maker');
 
-  const { submissionType, details } = deal;
+  const {
+    submissionType,
+    status: dealStatus,
+    details,
+  } = deal;
 
   const {
-    status: dealStatus,
     submissionDate,
   } = details;
 

--- a/portal/server/routes/contract/canIssueOrEditIssueFacility.test.js
+++ b/portal/server/routes/contract/canIssueOrEditIssueFacility.test.js
@@ -313,6 +313,7 @@ describe('canIssueOrEditIssueFacility', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
         status: 'Acknowledged by UKEF',
+        details: {},
       };
 
       const mockBond = {
@@ -368,6 +369,7 @@ describe('canIssueOrEditIssueFacility', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
         status: 'Acknowledged by UKEF',
+        details: {},
       };
 
       const mockLoan = {

--- a/portal/server/routes/contract/canIssueOrEditIssueFacility.test.js
+++ b/portal/server/routes/contract/canIssueOrEditIssueFacility.test.js
@@ -5,15 +5,14 @@ describe('canIssueOrEditIssueFacility', () => {
 
   const mockLoanThatCanBeIssued = {
     facilityStage: 'Conditional',
-    // status: 'Not started',
   };
 
   describe('when a deal status is `Acknowledged by UKEF`, AIN submissionType and a Conditional loan that has NOT been submitted', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -26,8 +25,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -40,8 +39,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Application',
+        status: 'Accepted by UKEF (with conditions)',
         details: {
-          status: 'Accepted by UKEF (with conditions)',
           submissionDate: 12345678910,
         },
       };
@@ -54,8 +53,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Application',
+        status: 'Accepted by UKEF (without conditions)',
         details: {
-          status: 'Accepted by UKEF (without conditions)',
           submissionDate: 12345678910,
         },
       };
@@ -68,8 +67,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Application',
+        status: 'Further Maker\'s input required',
         details: {
-          status: 'Further Maker\'s input required',
           submissionDate: 12345678910,
         },
       };
@@ -82,8 +81,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -101,8 +100,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Further Maker\'s input required',
         details: {
-          status: 'Further Maker\'s input required',
           submissionDate: 12345678910,
         },
       };
@@ -119,8 +118,8 @@ describe('canIssueOrEditIssueFacility', () => {
   describe('when a deal status is `Accepted by UKEF (with conditions)`, AIN submissionType and a Conditional loan that has NOT been submitted', () => {
     const mockDeal = {
       submissionType: 'Automatic Inclusion Notice',
+      status: 'Accepted by UKEF (with conditions)',
       details: {
-        status: 'Accepted by UKEF (with conditions)',
         submissionDate: 12345678910,
       },
     };
@@ -147,8 +146,8 @@ describe('canIssueOrEditIssueFacility', () => {
   describe('when a deal status is `Accepted by UKEF (without conditions)`, AIN submissionType and a Conditional loan that has NOT been submitted', () => {
     const mockDeal = {
       submissionType: 'Automatic Inclusion Notice',
+      status: 'Accepted by UKEF (without conditions)',
       details: {
-        status: 'Accepted by UKEF (without conditions)',
         submissionDate: 12345678910,
       },
     };
@@ -176,8 +175,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -195,8 +194,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -214,8 +213,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -233,8 +232,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return true', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -253,8 +252,8 @@ describe('canIssueOrEditIssueFacility', () => {
       const checkerUserRole = ['checker'];
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
+        status: 'Further Maker\'s input required',
         details: {
-          status: 'Further Maker\'s input required',
           submissionDate: 12345678910,
         },
       };
@@ -267,8 +266,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
+        status: 'Some other status',
         details: {
-          status: 'Some other status',
           submissionDate: 12345678910,
         },
       };
@@ -281,8 +280,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Some other submission type',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -295,8 +294,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
+        status: 'Acknowledged by UKEF',
         details: {
-          status: 'Acknowledged by UKEF',
           submissionDate: 12345678910,
         },
       };
@@ -313,9 +312,7 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
-        details: {
-          status: 'Acknowledged by UKEF',
-        },
+        status: 'Acknowledged by UKEF',
       };
 
       const mockBond = {
@@ -330,8 +327,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Ready for Checker\'s approval',
         details: {
-          status: 'Ready for Checker\'s approval',
           submissionDate: 12345678910,
         },
       };
@@ -348,8 +345,8 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Automatic Inclusion Notice',
+        status: 'Ready for Checker\'s approval',
         details: {
-          status: 'Ready for Checker\'s approval',
           submissionDate: 12345678910,
         },
       };
@@ -370,9 +367,7 @@ describe('canIssueOrEditIssueFacility', () => {
     it('should return false', () => {
       const mockDeal = {
         submissionType: 'Manual Inclusion Notice',
-        details: {
-          status: 'Acknowledged by UKEF',
-        },
+        status: 'Acknowledged by UKEF',
       };
 
       const mockLoan = {

--- a/portal/server/routes/contract/dealWithCanIssueOrEditIssueFacilityFlags.test.js
+++ b/portal/server/routes/contract/dealWithCanIssueOrEditIssueFacilityFlags.test.js
@@ -6,8 +6,8 @@ describe('dealWithCanIssueOrEditIssueFacilityFlags', () => {
 
   const mockDeal = {
     submissionType: 'Automatic Inclusion Notice',
+    status: 'Further Maker\'s input required',
     details: {
-      status: 'Further Maker\'s input required',
       submissionDate: 12345678,
     },
     bondTransactions: {

--- a/portal/server/routes/contract/isDealEditable.js
+++ b/portal/server/routes/contract/isDealEditable.js
@@ -8,7 +8,7 @@ const isDealEditable = (deal, user) => {
   const { submissionDate } = deal.details;
   const dealHasBeenSubmitted = submissionDate;
 
-  if (![STATUS.draft, STATUS.inputRequired].includes(deal.details.status)
+  if (![STATUS.draft, STATUS.inputRequired].includes(deal.status)
       || dealHasBeenSubmitted) {
     return false;
   }

--- a/portal/server/routes/contract/isDealEditable.test.js
+++ b/portal/server/routes/contract/isDealEditable.test.js
@@ -6,9 +6,7 @@ describe('isDealEditable', () => {
   describe('when user is NOT maker', () => {
     it('should return false', () => {
       const mockDeal = {
-        details: {
-          status: 'Further Maker\'s input required',
-        },
+        status: 'Further Maker\'s input required',
       };
 
       const checkerUser = { roles: ['checker'] };
@@ -21,9 +19,7 @@ describe('isDealEditable', () => {
   describe('when deal status is NOT `Draft` or `Further Maker\'s input required`', () => {
     it('should return false', () => {
       const mockAcceptedDeal = {
-        details: {
-          status: 'Accepted by UKEF (with conditions)',
-        },
+        status: 'Accepted by UKEF (with conditions)',
       };
 
       const result = isDealEditable(mockAcceptedDeal, mockMakerUser);
@@ -34,8 +30,8 @@ describe('isDealEditable', () => {
   describe('when deal has been submitted', () => {
     it('should return false', () => {
       const mockDeal = {
+        status: 'Draft',
         details: {
-          status: 'Draft',
           submissionDate: 12345678,
         },
       };
@@ -48,9 +44,7 @@ describe('isDealEditable', () => {
   describe('when user is maker, deal status `Draft`, deal not submitted', () => {
     it('should return true', () => {
       const mockDeal = {
-        details: {
-          status: 'Draft',
-        },
+        status: 'Draft',
       };
 
       const result = isDealEditable(mockDeal, mockMakerUser);
@@ -61,9 +55,7 @@ describe('isDealEditable', () => {
   describe('when user is maker, deal status `Further Maker\'s input required`, deal not submitted', () => {
     it('should return true', () => {
       const mockDeal = {
-        details: {
-          status: 'Further Maker\'s input required',
-        },
+        status: 'Further Maker\'s input required',
       };
 
       const result = isDealEditable(mockDeal, mockMakerUser);

--- a/portal/server/routes/contract/isDealEditable.test.js
+++ b/portal/server/routes/contract/isDealEditable.test.js
@@ -7,6 +7,7 @@ describe('isDealEditable', () => {
     it('should return false', () => {
       const mockDeal = {
         status: 'Further Maker\'s input required',
+        details: {},
       };
 
       const checkerUser = { roles: ['checker'] };
@@ -20,6 +21,7 @@ describe('isDealEditable', () => {
     it('should return false', () => {
       const mockAcceptedDeal = {
         status: 'Accepted by UKEF (with conditions)',
+        details: {},
       };
 
       const result = isDealEditable(mockAcceptedDeal, mockMakerUser);
@@ -45,6 +47,7 @@ describe('isDealEditable', () => {
     it('should return true', () => {
       const mockDeal = {
         status: 'Draft',
+        details: {},
       };
 
       const result = isDealEditable(mockDeal, mockMakerUser);
@@ -56,6 +59,7 @@ describe('isDealEditable', () => {
     it('should return true', () => {
       const mockDeal = {
         status: 'Further Maker\'s input required',
+        details: {},
       };
 
       const result = isDealEditable(mockDeal, mockMakerUser);

--- a/portal/server/routes/contract/userCanSubmitDeal.js
+++ b/portal/server/routes/contract/userCanSubmitDeal.js
@@ -1,7 +1,7 @@
 const { STATUS } = require('../../constants');
 
 const userCanSubmitDeal = (deal, user) => {
-  if ([STATUS.submitted, STATUS.refused].includes(deal.details.status)) {
+  if ([STATUS.submitted, STATUS.refused].includes(deal.status)) {
     return false;
   }
 

--- a/portal/server/routes/contract/userCanSubmitDeal.test.js
+++ b/portal/server/routes/contract/userCanSubmitDeal.test.js
@@ -4,9 +4,7 @@ describe('userCanSubmitDeal', () => {
   describe('when deal has `Submitted` status', () => {
     it('should return false', () => {
       const deal = {
-        details: {
-          status: 'Submitted',
-        },
+        status: 'Submitted',
       };
 
       const result = userCanSubmitDeal(deal);
@@ -17,9 +15,7 @@ describe('userCanSubmitDeal', () => {
   describe('when deal has `Rejected by UKEF` status', () => {
     it('should return false', () => {
       const deal = {
-        details: {
-          status: 'Rejected by UKEF',
-        },
+        status: 'Rejected by UKEF',
       };
 
       const result = userCanSubmitDeal(deal);

--- a/portal/server/routes/expiryStatusUtils.js
+++ b/portal/server/routes/expiryStatusUtils.js
@@ -119,7 +119,7 @@ const getMIAData = async (req, res, filterByDealStatus) => {
   let deals = [];
   let count = 0;
   if (applications.deals) {
-    miaWithConditions = applications.deals.filter((deal) => (deal.details.status === filterByDealStatus));
+    miaWithConditions = applications.deals.filter((deal) => (deal.status === filterByDealStatus));
     tempDeals = getExpiryDates(miaWithConditions, workingDays, true);
     // once we have the deals and expiry dates, filter the display
     console.log(`tempDeals: ${util.inspect(tempDeals)}`);

--- a/portal/server/routes/reports/countdown-indicator.js
+++ b/portal/server/routes/reports/countdown-indicator.js
@@ -50,8 +50,8 @@ router.get('/reports/countdown-indicator', async (req, res) => {
 
   // mock up by filtering here on conditional or unissued
   const incompleteFacilities = transactions;
-  const miaWithConditions = applications.deals.filter((deal) => (deal.details.status === 'Accepted by UKEF (with conditions)'));
-  const miaWithOutConditions = applications.deals.filter((deal) => (deal.details.status === 'Accepted by UKEF (without conditions)'));
+  const miaWithConditions = applications.deals.filter((deal) => (deal.status === 'Accepted by UKEF (with conditions)'));
+  const miaWithOutConditions = applications.deals.filter((deal) => (deal.status === 'Accepted by UKEF (without conditions)'));
 
   const status90Days = getRAGstatus(incompleteFacilities, 90, false);
   const status20Days = getRAGstatus(miaWithConditions, 28, true);

--- a/portal/server/routes/reports/mia-to-be-submitted-with-conditions.js
+++ b/portal/server/routes/reports/mia-to-be-submitted-with-conditions.js
@@ -49,7 +49,7 @@ router.get('/reports/mia-to-be-submitted/with-conditions/:page', async (req, res
   let deals = [];
   let count = 0;
   if (applications.deals) {
-    miaWithConditions = applications.deals.filter((deal) => (deal.details.status === filterByDealStatus));
+    miaWithConditions = applications.deals.filter((deal) => (deal.status === filterByDealStatus));
     tempDeals = getExpiryDates(miaWithConditions, workingDays, true);
     // once we have the deals and expiry dates, filter the display
     if (fromDays > 0) {

--- a/portal/server/routes/reports/mia-to-be-submitted-without-conditions.js
+++ b/portal/server/routes/reports/mia-to-be-submitted-without-conditions.js
@@ -45,7 +45,7 @@ router.get('/reports/mia-to-be-submitted/without-conditions/:page', async (req, 
   let deals = [];
   let count = 0;
   if (applications.deals) {
-    miaWithConditions = applications.deals.filter((deal) => (deal.details.status === filterByDealStatus));
+    miaWithConditions = applications.deals.filter((deal) => (deal.status === filterByDealStatus));
     tempDeals = getExpiryDates(miaWithConditions, workingDays, true);
     // once we have the deals and expiry dates, filter the display
     if (fromDays > 0) {

--- a/portal/server/routes/reports/reconciliation.js
+++ b/portal/server/routes/reports/reconciliation.js
@@ -38,7 +38,7 @@ router.get('/reports/reconciliation-report/:page', async (req, res) => {
 
   filters.push(
     {
-      field: 'details.status',
+      field: 'status',
       value: 'Submitted',
     },
   );

--- a/portal/templates/contract/components/abandon-deal-link.njk
+++ b/portal/templates/contract/components/abandon-deal-link.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% macro render(params) %}
-  {% if params.deal.details.status %}
+  {% if params.deal.status %}
 
     {% if params.user.roles.includes('maker') %}
-      {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) %}
+      {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) %}
         <a
           data-cy="AbandonLink"
           href="/contract/{{ params.deal._id }}/delete"

--- a/portal/templates/contract/components/bond-transactions-table.njk
+++ b/portal/templates/contract/components/bond-transactions-table.njk
@@ -8,8 +8,8 @@
 {% macro render(params) %}
   {% if params.deal.bondTransactions.items %}
     <div class="govuk-grid-column-full">
-      {% set dealStatus = params.deal.details.status %}
-      {% set dealPreviousStatus = params.deal.details.previousStatus %}
+      {% set dealStatus = params.deal.status %}
+      {% set dealPreviousStatus = params.deal.previousStatus %}
       {% set bonds = params.deal.bondTransactions.items %}
 
         <table class="govuk-table contract-table contract-transactions-table govuk-!-margin-bottom-0" data-cy="bond-transactions-table">

--- a/portal/templates/contract/components/clone-deal-link.njk
+++ b/portal/templates/contract/components/clone-deal-link.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% macro render(params) %}
-  {% if params.deal.details.status %}
+  {% if params.deal.status %}
 
     {% if params.user.roles.includes('maker') %}
       <a

--- a/portal/templates/contract/components/contract-actions.njk
+++ b/portal/templates/contract/components/contract-actions.njk
@@ -8,15 +8,15 @@
 
   {% if params.dealFormsCompleted %}
 
-    {% if params.deal.details.status %}
+    {% if params.deal.status %}
       {% if params.user.roles.includes('maker') %}
-          {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) %}
+          {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) %}
             <p data-cy="canProceed" class="govuk-body">You may now proceed to submit an {{params.deal.submissionType}}.</p>
           {% endif %}
       {% endif %}
 
       {% if params.user.roles.includes('checker') %}
-          {% if ["Ready for Checker's approval"].includes(params.deal.details.status) %}
+          {% if ["Ready for Checker's approval"].includes(params.deal.status) %}
             <p data-cy="canProceed" class="govuk-body">You may now proceed to submit an {{params.deal.submissionType}}.</p>
           {% endif %}
       {% endif %}
@@ -25,7 +25,7 @@
   {% else %}
 
     {% if params.user.roles.includes('maker') %}
-        {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) %}
+        {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) %}
           <p data-cy="canProceed" class="govuk-body">Please complete all form sections in order to submit your Supply Contract.</p>
         {% endif %}
     {% endif %}

--- a/portal/templates/contract/components/contract-actions/abandon-deal-button.njk
+++ b/portal/templates/contract/components/contract-actions/abandon-deal-button.njk
@@ -1,11 +1,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% macro render(params) %}
-  {% if params.deal.details.status %}
+  {% if params.deal.status %}
 
     {% if params.user.roles.includes('maker') %}
 
-      {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) %}
+      {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) %}
 
         {{ govukButton({
           "disabled": false,
@@ -17,7 +17,7 @@
           "href": "/contract/" + params.deal._id + "/delete"
         }) }}
 
-      {% elseif  ["Abandoned", "Acknowledged by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "Ready for Checker's approval"].includes(params.deal.details.status) %}
+      {% elseif  ["Abandoned", "Acknowledged by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "Ready for Checker's approval"].includes(params.deal.status) %}
 
         {{ govukButton({
           "disabled": true,

--- a/portal/templates/contract/components/contract-actions/please-complete-all-forms-text.njk
+++ b/portal/templates/contract/components/contract-actions/please-complete-all-forms-text.njk
@@ -1,7 +1,7 @@
 {% macro render(params) %}
-  {% if params.deal.details.status %}
+  {% if params.deal.status %}
     {% if params.user.roles.includes('maker') %}
-        {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) and not params.dealFormsCompleted %}
+        {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) and not params.dealFormsCompleted %}
           <p data-cy="pleaseCompleteAllForms" class="govuk-body">Please complete all form sections in order to submit your Supply Contract.</p>
         {% endif %}
     {% endif %}

--- a/portal/templates/contract/components/contract-actions/proceed-to-review-button.njk
+++ b/portal/templates/contract/components/contract-actions/proceed-to-review-button.njk
@@ -2,9 +2,9 @@
 
 {% macro render(params) %}
 
-  {% if not ["Submitted", "Rejected by UKEF"].includes(params.deal.details.status) and params.user.roles.includes('maker') %}
+  {% if not ["Submitted", "Rejected by UKEF"].includes(params.deal.status) and params.user.roles.includes('maker') %}
 
-    {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) and params.dealFormsCompleted %}
+    {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) and params.dealFormsCompleted %}
 
       {{ govukButton({
         "disabled": false,
@@ -15,7 +15,7 @@
         "href": "/contract/" + params.deal._id + "/ready-for-review"
       }) }}
 
-    {% elseif ["Ready for Checker's approval"].includes(params.deal.details.status) and params.dealFormsCompleted and not params.user.roles.includes('checker')%}
+    {% elseif ["Ready for Checker's approval"].includes(params.deal.status) and params.dealFormsCompleted and not params.user.roles.includes('checker')%}
 
       {{ govukButton({
         "disabled": true,
@@ -26,7 +26,7 @@
         "href": ""
       }) }}
 
-    {% elseif  ["Draft", "Further Maker's input required", "Abandoned", "Acknowledged by UKEF"].includes(params.deal.details.status) and not params.dealFormsCompleted and not params.dealHasIssuedFacilitiesToSubmit %}
+    {% elseif  ["Draft", "Further Maker's input required", "Abandoned", "Acknowledged by UKEF"].includes(params.deal.status) and not params.dealFormsCompleted and not params.dealHasIssuedFacilitiesToSubmit %}
 
       {{ govukButton({
         "disabled": true,
@@ -37,7 +37,7 @@
         "href": ""
       }) }}
 
-    {% elseif ["Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)"].includes(params.deal.details.status) %}
+    {% elseif ["Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)"].includes(params.deal.status) %}
 
       {% if params.allRequestedCoverStartDatesConfirmed %}
         {{ govukButton({
@@ -59,7 +59,7 @@
         }) }}
       {% endif %}
 
-    {% elseif ["Acknowledged by UKEF", "Ready for Checker's approval", "Further Maker's input required"].includes(params.deal.details.status) and params.dealHasIssuedFacilitiesToSubmit %}
+    {% elseif ["Acknowledged by UKEF", "Ready for Checker's approval", "Further Maker's input required"].includes(params.deal.status) and params.dealHasIssuedFacilitiesToSubmit %}
       {{ govukButton({
         "disabled": false,
         "text": "Proceed to review",

--- a/portal/templates/contract/components/contract-actions/proceed-to-submit-button.njk
+++ b/portal/templates/contract/components/contract-actions/proceed-to-submit-button.njk
@@ -2,9 +2,9 @@
 
 {% macro render(params) %}
 
-  {% if params.deal.details.status and params.userCanSubmit %}
+  {% if params.deal.status and params.userCanSubmit %}
 
-    {% if not ["Draft", "Further Maker's input required", "Acknowledged by UKEF", "In progress by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)"].includes(params.deal.details.status) and params.user.roles.includes('checker') and params.user.roles.includes('maker') %}
+    {% if not ["Draft", "Further Maker's input required", "Acknowledged by UKEF", "In progress by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)"].includes(params.deal.status) and params.user.roles.includes('checker') and params.user.roles.includes('maker') %}
       {{ govukButton({
         "disabled": false,
         "text": "Proceed to submit",
@@ -17,7 +17,7 @@
 
     {% if params.user.roles.includes('checker') and not params.user.roles.includes('maker') %}
 
-        {% if ["Ready for Checker's approval"].includes(params.deal.details.status) %}
+        {% if ["Ready for Checker's approval"].includes(params.deal.status) %}
 
           {{ govukButton({
             "disabled": false,
@@ -28,7 +28,7 @@
             "href": "/contract/" + params.deal._id + "/confirm-submission"
           }) }}
 
-        {% elseif  ["Draft", "Abandoned", "Acknowledged by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "In progress by UKEF"].includes(params.deal.details.status) %}
+        {% elseif  ["Draft", "Abandoned", "Acknowledged by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "In progress by UKEF"].includes(params.deal.status) %}
 
           {{ govukButton({
             "disabled": true,

--- a/portal/templates/contract/components/contract-actions/return-to-maker-button.njk
+++ b/portal/templates/contract/components/contract-actions/return-to-maker-button.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% macro render(params) %}
-  {% if params.deal.details.status and params.userCanSubmit %}
+  {% if params.deal.status and params.userCanSubmit %}
 
-    {% if not ["Draft", "Further Maker's input required", "Acknowledged by UKEF", "In progress by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)"].includes(params.deal.details.status) and params.user.roles.includes('checker') and params.user.roles.includes('maker') %}
+    {% if not ["Draft", "Further Maker's input required", "Acknowledged by UKEF", "In progress by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)"].includes(params.deal.status) and params.user.roles.includes('checker') and params.user.roles.includes('maker') %}
       {{ govukButton({
         "disabled": false,
         "text": "Return to Maker",
@@ -17,7 +17,7 @@
 
     {% if params.user.roles.includes('checker') and not params.user.roles.includes('maker') %}
 
-        {% if ["Ready for Checker's approval"].includes(params.deal.details.status) %}
+        {% if ["Ready for Checker's approval"].includes(params.deal.status) %}
 
           {{ govukButton({
             "disabled": false,
@@ -29,7 +29,7 @@
             "href": "/contract/" + params.deal._id + "/return-to-maker"
           }) }}
 
-        {% elseif  ["Draft", "Abandoned", "Acknowledged by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "In progress by UKEF"].includes(params.deal.details.status) %}
+        {% elseif  ["Draft", "Abandoned", "Acknowledged by UKEF", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "In progress by UKEF"].includes(params.deal.status) %}
 
           {{ govukButton({
             "disabled": true,

--- a/portal/templates/contract/components/contract-actions/review-eligibility-checklist-link.njk
+++ b/portal/templates/contract/components/contract-actions/review-eligibility-checklist-link.njk
@@ -1,7 +1,7 @@
 {% macro render(params) %}
-  {% if params.deal.details.status %}
+  {% if params.deal.status %}
     {% if params.user.roles.includes('checker') or params.user.roles.includes('maker') %}
-        {% if ["Ready for Checker's approval"].includes(params.deal.details.status) %}
+        {% if ["Ready for Checker's approval"].includes(params.deal.status) %}
 
           <p class="govuk-body">
              <a data-cy="reviewEligibilityChecklistForm" href="/contract/{{ params.deal._id }}/submission-details#eligibility-criteria" class="govuk-body govuk-link">

--- a/portal/templates/contract/components/contract-overview-table.njk
+++ b/portal/templates/contract/components/contract-overview-table.njk
@@ -35,11 +35,11 @@
         </td>
 
         <td data-cy="status" class="govuk-table__cell govuk-!-font-size-14">
-          {{ details.status | dashIfEmpty }}
+          {{ deal.status | dashIfEmpty }}
         </td>
 
         <td data-cy="previousStatus" class="govuk-table__cell govuk-!-font-size-14">
-          {{ details.previousStatus | dashIfEmpty }}
+          {{ deal.previousStatus | dashIfEmpty }}
         </td>
 
         <td data-cy="maker" class="govuk-table__cell govuk-!-font-size-14">

--- a/portal/templates/contract/components/edit-deal-name-link.njk
+++ b/portal/templates/contract/components/edit-deal-name-link.njk
@@ -1,12 +1,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% macro render(params) %}
-  {% if params.deal.details.status %}
+  {% if params.deal.status %}
 
     {% if params.user.roles.includes('maker') %}
       {% if params.user._id === params.deal.details.maker._id %}
 
-        {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) %}
+        {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) %}
           <a
             data-cy="EditDealName"
             class="govuk-link govuk-!-font-size-14"

--- a/portal/templates/contract/components/forms-incomplete-text.njk
+++ b/portal/templates/contract/components/forms-incomplete-text.njk
@@ -1,9 +1,9 @@
 {% macro render(params) %}
 
   <div data-cy="forms-incomplete-text">
-    {% if params.deal.details.status %}
+    {% if params.deal.status %}
       {% if params.user.roles.includes('maker') %}
-          {% if ["Draft", "Further Maker's input required"].includes(params.deal.details.status) and not params.canFullyCalculateDealSummary %}
+          {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) and not params.canFullyCalculateDealSummary %}
 
             <div class="govuk-error-summary govuk-!-padding-0 forms-incomplete-summary" data-module="govuk-error-summary">
               <div class="govuk-error-summary__body">

--- a/portal/templates/contract/components/issue-or-delete-facility-link.njk
+++ b/portal/templates/contract/components/issue-or-delete-facility-link.njk
@@ -3,7 +3,7 @@
   {% set userIsChecker = params.user.roles.includes('checker')%}
 
   {% set dealId = params.deal._id %}
-  {% set dealStatus = params.deal.details.status %}
+  {% set dealStatus = params.deal.status %}
   {% set dealSubmissionDate = params.deal.details.submissionDate %}
   {% set dealIsEditable = params.editable %}
 

--- a/portal/templates/contract/components/loan-transactions-table.njk
+++ b/portal/templates/contract/components/loan-transactions-table.njk
@@ -8,8 +8,8 @@
 {% macro render(params) %}
   {% if params.deal.loanTransactions.items %}
     <div class="govuk-grid-column-full">
-      {% set dealStatus = params.deal.details.status %}
-      {% set dealPreviousStatus = params.deal.details.previousStatus %}
+      {% set dealStatus = params.deal.status %}
+      {% set dealPreviousStatus = params.deal.previousStatus %}
       {% set loans = params.deal.loanTransactions.items %}
 
       <table class="govuk-table contract-table contract-transactions-table govuk-!-margin-bottom-0" data-cy="loan-transactions-table">

--- a/portal/templates/contract/components/requested-start-date-link.njk
+++ b/portal/templates/contract/components/requested-start-date-link.njk
@@ -1,9 +1,9 @@
 {% macro render(params) %}
 
   {% set dealId = params.deal._id %}
-  {% set dealStatus = params.deal.details.status %}
+  {% set dealStatus = params.deal.status %}
   {% set dealSubmissionType = params.deal.submissionType %}
-  {% set dealPreviousStatus = params.deal.details.previousStatus %}
+  {% set dealPreviousStatus = params.deal.previousStatus %}
 
   {% set facility = params.facility %}
   {% set facilityName = params.facilityName %}

--- a/portal/templates/contract/contract-submission-details.njk
+++ b/portal/templates/contract/contract-submission-details.njk
@@ -24,7 +24,7 @@
 
   <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-8">
 
-  {{ ukefComments.render(deal.details.status, deal.ukefComments, deal.specialConditions) }}
+  {{ ukefComments.render(deal.status, deal.ukefComments, deal.specialConditions) }}
 
   <h2 class="govuk-heading-l">
     <span data-cy="general-deal-info-heading">General deal information</span>

--- a/portal/templates/contract/contract-view-comments.njk
+++ b/portal/templates/contract/contract-view-comments.njk
@@ -19,7 +19,7 @@
 
   </div>
 
- {{ ukefComments.render(deal.details.status, deal.ukefComments, deal.specialConditions) }}
+ {{ ukefComments.render(deal.status, deal.ukefComments, deal.specialConditions) }}
  
   <h2 class="govuk-heading-s">Maker/Checker comments:</h2>
 

--- a/portal/templates/contract/contract-view.njk
+++ b/portal/templates/contract/contract-view.njk
@@ -75,7 +75,7 @@
                   About the Supply Contract
                 </span>
             <span data-cy="aboutSupplierDetailsStatus" class="govuk-grid-column-one-quarter">
-              {{ statusTag.render(deal.submissionstatus) }}
+              {{ statusTag.render(deal.submissionDetails.status) }}
             </span>
           </h2>
         </div>

--- a/portal/templates/contract/contract-view.njk
+++ b/portal/templates/contract/contract-view.njk
@@ -54,7 +54,7 @@
   <section>
     <div class="govuk-grid-row govuk-!-margin-bottom-2">
       <div class="govuk-grid-column-three-quarters">
-        {{ ukefComments.render(deal.details.status, deal.ukefComments, deal.specialConditions) }} &nbsp; <!--AP test --></div>
+        {{ ukefComments.render(deal.status, deal.ukefComments, deal.specialConditions) }} &nbsp; <!--AP test --></div>
       <div class="govuk-grid-column-one-quarter box__header-link">
         {{ cloneLink.render(componentData) }}
         {{ abandonLink.render(componentData) }}
@@ -75,7 +75,7 @@
                   About the Supply Contract
                 </span>
             <span data-cy="aboutSupplierDetailsStatus" class="govuk-grid-column-one-quarter">
-              {{ statusTag.render(deal.submissionDetails.status) }}
+              {{ statusTag.render(deal.submissionstatus) }}
             </span>
           </h2>
         </div>

--- a/portal/templates/reports/abandoned-supply-contracts.njk
+++ b/portal/templates/reports/abandoned-supply-contracts.njk
@@ -42,7 +42,7 @@
           </td>
 
           <td data-cy="status" class="govuk-table__cell govuk-!-font-size-14">
-            {{ contract.details.status }}
+            {{ contract.status }}
           </td>
 
           <td data-cy="submissionType" class="govuk-table__cell govuk-!-font-size-14">

--- a/portal/templates/reports/all-transactions-report.njk
+++ b/portal/templates/reports/all-transactions-report.njk
@@ -41,7 +41,7 @@
           </td>
 
           <td data-cy="status" class="govuk-table__cell govuk-!-font-size-14">
-            {{ transaction.deal.details.status }}
+            {{ transaction.deal.status }}
           </td>
 
           <td data-cy="transactionId" class="govuk-table__cell govuk-!-font-size-14">

--- a/portal/templates/reports/audit-supply-contracts.njk
+++ b/portal/templates/reports/audit-supply-contracts.njk
@@ -56,7 +56,7 @@
           </td>
 
           <td data-cy="status" class="govuk-table__cell govuk-!-font-size-14">
-            {{ contract.details.status }}
+            {{ contract.status }}
           </td>
 
           {% if user and user.roles.includes("admin")%}

--- a/portal/templates/reports/reconciliation-report.njk
+++ b/portal/templates/reports/reconciliation-report.njk
@@ -61,7 +61,7 @@
           </td>
 
           <td data-cy="status" class="govuk-table__cell govuk-!-font-size-14">
-            {{ deal.details.status }}
+            {{ deal.status }}
           </td>
 
         </tr>

--- a/portal/templates/reports/transactions-report.njk
+++ b/portal/templates/reports/transactions-report.njk
@@ -36,7 +36,7 @@
           </td>
 
           <td data-cy="status" class="govuk-table__cell govuk-!-font-size-14">
-            {{ transaction.deal.details.status }}
+            {{ transaction.deal.status }}
           </td>
 
           <td data-cy="transactionId" class="govuk-table__cell govuk-!-font-size-14">

--- a/reference-data-proxy/src/v1/swagger-definitions/portal-bss-deal.js
+++ b/reference-data-proxy/src/v1/swagger-definitions/portal-bss-deal.js
@@ -19,12 +19,15 @@
  *       additionalRefName:
  *         type: string
  *         example: Test
+ *       status:
+ *         type: string
+ *         example: Submitted
+ *       previousStatus:
+ *         type: string
+ *         example: Ready for Checker's approval
  *       details:
  *         type: object
  *         properties:
- *           status:
- *             type: string
- *             example: Submitted
  *           submissionType:
  *             type: string
  *             example: Automatic Inclusion Notice
@@ -35,10 +38,6 @@
  *           created:
  *             type: string
  *             example: '1632389070727'
-
- *           previousStatus:
- *             type: string
- *             example: Ready for Checker's approval
  *           submissionCount:
  *             type: integer
  *             emample: 1

--- a/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
@@ -115,9 +115,9 @@ query Deal($_id: String! $tasksFilters: TasksFilters $activityFilters: ActivityF
       submissionType
       bankInternalRefName
       additionalRefName
+      status,
       details {
         ukefDealId,
-        status,
         submissionDate,
         owningBank {
           name,

--- a/trade-finance-manager-api/graphql-query-tests/mock-deal.js
+++ b/trade-finance-manager-api/graphql-query-tests/mock-deal.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
     submissionType: 'Automatic Inclusion Notice',
     bankInternalRefName: 'Mock supply contract ID',
     additionalRefName: 'Mock supply contract name',
+    status: 'Acknowledged by UKEF',
+    previousStatus: 'Submitted',
     details: {
-      status: 'Acknowledged by UKEF',
       bank: 'Mock bank',
       ukefDealId: '20010739',
-      previousStatus: 'Submitted',
       maker: {
         username: 'JOE',
         firstname: 'Joe',

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -30,7 +30,6 @@ type Checker {
 }
 
 type DealDetails {
-  status: String
   ukefDealId: String
   maker: Maker
   checker: Checker
@@ -359,6 +358,7 @@ type DealSnapshot {
   bankInternalRefName: String
   additionalRefName: String
   updatedAt: Float
+  status: String
   details: DealDetails
   totals: DealTotals
   facilities: [Facility]

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -143,11 +143,8 @@ module.exports = {
     const deal = ALL_MOCK_DEALS.find((d) => d._id === dealId); // eslint-disable-line no-underscore-dangle
     const updatedDeal = {
       ...deal,
-      details: {
-        ...deal.details,
-        status: statusUpdate,
-        previousStatus: deal.details.previousStatus,
-      },
+      status: statusUpdate,
+      previousStatus: deal.previousStatus,
     };
     return Promise.resolve(updatedDeal);
   },

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-second-submit-facilities-unissued-to-issued.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-second-submit-facilities-unissued-to-issued.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_AIN_SUBMITTED_FACILITIES_UNISSUED_TO_ISSUED = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Ready for Checker\'s approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted-non-gbp-contract-value.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted-non-gbp-contract-value.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_AIN_SUBMITTED_NON_GBP_CONTRACT_VALUE = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Ready for Checker\'s approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-AIN-submitted.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_AIN_SUBMITTED = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Ready for Checker\'s approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-not-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-not-submitted.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
   submissionType: 'Manual Inclusion Application',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Ready for Checker\'s approval',
+  previousStatus: 'Draft',
   details: {
-    status: 'Ready for Checker\'s approval',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Draft',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit-facilities-unissued-to-issued.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit-facilities-unissued-to-issued.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_MIA_SUBMITTED_FACILITIES_UNISSUED_TO_ISSUED = {
   submissionType: 'Manual Inclusion Application',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Ready for Checker\'s approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-second-submit.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
   submissionType: 'Manual Inclusion Application',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIA-submitted.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
   submissionType: 'Manual Inclusion Application',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Ready for Checker\'s approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN-second-submit-facilities-unissued-to-issued.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN-second-submit-facilities-unissued-to-issued.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_MIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED = {
   submissionType: 'Manual Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Submitted',
+  previousStatus: 'Ready for Checker\'s approval',
   details: {
-    status: 'Submitted',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Ready for Checker\'s approval',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-MIN.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
   submissionType: 'Manual Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-acbs.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-acbs.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-facilities-USD-currency.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-facilities-USD-currency.js
@@ -6,11 +6,11 @@ const MOCK_DEAL = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-issued-facilities.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_ISSUED_FACILITIES = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-companies-house.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-companies-house.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_NO_COMPANIES_HOUSE = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-party-db.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal-no-party-db.js
@@ -4,11 +4,11 @@ const MOCK_DEAL_NO_PARTY_DB = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal.js
@@ -4,11 +4,11 @@ const MOCK_DEAL = {
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',
   additionalRefName: 'Mock supply contract name',
+  status: 'Acknowledged by UKEF',
+  previousStatus: 'Submitted',
   details: {
-    status: 'Acknowledged by UKEF',
     bank: 'Mock bank',
     ukefDealId: '20010739',
-    previousStatus: 'Submitted',
     maker: {
       username: 'JOE',
       firstname: 'Joe',

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.api-test.js
@@ -23,12 +23,12 @@ describe('mappings - map submitted deal - mapBssEwcsDeal', () => {
       loanTransactions,
       eligibility,
       exporter,
+      status,
     } = mockDeal.dealSnapshot;
 
     const {
       submissionCount,
       submissionDate,
-      status,
       ukefDealId,
       maker,
     } = details;

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.js
@@ -15,12 +15,12 @@ const mapBssEwcsDeal = (deal) => {
     loanTransactions,
     eligibility,
     exporter,
+    status,
   } = dealSnapshot;
 
   const {
     submissionCount,
     submissionDate,
-    status,
     ukefDealId,
     maker,
   } = details;

--- a/trade-finance-manager-ui/server/graphql/queries/deal-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deal-query.js
@@ -79,9 +79,9 @@ const dealQuery = gql`
         submissionType
         bankInternalRefName
         additionalRefName
+        status
         details {
           ukefDealId
-          status
           submissionDate
           owningBank {
             name

--- a/trade-finance-manager-ui/server/graphql/queries/deals-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deals-query.js
@@ -16,8 +16,8 @@ query Deals($searchString: String, $sortBy: DealsSortBy, $byField: [DealsByField
         updatedAt
         bankInternalRefName
         additionalRefName
+        status
         details {
-          status
           ukefDealId
           submissionDate
           maker {

--- a/trade-finance-manager-ui/templates/case/mock_data/deal.json
+++ b/trade-finance-manager-ui/templates/case/mock_data/deal.json
@@ -3,9 +3,9 @@
   "submissionType": "Automatic Inclusion Notice",
   "bankInternalRefName": "Smoke test 17/02/21",
   "additionalRefName": "Smoke test 17/02/21",
+  "status": "Submitted",
   "details": {
     "ukefDealId": "0040005777",
-    "status": "Submitted",
     "submissionDate": "1613557575317",
     "owningBank": {
       "name": "UKEF test bank (Delegated)",

--- a/utils/mock-data-loader/graphql/queries/deals-query.js
+++ b/utils/mock-data-loader/graphql/queries/deals-query.js
@@ -1,6 +1,6 @@
 const gql = require('graphql-tag');
 
-//   deals(params: {start:0, pagesize: $pagesize, filter: [{field: "details.status", value: "Draft"}]}) {
+//   deals(params: {start:0, pagesize: $pagesize, filter: [{field: "status", value: "Draft"}]}) {
 const dealsQuery = `
 query {
   deals {


### PR DESCRIPTION
## Summary

No more:

```
deal.details.status
deal.details.previousStatus
```

It's now aligned with GEF:

```
deal.status
deal.previousStatus
```

Although, GEF doesn't have `previousStatus`. Might need this in the future. It already exists for BSS, so just moved to the top level whilst I was there.



## Also
- Fixed TFM e2e test issue for "searching all deals by date" where a deal was not setting all queriable date fields to yesterday.