### PR TITLE
Fix TFM mappings for deals table, improve tests

### DIFF
--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
@@ -32,7 +32,7 @@ context('Portal to TFM deal submission', () => {
       });
   });
 
-  it('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM. Exporter and submission type should display', () => {
+  t('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM', () => {
     //---------------------------------------------------------------
     // portal maker submits deal for review
     //---------------------------------------------------------------
@@ -71,25 +71,11 @@ context('Portal to TFM deal submission', () => {
     tfmPages.landingPage.submitButton().click();
 
 
-    //---------------------------------------------------------------
-    // user vists the case/deal page
-    //---------------------------------------------------------------
     const tfmCaseDealPage = `${tfmRootUrl}/case/${dealId}/deal`;
     cy.forceVisit(tfmCaseDealPage);
 
     //---------------------------------------------------------------
-    // deal stage and product type should be  populated in the Case Summary
-    //---------------------------------------------------------------
-    tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
-      expect(text.trim()).to.contain('Application');
-    });
-
-    tfmPartials.caseSummary.ukefProduct().invoke('text').then((text) => {
-      expect(text.trim()).to.contain('BSS & EWCS');
-    });
-
-    //---------------------------------------------------------------
-    // submission type and exporter should be displayed in the Case Summary
+    // // deal stage and product type is populated
     //---------------------------------------------------------------
     tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
       expect(text.trim()).to.contain('Confirmed');

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
@@ -6,6 +6,8 @@ import tfmPartials from '../../../../../../trade-finance-manager/cypress/integra
 import MOCK_USERS from '../../../../../../portal/cypress/fixtures/mockUsers';
 import MOCK_AIN_DEAL_READY_TO_SUBMIT from '../test-data/AIN-deal/dealReadyToSubmit';
 
+const mockDeal = MOCK_AIN_DEAL_READY_TO_SUBMIT();
+
 const MAKER_LOGIN = MOCK_USERS.find((user) => (user.roles.includes('maker') && user.username === 'BANK1_MAKER1'));
 const CHECKER_LOGIN = MOCK_USERS.find((user) => (user.roles.includes('checker') && user.username === 'BANK1_CHECKER1'));
 
@@ -30,7 +32,7 @@ context('Portal to TFM deal submission', () => {
       });
   });
 
-  it('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM', () => {
+  it('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM. Exporter and submission type should display', () => {
     //---------------------------------------------------------------
     // portal maker submits deal for review
     //---------------------------------------------------------------
@@ -68,12 +70,26 @@ context('Portal to TFM deal submission', () => {
     tfmPages.landingPage.email().type('BUSINESS_SUPPORT_USER_1');
     tfmPages.landingPage.submitButton().click();
 
+
+    //---------------------------------------------------------------
+    // user vists the case/deal page
+    //---------------------------------------------------------------
     const tfmCaseDealPage = `${tfmRootUrl}/case/${dealId}/deal`;
     cy.forceVisit(tfmCaseDealPage);
 
+    //---------------------------------------------------------------
+    // deal stage and product type should be  populated in the Case Summary
+    //---------------------------------------------------------------
+    tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
+      expect(text.trim()).to.contain('Application');
+    });
+
+    tfmPartials.caseSummary.ukefProduct().invoke('text').then((text) => {
+      expect(text.trim()).to.contain('BSS & EWCS');
+    });
 
     //---------------------------------------------------------------
-    // deal stage and product type is populated
+    // submission type and exporter should be displayed in the Case Summary
     //---------------------------------------------------------------
     tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
       expect(text.trim()).to.contain('Confirmed');

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-AIN-deal-creates-tfm-deal-stage-and-product/submit-AIN-deal-creates-tfm-deal-stage-and-product.spec.js
@@ -18,7 +18,7 @@ context('Portal to TFM deal submission', () => {
 
   before(() => {
     cy.insertManyDeals([
-      MOCK_AIN_DEAL_READY_TO_SUBMIT(),
+      mockDeal,
     ], MAKER_LOGIN)
       .then((insertedDeals) => {
         [deal] = insertedDeals;
@@ -32,7 +32,7 @@ context('Portal to TFM deal submission', () => {
       });
   });
 
-  t('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM', () => {
+  it('Portal AIN deal is submitted to UKEF, `Confirmed` deal stage and product is added to the deal in TFM', () => {
     //---------------------------------------------------------------
     // portal maker submits deal for review
     //---------------------------------------------------------------
@@ -70,12 +70,11 @@ context('Portal to TFM deal submission', () => {
     tfmPages.landingPage.email().type('BUSINESS_SUPPORT_USER_1');
     tfmPages.landingPage.submitButton().click();
 
-
     const tfmCaseDealPage = `${tfmRootUrl}/case/${dealId}/deal`;
     cy.forceVisit(tfmCaseDealPage);
 
     //---------------------------------------------------------------
-    // // deal stage and product type is populated
+    // deal stage and product type is populated
     //---------------------------------------------------------------
     tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
       expect(text.trim()).to.contain('Confirmed');

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-MIA-deal-creates-tfm-deal-stage-and-product/submit-MIA-deal-creates-tfm-deal-stage-and-product.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-MIA-deal-creates-tfm-deal-stage-and-product/submit-MIA-deal-creates-tfm-deal-stage-and-product.spec.js
@@ -32,7 +32,7 @@ context('Portal to TFM deal submission', () => {
       });
   });
 
-  it('Portal MIA deal is submitted to UKEF, `Application` deal stage and product is added to the deal in TFM. Exporter and submission type should display', () => {
+  it('Portal MIA deal is submitted to UKEF, `Application` deal stage and product is added to the deal in TFM', () => {
     //---------------------------------------------------------------
     // portal maker submits deal for review
     //---------------------------------------------------------------
@@ -69,32 +69,12 @@ context('Portal to TFM deal submission', () => {
 
     tfmPages.landingPage.email().type('BUSINESS_SUPPORT_USER_1');
     tfmPages.landingPage.submitButton().click();
-
-
-    //---------------------------------------------------------------
-    // exporter and submission type should be displayed in the deals table
-    //---------------------------------------------------------------
-    cy.url().should('include', '/deals');
-    const row = tfmPages.dealsPage.dealsTable.row(mockDeal._id);
-
-    row.submissionType().invoke('text').then((text) => {
-      expect(text.trim()).to.contain(mockDeal.submissionType);
-    });
-
-    row.exporterName().invoke('text').then((text) => {
-      expect(text.trim()).to.contain(mockDeal.exporter.companyName);
-    });
-
-
-    //---------------------------------------------------------------
-    // user vists the case/deal page
-    //---------------------------------------------------------------
     const tfmCaseDealPage = `${tfmRootUrl}/case/${dealId}/deal`;
     cy.forceVisit(tfmCaseDealPage);
 
 
     //---------------------------------------------------------------
-    // deal stage and product type should be  populated in the Case Summary
+    // deal stage and product type is populated
     //---------------------------------------------------------------
     tfmPartials.caseSummary.ukefDealStage().invoke('text').then((text) => {
       expect(text.trim()).to.contain('Application');
@@ -103,18 +83,5 @@ context('Portal to TFM deal submission', () => {
     tfmPartials.caseSummary.ukefProduct().invoke('text').then((text) => {
       expect(text.trim()).to.contain('BSS & EWCS');
     });
-
-    //---------------------------------------------------------------
-    // submission type and exporter should be displayed in the Case Summary
-    //---------------------------------------------------------------
-    tfmPartials.caseSummary.dealSubmissionType().invoke('text').then((text) => {
-      expect(text.trim()).to.contain(mockDeal.submissionType);
-    });
-
-    tfmPartials.caseSummary.exporterName().invoke('text').then((text) => {
-      expect(text.trim()).to.contain(mockDeal.exporter.companyName);
-    });
-
-    // todo test in AIN spec as well
   });
 });

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/AIN-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/AIN-deal/dealThatJustNeedsDates.json
@@ -176,5 +176,8 @@
       "feeFrequency": null,
       "feeType": "At maturity"
     }
-  ]
+  ],
+  "exporter": {
+    "companyName": "UKFS"
+  }
 }

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIA-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIA-deal/dealThatJustNeedsDates.json
@@ -175,5 +175,8 @@
       "feeFrequency": null,
       "feeType": "At maturity"
     }
-  ]
+  ],
+  "exporter": {
+    "companyName": "UKFS"
+  }
 }

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/deal.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/deal.spec.js
@@ -45,7 +45,7 @@ context('User can view a case deal', () => {
     pages.caseDealPage.mgaVersion().should('exist');
   });
 
-  it.only('should render case summary fields', () => {
+  it('should render case summary fields', () => {
     partials.caseSummary.dealSubmissionType().invoke('text').then((text) => {
       expect(text.trim()).to.contain(MOCK_DEAL_AIN.submissionType);
     });

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/deal.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/deal.spec.js
@@ -1,5 +1,6 @@
 import relative from '../../relativeURL';
 import pages from '../../pages';
+import partials from '../../partials';
 import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
 import MOCK_USERS from '../../../fixtures/users';
 import { MOCK_MAKER_TFM, ADMIN_LOGIN } from '../../../fixtures/users-portal';
@@ -42,6 +43,16 @@ context('User can view a case deal', () => {
     pages.caseDealPage.dealBankDetails().should('exist');
     pages.caseDealPage.dealFacilities().should('exist');
     pages.caseDealPage.mgaVersion().should('exist');
+  });
+
+  it.only('should render case summary fields', () => {
+    partials.caseSummary.dealSubmissionType().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(MOCK_DEAL_AIN.submissionType);
+    });
+
+    partials.caseSummary.exporterName().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(MOCK_DEAL_AIN.exporter.companyName);
+    });
   });
 
   it('should render correct MGA version', () => {

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -110,12 +110,49 @@ context('User can view and filter multiple deals', () => {
     cy.deleteTfmDeals();
   });
 
-  it('should render all deals by default', () => {
+  it.only('should render all deals by default with correct fields in table', () => {
     const TOTAL_DEALS = ALL_SUBMITTED_DEALS.length;
     pages.dealsPage.dealsTableRows().should('have.length', TOTAL_DEALS);
 
     pages.dealsPage.heading().invoke('text').then((text) => {
       expect(text.trim()).to.equal('All deals');
+    });
+    
+    // test that one deal has correct fields displayed
+    const firstDeal = ALL_SUBMITTED_DEALS[0];
+    const row = pages.dealsPage.dealsTable.row(firstDeal._id);
+
+    row.dealLinkText().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.dealSnapshot.details.ukefDealId);
+    });
+
+    row.product().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.tfm.product);
+    });
+
+    row.submissionType().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.dealSnapshot.submissionType);
+    });
+
+    row.exporterName().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.dealSnapshot.exporter.companyName);
+    });
+
+    row.buyerName().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.dealSnapshot.submissionDetails['buyer-name']);
+    });
+
+    row.bank().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.dealSnapshot.details.owningBank.name);
+    });
+
+    row.stage().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(firstDeal.tfm.stage);
+    });
+
+    const todayFormatted = format(new Date(), 'd MMM yyyy');
+    row.dateReceived().invoke('text').then((text) => {
+      expect(text.trim()).to.contain(todayFormatted);
     });
   });
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -110,7 +110,7 @@ context('User can view and filter multiple deals', () => {
     cy.deleteTfmDeals();
   });
 
-  it.only('should render all deals by default with correct fields in table', () => {
+  it('should render all deals by default with correct fields in table', () => {
     const TOTAL_DEALS = ALL_SUBMITTED_DEALS.length;
     pages.dealsPage.dealsTableRows().should('have.length', TOTAL_DEALS);
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/dealsPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/dealsPage.js
@@ -22,8 +22,14 @@ const dealsPage = {
       cy.get(`[data-cy="deal-${dealId}"]`).as('row');
       return {
         dealLink: () => cy.get('@row').get(`[data-cy="deal-${dealId}-ukef-deal-id-link"]`),
+        dealLinkText: () => cy.get('@row').get(`[data-cy="deal-${dealId}-ukef-deal-id-link-text"]`),
+        product: () => cy.get('@row').get(`[data-cy="deal-${dealId}-product"]`),
         submissionType: () => cy.get('@row').get(`[data-cy="deal-${dealId}-type"]`),
         exporterName: () => cy.get('@row').get(`[data-cy="deal-${dealId}-exporterName"]`),
+        buyerName: () => cy.get('@row').get(`[data-cy="deal-${dealId}-buyerName"]`),
+        bank: () => cy.get('@row').get(`[data-cy="deal-${dealId}-bank"]`),
+        stage: () => cy.get('@row').get(`[data-cy="deal-${dealId}-stage"]`),
+        dateReceived: () => cy.get('@row').get(`[data-cy="deal-${dealId}-date-received"]`),
       };
     },
   },

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/dealsPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/dealsPage.js
@@ -22,6 +22,8 @@ const dealsPage = {
       cy.get(`[data-cy="deal-${dealId}"]`).as('row');
       return {
         dealLink: () => cy.get('@row').get(`[data-cy="deal-${dealId}-ukef-deal-id-link"]`),
+        submissionType: () => cy.get('@row').get(`[data-cy="deal-${dealId}-type"]`),
+        exporterName: () => cy.get('@row').get(`[data-cy="deal-${dealId}-exporterName"]`),
       };
     },
   },

--- a/trade-finance-manager-api/src/graphql/reducers/deals-light.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deals-light.api-test.js
@@ -33,8 +33,10 @@ describe('reducer - deals', () => {
       const expected = {
         _id: mockBssDeal._id,
         dealSnapshot: {
+          submissionType: mockBssDeal.dealSnapshot.submissionType,
           details: mockBssDeal.dealSnapshot.details,
           submissionDetails: mapSubmissionDetails(mockBssDeal.dealSnapshot.submissionDetails),
+          exporter: mockBssDeal.dealSnapshot.exporter,
         },
         tfm: mapDealTfm(mockBssDeal),
       };
@@ -49,8 +51,10 @@ describe('reducer - deals', () => {
       const expected = {
         _id: mockGefDeal._id,
         dealSnapshot: {
+          submissionType: mockGefDeal.dealSnapshot.submissionType,
           details: mapGefDealDetails(mockGefDeal.dealSnapshot),
           submissionDetails: mapGefSubmissionDetails(mockGefDeal.dealSnapshot),
+          exporter: mockGefDeal.dealSnapshot.exporter,
         },
         tfm: mapDealTfm(mockGefDeal),
       };

--- a/trade-finance-manager-api/src/graphql/reducers/deals-light.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deals-light.js
@@ -11,7 +11,9 @@ const mapBssDeal = (deal) => {
     _id,
     dealSnapshot: {
       details: dealSnapshot.details,
+      submissionType: dealSnapshot.submissionType,
       submissionDetails: mapSubmissionDetails(dealSnapshot.submissionDetails),
+      exporter: dealSnapshot.exporter,
     },
     tfm: mapDealTfm(deal),
   };
@@ -26,7 +28,9 @@ const mapGefDeal = (deal) => {
     _id,
     dealSnapshot: {
       details: mapGefDealDetails(dealSnapshot),
+      submissionType: dealSnapshot.submissionType,
       submissionDetails: mapGefSubmissionDetails(dealSnapshot),
+      exporter: dealSnapshot.exporter,
     },
     tfm: mapDealTfm(deal),
   };

--- a/trade-finance-manager-ui/templates/deals/_macros/deals-table.component-test.js
+++ b/trade-finance-manager-ui/templates/deals/_macros/deals-table.component-test.js
@@ -23,6 +23,9 @@ describe(component, () => {
             supplierName: 'Supplier name',
             buyerName: 'Buyer name',
           },
+          exporter: {
+            companyName: 'test',
+          },
         },
         tfm: {
           dateReceived: '13-07-2021',
@@ -43,6 +46,9 @@ describe(component, () => {
           submissionDetails: {
             supplierName: 'Supplier name',
             buyerName: 'Buyer name',
+          },
+          exporter: {
+            companyName: 'test',
           },
         },
         tfm: {
@@ -133,7 +139,7 @@ describe(component, () => {
     it('should render exporter name table cell', () => {
       params.deals.forEach((deal) => {
         const cellSelector = `[data-cy="deal-${deal._id}-exporterName"]`;
-        wrapper.expectText(cellSelector).toRead(deal.dealSnapshot.submissionDetails.supplierName);
+        wrapper.expectText(cellSelector).toRead(deal.dealSnapshot.exporter.companyName);
       });
     });
 

--- a/trade-finance-manager-ui/templates/deals/_macros/deals-table.njk
+++ b/trade-finance-manager-ui/templates/deals/_macros/deals-table.njk
@@ -81,7 +81,7 @@
             </td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-product">{{ deal.tfm.product | dashIfEmpty }}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-type">{{ deal.dealSnapshot.submissionType | dashIfEmpty}}</td>
-            <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-exporterName">{{ deal.dealSnapshot.submissionDetails.supplierName | dashIfEmpty}}</td>
+            <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-exporterName">{{ deal.dealSnapshot.exporter.companyName | dashIfEmpty}}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-buyerName">{{ deal.dealSnapshot.submissionDetails.buyerName | dashIfEmpty}}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-bank">{{ deal.dealSnapshot.details.owningBank.name | dashIfEmpty }}</td>
             <td class="govuk-table__cell govuk-body-s" data-cy="deal-{{ deal._id }}-stage">


### PR DESCRIPTION
This fixes an issue where exporter company name and submissionType was now displaying in the TFM deals table. This was caused after data changes.

- add `submissionType` and `exporter` to deals-light query
- `deals-table` using `exporter.companyName` instead of `supplierName`
- add extra e2e tests/assertions for TFM displaying submissionType, exporter name and all other fields, in deals table
