### PR TITLE
GEF deal creation with bank object instead of bankId

### DIFF
--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -2,7 +2,6 @@ const { ObjectID } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 const CONSTANTS = require('../../../../constants');
 const { findAllGefFacilitiesByDealId } = require('../gef-facility/get-facilities.controller');
-const { findOneBank } = require('../../bank/get-bank.controller');
 const { findOneUser } = require('../../user/get-user.controller');
 
 const extendDealWithFacilities = async (deal) => {
@@ -113,21 +112,15 @@ const findOneGefDeal = async (_id, callback) => {
   if (deal) {
     const promises = await Promise.all([
       findAllGefFacilitiesByDealId(_id),
-      findOneBank(deal.bankId),
       findOneUser(deal.userId),
     ]);
 
     const [
       facilities,
-      bank,
       maker,
     ] = [...promises];
 
     deal.facilities = facilities;
-
-    if (bank) {
-      deal.bank = bank;
-    }
 
     if (maker) {
       deal.maker = maker;

--- a/dtfs-central-api/src/v1/routes/portal-routes.js
+++ b/dtfs-central-api/src/v1/routes/portal-routes.js
@@ -68,7 +68,7 @@ portalRouter.route('/banks/:id')
  *                 type: integer
  *           example:
  *             sort: { lastUpdated: -1, status: 'Draft' }
- *             filters: { '$and': [ { userId: '123456' }, { bankId: '9' } ] }
+ *             filters: { '$and': [ { userId: '123456' }, { bank: { id: '9' } } ] }
  *             start: 0
  *             pagesize: 10
  *     responses:

--- a/dtfs-central-api/src/v1/swagger-definitions/portal/deal-gef.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/portal/deal-gef.js
@@ -16,9 +16,8 @@
  *       status:
  *         type: string
  *         example: DRAFT
- *       bankId:
- *         type: string
- *         example: '9'
+ *       owningBank:
+ *         $ref: '#/definitions/Bank'
  *       exporter:
  *         type: object
  *         example: {}

--- a/dtfs-central-api/src/v1/swagger-definitions/portal/deal-gef.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/portal/deal-gef.js
@@ -16,7 +16,7 @@
  *       status:
  *         type: string
  *         example: DRAFT
- *       owningBank:
+ *       bank:
  *         $ref: '#/definitions/Bank'
  *       exporter:
  *         type: object

--- a/e2e-tests/gef/cypress/fixtures/MOCKS/MOCK_DEALS.js
+++ b/e2e-tests/gef/cypress/fixtures/MOCKS/MOCK_DEALS.js
@@ -8,7 +8,7 @@ const threeDaysAgoUnix = getUnixTime(threeDaysAgo).toString();
 const MOCK_AIN_APPLICATION = {
   dealType: 'GEF',
   status: CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED,
-  bankId: '9',
+  bank: { id: '9' },
   exporterId: '61a7710b2ae62b0013dae686',
   eligibility: {
     criteria: [],
@@ -195,7 +195,7 @@ const MOCK_USER_MAKER = {
   email: 'maker1@ukexportfinance.gov.uk',
   timezone: 'Europe/London',
   roles: ['maker'],
-  bankId: '9',
+  bank: { id: '9' },
   bank: {
     id: '9',
     name: 'UKEF test bank (Delegated)',

--- a/e2e-tests/portal/cypress/fixtures/mockDeals.js
+++ b/e2e-tests/portal/cypress/fixtures/mockDeals.js
@@ -11,28 +11,28 @@ const MAKER_LOGIN = mockUsers.find((user) =>
   user.roles.includes('maker') && user.roles.length === 1);
 
 const MOCK_DEAL_ONE = {
-  bankId: MAKER_LOGIN.bank.id,
+  bank: { id: MAKER_LOGIN.bank.id },
   bankInternalRefName: 'Mock1',
   userId: MAKER_LOGIN._id,
   exporter: exporterOne,
 };
 
 const MOCK_DEAL_TWO = {
-  bankId: MAKER_LOGIN.bank.id,
+  bank: { id: MAKER_LOGIN.bank.id },
   bankInternalRefName: 'Mock2',
   userId: MAKER_LOGIN._id,
   exporter: exporterTwo,
 };
 
 const MOCK_DEAL_THREE = {
-  bankId: MAKER_LOGIN.bank.id,
+  bank: { id: MAKER_LOGIN.bank.id },
   bankInternalRefName: 'Mock3',
   userId: MAKER_LOGIN._id,
   exporter: exporterThree,
 };
 
 const MOCK_DEAL_FOUR = {
-  bankId: MAKER_LOGIN.bank.id,
+  bank: { id: MAKER_LOGIN.bank.id },
   bankInternalRefName: 'Mock4',
   userId: MAKER_LOGIN._id,
   exporter: exporterFour,

--- a/e2e-tests/portal/cypress/integration/journeys/checker/dashboard/gef-dashboard.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/dashboard/gef-dashboard.spec.js
@@ -12,11 +12,11 @@ context('View a deal with checker role', () => {
   let checkerDeal;
 
   const checkerDealData = {
-    bankId: MAKER_LOGIN.bank.id,
+    bank: { id: MAKER_LOGIN.bank.id },
     bankInternalRefName: 'abc-123-def',
   };
   const draftDealData = {
-    bankId: MAKER_LOGIN.bank.id,
+    bank: { id: MAKER_LOGIN.bank.id },
     bankInternalRefName: 'abc-456-def',
   };
 

--- a/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-deals/dashboard-pagination.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-deals/dashboard-pagination.spec.js
@@ -12,7 +12,7 @@ context('Dashboard Deals pagination controls', () => {
 
     const dummyDeals = new Array(21).fill('').map((_, i) => ({
       bankInternalRefName: `abc-${i + 1}-def`,
-      bankId: '9',
+      bank: { id: '9' },
     }));
 
     cy.insertManyGefApplications(dummyDeals, MAKER_LOGIN)

--- a/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-deals/dashboard-table-data.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-deals/dashboard-table-data.spec.js
@@ -15,7 +15,7 @@ context('View a deal', () => {
     let deal;
 
     const dummyDeal = {
-      bankId: MAKER_LOGIN.bank.id,
+      bank: { id: MAKER_LOGIN.bank.id },
       bankInternalRefName: 'Mock GEF exporter',
       userId: MAKER_LOGIN._id,
     };

--- a/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-facilities/dashboard-paginate.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-facilities/dashboard-paginate.spec.js
@@ -5,7 +5,7 @@ const mockUsers = require('../../../../../fixtures/mockUsers');
 const MAKER_LOGIN = mockUsers.find((user) => (user.roles.includes('maker')));
 
 const dummyDeal = {
-  bankId: MAKER_LOGIN.bank.id,
+  bank: { id: MAKER_LOGIN.bank.id },
   bankInternalRefName: 'Mock GEF exporter',
 };
 

--- a/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-facilities/dashboard-table-data.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/dashboard/gef-facilities/dashboard-table-data.spec.js
@@ -9,7 +9,7 @@ const MAKER_LOGIN = mockUsers.find(
 );
 
 const dummyDeal = {
-  bankId: MAKER_LOGIN.bank.id,
+  bank: { id: MAKER_LOGIN.bank.id },
   bankInternalRefName: 'Mock GEF exporter',
 };
 

--- a/gef-ui/server/controllers/application-abandon/index.test.js
+++ b/gef-ui/server/controllers/application-abandon/index.test.js
@@ -32,7 +32,7 @@ const MockApplicationResponse = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANKID';
+  res.bank = { id: 'BANKID' };
   res.bankInternalRefName = 'My test';
   res.status = CONSTANTS.DEAL_STATUS.DRAFT;
   res.eligibility = {

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -13,7 +13,6 @@ describe('controllers/application-detaills', () => {
   let mockResponse;
   let mockRequest;
   let mockApplicationResponse;
-  let mockFacilityResponse;
   let mockFacilitiesResponse;
   let mockUserResponse;
   let mockEligibilityCriteriaResponse;
@@ -22,13 +21,12 @@ describe('controllers/application-detaills', () => {
     mockResponse = MOCKS.MockResponse();
     mockRequest = MOCKS.MockRequest();
     mockApplicationResponse = MOCKS.MockApplicationResponseDraft();
-    mockFacilityResponse = MOCKS.MockFacilityResponse();
     mockFacilitiesResponse = MOCKS.MockFacilitiesResponse();
     mockUserResponse = MOCKS.MockUserResponse();
     mockEligibilityCriteriaResponse = MOCKS.MockEligibilityCriteriaResponse();
 
     api.getApplication.mockResolvedValue(mockApplicationResponse);
-    api.getFacilities.mockResolvedValue(mockFacilityResponse);
+    api.getFacilities.mockResolvedValue(mockFacilitiesResponse);
     api.getEligibilityCriteria.mockResolvedValue(mockEligibilityCriteriaResponse);
     api.getUserDetails.mockResolvedValue(mockUserResponse);
   });

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -4,7 +4,7 @@ import {
 } from '.';
 import api from '../../services/api';
 
-import mocks from '../mocks';
+import MOCKS from '../mocks';
 import CONSTANTS from '../../constants';
 
 jest.mock('../../services/api');
@@ -14,16 +14,18 @@ describe('controllers/application-detaills', () => {
   let mockRequest;
   let mockApplicationResponse;
   let mockFacilityResponse;
+  let mockFacilitiesResponse;
   let mockUserResponse;
   let mockEligibilityCriteriaResponse;
 
   beforeEach(() => {
-    mockResponse = mocks.MockResponse();
-    mockRequest = mocks.MockRequest();
-    mockApplicationResponse = mocks.MockApplicationResponseDraft();
-    mockFacilityResponse = mocks.MockFacilityResponse();
-    mockUserResponse = mocks.MockUserResponse();
-    mockEligibilityCriteriaResponse = mocks.MockEligibilityCriteriaResponse();
+    mockResponse = MOCKS.MockResponse();
+    mockRequest = MOCKS.MockRequest();
+    mockApplicationResponse = MOCKS.MockApplicationResponseDraft();
+    mockFacilityResponse = MOCKS.MockFacilityResponse();
+    mockFacilitiesResponse = MOCKS.MockFacilitiesResponse();
+    mockUserResponse = MOCKS.MockUserResponse();
+    mockEligibilityCriteriaResponse = MOCKS.MockEligibilityCriteriaResponse();
 
     api.getApplication.mockResolvedValue(mockApplicationResponse);
     api.getFacilities.mockResolvedValue(mockFacilityResponse);
@@ -37,7 +39,7 @@ describe('controllers/application-detaills', () => {
 
   describe('GET Application Details', () => {
     it('redirects to dashboard if user is not authorised', async () => {
-      mockApplicationResponse.bankId = 'ANOTHER_BANK';
+      mockApplicationResponse.bank = { id: 'ANOTHER_BANK' };
       api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
 
       await applicationDetails(mockRequest, mockResponse);
@@ -276,7 +278,7 @@ describe('controllers/application-detaills', () => {
         mockApplicationResponse.status = CONSTANTS.DEAL_STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS;
         api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
 
-        await applicationDetails(mocks.MockRequestUrl('/gef/appliction/123/review-decision'), mockResponse);
+        await applicationDetails(MOCKS.MockRequestUrl('/gef/appliction/123/review-decision'), mockResponse);
 
         expect(mockResponse.render)
           .toHaveBeenCalledWith('partials/review-decision.njk', expect.objectContaining({
@@ -288,7 +290,7 @@ describe('controllers/application-detaills', () => {
         mockApplicationResponse.status = CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED;
         api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
 
-        await applicationDetails(mocks.MockRequestUrl('/gef/application/123/unissued-facilities'), mockResponse);
+        await applicationDetails(MOCKS.MockRequestUrl('/gef/application/123/unissued-facilities'), mockResponse);
 
         expect(mockResponse.render)
           .toHaveBeenCalledWith('partials/unissued-facilities.njk', expect.objectContaining({

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -13,6 +13,7 @@ describe('controllers/application-detaills', () => {
   let mockResponse;
   let mockRequest;
   let mockApplicationResponse;
+  let mockFacilityResponse;
   let mockFacilitiesResponse;
   let mockUserResponse;
   let mockEligibilityCriteriaResponse;
@@ -21,6 +22,7 @@ describe('controllers/application-detaills', () => {
     mockResponse = MOCKS.MockResponse();
     mockRequest = MOCKS.MockRequest();
     mockApplicationResponse = MOCKS.MockApplicationResponseDraft();
+    mockFacilityResponse = MOCKS.MockFacilityResponse();
     mockFacilitiesResponse = MOCKS.MockFacilitiesResponse();
     mockUserResponse = MOCKS.MockUserResponse();
     mockEligibilityCriteriaResponse = MOCKS.MockEligibilityCriteriaResponse();

--- a/gef-ui/server/controllers/clone-gef-deal/index.js
+++ b/gef-ui/server/controllers/clone-gef-deal/index.js
@@ -3,7 +3,7 @@ const api = require('../../services/api');
 
 exports.cloneDealCreateApplication = async (req, res, next) => {
   const { body, session } = req;
-  const { _id: userId, bank: { id: bankId } } = session.user;
+  const { _id: userId, bank } = session.user;
   const { dealId } = req.params;
 
   try {
@@ -11,7 +11,7 @@ exports.cloneDealCreateApplication = async (req, res, next) => {
       dealId,
       ...body,
       userId,
-      bankId,
+      bank,
     });
 
     // Validation errors

--- a/gef-ui/server/controllers/clone-gef-deal/index.test.js
+++ b/gef-ui/server/controllers/clone-gef-deal/index.test.js
@@ -7,7 +7,7 @@ jest.mock('../../services/api');
 const MockApplicationResponse = () => ({
   _id: '1234',
   exporter: {},
-  bankId: 'BANKID',
+  bank: { id: 'BANKID' },
   bankInternalRefName: 'Cloned deal',
   additionalRefName: 'additional',
   status: CONSTANTS.DEAL_STATUS.DRAFT,

--- a/gef-ui/server/controllers/confirm-cover-start-date/index.test.js
+++ b/gef-ui/server/controllers/confirm-cover-start-date/index.test.js
@@ -45,7 +45,7 @@ const MockApplicationResponse = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANKID';
+  res.bank = { id: 'BANKID' };
   res.bankInternalRefName = 'Internal refernce';
   res.additionalRefName = 'Additional reference';
   res.status = CONSTANTS.DEAL_STATUS.DRAFT;

--- a/gef-ui/server/controllers/facility-guarantee/index.test.js
+++ b/gef-ui/server/controllers/facility-guarantee/index.test.js
@@ -32,7 +32,7 @@ const MockApplicationResponse = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANK_ID';
+  res.bank = { id: 'BANK_ID' };
   res.bankInternalRefName = 'My test';
   res.status = CONSTANTS.DEAL_STATUS.DRAFT;
   return res;

--- a/gef-ui/server/controllers/facility-value/index.test.js
+++ b/gef-ui/server/controllers/facility-value/index.test.js
@@ -38,7 +38,7 @@ const MockApplicationResponse = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANK_ID';
+  res.bank = { id: 'BANK_ID' };
   res.bankInternalRefName = 'My test';
   res.status = CONSTANTS.DEAL_STATUS.DRAFT;
   return res;

--- a/gef-ui/server/controllers/mocks/index.js
+++ b/gef-ui/server/controllers/mocks/index.js
@@ -1,4 +1,5 @@
 const Chance = require('chance');
+const { sub } = require('date-fns');
 
 const CONSTANTS = require('../../constants');
 
@@ -66,7 +67,7 @@ const MockRequestUrlChecker = (url) => ({
 const MockApplicationResponseDraft = () => ({
   _id: '1234',
   exporter: {},
-  bankId: 'BANKID',
+  bank: { id: 'BANKID' },
   bankInternalRefName: 'Internal reference',
   additionalRefName: 'Additional reference',
   status: CONSTANTS.DEAL_STATUS.DRAFT,
@@ -85,45 +86,50 @@ const MockApplicationResponseDraft = () => ({
   comments: [],
   ukefDealId: null,
   createdAt: chance.timestamp(),
-  submissionDate: chance.timestamp(),
 });
 
-const MockApplicationResponseSubmitted = () => ({
-  _id: '1234',
-  exporter: {},
-  bankId: 'BANKID',
-  bankInternalRefName: 'Internal reference',
-  additionalRefName: 'Additional reference',
-  status: CONSTANTS.DEAL_STATUS.UKEF_IN_PROGRESS,
-  userId: 'mock-user',
-  checkerId: 1235,
-  supportingInformation: {
-    status: CONSTANTS.DEAL_STATUS.NOT_STARTED,
-  },
-  eligibility: {
-    criteria: [
-      { id: 12, answer: null, text: 'Test' },
-    ],
-  },
-  editedBy: ['MAKER_CHECKER'],
-  submissionType: 'Automatic Inclusion Notice',
-  submissionCount: 1,
-  comments: [],
-  ukefDealId: 123456,
-  createdAt: chance.timestamp(),
-  submissionDate: chance.timestamp(),
-  portalActivities: [{
-    type: 'NOTICE',
-    timestamp: chance.timestamp(),
-    author: {
-      firstName: 'Joe',
-      lastName: 'Bloggs',
-      id: 1235,
+const MockApplicationResponseSubmitted = () => {
+  const now = new Date();
+  const yesterday = sub(now, { days: 1 });
+
+  return {
+    _id: '1234',
+    exporter: {},
+    bank: { id: 'BANKID' },
+    bankInternalRefName: 'Internal reference',
+    additionalRefName: 'Additional reference',
+    status: CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF,
+    userId: 'mock-user',
+    checkerId: 1235,
+    supportingInformation: {
+      status: CONSTANTS.DEAL_STATUS.COMPLETED,
     },
-    text: '',
-    label: 'Automatic inclusion notice submitted to UKEF',
-  }],
-});
+    eligibility: {
+      criteria: [
+        { id: 12, answer: null, text: 'Test' },
+      ],
+      status: CONSTANTS.DEAL_STATUS.COMPLETED,
+    },
+    editedBy: ['MAKER_CHECKER'],
+    submissionType: 'Automatic Inclusion Notice',
+    submissionCount: 1,
+    comments: [],
+    ukefDealId: 123456,
+    createdAt: chance.timestamp(),
+    submissionDate: yesterday,
+    portalActivities: [{
+      type: 'NOTICE',
+      timestamp: chance.timestamp(),
+      author: {
+        firstName: 'Joe',
+        lastName: 'Bloggs',
+        id: 1235,
+      },
+      text: '',
+      label: 'Automatic inclusion notice submitted to UKEF',
+    }],
+  };
+};
 
 const MockUserResponse = () => ({
   username: 'maker',
@@ -176,7 +182,7 @@ const MockApplicationResponseSubmission = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANKID';
+  res.bank = { id: 'BANKID' };
   res.bankInternalRefName = 'My test';
   res.eligibility = {
     criteria: [
@@ -273,6 +279,25 @@ const MockExpectedFacilityRenderChange = (change) => ({
   change,
 });
 
+const MockFacilitiesResponse = () => ({
+  items: [
+    {
+      details: {
+        type: 'CASH',
+        name: 'Foundry4',
+        hasBeenIssued: true,
+        monthsOfCover: null,
+        issueDate: '2022-01-05T00:00:00.000+00:00',
+        coverStartDate: '2022-01-02T00:00:00.000+00:00',
+        shouldCoverStartOnSubmission: true,
+        coverEndDate: '2030-01-02T00:00:00.000+00:00',
+      },
+      status: CONSTANTS.DEAL_STATUS.COMPLETED,
+    },
+  ],
+  status: CONSTANTS.DEAL_STATUS.COMPLETED,
+});
+
 module.exports = {
   MockResponse,
   MockRequest,
@@ -291,4 +316,5 @@ module.exports = {
   MockRequestUnissued,
   MockFacilityResponseUnissued,
   MockExpectedFacilityRenderChange,
+  MockFacilitiesResponse,
 };

--- a/gef-ui/server/controllers/name-application/index.js
+++ b/gef-ui/server/controllers/name-application/index.js
@@ -20,13 +20,13 @@ const nameApplication = async (req, res, next) => {
 
 const createApplication = async (req, res, next) => {
   const { body, session } = req;
-  const { _id: userId, bank: { id: bankId } } = session.user;
+  const { _id: userId, bank } = session.user;
 
   try {
     const application = await api.createApplication({
       ...body,
       userId,
-      bankId,
+      bank,
     });
 
     // Validation errors

--- a/gef-ui/server/controllers/name-application/index.test.js
+++ b/gef-ui/server/controllers/name-application/index.test.js
@@ -31,7 +31,7 @@ const MockApplicationResponse = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANKID';
+  res.bank = {};
   res.bankInternalRefName = 'My test';
   res.additionalRefName = 'additional';
   res.status = CONSTANTS.DEAL_STATUS.DRAFT;

--- a/gef-ui/server/controllers/review-decision/index.test.js
+++ b/gef-ui/server/controllers/review-decision/index.test.js
@@ -45,7 +45,7 @@ const MockApplicationResponse = () => {
     createdAt: '1625482095783',
     comment: 'The client needs this asap.',
   }];
-  res.bankId = 'BANKID';
+  res.bank = { id: 'BANKID' };
   res.submissionType = 'Automatic Inclusion Notice';
   res.status = CONSTANTS.DEAL_STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS;
   return res;

--- a/gef-ui/server/controllers/submit-to-ukef/index.test.js
+++ b/gef-ui/server/controllers/submit-to-ukef/index.test.js
@@ -46,7 +46,7 @@ const MockApplicationResponse = () => {
     createdAt: '1625482095783',
     comment: 'The client needs this asap.',
   }];
-  res.bankId = 'BANKID';
+  res.bank = { id: 'BANKID' };
   res.submissionType = 'Automatic Inclusion Notice';
   return res;
 };

--- a/gef-ui/server/controllers/supporting-information/supporting-documents/index.test.js
+++ b/gef-ui/server/controllers/supporting-information/supporting-documents/index.test.js
@@ -4,6 +4,7 @@ import {
 import Application from '../../../models/application';
 import validateFile from '../../../utils/validateFile';
 import { uploadAndSaveToDeal, removeFileFromDeal } from '../../../utils/fileUtils';
+import MOCKS from '../../mocks/index';
 
 jest.mock('../../../models/application');
 jest.mock('../../../utils/validateFile', () => jest.fn(() => [true, null]));
@@ -22,15 +23,11 @@ const MockResponse = () => {
 
 const mockNext = jest.fn();
 
-const MockApplication = () => ({
-  _id: 'mock-id',
-  supportingInformation: {},
-});
 
 describe('controllers/supporting-documents', () => {
   const mockResponse = MockResponse();
   let mockRequest;
-  Application.findById.mockResolvedValue(MockApplication());
+  Application.findById.mockResolvedValue(MOCKS.MockApplicationResponseDraft());
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -60,6 +57,7 @@ describe('controllers/supporting-documents', () => {
 
     it('renders the manual inclusion questionnaire page as expected', async () => {
       Application.findById.mockResolvedValueOnce({
+        ...MOCKS.MockApplicationResponseDraft(),
         supportingInformation: {
           manualInclusion: [{
             _id: 'mockFileId',
@@ -192,6 +190,7 @@ describe('controllers/supporting-documents', () => {
 
       it('returns error if error thrown when deleting', async () => {
         Application.findById.mockResolvedValueOnce({
+          ...MOCKS.MockApplicationResponseDraft(),
           supportingInformation: {
             manualInclusion: [{
               _id: 'mockFileId',
@@ -217,6 +216,7 @@ describe('controllers/supporting-documents', () => {
 
       it('deletes a file from application if ID passed', async () => {
         Application.findById.mockResolvedValueOnce({
+          ...MOCKS.MockApplicationResponseDraft(),
           supportingInformation: {
             manualInclusion: [{
               _id: 'mockFileId',
@@ -260,6 +260,7 @@ describe('controllers/supporting-documents', () => {
 
       it('returns error if there are more than 20 files', async () => {
         Application.findById.mockResolvedValueOnce({
+          ...MOCKS.MockApplicationResponseDraft(),
           supportingInformation: {
             manualInclusion: new Array(21).fill({}).map((_, i) => ({
               _id: `mockFileId${i}`,
@@ -283,6 +284,7 @@ describe('controllers/supporting-documents', () => {
 
       it('redirects to application details if there is between 1 and 20 files', async () => {
         Application.findById.mockResolvedValueOnce({
+          ...MOCKS.MockApplicationResponseDraft(),
           supportingInformation: {
             manualInclusion: [{
               _id: 'mockFileId',

--- a/gef-ui/server/controllers/supporting-information/supporting-documents/index.test.js
+++ b/gef-ui/server/controllers/supporting-information/supporting-documents/index.test.js
@@ -23,7 +23,6 @@ const MockResponse = () => {
 
 const mockNext = jest.fn();
 
-
 describe('controllers/supporting-documents', () => {
   const mockResponse = MockResponse();
   let mockRequest;

--- a/gef-ui/server/controllers/unissued-facilities/index.test.js
+++ b/gef-ui/server/controllers/unissued-facilities/index.test.js
@@ -19,7 +19,7 @@ describe('renderChangeFacilityPartial()', () => {
     mockRequest = MOCKS.MockRequestUnissued();
     mockFacilityResponse = MOCKS.MockFacilityResponseUnissued();
 
-    api.getApplication.mockResolvedValue({});
+    api.getApplication.mockResolvedValue(MOCKS.MockApplicationResponseSubmitted());
     api.getFacility.mockResolvedValue(mockFacilityResponse);
     api.updateFacility.mockResolvedValue({});
   });
@@ -58,7 +58,7 @@ describe('changeUnissuedFacility()', () => {
     mockRequest = MOCKS.MockRequestUnissued();
     mockFacilityResponse = MOCKS.MockFacilityResponseUnissued();
 
-    api.getApplication.mockResolvedValue({});
+    api.getApplication.mockResolvedValue(MOCKS.MockApplicationResponseSubmitted());
     api.getFacility.mockResolvedValue(mockFacilityResponse);
     api.updateFacility.mockResolvedValue({});
   });
@@ -104,7 +104,7 @@ describe('changeUnissuedFacilityPreview()', () => {
     mockRequest = MOCKS.MockRequestUnissued();
     mockFacilityResponse = MOCKS.MockFacilityResponseUnissued();
 
-    api.getApplication.mockResolvedValue({});
+    api.getApplication.mockResolvedValue(MOCKS.MockApplicationResponseSubmitted());
     api.getFacility.mockResolvedValue(mockFacilityResponse);
     api.updateFacility.mockResolvedValue({});
   });
@@ -143,15 +143,23 @@ describe('changeUnissuedFacilityPreview()', () => {
 describe('postChangeUnissuedFacility()', () => {
   let mockResponse;
   let mockRequest;
+  let mockApplicationResponse;
+  let mockUserResponse;
   let mockFacilityResponse;
+  let mockFacilitiesResponse;
 
   beforeEach(() => {
     mockResponse = MOCKS.MockResponseUnissued();
     mockRequest = MOCKS.MockRequestUnissued();
+    mockApplicationResponse = MOCKS.MockApplicationResponseSubmitted();
+    mockUserResponse = MOCKS.MockUserResponse();
     mockFacilityResponse = MOCKS.MockFacilityResponseUnissued();
+    mockFacilitiesResponse = MOCKS.MockFacilitiesResponse();
 
-    api.getApplication.mockResolvedValue({});
+    api.getApplication.mockResolvedValue(mockApplicationResponse);
+    api.getUserDetails.mockResolvedValue(mockUserResponse);
     api.getFacility.mockResolvedValue(mockFacilityResponse);
+    api.getFacilities.mockResolvedValue(mockFacilitiesResponse);
     api.updateFacility.mockResolvedValue({});
   });
 
@@ -245,14 +253,20 @@ describe('postChangeUnissuedFacilityPreview()', () => {
   let mockResponse;
   let mockRequest;
   let mockFacilityResponse;
+  let mockFacilitiesResponse;
+  let mockUserResponse;
 
   beforeEach(() => {
     mockResponse = MOCKS.MockResponseUnissued();
     mockRequest = MOCKS.MockRequestUnissued();
     mockFacilityResponse = MOCKS.MockFacilityResponseUnissued();
+    mockFacilitiesResponse = MOCKS.MockFacilitiesResponse();
+    mockUserResponse = MOCKS.MockUserResponse();
 
-    api.getApplication.mockResolvedValue({});
+    api.getApplication.mockResolvedValue(MOCKS.MockApplicationResponseSubmitted());
+    api.getUserDetails.mockResolvedValue(mockUserResponse);
     api.getFacility.mockResolvedValue(mockFacilityResponse);
+    api.getFacilities.mockResolvedValue(mockFacilitiesResponse);
     api.updateFacility.mockResolvedValue({});
   });
 

--- a/gef-ui/server/controllers/unissued-facilities/validation.js
+++ b/gef-ui/server/controllers/unissued-facilities/validation.js
@@ -31,6 +31,7 @@ const facilityValidation = async (req, res) => {
   } = body;
 
   const application = await api.getApplication(dealId);
+
   const aboutFacilityErrors = [];
 
   const issueDateIsFullyComplete = issueDateDay && issueDateMonth && issueDateYear;

--- a/gef-ui/server/models/application.js
+++ b/gef-ui/server/models/application.js
@@ -60,7 +60,7 @@ class Application {
   static async findById(id, user, userToken) {
     try {
       const application = await getApplication(id);
-      if (application.bankId !== user.bank.id) {
+      if (application.bank.id !== user.bank.id) {
         return null;
       }
 

--- a/gef-ui/server/models/application.test.js
+++ b/gef-ui/server/models/application.test.js
@@ -21,7 +21,7 @@ const MockApplicationResponse = () => {
   const res = {};
   res._id = '1234';
   res.exporter = {};
-  res.bankId = 'BANKID';
+  res.bank = { id: 'BANKID' };
   res.bankInternalRefName = 'My test';
   res.status = CONSTANTS.DEAL_STATUS.DRAFT;
   res.userId = 'mock-user';

--- a/gef-ui/server/models/facility.js
+++ b/gef-ui/server/models/facility.js
@@ -8,8 +8,8 @@ class Facility {
   static async find(dealId, facilityId, status, user) {
     try {
       const { details } = await getFacility(facilityId);
-      const { bankId } = await getApplication(dealId);
-      if (bankId !== user.bank.id) {
+      const { bank } = await getApplication(dealId);
+      if (bank.id !== user.bank.id) {
         return null;
       }
       const facilityTypeConst = FACILITY_TYPE[details.type];

--- a/gef-ui/server/utils/MOCKS/index.js
+++ b/gef-ui/server/utils/MOCKS/index.js
@@ -6,7 +6,7 @@ const MOCK_AIN_APPLICATION = {
   dealType: 'GEF',
   userId: '619bae3467cc7c002069fc1e',
   status: CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED,
-  bankId: '9',
+  bank: { id: '9' },
   exporterId: '61a7710b2ae62b0013dae686',
   eligibility: {
     criteria: [],
@@ -144,7 +144,7 @@ const MOCK_AIN_APPLICATION_UNISSUED_ONLY = {
   dealType: 'GEF',
   userId: '619bae3467cc7c002069fc1e',
   status: CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED,
-  bankId: '9',
+  bank: { id: '9' },
   exporterId: '61a7710b2ae62b0013dae686',
   eligibility: {
     criteria: [],
@@ -250,7 +250,7 @@ const MOCK_AIN_APPLICATION_ISSUED_ONLY = {
   dealType: 'GEF',
   userId: '619bae3467cc7c002069fc1e',
   status: CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED,
-  bankId: '9',
+  bank: { id: '9' },
   exporterId: '61a7710b2ae62b0013dae686',
   eligibility: {
     criteria: [],
@@ -480,7 +480,7 @@ const MOCK_DEAL = {
   dealType: 'GEF',
   userId: '619bae3467cc7c002069fc1e',
   status: CONSTANTS.DEAL_STATUS.BANK_CHECK,
-  bankId: '9',
+  bank: { id: '9' },
   exporterId: '61a7710b2ae62b0013dae686',
   eligibility: {
     criteria: [],
@@ -618,7 +618,7 @@ const MOCK_AIN_APPLICATION_FALSE_COMMENTS = {
   dealType: 'GEF',
   userId: '619bae3467cc7c002069fc1e',
   status: CONSTANTS.DEAL_STATUS.DRAFT,
-  bankId: '9',
+  bank: { id: '9' },
   exporterId: '61a7710b2ae62b0013dae686',
   eligibility: {
     criteria: [],

--- a/gef-ui/server/utils/helpers.js
+++ b/gef-ui/server/utils/helpers.js
@@ -413,11 +413,15 @@ const areUnissuedFacilitiesPresent = (application) => {
    from date of submission
 */
 const facilityIssueDeadline = (submissionDate) => {
-  // converts to timestamp from epoch - '+' to convert from str to int
-  const date = new Date(+submissionDate);
-  const deadlineDate = add(new Date(date), { months: 3 });
+  if (submissionDate) {
+    // converts to timestamp from epoch - '+' to convert from str to int
+    const date = new Date(+submissionDate);
+    const deadlineDate = add(new Date(date), { months: 3 });
 
-  return format(deadlineDate, 'dd MMM yyyy');
+    return format(deadlineDate, 'dd MMM yyyy');
+  }
+
+  return null;
 };
 
 /* govukTable mapping function to return array of facilities which are
@@ -514,7 +518,7 @@ const makerCanReSubmit = (maker, application) => {
     facilitiesChangedToIssued = hasChangedToIssued(application);
   }
   const coverDateConfirmed = coverDatesConfirmed(application.facilities);
-  const makerAuthorised = (maker.roles.includes('maker') && maker.bank.id === application.bankId);
+  const makerAuthorised = (maker.roles.includes('maker') && maker.bank.id === application.bank.id);
 
   return coverDateConfirmed && facilitiesChangedToIssued && acceptableStatus.includes(application.status) && makerAuthorised;
 };

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -940,6 +940,12 @@ describe('facilityIssueDeadline()', () => {
 
     expect(result).toEqual(expected);
   });
+
+  it('should return null when there is no submissionDate', () => {
+    const result = facilityIssueDeadline();
+
+    expect(result).toEqual(null);
+  });
 });
 
 describe('summaryItemsConditions()', () => {
@@ -1124,12 +1130,14 @@ describe('summaryItemsConditions()', () => {
     MOCK_REQUEST.bank.id = 10;
     expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(false);
   });
+
   it('Should return FALSE as the user does not have `maker` role', () => {
     MOCK_REQUEST.roles = ['checker'];
     expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(false);
   });
+
   it('Should return FALSE as the Application maker is from a different current logged-in maker', () => {
-    MOCK_DEAL.bankId = 1;
+    MOCK_DEAL.bank = { id: 1 };
     expect(makerCanReSubmit(MOCK_REQUEST, MOCK_DEAL)).toEqual(false);
   });
 });

--- a/gef-ui/server/utils/user-authorisation-level.test.js
+++ b/gef-ui/server/utils/user-authorisation-level.test.js
@@ -33,7 +33,7 @@ const draftApplication = {
   _id: '123456789',
   userId: '11112',
   status: CONSTANTS.DEAL_STATUS.DRAFT,
-  bankId: '9',
+  bank: { id: '9' },
   exporter: {},
   bankInternalRefName: 'ref0001',
   mandatoryVersionId: null,

--- a/portal-api/api-tests/fixtures/gef/application.js
+++ b/portal-api/api-tests/fixtures/gef/application.js
@@ -3,7 +3,7 @@ const CONSTANTS = require('../../../src/constants');
 const APPLICATION = [{
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 1',
   additionalRefName: 'Team 1',
   exporter: {},
@@ -17,7 +17,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 2',
   additionalRefName: 'Team 2',
   exporter: {},
@@ -31,7 +31,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 3',
   additionalRefName: 'Team 3',
   exporter: {},
@@ -45,7 +45,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 4',
   additionalRefName: 'Team 4',
   exporter: {},
@@ -59,7 +59,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 5',
   additionalRefName: 'Team 5',
   exporter: {},
@@ -73,7 +73,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 6',
   additionalRefName: 'Team 6',
   exporter: {},
@@ -87,7 +87,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 7',
   additionalRefName: 'Team 7',
   exporter: {},
@@ -101,7 +101,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 8',
   additionalRefName: 'Team 8',
   exporter: {},
@@ -115,7 +115,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 9',
   additionalRefName: 'Team 9',
   exporter: {},
@@ -129,7 +129,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 10',
   additionalRefName: 'Team 10',
   exporter: {},
@@ -143,7 +143,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 11',
   additionalRefName: 'Team 11',
   exporter: {},
@@ -157,7 +157,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 12',
   additionalRefName: 'Team 12',
   exporter: {},
@@ -171,7 +171,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 13',
   additionalRefName: 'Team 13',
   exporter: {},
@@ -185,7 +185,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 14',
   additionalRefName: 'Team 14',
   exporter: {},
@@ -199,7 +199,7 @@ const APPLICATION = [{
 }, {
   dealType: 'GEF',
   userId: null,
-  bankId: null,
+  bank: {},
   bankInternalRefName: 'Bank 15',
   additionalRefName: 'Team 15',
   exporter: {},

--- a/portal-api/api-tests/graphql/queries/query-all-deals.api-test.js
+++ b/portal-api/api-tests/graphql/queries/query-all-deals.api-test.js
@@ -156,7 +156,7 @@ describe('/graphql query deals', () => {
       expect(body.data.allDeals.status.code).toEqual(200);
     });
 
-    it('returns a list of deals ordered by "updated", filtered by <user>.bank.id', async () => {
+    it('returns a list of deals ordered by "updated"', async () => {
       const deals = [
         aDeal({ additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
         aDeal({ additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
@@ -171,12 +171,12 @@ describe('/graphql query deals', () => {
       await as(anHSBCMaker).post(deals[0]).to('/v1/deals');
       await as(aBarclaysMaker).post(deals[3]).to('/v1/deals');
 
-      // const { status, body } = await as(anHSBCMaker).get('/v1/deals', anHSBCMaker.token);
       const { body } = await as(anHSBCMaker).post(queryBody).to('/graphql');
       expect(body.data.allDeals.status.code).toEqual(200);
 
       // expect to see deals in reverse order; most recent on top..
-      expect(body.data.allDeals.deals.length).toEqual(3);
+      expect(body.data.allDeals.deals.length).toEqual(deals.length);
+
       body.data.allDeals.deals.forEach((deal, index) => {
         expect(deal.bankRef).toEqual(deals[index].additionalRefName);
       });
@@ -211,7 +211,7 @@ describe('/graphql query deals', () => {
   });
 
   describe('/graphql list deals pagination', () => {
-    it('returns a list of deals, ordered by "updated", paginated by start/pagesize, filtered by <user>.bank.id', async () => {
+    it('returns a list of deals, ordered by "updated", paginated by start/pagesize', async () => {
       const deals = [
         aDeal({ additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
         aDeal({ additionalRefName: 'bank1-1', bankInternalRefName: 'mockSupplyContractId' }),
@@ -233,7 +233,6 @@ describe('/graphql query deals', () => {
       await as(aBarclaysMaker).post(deals[6]).to('/v1/deals');
       await as(aBarclaysMaker).post(deals[7]).to('/v1/deals');
 
-      //      const { status, body } = await as(anHSBCMaker).get('/v1/deals/2/2');
       const { body } = await as(anHSBCMaker).post({ query: dealsPaginationQuery1 }).to('/graphql');
       expect(body.data.allDeals.status.code).toEqual(200);
 

--- a/portal-api/api-tests/graphql/queries/query-all-deals.api-test.js
+++ b/portal-api/api-tests/graphql/queries/query-all-deals.api-test.js
@@ -156,6 +156,9 @@ describe('/graphql query deals', () => {
       expect(body.data.allDeals.status.code).toEqual(200);
     });
 
+    // TODO: DTFS2-5184: disabled due to flakiness with updated timestamp
+    // and this will be all change shortly (combining BSS and GEF `all deals` into one)
+    /*
     it('returns a list of deals ordered by "updated"', async () => {
       const deals = [
         aDeal({ additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
@@ -181,6 +184,7 @@ describe('/graphql query deals', () => {
         expect(deal.bankRef).toEqual(deals[index].additionalRefName);
       });
     });
+    */
 
     it('returns a list of deals ordered by "updated" if <user>.bank.id == *', async () => {
       const deals = [
@@ -211,6 +215,9 @@ describe('/graphql query deals', () => {
   });
 
   describe('/graphql list deals pagination', () => {
+    // TODO: DTFS2-5184: disabled due to flakiness with updated timestamp
+    // and this will be all change shortly (combining BSS and GEF `all deals` into one)
+    /*
     it('returns a list of deals, ordered by "updated", paginated by start/pagesize', async () => {
       const deals = [
         aDeal({ additionalRefName: 'bank1-0', bankInternalRefName: 'mockSupplyContractId' }),
@@ -243,6 +250,7 @@ describe('/graphql query deals', () => {
 
       expect(body.data.allDeals.count).toEqual(6);
     });
+    */
 
 
     it('returns a list of deals, ordered by "updated", paginated by start/pagesize, if <user>.bank.id == *', async () => {

--- a/portal-api/api-tests/v1/gef/clone-application.api-test.js
+++ b/portal-api/api-tests/v1/gef/clone-application.api-test.js
@@ -39,7 +39,7 @@ describe(baseUrl, () => {
       const mockDeal = await as(aMaker).post({
         dealType: 'GEF',
         userId: aMaker._id,
-        bankId: aMaker.bank.id,
+        bank: { id: aMaker.bank.id },
         bankInternalRefName: 'Bank 1',
         additionalRefName: 'Team 1',
         exporter: {},
@@ -60,7 +60,7 @@ describe(baseUrl, () => {
       const mockDeal = await as(aMaker).post({
         dealType: 'GEF',
         userId: aMaker._id,
-        bankId: aMaker.bank.id,
+        bank: { id: aMaker.bank.id },
         bankInternalRefName: 'Bank 1',
         additionalRefName: 'Team 1',
         exporter: {},
@@ -80,7 +80,7 @@ describe(baseUrl, () => {
       const mockDeal = await as(aMaker).post({
         dealType: 'GEF',
         userId: aMaker._id,
-        bankId: aMaker.bank.id,
+        bank: { id: aMaker.bank.id },
         bankInternalRefName: 'Bank 1',
         additionalRefName: 'Team 1',
         exporter: {},
@@ -101,7 +101,7 @@ describe(baseUrl, () => {
       const mockDeal = await as(aMaker).post({
         dealType: 'GEF',
         userId: aMaker._id,
-        bankId: aMaker.bank.id,
+        bank: { id: aMaker.bank.id },
         bankInternalRefName: 'Bank 1',
         additionalRefName: 'Team 1',
         exporter: {},

--- a/portal-api/api-tests/v1/gef/files.api-test.js
+++ b/portal-api/api-tests/v1/gef/files.api-test.js
@@ -44,7 +44,7 @@ describe(baseUrl, () => {
       .post({
         dealType: 'GEF',
         userId: aMaker._id,
-        bankId: aMaker.bank.id,
+        bank: { id: aMaker.bank.id },
         bankInternalRefName: 'Bank 1',
         additionalRefName: 'Team 1',
         exporter: {},

--- a/portal-api/src/graphql/schemas/index.js
+++ b/portal-api/src/graphql/schemas/index.js
@@ -11,8 +11,10 @@ type Currency {
   id: String
 }
 
-type OwningBank {
+type Bank {
+  id: String
   name: String
+  emails: [String]
 }
 
 type Maker {
@@ -41,7 +43,7 @@ type DealDetails {
   approvalDate: String
   created: String
   workflowStatus: String
-  owningBank: OwningBank
+  owningBank: Bank
 }
 
 type Deal {
@@ -174,7 +176,7 @@ type GefDeal {
   _id: String
   userId: String
   status: String
-  bankId: String
+  bank: Bank
   bankInternalRefName: String
   mandatoryVersionId: String
   additionalRefName: String

--- a/portal-api/src/v1/controllers/deal.controller.js
+++ b/portal-api/src/v1/controllers/deal.controller.js
@@ -79,11 +79,6 @@ const dealsQuery = (user, filter) => {
 const allDealsFilters = (user, filters = []) => {
   const sanitisedFilters = [...filters];
 
-  // add the bank clause if we're not a superuser
-  if (!isSuperUser(user)) {
-    sanitisedFilters.push({ 'bank.id': user.bank.id });
-  }
-
   let result = {};
   if (sanitisedFilters.length === 1) {
     [result] = sanitisedFilters;

--- a/portal-api/src/v1/controllers/deal.controller.js
+++ b/portal-api/src/v1/controllers/deal.controller.js
@@ -81,7 +81,7 @@ const allDealsFilters = (user, filters = []) => {
 
   // add the bank clause if we're not a superuser
   if (!isSuperUser(user)) {
-    sanitisedFilters.push({ bankId: user.bank && user.bank.id });
+    sanitisedFilters.push({ 'bank.id': user.bank.id });
   }
 
   let result = {};
@@ -117,6 +117,7 @@ exports.findAllDeals = findAllDeals;
 
 const findAllPaginatedDeals = async (requestingUser, filters, sort, start = 0, pagesize = 20) => {
   const sanitisedFilters = allDealsFilters(requestingUser, filters);
+
   return api.queryAllDeals(sanitisedFilters, sort, start, pagesize);
 };
 exports.findAllPaginatedDeals = findAllPaginatedDeals;

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -335,7 +335,7 @@ const dealsFilters = (user, filters = []) => {
 
   // add the bank clause if we're not a superuser
   if (!isSuperUser(user)) {
-    amendedFilters.push({ bankId: { $eq: user.bank.id } });
+    amendedFilters.push({ 'bank.id': { $eq: user.bank.id } });
   }
 
   let result = {};

--- a/portal-api/src/v1/gef/controllers/clone-application.controller.js
+++ b/portal-api/src/v1/gef/controllers/clone-application.controller.js
@@ -94,7 +94,7 @@ const cloneFacilities = async (currentDealId, newDealId) => {
   }
 };
 
-const cloneDeal = async (dealId, bankInternalRefName, additionalRefName, userId, bankId) => {
+const cloneDeal = async (dealId, bankInternalRefName, additionalRefName, userId, bank) => {
   const applicationCollection = 'deals';
   const collection = await db.getCollection(applicationCollection);
   // remove unused properties at the top of the Object (i.e. _id, ukefDecision, etc).
@@ -131,7 +131,7 @@ const cloneDeal = async (dealId, bankInternalRefName, additionalRefName, userId,
   clonedDeal.bankInternalRefName = bankInternalRefName;
   clonedDeal.additionalRefName = additionalRefName;
   clonedDeal.userId = userId;
-  clonedDeal.bankId = bankId;
+  clonedDeal.bank = bank;
   clonedDeal.ukefDealId = null;
   clonedDeal.checkerId = null;
   clonedDeal.editedBy = [userId];
@@ -149,7 +149,11 @@ const cloneDeal = async (dealId, bankInternalRefName, additionalRefName, userId,
 exports.clone = async (req, res) => {
   const {
     body: {
-      dealId: existingDealId, bankInternalRefName, additionalRefName, userId, bankId,
+      dealId: existingDealId,
+      bankInternalRefName,
+      additionalRefName,
+      userId,
+      bank,
     },
   } = req;
 
@@ -159,7 +163,7 @@ exports.clone = async (req, res) => {
     res.status(422).send(validateErrs);
   } else {
     // clone GEF deal
-    const { newDealId } = await cloneDeal(existingDealId, bankInternalRefName, additionalRefName, userId, bankId);
+    const { newDealId } = await cloneDeal(existingDealId, bankInternalRefName, additionalRefName, userId, bank);
 
     // clone the corresponding facilities
     await cloneFacilities(existingDealId, newDealId);

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -167,7 +167,7 @@ const facilitiesFilters = (user, filters = []) => {
   const amendedFilters = [...filters];
 
   // add the bank clause if we're not a superuser
-  if (!isSuperUser(user)) { amendedFilters.push({ 'deal.bankId': { $eq: user.bank.id } }); }
+  if (!isSuperUser(user)) { amendedFilters.push({ 'deal.bank.id': { $eq: user.bank.id } }); }
 
   let result = {};
   if (amendedFilters.length === 1) {

--- a/portal-api/src/v1/gef/models/application.js
+++ b/portal-api/src/v1/gef/models/application.js
@@ -9,7 +9,7 @@ class Application {
       this.dealType = DEAL_TYPE;
       this.userId = req.userId ? String(req.userId) : null;
       this.status = STATUS.DRAFT;
-      this.bankId = req.bankId ? String(req.bankId) : null;
+      this.bank = req.bank;
 
       this.exporter = req.exporter ? req.exporter : {
         status: STATUS.NOT_STARTED,

--- a/portal-api/src/v1/gef/utils.service.js
+++ b/portal-api/src/v1/gef/utils.service.js
@@ -20,9 +20,9 @@ exports.userHasAccess = (user, deal, roles = []) => {
   if (!user?.bank?.id) return false;
 
   // if the deal has no bank ID for some reason
-  if (!deal?.bankId) return false;
+  if (!deal?.bank?.id) return false;
 
   const hasRole = roles.some((role) => user.roles.includes(role));
 
-  return user.bank.id === deal.bankId && (!roles.length || hasRole);
+  return user.bank.id === deal.bank.id && (!roles.length || hasRole);
 };

--- a/portal/server/controllers/dashboard/deals.js
+++ b/portal/server/controllers/dashboard/deals.js
@@ -20,7 +20,7 @@ const getRoles = (roles) => {
   };
 };
 
-const dashboardFilters = (filter, userId) => {
+const dashboardFilters = (filter, user, dealType) => {
   const allFilters = [];
 
   const { createdByYou } = filter;
@@ -28,9 +28,24 @@ const dashboardFilters = (filter, userId) => {
   if (createdByYou) {
     allFilters.push({
       field: 'userId',
-      value: userId,
+      value: user._id,
     });
   }
+
+  if (dealType === PRODUCT.BSS_EWCS) {
+    allFilters.push({
+      field: 'details.owningBank.id',
+      value: user.bank.id,
+    });
+  }
+
+  if (dealType === PRODUCT.GEF) {
+    allFilters.push({
+      field: 'bank.id',
+      value: user.bank.id,
+    });
+  }
+
   return allFilters;
 };
 
@@ -40,7 +55,7 @@ exports.bssDeals = async (req, res) => {
   const { isMaker, isChecker } = getRoles(req.session.user.roles);
 
   let filters = [];
-  filters = dashboardFilters(req.body, req.session.user._id);
+  filters = dashboardFilters(req.body, req.session.user);
 
   if (isChecker && !isMaker) {
     filters.push({
@@ -79,7 +94,7 @@ exports.gefDeals = async (req, res) => {
   const { isMaker, isChecker } = getRoles(req.session.user.roles);
 
   let filters = [];
-  filters = dashboardFilters(req.body, req.session.user._id);
+  filters = dashboardFilters(req.body, req.session.user);
 
   if (isChecker && !isMaker) {
     filters.push({

--- a/portal/server/controllers/dashboard/deals.js
+++ b/portal/server/controllers/dashboard/deals.js
@@ -92,6 +92,7 @@ exports.gefDeals = async (req, res) => {
     api.gefDeals(req.params.page * PAGESIZE, PAGESIZE, filters, userToken),
     res,
   );
+
   const deals = rawDeals.map((deal) => {
     let exporter = '';
 
@@ -116,6 +117,7 @@ exports.gefDeals = async (req, res) => {
     currentPage: parseInt(req.params.page, 10),
     totalItems: count,
   };
+
   return res.render('dashboard/deals.njk', {
     deals,
     pages,

--- a/portal/server/graphql/queries/gef-facilities-query.js
+++ b/portal/server/graphql/queries/gef-facilities-query.js
@@ -18,7 +18,9 @@ query gefFacilities($start: Int, $pagesize: Int, $filters: [TransactionFilters])
       submittedAsIssuedDate
       deal {
         _id
-        bankId
+        bank {
+          id
+        }
         submissionType,
         status
       }

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -36,8 +36,8 @@ const clearACBSLog = async () => {
 
 const createACBS = async (deal) => {
   // Add bank's full details so we can reference partyUrn in function
-  const bankId = deal.dealSnapshot.bankId
-    ? deal.dealSnapshot.bankId
+  const bankId = deal.dealSnapshot.bank
+    ? deal.dealSnapshot.bank.id
     : deal.dealSnapshot.details.owningBank.id;
 
   const bank = await findOneBank(bankId);

--- a/utils/mock-data-loader/gef/application.js
+++ b/utils/mock-data-loader/gef/application.js
@@ -5,28 +5,28 @@ const {
 
 const APPLICATION = [{
   // not started
-  bankId: '9',
+  bank: { id: '9' },
   bankInternalRefName: 'Barclays 123',
   additionalRefName: null,
   mandatoryVersionId: '123', // further down the line you may want exact mongoIDs
   exporter: EXPORTER_COMPLETED,
 }, {
   // in progress
-  bankId: '9',
+  bank: { id: '9' },
   bankInternalRefName: 'UKEF Test 123',
   additionalRefName: '',
   mandatoryVersionId: '123',
   exporter: EXPORTER_NO_INDUSTRIES,
 }, {
   // completed
-  bankId: '9',
+  bank: { id: '9' },
   bankInternalRefName: 'HSBC 123',
   additionalRefName: 'Some Additional Reference',
   mandatoryVersionId: '123',
   exporter: EXPORTER_COMPLETED,
 }, {
   // in progress - no exporter
-  bankId: '9',
+  bank: { id: '9' },
   bankInternalRefName: 'UKEF Test 123',
   additionalRefName: '',
   mandatoryVersionId: '123',


### PR DESCRIPTION
Instead of GEF deals having: `deal.bankId` string, it now stores the whole bank object in the deal: `deal.bank`.

This is now the same as BSS - although BSS will be updated in another PR so the bank object is on the top level and has the same object name.

This change also simplifies a Central API 'get deal' endpoint, where it used to make an API call to get the bank from `bankId`.

## Changes to Portal "all deals" filters

Currently we have an "all deals" query made from Portal  for 2 views - 1 for BSS, 1 for GEF. Filters are passed to the query which check that the bank id matches the users's bank id. This was being made inside the portal-api by default regardless of the `dealType`. This has been moved to the UI side, so it's just an additional filter passed from the UI and now handles the current differences between BSS and GEF data structure.

In the next PR this can be reverted because the data structure will be the same.

Also, there are 2 failing Portal APi tests (99.9% sure these are flaky) that have been disabled (Agreed with the team). They assert BSS deals sorting order by updated timestamp. This works in the real world, but fails a lot in the API tests. This will all change in 2 PRs time so feels like wasted time trying to fix (already spent time on it with no success).