### PR TITLE
ACBS

### DIFF
--- a/azure-functions/acbs-function/constants/deal.js
+++ b/azure-functions/acbs-function/constants/deal.js
@@ -13,7 +13,7 @@ const SME_TYPE = {
 };
 
 const EXPIRATION_DATE = {
-  NONE: null,
+  NONE: '9999-12-31',
 };
 
 const PARTY = {

--- a/azure-functions/acbs-function/mappings/deal/helpers/get-deal-currency.js
+++ b/azure-functions/acbs-function/mappings/deal/helpers/get-deal-currency.js
@@ -5,7 +5,7 @@ const getDealCurrency = (deal) => {
   // GEF
   if (deal.dealSnapshot.dealType === CONSTANTS.PRODUCT.TYPE.GEF) {
     const currency = getBaseCurrency(deal.dealSnapshot.facilities);
-    return !currency ? CONSTANTS.DEAL.CURRENCY.DEFAULT : currency;
+    return !currency && !!currency.id ? CONSTANTS.DEAL.CURRENCY.DEFAULT : currency;
   }
   // BSS/ECWS
   return (

--- a/azure-functions/acbs-function/mappings/facility/facility-covenant.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-covenant.js
@@ -10,7 +10,6 @@
   "effectiveDate"
   */
 
-const helpers = require('./helpers');
 const CONSTANTS = require('../../constants');
 
 const facilityCovenant = (deal, facility, covenantType) => {
@@ -26,7 +25,7 @@ const facilityCovenant = (deal, facility, covenantType) => {
     facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
     covenantType,
-    maximumLiability: helpers.getMaximumLiability(facility.facilitySnapshot),
+    maximumLiability: Number(facility.facilitySnapshot.value),
     currency: facility.facilitySnapshot.currency.id,
     guaranteeCommencementDate,
     guaranteeExpiryDate,

--- a/azure-functions/acbs-function/mappings/facility/facility-master.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-master.js
@@ -35,6 +35,7 @@
   "obligorPartyIdentifier":         Supplier partyUrn,
   "obligorName":                    Supplier name
   "obligorIndustryClassification":  ACBS Supplier industry classification - must be 4 characters e.g. 0104
+  "probabilityOfDefault":           Optional field used for GEF
   */
 
 const helpers = require('./helpers');
@@ -84,6 +85,7 @@ const facilityMaster = (deal, facility, acbsData, acbsReference) => {
     obligorPartyIdentifier: acbsData.parties.exporter.partyIdentifier,
     obligorName: deal.dealSnapshot.exporter.companyName.substring(0, 35),
     obligorIndustryClassification: acbsReference.supplierAcbsIndustryCode,
+    probabilityOfDefault: deal.tfm.probabilityOfDefault,
   };
 };
 

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-cover-start-date.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-cover-start-date.js
@@ -1,0 +1,21 @@
+const { formatDate } = require('../../../helpers/date');
+
+/**
+ * Evaluates the cover start date of a facility.
+ * When the product is BSS/EWCS then requestedCoverStartDate
+ * property is referred to else coverStartDate.
+ * @param {Object} facility Deal's facility object
+ * @param {Bool} formatted Return in YYYY-MM-DD date format
+ * @returns {String} String Cover start date
+ */
+const getCoverStartDate = (facility, formatted) => {
+  if (facility.facilitySnapshot.requestedCoverStartDate) {
+    return facility.facilitySnapshot.requestedCoverStartDate;
+  }
+
+  return formatted
+    ? formatDate(facility.facilitySnapshot.coverStartDate)
+    : facility.facilitySnapshot.coverStartDate;
+};
+
+module.exports = getCoverStartDate;

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-facility-issue-status.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-facility-issue-status.js
@@ -1,0 +1,16 @@
+const isIssued = require('./is-issued');
+
+const hasFacilityBeenIssued = (facility) => {
+  // GEF
+  if (facility.facilitySnapshot.hasBeenIssued) {
+    return facility.facilitySnapshot.hasBeenIssued;
+  }
+  // BSS/EWCS
+  if (facility.facilitySnapshot.facilityStage) {
+    return isIssued(facility.facilitySnapshot.facilityStage);
+  }
+
+  return false;
+};
+
+module.exports = hasFacilityBeenIssued;

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-issue-date.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-issue-date.js
@@ -1,11 +1,11 @@
-
 const { formatTimestamp } = require('../../../helpers/date');
-const isIssued = require('./is-issued');
+const hasFacilityBeenIssued = require('./get-facility-issue-status');
+const getCoverStartDate = require('./get-cover-start-date');
 
 const getIssueDate = (facility, submissionDate) => {
   if (facility.facilitySnapshot) {
-    return isIssued(facility.facilitySnapshot.facilityStage)
-      ? formatTimestamp(facility.facilitySnapshot.requestedCoverStartDate)
+    return hasFacilityBeenIssued(facility)
+      ? formatTimestamp(getCoverStartDate(facility, true))
       : formatTimestamp(submissionDate);
   }
   return formatTimestamp(submissionDate);

--- a/azure-functions/acbs-function/mappings/facility/helpers/index.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/index.js
@@ -16,6 +16,8 @@ const getMaximumLiability = require('./get-maximum-liability');
 const mapFeeFrequency = require('./map-fee-frequency');
 const getInsuredPercentage = require('./get-insured-percentage');
 const getBaseCurrency = require('./get-base-currency');
+const getCoverStartDate = require('./get-cover-start-date');
+const hasFacilityBeenIssued = require('./get-facility-issue-status');
 
 module.exports = {
   isIssued,
@@ -36,4 +38,6 @@ module.exports = {
   mapFeeFrequency,
   getInsuredPercentage,
   getBaseCurrency,
+  getCoverStartDate,
+  hasFacilityBeenIssued,
 };


### PR DESCRIPTION
This commit deals with various ACBS bug patches on both deal and facilities records level.

### Deal Records
1. Investor record expiration date - ACBS bug raised with Mulesoft team, a temporary patch has been applied as per the recommendation by the Mulesoft support.
2. Deal currency - `GBP` returned as default currency when an unexpected object is returned.

### Facility Records
1. Master - Probability of default, an optional GEF field has been added.
2. Covenant - Maximum liability has been changed from UKEF exposure value to total facility value.
3. Helper functions - Introduction of following two helper functions to improve code readability and refactorization: 
    3.1. getCoverStartDate - Returns facilities cover start date
    3.2. hasFacilityBeenIssued - Returns whether facility has been issued