### PR TITLE
DTFS2-4174 - TFM tasks patches (update unlocking task rule, send emails for underwriting tasks unlocking)

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-all-tasks.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-all-tasks.spec.js
@@ -13,6 +13,7 @@ import {
   assertTaskStatusAndLink,
   submitTaskCompleteAndAssertOtherTasks,
   assertTaskStatus,
+  assertTaskLinkDoesNotExist,
 } from './tasks-helpers';
 
 
@@ -169,7 +170,7 @@ context('Case tasks - MIA deal - all tasks', () => {
 
   const startAndCompleteAllUnderwritingTasks = () => {
     // complete Underwriting group tasks in an order that is NOT ascending
-    startAndCompleteLastUnderwritingTask();
+    // startAndCompleteLastUnderwritingTask();
     startAndCompleteFirstUnderwritingTask();
     startAndCompleteSecondUnderwritingTask();
   };
@@ -224,7 +225,21 @@ context('Case tasks - MIA deal - all tasks', () => {
     });
 
     // Start and complete all tasks in Underwriting Group.
-    startAndCompleteAllUnderwritingTasks();
+    // startAndCompleteAllUnderwritingTasks();
+
+    // Complete the last Underwriting task first
+    startAndCompleteLastUnderwritingTask();
+
+    // the next task in the next group should remain unlocked.
+    const group4GroupId = 4;
+    const group4FirstTaskRow = pages.tasksPage.tasks.row(group4GroupId, 1);
+
+    assertTaskLinkDoesNotExist(group4FirstTaskRow)
+    assertTaskStatus(group4FirstTaskRow, 'Cannot start yet');
+
+    // Complete the remaining Underwriting tasks.
+    startAndCompleteFirstUnderwritingTask();
+    startAndCompleteSecondUnderwritingTask();
 
     // Complete all tasks in 'Approvals' group
     cy.wrap(group4Tasks).each((_, index) => {

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-all-tasks.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-all-tasks.spec.js
@@ -168,13 +168,6 @@ context('Case tasks - MIA deal - all tasks', () => {
     lastTaskRow.link().should('not.exist');
   };
 
-  const startAndCompleteAllUnderwritingTasks = () => {
-    // complete Underwriting group tasks in an order that is NOT ascending
-    // startAndCompleteLastUnderwritingTask();
-    startAndCompleteFirstUnderwritingTask();
-    startAndCompleteSecondUnderwritingTask();
-  };
-
   it('user cannot start a task in a group until all tasks in the previous group are completed. Each time a task is completed, the next task can be started.', () => {
     partials.caseSubNavigation.tasksLink().click();
     cy.url().should('eq', relative(`/case/${dealId}/tasks`));

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-all-tasks.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-all-tasks.spec.js
@@ -214,7 +214,6 @@ context('Case tasks - MIA deal - all tasks', () => {
       });
     });
 
-    // Complete all tasks in 'Underwriters' group
     // Because the 'Complete an adverse history check' task in 'Adverse history check' group has been completed,
     // All tasks in Underwriting Group are should be unlocked and editable
     const underwritingunderwritingGroupId = 3;
@@ -224,13 +223,10 @@ context('Case tasks - MIA deal - all tasks', () => {
       assertTaskStatusAndLink(underwritingunderwritingGroupId, taskId, 'To do');
     });
 
-    // Start and complete all tasks in Underwriting Group.
-    // startAndCompleteAllUnderwritingTasks();
-
     // Complete the last Underwriting task first
     startAndCompleteLastUnderwritingTask();
 
-    // the next task in the next group should remain unlocked.
+    // The next task in the next group should remain unlocked.
     const group4GroupId = 4;
     const group4FirstTaskRow = pages.tasksPage.tasks.row(group4GroupId, 1);
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-helpers.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-helpers.js
@@ -70,14 +70,26 @@ const assertCompleteTask = (groupId, taskId) => {
   });
 };
 
+const assertTaskStatus = (row,  expectedStatus) => {
+  row.status().invoke('text').then((text) => {
+    expect(text.trim()).to.equal(expectedStatus);
+  });
+};
+
+const assertTaskLinkExists = (row) => {
+  row.link().should('exist');
+};
+
+const assertTaskLinkDoesNotExist = (row) => {
+  row.link().should('not.exist');
+};
+
 const assertTaskStatusAndLink = (groupId, taskId, expectedStatus) => {
   const taskRow = pages.tasksPage.tasks.row(groupId, taskId);
 
-  taskRow.status().invoke('text').then((text) => {
-    expect(text.trim()).to.equal(expectedStatus);
-  });
+  assertTaskStatus(taskRow, expectedStatus);
 
-  taskRow.link().should('exist');
+  assertTaskLinkExists(taskRow);
 };
 
 const assertNextTaskStatus = (currentGroupId, currentTaskId) => {
@@ -154,21 +166,17 @@ const submitTaskCompleteAndAssertOtherTasks = (groupId, taskId, userId) => {
   assertCannotClickPreviousTask(groupId, taskId);
 };
 
-const assertTaskStatus = (row, expectedStatus) => {
-  row.status().invoke('text').then((text) => {
-    expect(text.trim()).to.equal(expectedStatus);
-  });
-};
-
 module.exports = {
   getGroup,
   MIA_TASKS_STRUCTURE,
   submitTaskInProgress,
   submitTaskComplete,
   assertCompleteTask,
+  assertTaskStatus,
+  assertTaskLinkExists,
+  assertTaskLinkDoesNotExist,
   assertTaskStatusAndLink,
   assertNextTaskStatus,
   assertCannotClickNextTask,
   submitTaskCompleteAndAssertOtherTasks,
-  assertTaskStatus,
 };

--- a/trade-finance-manager-api/src/v1/controllers/send-tfm-email.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-tfm-email.js
@@ -22,12 +22,12 @@ const sendTfmEmail = async (
   };
 
   let emailHistory = [];
-  if (deal.tfm.history && deal.tfm.history.emails) {
+  if (deal.tfm?.history && deal.tfm.history.emails) {
     emailHistory = deal.tfm.history.emails;
   }
 
   const updatedHistory = {
-    ...deal.tfm.history,
+    ...deal.tfm?.history,
     emails: [
       ...emailHistory,
       newHistoryObject,

--- a/trade-finance-manager-api/src/v1/controllers/tasks.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tasks.controller.js
@@ -85,7 +85,7 @@ const updateAllTasks = async (allTaskGroups, groupId, taskUpdate, deal, urlOrigi
 
   /**
    * If 'Adverse History Check' task is completed
-   * All tasks in the Underwriting Group Task become unlocked/able to be started
+   * All tasks in the Underwriting Group Task become unlocked and are able to be started
    * */
   const canUnlockUnderWritingGroupTasks = isAdverseHistoryTaskIsComplete(taskGroups);
 
@@ -99,11 +99,17 @@ const updateAllTasks = async (allTaskGroups, groupId, taskUpdate, deal, urlOrigi
             task.id === taskUpdate.id
             && task.groupId === taskUpdate.groupId);
 
-          const shouldUpdate = (!isTaskThatIsBeingUpdated
+          // add the task to list of emails to be sent
+          if (!isTaskThatIsBeingUpdated) {
+            taskEmailsToSend.push(task);
+          }
+
+          // unlock the task
+          const shouldUnlock = (!isTaskThatIsBeingUpdated
             && !task.canEdit
             && task.status === CONSTANTS.TASKS.STATUS.CANNOT_START);
 
-          if (shouldUpdate) {
+          if (shouldUnlock) {
             return {
               ...task,
               canEdit: true,

--- a/trade-finance-manager-api/src/v1/helpers/tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/tasks.api-test.js
@@ -6,10 +6,12 @@ const {
   getGroupByTitle,
   isFirstTaskInAGroup,
   isFirstTaskInFirstGroup,
+  groupHasAllTasksCompleted,
   taskIsCompletedImmediately,
   isAdverseHistoryTaskIsComplete,
   shouldUpdateDealStage,
 } = require('./tasks');
+const CONSTANTS = require('../../constants');
 
 describe('helpers - tasks', () => {
   describe('getFirstTask', () => {
@@ -127,11 +129,46 @@ describe('helpers - tasks', () => {
     });
   });
 
+  describe('groupHasAllTasksCompleted', () => {
+    it('returns true when all tasks are completed', () => {
+      const mockGroupTasks = [
+        {
+          id: 1,
+          title: 'mock',
+          status: CONSTANTS.TASKS.STATUS.COMPLETED,
+        },
+      ];
+
+      const result = groupHasAllTasksCompleted(mockGroupTasks);
+      
+      expect(result).toEqual(true);
+    });
+
+    it('returns false when tasks are NOT completed', () => {
+      const mockGroupTasks = [
+        {
+          id: 1,
+          title: 'mock',
+          status: CONSTANTS.TASKS.STATUS.COMPLETED,
+        },
+        {
+          id: 2,
+          title: 'mock',
+          status: CONSTANTS.TASKS.STATUS.TO_DO,
+        },
+      ];
+
+      const result = groupHasAllTasksCompleted(mockGroupTasks);
+
+      expect(result).toEqual(false);
+    });
+  });
+
   describe('taskIsCompletedImmediately', () => {
     it('should return true when status changes from `To do` to `Done`', () => {
       const result = taskIsCompletedImmediately(
         'To do',
-        'Done',
+        CONSTANTS.TASKS.STATUS.COMPLETED,
       );
 
       expect(result).toEqual(true);
@@ -161,7 +198,7 @@ describe('helpers - tasks', () => {
           {
             id: 1,
             title: 'Complete an adverse history check',
-            status: 'Done',
+            status: CONSTANTS.TASKS.STATUS.COMPLETED,
           },
         ],
       },
@@ -212,7 +249,7 @@ describe('helpers - tasks', () => {
 
     it('should return true when submissionType is MIA, is first task in first group, task status changes from `To do` to `Done`', () => {
       const statusFrom = 'To do';
-      const statusTo = 'Done';
+      const statusTo = CONSTANTS.TASKS.STATUS.COMPLETED;
 
       const result = shouldUpdateDealStage(
         submissionType,

--- a/trade-finance-manager-api/src/v1/helpers/tasks.js
+++ b/trade-finance-manager-api/src/v1/helpers/tasks.js
@@ -24,6 +24,19 @@ const isFirstTaskInAGroup = (taskId, groupId) =>
 const isFirstTaskInFirstGroup = (taskId, groupId) =>
   (taskId === '1' && groupId === 1);
 
+const groupHasAllTasksCompleted = (groupTasks) => {
+  const totalTasks = groupTasks.length;
+
+  const completedTasks = groupTasks.filter((task) =>
+    task.status === CONSTANTS.TASKS.STATUS.COMPLETED);
+
+  if (completedTasks.length === totalTasks) {
+    return true;
+  }
+
+  return false;
+};
+
 /**
 * Check if a task status is changing from 'To do' to 'Completed'
 * */
@@ -83,6 +96,7 @@ module.exports = {
   getGroupByTitle,
   isFirstTaskInAGroup,
   isFirstTaskInFirstGroup,
+  groupHasAllTasksCompleted,
   taskIsCompletedImmediately,
   isAdverseHistoryTaskIsComplete,
   shouldUpdateDealStage,

--- a/trade-finance-manager-api/src/v1/tasks/tasks-edit-logic.api-test.js
+++ b/trade-finance-manager-api/src/v1/tasks/tasks-edit-logic.api-test.js
@@ -41,16 +41,16 @@ describe('tasks edit logic', () => {
     });
 
     describe('when the group is not the first group and task id is first in the group', () => {
-      it('should return true when the previous group\'s last task has `Done` status', () => {
-        const MOCK_SECOND_GROUP = {
-          id: 2,
-          groupTasks: [
-            { id: '1', groupId: 2, status: 'To do' },
-            { id: '2', groupId: 2, status: 'To do' },
-            { id: '3', groupId: 2, status: 'To do' },
-          ],
-        };
+      const MOCK_SECOND_GROUP = {
+        id: 2,
+        groupTasks: [
+          { id: '1', groupId: 2, status: 'To do' },
+          { id: '2', groupId: 2, status: 'To do' },
+          { id: '3', groupId: 2, status: 'To do' },
+        ],
+      };
 
+      it('should return true when the previous group has all tasks completed', () => {
         const MOCK_AIN_TASKS_FIRST_GROUP_COMPLETED = [
           {
             groupTitle: CONSTANTS.TASKS.AIN.GROUP_1.GROUP_TITLE,
@@ -59,7 +59,7 @@ describe('tasks edit logic', () => {
               {
                 id: '1',
                 groupId: 1,
-                title: CONSTANTS.TASKS.AIN.GROUP_1.MATCH_OR_CREATE_PARTIES,
+                title: CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
                 team: CONSTANTS.TEAMS.BUSINESS_SUPPORT,
                 status: CONSTANTS.TASKS.STATUS.COMPLETED,
                 assignedTo: {
@@ -70,7 +70,7 @@ describe('tasks edit logic', () => {
               {
                 id: '2',
                 groupId: 1,
-                title: CONSTANTS.TASKS.AIN.GROUP_1.CREATE_OR_LINK_SALESFORCE,
+                title: CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE,
                 team: CONSTANTS.TEAMS.BUSINESS_SUPPORT,
                 status: CONSTANTS.TASKS.STATUS.COMPLETED,
                 assignedTo: {
@@ -89,6 +89,47 @@ describe('tasks edit logic', () => {
           '1',
         );
         expect(result).toEqual(true);
+      });
+
+      it('should return false if any task in the previous group is NOT completed', () => {
+        const MOCK_AIN_TASKS_FIRST_GROUP_INCOMPLETE = [
+          {
+            groupTitle: CONSTANTS.TASKS.AIN.GROUP_1.GROUP_TITLE,
+            id: 1,
+            groupTasks: [
+              {
+                id: '1',
+                groupId: 1,
+                title: CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
+                team: CONSTANTS.TEAMS.BUSINESS_SUPPORT,
+                status: CONSTANTS.TASKS.STATUS.TO_DO,
+                assignedTo: {
+                  userId: CONSTANTS.TASKS.UNASSIGNED,
+                  userFullName: CONSTANTS.TASKS.UNASSIGNED,
+                },
+              },
+              {
+                id: '2',
+                groupId: 2,
+                title: CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE,
+                team: CONSTANTS.TEAMS.BUSINESS_SUPPORT,
+                status: CONSTANTS.TASKS.STATUS.COMPLETED,
+                assignedTo: {
+                  userId: CONSTANTS.TASKS.UNASSIGNED,
+                  userFullName: CONSTANTS.TASKS.UNASSIGNED,
+                },
+              },
+            ],
+          },
+          MOCK_SECOND_GROUP,
+        ];
+
+        const result = previousTaskIsComplete(
+          MOCK_AIN_TASKS_FIRST_GROUP_INCOMPLETE,
+          MOCK_SECOND_GROUP,
+          '1',
+        );
+        expect(result).toEqual(false);
       });
     });
 

--- a/trade-finance-manager-api/src/v1/tasks/tasks-edit-logic.js
+++ b/trade-finance-manager-api/src/v1/tasks/tasks-edit-logic.js
@@ -94,16 +94,6 @@ const taskCanBeEditedWithoutPreviousTaskComplete = (group, task) => {
   return false;
 };
 
-const isPreviousTaskIsInDifferentGroup = (allTaskGroups, group, currentTaskId) => {
-  // const currentTask 
-  if (isFirstTaskInAGroup(currentTaskId, group.id)) {
-    // const previousGroupId = group.id - 1;
-    // const previousGroup = getGroupById(allTaskGroups, previousGroupId);
-    return true;
-  }
-
-  return false;
-};
 
 /**
  * Rules/conditions for task.canEdit and task.status

--- a/trade-finance-manager-api/src/v1/tasks/tasks-edit-logic.js
+++ b/trade-finance-manager-api/src/v1/tasks/tasks-edit-logic.js
@@ -1,10 +1,11 @@
 const CONSTANTS = require('../../constants');
 const {
-  isFirstTaskInFirstGroup,
-  isFirstTaskInAGroup,
   getGroupById,
   getTaskInGroupById,
   getTaskInGroupByTitle,
+  isFirstTaskInAGroup,
+  isFirstTaskInFirstGroup,
+  groupHasAllTasksCompleted,
 } = require('../helpers/tasks');
 
 /**
@@ -22,17 +23,18 @@ const previousTaskIsComplete = (allTaskGroups, group, taskId) => {
 
   if (isFirstTaskInAGroup(taskId, group.id)) {
     /**
-     * Check that the previous task in the previous group is completed
+     * Check that all tasks in the previous group are completed
      * */
     const previousGroupId = group.id - 1;
     const previousGroup = getGroupById(allTaskGroups, previousGroupId);
 
-    const totalTasksInPreviousGroup = previousGroup.groupTasks.length;
-    const lastTaskInPreviousGroup = previousGroup.groupTasks[totalTasksInPreviousGroup - 1];
+    const previousGroupHasAllTasksCompleted = groupHasAllTasksCompleted(previousGroup.groupTasks);
 
-    if (lastTaskInPreviousGroup.status === CONSTANTS.TASKS.STATUS.COMPLETED) {
+    if (previousGroupHasAllTasksCompleted) {
       return true;
     }
+
+    return false;
   } else {
     /**
      * Check that the previous task in the current group is completed
@@ -86,6 +88,17 @@ const taskCanBeEditedWithoutPreviousTaskComplete = (group, task) => {
 
   if (taskIsInUnderwritingGroup
     && task.canEdit) {
+    return true;
+  }
+
+  return false;
+};
+
+const isPreviousTaskIsInDifferentGroup = (allTaskGroups, group, currentTaskId) => {
+  // const currentTask 
+  if (isFirstTaskInAGroup(currentTaskId, group.id)) {
+    // const previousGroupId = group.id - 1;
+    // const previousGroup = getGroupById(allTaskGroups, previousGroupId);
     return true;
   }
 


### PR DESCRIPTION
- ensure that when the Underwriting Group Tasks are unlocked, emails are sent out.
- only unlock a task in a group, if *all* tasks in the previous group are completed (it used to only check the previous task).
- improve test coverage