### PR TITLE
fix - GEF status update emails

### DIFF
--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -21,7 +21,7 @@ const api = require('../../../src/v1/api');
 jest.mock('../../../src/reference-data/api', () => ({
   sendEmail: jest.fn(() => Promise.resolve({})),
   numberGenerator: {
-    create: () => ({}),
+    create: () => ({ ukefId: '1' }),
   },
 }));
 

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -210,8 +210,8 @@ const sendStatusUpdateEmail = async (user, existingApplication, status) => {
       submissionType: existingApplication.submissionType || '',
       supplierName: companyName,
       bankInternalRefName,
-      currentStatus: DEAL_STATUS[status],
-      previousStatus: DEAL_STATUS[previousStatus],
+      currentStatus: status,
+      previousStatus: previousStatus,
       updatedByName: `${user.firstname} ${user.surname}`,
       updatedByEmail: user.email,
     });


### PR DESCRIPTION
Sending an email when the deal status changes previously relied on references to uppercase constants and matching uppercase value in the deal. We changed the uppercase deal status to be non-uppercase and this stopped the emails from being sent (no status found, therefore Notify would reject the email because of missing email variables).

There was also no test coverage for this.

This is now fixed, added test coverage.