### PR TITLE
fix TFM deals query issue, improve graphQL error handling

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/mappings/map-deals.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/mappings/map-deals.api-test.js
@@ -1,0 +1,150 @@
+const externalApis = require('../../../src/v1/api');
+const mapDeals = require('../../../src/v1/mappings/map-deals');
+
+const {
+  eligibility,
+  facilities,
+  bondTransactions,
+  loanTransactions,
+} = require('../../../src/v1/__mocks__/mock-deal');
+const MOCK_BSS_DEAL = require('../../../src/v1/__mocks__/mock-deal');
+const MOCK_GEF_DEAL = require('../../../src/v1/__mocks__/mock-gef-deal');
+
+describe('mappings - map-deals', () => {
+  const mockFindFacilitesByDealIdResponse = MOCK_GEF_DEAL.facilities.map((facility) => ({
+    facilitySnapshot: facility,
+    tfm: {},
+  }));
+
+  const mockFindOneFacilityResponse = {
+    facilitySnapshot: bondTransactions.items[0],
+    tfm: {},
+  };
+
+  const findFacilitesByDealIdSpy = jest.fn(() => Promise.resolve(mockFindFacilitesByDealIdResponse));
+  const findOneFacilitySpy = jest.fn(() => Promise.resolve(mockFindOneFacilityResponse));
+
+  beforeEach(() => {
+    findFacilitesByDealIdSpy.mockClear();
+    findOneFacilitySpy.mockClear();
+
+    externalApis.findFacilitesByDealId = findFacilitesByDealIdSpy;
+    externalApis.findOneFacility = findOneFacilitySpy;
+  });
+
+  describe('GEF deals', () => {
+    const mockDeals = [
+      { _id: MOCK_GEF_DEAL._id, dealSnapshot: MOCK_GEF_DEAL },
+      { _id: MOCK_GEF_DEAL._id, dealSnapshot: MOCK_GEF_DEAL },
+    ];
+
+    it('should call api.findFacilitesByDealId with deal id', async () => {
+      await mapDeals(mockDeals);
+
+      const expectedCallCount = mockDeals.length;
+
+      expect(findFacilitesByDealIdSpy).toHaveBeenCalledTimes(expectedCallCount);
+
+      const findOneFacilityCalls = externalApis.findFacilitesByDealId.mock.calls;
+
+      // both deals use the same mock deals
+      const expectedCalls = [
+        [MOCK_GEF_DEAL._id],
+        [MOCK_GEF_DEAL._id],
+      ];
+
+      expect(findOneFacilityCalls).toEqual(expectedCalls);
+    });
+
+    it('should return deals mapped with facilities returned from API', async () => {
+      const result = await mapDeals(mockDeals);
+
+      const expectedDealShape = {
+        ...mockDeals[0],
+        dealSnapshot: {
+          ...mockDeals[0].dealSnapshot,
+          facilities: mockFindFacilitesByDealIdResponse,
+        },
+      };
+
+      const expected = [
+        expectedDealShape,
+        expectedDealShape,
+      ];
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('BSS/EWCS deals', () => {
+    const mockBonds = bondTransactions.items.map(({ _id }) => ({ _id }));
+    const mockLoans = loanTransactions.items.map(({ _id }) => ({ _id }));
+
+    const mockDeal = {
+      dealSnapshot: {
+        dealType: MOCK_BSS_DEAL.dealType,
+        eligibility,
+        facilities,
+        bondTransactions: {
+          items: mockBonds,
+        },
+        loanTransactions: {
+          items: mockLoans,
+        },
+      },
+    };
+
+    const mockDeals = [
+      mockDeal,
+      mockDeal,
+    ];
+
+    const allFacilities = [...mockBonds, ...mockLoans];
+
+    it('should call api.findOneFacility with facility id, for each facility', async () => {
+      await mapDeals(mockDeals);
+
+      const totalFacilities = allFacilities.length;
+      const totalDeals = mockDeals.length;
+      const expectedCallCount = (totalFacilities * totalDeals);
+
+      expect(findOneFacilitySpy).toHaveBeenCalledTimes(expectedCallCount);
+
+      const findOneFacilityCalls = externalApis.findOneFacility.mock.calls;
+
+      const facilityIds = allFacilities.map((facility) => facility._id);
+
+      // both deals use the same mock facilities
+      const expectedCalls = [
+        ...facilityIds.map((id) => [id]),
+        ...facilityIds.map((id) => [id]),
+      ];
+
+      expect(findOneFacilityCalls).toEqual(expectedCalls);
+    });
+
+    it('should return deals mapped with facilities returned from API and remove items array from bondTransactions and loanTransactions', async () => {
+      const result = await mapDeals(mockDeals);
+
+      const mockDealWithoutBondsAndLoans = mockDeal;
+      delete mockDealWithoutBondsAndLoans.bondTransactions;
+      delete mockDealWithoutBondsAndLoans.loanTransactions;
+
+      const expectedDealShape = {
+        dealSnapshot: {
+          ...mockDeal.dealSnapshot,
+          bondTransactions: {},
+          loanTransactions: {},
+          facilities: allFacilities.map((f) => mockFindOneFacilityResponse),
+        },
+      };
+
+      const expected = [
+        expectedDealShape,
+        expectedDealShape,
+      ];
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/createApp.js
+++ b/trade-finance-manager-api/src/createApp.js
@@ -39,6 +39,26 @@ const schemaWithMiddleware = applyMiddleware(schema, graphqlPermissions);
 const server = new ApolloServer({
   typeDefs,
   resolvers,
+  formatResponse: (response, context) => {
+    const { graphqlPermissions: permissions } = context.context;
+
+    const isAuthenticated = (permissions.read || permissions.write);
+
+    const dataKeys = Object.keys(response.data);
+
+    // if there is no data, object will be null.
+    const hasData = response.data[dataKeys[0]];
+
+    if (isAuthenticated && !hasData) {
+      return {
+        errors: [
+          { message: 'Server error returning query.' },
+        ],
+      };
+    }
+
+    return response;
+  },
   context: ({ req }) => ({
     graphqlPermissions: graphqlKeyAuthentication(req),
     user: req.user,

--- a/trade-finance-manager-api/src/v1/mappings/map-deals.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-deals.js
@@ -20,8 +20,8 @@ const mapDeals = async (deals) => {
     delete deal.dealSnapshot.loanTransactions.items;
 
     if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
-      deal.dealSnapshot.facilities = await Promise.all(dealSnapshot.facilities.map(async (facilityId) =>
-        api.findOneFacility(facilityId)));
+      deal.dealSnapshot.facilities = await Promise.all(dealSnapshot.facilities.map(async ({ _id }) =>
+        api.findOneFacility(_id)));
     }
 
     return deal;


### PR DESCRIPTION
- update `map-deals` BSS/EWCS facility API call to consume _id from object (used to rely on this being an array of ids)
- add test coverage
- add graphQL error response handling so that:
  - if user is authenticated and for some reason the resolver does not return any data, it will throw a custom error.
  - if user is not authenticated, it will throw default unauth error from middleware

Without the custom error handling - if a user was authenticated and there was an error with the resolvers, this would be returned which is misleading and has tripped us up many times.

```js
[
  { message: 'Not Authorised!' }
]
```

Now it will return:

```js
[
  { message: 'Server error returning query.' }
]

```