### PR TITLE
Add exporter.companyName to mock BSS deals used in E2E tests

### DIFF
--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal-unissued-facilities/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal-unissued-facilities/dealThatJustNeedsDates.json
@@ -160,5 +160,8 @@
       "feeFrequency": null,
       "feeType": "At maturity"
     }
-  ]
+  ],
+  "exporter": {
+    "companyName": "UKFS"
+  }
 }

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal/dealThatJustNeedsDates.json
@@ -176,5 +176,8 @@
       "feeFrequency": null,
       "feeType": "At maturity"
     }
-  ]
+  ],
+  "exporter": {
+    "companyName": "UKFS"
+  }
 }


### PR DESCRIPTION
Without this, a "missing email variable" error is thrown in E2E tests.

In the real world this would exist as it's a required field.