### PR TITLE
DTFS2-5355 : GEF Email

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -586,7 +586,7 @@ describe('/v1/deals', () => {
 
         expect(status).toEqual(200);
         expect(body.submissionType).toEqual(CONSTANTS.DEALS.SUBMISSION_TYPE.MIN);
-        expect(typeof body.manualInclusionNoticeSubmissionDate).toEqual('string');
+        expect(typeof body.manualInclusionNoticeSubmissionDate).toEqual('number');
       });
     });
   });

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal-MIN.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal-MIN.js
@@ -4,7 +4,7 @@ const MOCK_GEF_DEAL_MIN = {
   ...MOCK_GEF_DEAL,
   _id: 'MOCK_GEF_DEAL_MIN',
   submissionType: 'Manual Inclusion Notice',
-  manualInclusionNoticeSubmissionDate: 'string',
+  manualInclusionNoticeSubmissionDate: 1234,
 };
 
 module.exports = MOCK_GEF_DEAL_MIN;

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.api-test.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.api-test.js
@@ -2,6 +2,7 @@ const { format } = require('date-fns');
 const gefEmailVariables = require('./gef-email-variables');
 const mapSubmittedDeal = require('../../mappings/map-submitted-deal');
 const { generateAddressString } = require('../../helpers/generate-address-string');
+const getSubmissionDate = require('../../helpers/get-submission-date');
 const MOCK_GEF_DEAL = require('../../__mocks__/mock-gef-deal');
 
 describe('generate AIN/MIN confirmation email variables - GEF', () => {
@@ -23,7 +24,7 @@ describe('generate AIN/MIN confirmation email variables - GEF', () => {
       ukefDealId: mockSubmittedDeal.ukefDealId,
       bankGefDealId: mockSubmittedDeal.bankInternalRefName,
       dealName: mockSubmittedDeal.additionalRefName,
-      submissionDate: format(Number(mockSubmittedDeal.submissionDate), 'do MMMM yyyy'),
+      submissionDate: format(getSubmissionDate(mockSubmittedDeal), 'do MMMM yyyy'),
       exporterCompaniesHouseRegistrationNumber: mockSubmittedDeal.exporter.companiesHouseRegistrationNumber,
       exporterAddress: generateAddressString(mockSubmittedDeal.exporter.registeredAddress),
       industrySector: mockSubmittedDeal.exporter.selectedIndustry.name,

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.js
@@ -1,17 +1,6 @@
 const { format } = require('date-fns');
 const { generateAddressString } = require('../../helpers/generate-address-string');
-
-/**
- * If `MIN` relevant submission date is returned else standard `Appliction` submision date.
- * Date retuned in EPOCH format.
- * @param {Object} Deal deal object decapsulating `manualInclusionNoticeSubmissionDate` and `submissionDate`
- * @returns {Integer} EPOCH
- */
-const getSubmissionDate = ({ manualInclusionNoticeSubmissionDate, submissionDate }) => (
-  manualInclusionNoticeSubmissionDate
-    ? Number(manualInclusionNoticeSubmissionDate)
-    : Number(submissionDate)
-);
+const getSubmissionDate = require('../../helpers/get-submission-date');
 
 const gefEmailVariables = (deal, facilityLists) => {
   const {

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.js
@@ -1,6 +1,18 @@
 const { format } = require('date-fns');
 const { generateAddressString } = require('../../helpers/generate-address-string');
 
+/**
+ * If `MIN` relevant submission date is returned else standard `Appliction` submision date.
+ * Date retuned in EPOCH format.
+ * @param {Object} Deal deal object decapsulating `manualInclusionNoticeSubmissionDate` and `submissionDate`
+ * @returns {Integer} EPOCH
+ */
+const getSubmissionDate = ({ manualInclusionNoticeSubmissionDate, submissionDate }) => (
+  manualInclusionNoticeSubmissionDate
+    ? Number(manualInclusionNoticeSubmissionDate)
+    : Number(submissionDate)
+);
+
 const gefEmailVariables = (deal, facilityLists) => {
   const {
     submissionType,
@@ -8,7 +20,6 @@ const gefEmailVariables = (deal, facilityLists) => {
     exporter,
     bankInternalRefName,
     additionalRefName,
-    submissionDate,
     ukefDealId,
   } = deal;
 
@@ -22,7 +33,7 @@ const gefEmailVariables = (deal, facilityLists) => {
     ukefDealId,
     bankGefDealId: bankInternalRefName,
     dealName: additionalRefName,
-    submissionDate: format(Number(submissionDate), 'do MMMM yyyy'),
+    submissionDate: format(getSubmissionDate(deal), 'do MMMM yyyy'),
     exporterCompaniesHouseRegistrationNumber: exporter.companiesHouseRegistrationNumber,
     exporterAddress: generateAddressString(exporter.registeredAddress),
     industrySector: exporter.selectedIndustry.name,

--- a/trade-finance-manager-api/src/v1/helpers/get-submission-date.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/get-submission-date.api-test.js
@@ -5,14 +5,14 @@ const MOCK_GEF_MIN_DEAL = require('../__mocks__/mock-gef-deal-MIN');
 
 describe('Ascertain deal submission date', () => {
   it('Should return `submissionDate` as deal is an AIN', () => {
-    expect(getSubmissionDate(MOCK_GEF_AIN_DEAL)).toEqual(1626169888809);
+    expect(getSubmissionDate(MOCK_GEF_AIN_DEAL)).toEqual(Number(MOCK_GEF_AIN_DEAL.submissionDate));
   });
 
   it('Should return `submissionDate` as deal is a MIA', () => {
-    expect(getSubmissionDate(MOCK_GEF_MIA_DEAL)).toEqual(1626169888809);
+    expect(getSubmissionDate(MOCK_GEF_MIA_DEAL)).toEqual(Number(MOCK_GEF_MIA_DEAL.submissionDate));
   });
 
   it('Should return `manualInclusionNoticeSubmissionDate` as deal is a MIN', () => {
-    expect(getSubmissionDate(MOCK_GEF_MIN_DEAL)).toEqual(1234);
+    expect(getSubmissionDate(MOCK_GEF_MIN_DEAL)).toEqual(MOCK_GEF_MIN_DEAL.manualInclusionNoticeSubmissionDate);
   });
 });

--- a/trade-finance-manager-api/src/v1/helpers/get-submission-date.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/get-submission-date.api-test.js
@@ -1,0 +1,18 @@
+const getSubmissionDate = require('./get-submission-date');
+const MOCK_GEF_AIN_DEAL = require('../__mocks__/mock-gef-deal');
+const MOCK_GEF_MIA_DEAL = require('../__mocks__/mock-gef-deal-MIA');
+const MOCK_GEF_MIN_DEAL = require('../__mocks__/mock-gef-deal-MIN');
+
+describe('Ascertain deal submission date', () => {
+  it('Should return `submissionDate` as deal is an AIN', () => {
+    expect(getSubmissionDate(MOCK_GEF_AIN_DEAL)).toEqual(1626169888809);
+  });
+
+  it('Should return `submissionDate` as deal is a MIA', () => {
+    expect(getSubmissionDate(MOCK_GEF_MIA_DEAL)).toEqual(1626169888809);
+  });
+
+  it('Should return `manualInclusionNoticeSubmissionDate` as deal is a MIN', () => {
+    expect(getSubmissionDate(MOCK_GEF_MIN_DEAL)).toEqual(1234);
+  });
+});

--- a/trade-finance-manager-api/src/v1/helpers/get-submission-date.js
+++ b/trade-finance-manager-api/src/v1/helpers/get-submission-date.js
@@ -1,0 +1,13 @@
+/**
+ * If `MIN` relevant submission date is returned else standard `Appliction` submision date.
+ * Date retuned in EPOCH format.
+ * @param {Object} Deal deal object decapsulating `manualInclusionNoticeSubmissionDate` and `submissionDate`
+ * @returns {Integer} EPOCH
+ */
+const getSubmissionDate = ({ manualInclusionNoticeSubmissionDate, submissionDate }) => (
+  manualInclusionNoticeSubmissionDate
+    ? Number(manualInclusionNoticeSubmissionDate)
+    : Number(submissionDate)
+);
+
+module.exports = getSubmissionDate;


### PR DESCRIPTION
### Patch Note
This bug patch mitigates GEF email variable for submission date. If the application is MIN `manualInclusionNoticeSubmissionDate` is returned else `submissionDate` thus rendering MIN submission date in the confirmation email.

* Introduction of `getSubmissionDate` helper function to ascertain submission date.
* `manualInclusionNoticeSubmissionDate` has been updated to `1234` on mock MIN deal.
* Updated jest test