### PR TITLE
DTFS2-4585 : Facility issue - Loan & Fee records creations

### DIFF
--- a/azure-functions/acbs-function/helpers/date.js
+++ b/azure-functions/acbs-function/helpers/date.js
@@ -4,7 +4,7 @@ const isDate = (dateStr) => moment(dateStr, 'YYYY-MM-DD', true).isValid();
 const now = () => moment().format('YYYY-MM-DD');
 
 const formatYear = (year) => (year < 1000 ? (2000 + parseInt(year, 10)).toString() : year && year.toString());
-const formatDate = (dateStr) => moment(dateStr).format('YYYY-MM-DD');
+const formatDate = (dateStr) => moment(isDate(dateStr) ? dateStr : Number(dateStr)).format('YYYY-MM-DD');
 const formatTimestamp = (dateStr) => moment.utc(isDate(dateStr) ? dateStr : Number(dateStr)).format('YYYY-MM-DD');
 
 const addDay = (date, day) => moment(date).add({ day }).format('YYYY-MM-DD');

--- a/azure-functions/acbs-function/mappings/facility/facility-fee.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-fee.js
@@ -37,7 +37,7 @@ const constructFeeRecord = (deal, facility, premiumScheduleIndex = 0) => {
     period: helpers.getFeeRecordPeriod(facility, deal.dealSnapshot.dealType, premiumScheduleIndex),
     currency: facility.facilitySnapshot.currency.id,
     lenderTypeCode: CONSTANTS.FACILITY.LENDER_TYPE.TYPE1,
-    incomeClassCode: helpers.getIncomeClassCode(facility, deal.dealSnapshot.dealType),
+    incomeClassCode: helpers.getIncomeClassCode(deal.dealSnapshot.dealType),
     spreadToInvestorsIndicator: true,
   };
 };

--- a/azure-functions/acbs-function/mappings/facility/facility-update.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-update.js
@@ -40,17 +40,17 @@
 const helpers = require('./helpers');
 const CONSTANTS = require('../../constants');
 
-const facilityUpdate = (facility, acbsFacility, obligorName, dealType) => ({
+const facilityUpdate = (facility, acbsFacility, deal) => ({
   ...acbsFacility,
-  exposurePeriod: String(helpers.getExposurePeriod(facility, dealType)),
-  description: helpers.getDescription(facility, dealType),
+  exposurePeriod: String(helpers.getExposurePeriod(facility, deal.dealSnapshot.dealType)),
+  description: helpers.getDescription(facility, deal.dealSnapshot.dealType),
   capitalConversionFactorCode: helpers.getCapitalConversionFactorCode(facility),
   issueDate: helpers.getIssueDate(facility, acbsFacility.effectiveDate),
   facilityStageCode: CONSTANTS.FACILITY.STAGE_CODE.ISSUED,
   foreCastPercentage: CONSTANTS.FACILITY.FORECAST_PERCENTAGE.ISSUED,
   guaranteePercentage: CONSTANTS.FACILITY.GUARANTEE_PERCENTAGE.ISSUED,
-  productTypeName: dealType,
-  obligorName: obligorName.substring(0, 35),
+  productTypeName: deal.dealSnapshot.dealType,
+  obligorName: deal.exporter.companyName.substring(0, 35),
 });
 
 module.exports = facilityUpdate;

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-income-class-code.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-income-class-code.js
@@ -2,11 +2,10 @@ const CONSTANTS = require('../../../constants');
 
 /**
  * Return facility income class code
- * @param {Object} facility Facility object
  * @param {String} dealType Deal type i.e. GEF, BSS, EWCS
  * @returns {String} Facility income class code
  */
-const getIncomeClassCode = (facility, dealType) => {
+const getIncomeClassCode = (dealType) => {
   switch (dealType) {
     case CONSTANTS.PRODUCT.TYPE.BSS:
       return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.BSS;

--- a/reference-data-proxy/src/utils/swagger-definitions/acbs.ts
+++ b/reference-data-proxy/src/utils/swagger-definitions/acbs.ts
@@ -36,9 +36,9 @@
  *       facility:
  *         type: object
  *         example: { allFacilityFields: true }
- *       supplierName:
- *         type: string
- *         example: 'The Supplier'
+ *       deal:
+ *         type: object
+ *         example: { submissionType: 'GEF', submissionDate: 123, exporter: {} }
  *   ACBSIssueFacilityResponseBody:
  *     type: object
  *     properties:

--- a/reference-data-proxy/src/v1/controllers/acbs.controller.ts
+++ b/reference-data-proxy/src/v1/controllers/acbs.controller.ts
@@ -77,7 +77,8 @@ export const findOne = async (req: Request, res: Response) => {
   return res.status(500).send();
 };
 
-const issueAcbsFacility = async (id: any, facility: any, dealType: any, supplierName: any) => {
+const issueAcbsFacility = async (id: any, facility: object, deal: object) => {
+  console.log({ id }, { facility }, { deal });
   if (id) {
     const response = await axios({
       method: 'post',
@@ -85,8 +86,7 @@ const issueAcbsFacility = async (id: any, facility: any, dealType: any, supplier
       data: {
         facilityId: id,
         facility,
-        dealType,
-        supplierName,
+        deal,
       },
     }).catch((err: any) => err);
     return response;
@@ -97,8 +97,8 @@ const issueAcbsFacility = async (id: any, facility: any, dealType: any, supplier
 export const issueAcbsFacilityPOST = async (req: Request, res: Response) => {
   if (req) {
     const { id } = req.params;
-    const { facility, dealType, supplierName } = req.body;
-    const { status, data } = await issueAcbsFacility(id, facility, dealType, supplierName);
+    const { facility, deal } = req.body;
+    const { status, data } = await issueAcbsFacility(id, facility, deal);
     return res.status(status).send(data);
   }
   return res.status(400).send();

--- a/reference-data-proxy/src/v1/controllers/acbs.controller.ts
+++ b/reference-data-proxy/src/v1/controllers/acbs.controller.ts
@@ -78,7 +78,6 @@ export const findOne = async (req: Request, res: Response) => {
 };
 
 const issueAcbsFacility = async (id: any, facility: object, deal: object) => {
-  console.log({ id }, { facility }, { deal });
   if (id) {
     const response = await axios({
       method: 'post',

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -447,8 +447,8 @@ const createACBS = async (deal, bank) => {
   return {};
 };
 
-const updateACBSfacility = async (facility, dealType, supplierName) => {
-  if (!!facility && !!dealType && !!supplierName) {
+const updateACBSfacility = async (facility, deal) => {
+  if (!!facility && !!deal) {
     try {
       const response = await axios({
         method: 'post',
@@ -458,8 +458,7 @@ const updateACBSfacility = async (facility, dealType, supplierName) => {
         },
         data: {
           facility,
-          dealType,
-          supplierName,
+          deal,
         },
       });
       return response.data;

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -122,7 +122,16 @@ const issueAcbsFacilities = async (deal) => {
     // Only concerned with issued facilities on Portal that aren't issued on ACBS
     const facilityStageInAcbs = facility.tfm.acbs && facility.tfm.acbs.facilityStage;
     return !isIssued(facilityStageInAcbs) && !facility.tfm.acbs.issuedFacilityMaster && isIssued(facility.facilityStage);
-  }).map((facility) => api.updateACBSfacility(facility, deal.dealType, deal.exporter.companyName));
+  }).map((facility) => api.updateACBSfacility(facility, {
+    dealSnapshot: {
+      dealType: deal.dealType,
+      submissionType: deal.submissionType,
+      submissionDate: deal.submissionDate,
+    },
+    exporter: {
+      ...deal.exporter,
+    },
+  }));
 
   const acbsIssuedFacilities = await Promise.all(acbsIssuedFacilitiesPromises);
 


### PR DESCRIPTION
### Introduction
Upon issuance of a facility, its `loan` and `fee` records must be created. This ticket aims to deliver respective ACBS records creations, while keeping the mapping functions consistent for both creation and update. 

* Reduction of arguments when issuing facility in `acbs.controller`.
* Optimised `deal` object for required properties only.
* `formatDate` now evaluates EPOCH date in string or integer, mitigates returning Invalid date.
* Removal of unwanted argument from `getIncomeClassCode` helper function.
* Improved documentation.