### PR TITLE
DTFS2-4615 - Filter dashboard facilities by keyword. Reusable keyword query functions

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-by-keyword.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-by-keyword.spec.js
@@ -1,0 +1,104 @@
+const relative = require('../../../relativeURL');
+const MOCK_USERS = require('../../../../fixtures/users');
+const { dashboardFacilities } = require('../../../pages');
+const { dashboardFilters } = require('../../../partials');
+const {
+  BSS_DEAL_AIN,
+  BSS_FACILITY_BOND_ISSUED,
+  BSS_FACILITY_BOND_UNISSUED,
+} = require('../fixtures');
+
+const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
+
+const filters = dashboardFilters;
+
+context('Dashboard Facilities filters - filter by keyword', () => {
+  const MOCK_KEYWORD = 'Special facility';
+
+  const ALL_FACILITIES = [];
+
+  const BSS_FACILITY_SPECIAL_NAME = {
+    ...BSS_FACILITY_BOND_ISSUED,
+    name: MOCK_KEYWORD,
+  };
+
+  before(() => {
+    cy.deleteGefApplications(ADMIN);
+    cy.deleteDeals(ADMIN);
+
+    cy.insertOneDeal(BSS_DEAL_AIN, BANK1_MAKER1).then((deal) => {
+      const dealId = deal._id;
+
+      const facilities = [
+        BSS_FACILITY_SPECIAL_NAME,
+        BSS_FACILITY_BOND_UNISSUED,
+      ];
+
+      cy.createFacilities(dealId, facilities, BANK1_MAKER1).then((insertedFacilities) => {
+        insertedFacilities.forEach((facility) => {
+          ALL_FACILITIES.push(facility);
+        });
+      });
+    });
+
+  });
+
+  describe('Keyword', () => {
+    before(() => {
+      cy.login(BANK1_MAKER1);
+      dashboardFacilities.visit();
+      cy.url().should('eq', relative('/dashboard/facilities/0'));
+    });
+
+    it('submits the filter and redirects to the dashboard', () => {
+      // toggle to show filters (hidden by default)
+      filters.showHideButton().click();
+
+      // apply filter
+      filters.panel.form.keyword.input().type(MOCK_KEYWORD);
+      filters.panel.form.applyFiltersButton().click();
+
+      cy.url().should('eq', relative('/dashboard/facilities/0'));
+    });
+
+    it('renders submitted keyword', () => {
+      // toggle to show filters (hidden by default)
+      filters.showHideButton().click();
+
+      filters.panel.form.keyword.input().should('have.value', MOCK_KEYWORD);
+    });
+
+    it('renders the applied keyword in the `applied filters` section', () => {
+      filters.panel.selectedFilters.container().should('be.visible');
+      filters.panel.selectedFilters.list().should('be.visible');
+
+      const firstAppliedFilterHeading = filters.panel.selectedFilters.heading().first();
+
+      firstAppliedFilterHeading.should('be.visible');
+      firstAppliedFilterHeading.should('have.text', 'Keyword');
+
+      const firstAppliedFilter = filters.panel.selectedFilters.listItem().first();
+
+      firstAppliedFilter.should('be.visible');
+
+      const expectedText = `Remove this filter ${MOCK_KEYWORD}`;
+      firstAppliedFilter.should('have.text', expectedText);
+    });
+
+    it('renders the applied keyword in the `main container selected filters` section', () => {
+      filters.mainContainer.selectedFilters.keyword(MOCK_KEYWORD).should('be.visible');
+
+      const expectedText = `Remove this filter ${MOCK_KEYWORD}`;
+      filters.mainContainer.selectedFilters.keyword(MOCK_KEYWORD).contains(expectedText);
+    });
+
+    it(`renders only facilities that have ${MOCK_KEYWORD} in a field`, () => {
+      const ALL_KEYWORD_FACILITIES = ALL_FACILITIES.filter(({ name }) => name === MOCK_KEYWORD);
+      dashboardFacilities.rows().should('have.length', ALL_KEYWORD_FACILITIES.length);
+
+      const firstDraftDeal = ALL_KEYWORD_FACILITIES[0];
+
+      dashboardFacilities.row.nameLink(firstDraftDeal._id).contains(MOCK_KEYWORD);
+    });
+  });
+});

--- a/portal/server/constants/field-names.js
+++ b/portal/server/constants/field-names.js
@@ -9,6 +9,11 @@ const DEAL = {
 const FACILITY = {
   TYPE: 'type',
   HAS_BEEN_ISSUED: 'hasBeenIssued',
+  NAME: 'name',
+  UKEF_FACILITY_ID: 'ukefFacilityId',
+  CURRENCY: 'currency',
+  VALUE: 'value',
+  DEAL_SUBMISSION_TYPE: 'deal.submissionType',
 };
 
 module.exports = {

--- a/portal/server/controllers/dashboard/deals/deals-filters-keyword-query.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-keyword-query.js
@@ -1,0 +1,21 @@
+const CONSTANTS = require('../../../constants');
+const { generateKeywordQuery } = require('../filters/generate-keyword-query');
+
+const dashboardDealsFiltersKeywordQuery = (keywordValue) => {
+  const fields = [
+    CONSTANTS.FIELD_NAMES.DEAL.BANK_INTERNAL_REF_NAME,
+    CONSTANTS.FIELD_NAMES.DEAL.STATUS,
+    CONSTANTS.FIELD_NAMES.DEAL.DEAL_TYPE,
+    CONSTANTS.FIELD_NAMES.DEAL.SUBMISSION_TYPE,
+    CONSTANTS.FIELD_NAMES.DEAL.EXPORTER_COMPANY_NAME,
+  ];
+
+  const keywordQuery = generateKeywordQuery(
+    fields,
+    keywordValue,
+  );
+
+  return keywordQuery;
+};
+
+module.exports = dashboardDealsFiltersKeywordQuery;

--- a/portal/server/controllers/dashboard/deals/deals-filters-keyword-query.test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-keyword-query.test.js
@@ -1,0 +1,26 @@
+import CONSTANTS from '../../../constants';
+import { generateKeywordQuery } from '../filters/generate-keyword-query';
+import dealsKeywordQuery from './deals-filters-keyword-query';
+
+describe('controllers/dashboard/deals - filters - keyword query', () => {
+  const keywordValue = 'testing';
+
+  it('should return result of generateKeywordQuery', () => {
+    const expectedFields = [
+      CONSTANTS.FIELD_NAMES.DEAL.BANK_INTERNAL_REF_NAME,
+      CONSTANTS.FIELD_NAMES.DEAL.STATUS,
+      CONSTANTS.FIELD_NAMES.DEAL.DEAL_TYPE,
+      CONSTANTS.FIELD_NAMES.DEAL.SUBMISSION_TYPE,
+      CONSTANTS.FIELD_NAMES.DEAL.EXPORTER_COMPANY_NAME,
+    ];
+
+    const result = dealsKeywordQuery(keywordValue);
+
+    const expected = generateKeywordQuery(
+      expectedFields,
+      keywordValue,
+    );
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.js
@@ -4,6 +4,7 @@ const {
   getUserRoles,
   isSuperUser,
 } = require('../../../helpers');
+const keywordQuery = require('./deals-filters-keyword-query');
 
 /**
  * Generates an array of objects to be sent to API (for DB query)
@@ -67,34 +68,7 @@ const dashboardDealsFiltersQuery = (
 
       if (isKeywordField) {
         const keywordValue = filterValue[0];
-
-        const keywordFilters = [
-          {
-            [CONSTANTS.FIELD_NAMES.DEAL.BANK_INTERNAL_REF_NAME]: {
-              $regex: keywordValue, $options: 'i',
-            },
-          },
-          {
-            [CONSTANTS.FIELD_NAMES.DEAL.STATUS]: {
-              $regex: keywordValue, $options: 'i',
-            },
-          },
-          {
-            [CONSTANTS.FIELD_NAMES.DEAL.DEAL_TYPE]: {
-              $regex: keywordValue, $options: 'i',
-            },
-          },
-          {
-            [CONSTANTS.FIELD_NAMES.DEAL.SUBMISSION_TYPE]: {
-              $regex: keywordValue, $options: 'i',
-            },
-          },
-          {
-            [CONSTANTS.FIELD_NAMES.DEAL.EXPORTER_COMPANY_NAME]: {
-              $regex: keywordValue, $options: 'i',
-            },
-          },
-        ];
+        const keywordFilters = keywordQuery(keywordValue);
 
         query.$or = [
           ...query.$or,

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.test.js
@@ -5,6 +5,7 @@ import {
   FIELD_NAMES,
 } from '../../../constants';
 import CONTENT_STRINGS from '../../../content-strings';
+import keywordQuery from './deals-filters-keyword-query';
 
 describe('controllers/dashboard/deals - filters query', () => {
   const mockUser = {
@@ -98,9 +99,15 @@ describe('controllers/dashboard/deals - filters query', () => {
 
   it('should add multiple custom filters to the query', () => {
     const mockCreatedByYou = '';
+    const mockKeyword = 'test';
     const mockFilters = [
       { [FIELD_NAMES.DEAL.DEAL_TYPE]: ['BSS', 'EWCS'] },
       { [FIELD_NAMES.DEAL.SUBMISSION_TYPE]: [SUBMISSION_TYPE.AIN] },
+      {
+        [CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD]: [
+          mockKeyword,
+        ],
+      },
     ];
     mockUser.bank.id = '*';
     mockUser.roles = [];
@@ -116,55 +123,7 @@ describe('controllers/dashboard/deals - filters query', () => {
         { [FIELD_NAMES.DEAL.DEAL_TYPE]: mockFilters[0].dealType[0] },
         { [FIELD_NAMES.DEAL.DEAL_TYPE]: mockFilters[0].dealType[1] },
         { [FIELD_NAMES.DEAL.SUBMISSION_TYPE]: mockFilters[1].submissionType[0] },
-      ],
-    };
-
-    expect(result).toEqual(expected);
-  });
-
-  it('should add multiple keyword filters with the same value', () => {
-    const mockCreatedByYou = '';
-    const mockFilters = [
-      { keyword: ['Mock'] },
-    ];
-    mockUser.bank.id = '*';
-    mockUser.roles = [];
-
-    const result = dashboardDealsFiltersQuery(
-      mockCreatedByYou,
-      mockFilters,
-      mockUser,
-    );
-
-    const expectedKeywordValue = mockFilters[0].keyword[0];
-
-    const expected = {
-      $or: [
-        {
-          [FIELD_NAMES.DEAL.BANK_INTERNAL_REF_NAME]: {
-            $regex: expectedKeywordValue, $options: 'i',
-          },
-        },
-        {
-          [FIELD_NAMES.DEAL.STATUS]: {
-            $regex: expectedKeywordValue, $options: 'i',
-          },
-        },
-        {
-          [FIELD_NAMES.DEAL.DEAL_TYPE]: {
-            $regex: expectedKeywordValue, $options: 'i',
-          },
-        },
-        {
-          [FIELD_NAMES.DEAL.SUBMISSION_TYPE]: {
-            $regex: expectedKeywordValue, $options: 'i',
-          },
-        },
-        {
-          [FIELD_NAMES.DEAL.EXPORTER_COMPANY_NAME]: {
-            $regex: expectedKeywordValue, $options: 'i',
-          },
-        },
+        ...keywordQuery(mockKeyword),
       ],
     };
 

--- a/portal/server/controllers/dashboard/deals/selected-filters.js
+++ b/portal/server/controllers/dashboard/deals/selected-filters.js
@@ -21,7 +21,7 @@ const selectedFilters = (submittedFilters) => {
   if (hasKeyword) {
     selected.push(generateSelectedFiltersObject(
       CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.KEYWORD,
-      'keyword',
+      CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD,
       submittedFilters.keyword,
     ));
   }

--- a/portal/server/controllers/dashboard/deals/selected-filters.test.js
+++ b/portal/server/controllers/dashboard/deals/selected-filters.test.js
@@ -21,7 +21,7 @@ describe('controllers/dashboard/deals - selected-filters', () => {
       const expected = [
         generateSelectedFiltersObject(
           CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.KEYWORD,
-          'keyword',
+          CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD,
           mockSubmittedFilters.keyword,
         ),
         generateSelectedFiltersObject(

--- a/portal/server/controllers/dashboard/facilities/facilities-filters-keyword-query.js
+++ b/portal/server/controllers/dashboard/facilities/facilities-filters-keyword-query.js
@@ -1,0 +1,22 @@
+const CONSTANTS = require('../../../constants');
+const { generateKeywordQuery } = require('../filters/generate-keyword-query');
+
+const dashboardFacilitiesFiltersKeywordQuery = (keywordValue) => {
+  const fields = [
+    CONSTANTS.FIELD_NAMES.FACILITY.DEAL_SUBMISSION_TYPE,
+    CONSTANTS.FIELD_NAMES.FACILITY.NAME,
+    CONSTANTS.FIELD_NAMES.FACILITY.UKEF_FACILITY_ID,
+    CONSTANTS.FIELD_NAMES.FACILITY.CURRENCY,
+    CONSTANTS.FIELD_NAMES.FACILITY.VALUE,
+    CONSTANTS.FIELD_NAMES.FACILITY.TYPE,
+  ];
+
+  const keywordQuery = generateKeywordQuery(
+    fields,
+    keywordValue,
+  );
+
+  return keywordQuery;
+};
+
+module.exports = dashboardFacilitiesFiltersKeywordQuery;

--- a/portal/server/controllers/dashboard/facilities/facilities-filters-keyword-query.test.js
+++ b/portal/server/controllers/dashboard/facilities/facilities-filters-keyword-query.test.js
@@ -1,0 +1,27 @@
+import CONSTANTS from '../../../constants';
+import { generateKeywordQuery } from '../filters/generate-keyword-query';
+import facilitiesKeywordQuery from './facilities-filters-keyword-query';
+
+describe('controllers/dashboard/facilities - filters - keyword query', () => {
+  const keywordValue = 'testing';
+
+  it('should return result of generateKeywordQuery', () => {
+    const expectedFields = [
+      CONSTANTS.FIELD_NAMES.FACILITY.DEAL_SUBMISSION_TYPE,
+      CONSTANTS.FIELD_NAMES.FACILITY.NAME,
+      CONSTANTS.FIELD_NAMES.FACILITY.UKEF_FACILITY_ID,
+      CONSTANTS.FIELD_NAMES.FACILITY.CURRENCY,
+      CONSTANTS.FIELD_NAMES.FACILITY.VALUE,
+      CONSTANTS.FIELD_NAMES.FACILITY.TYPE,
+    ];
+
+    const result = facilitiesKeywordQuery(keywordValue);
+
+    const expected = generateKeywordQuery(
+      expectedFields,
+      keywordValue,
+    );
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/portal/server/controllers/dashboard/facilities/facilities-filters-query.js
+++ b/portal/server/controllers/dashboard/facilities/facilities-filters-query.js
@@ -1,3 +1,6 @@
+const CONTENT_STRINGS = require('../../../content-strings');
+const keywordQuery = require('./facilities-filters-keyword-query');
+
 /**
  * Generates an array of objects to be sent to API (for DB query)
  *
@@ -23,11 +26,25 @@ const dashboardFacilitiesFiltersQuery = (
       const fieldName = Object.keys(filterObj)[0];
       const filterValue = filterObj[fieldName];
 
-      filterValue.forEach((value) => {
-        query.$or.push({
-          [fieldName]: value,
+      const isKeywordField = (fieldName === CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD);
+
+      if (isKeywordField) {
+        const keywordValue = filterValue[0];
+        const keywordFilters = keywordQuery(keywordValue);
+
+        query.$or = [
+          ...query.$or,
+          ...keywordFilters,
+        ];
+      }
+
+      if (!isKeywordField) {
+        filterValue.forEach((value) => {
+          query.$or.push({
+            [fieldName]: value,
+          });
         });
-      });
+      }
     });
   }
 

--- a/portal/server/controllers/dashboard/facilities/facilities-filters-query.test.js
+++ b/portal/server/controllers/dashboard/facilities/facilities-filters-query.test.js
@@ -1,5 +1,7 @@
 import { dashboardFacilitiesFiltersQuery } from './facilities-filters-query';
 import CONSTANTS from '../../../constants';
+import CONTENT_STRINGS from '../../../content-strings';
+import keywordQuery from './facilities-filters-keyword-query';
 
 describe('controllers/dashboard/facilities - filters query', () => {
   const mockUser = {
@@ -26,6 +28,7 @@ describe('controllers/dashboard/facilities - filters query', () => {
   });
 
   it('should add multiple custom filters to the query', () => {
+    const mockKeyword = 'test';
     const mockFilters = [
       {
         [CONSTANTS.FIELD_NAMES.FACILITY.TYPE]: [
@@ -36,6 +39,11 @@ describe('controllers/dashboard/facilities - filters query', () => {
       {
         [CONSTANTS.FIELD_NAMES.FACILITY.HAS_BEEN_ISSUED]: [
           true,
+        ],
+      },
+      {
+        [CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD]: [
+          mockKeyword,
         ],
       },
     ];
@@ -53,6 +61,7 @@ describe('controllers/dashboard/facilities - filters query', () => {
         { [CONSTANTS.FIELD_NAMES.FACILITY.TYPE]: mockFilters[0].type[0] },
         { [CONSTANTS.FIELD_NAMES.FACILITY.TYPE]: mockFilters[0].type[1] },
         { [CONSTANTS.FIELD_NAMES.FACILITY.HAS_BEEN_ISSUED]: mockFilters[1].hasBeenIssued[0] },
+        ...keywordQuery(mockKeyword),
       ],
     };
 

--- a/portal/server/controllers/dashboard/facilities/index.js
+++ b/portal/server/controllers/dashboard/facilities/index.js
@@ -70,6 +70,7 @@ const getTemplateVariables = (
     pages,
     filters: templateFilters(filtersObj),
     selectedFilters: selectedFilters(filtersObj),
+    keyword: sessionFilters.keyword,
   };
 
   return templateVariables;

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -143,6 +143,7 @@ describe('controllers/dashboard/facilities', () => {
         pages: expectedPages,
         filters: templateFilters(expectedFiltersObj),
         selectedFilters: selectedFilters(expectedFiltersObj),
+        keyword: mockReq.session.dashboardFilters.keyword,
       };
 
       expect(result).toEqual(expected);

--- a/portal/server/controllers/dashboard/facilities/selected-filters.js
+++ b/portal/server/controllers/dashboard/facilities/selected-filters.js
@@ -16,6 +16,16 @@ const CONSTANTS = require('../../../constants');
 const selectedFilters = (submittedFilters) => {
   const selected = [];
 
+  const hasKeyword = (submittedFilters.keyword && submittedFilters.keyword[0].length);
+
+  if (hasKeyword) {
+    selected.push(generateSelectedFiltersObject(
+      CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.KEYWORD,
+      CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD,
+      submittedFilters.keyword,
+    ));
+  }
+
   if (submittedFilters[CONSTANTS.FIELD_NAMES.FACILITY.TYPE]) {
     selected.push(generateSelectedFiltersObject(
       CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.PRODUCT,

--- a/portal/server/controllers/dashboard/facilities/selected-filters.test.js
+++ b/portal/server/controllers/dashboard/facilities/selected-filters.test.js
@@ -11,6 +11,7 @@ describe('controllers/dashboard/facilities - selected-filters', () => {
   describe('selectedFilters', () => {
     it('should return an array of objects for all selected/submitted filters', () => {
       const mockSubmittedFilters = {
+        keyword: ['Testing'],
         type: [CONSTANTS.FACILITY_TYPE.BOND, CONSTANTS.FACILITY_TYPE.LOAN],
         'deal.submissionType': [CONSTANTS.SUBMISSION_TYPE.AIN],
         hasBeenIssued: ['true'],
@@ -19,6 +20,11 @@ describe('controllers/dashboard/facilities - selected-filters', () => {
       const result = selectedFilters(mockSubmittedFilters);
 
       const expected = [
+        generateSelectedFiltersObject(
+          CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.KEYWORD,
+          CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD,
+          mockSubmittedFilters.keyword,
+        ),
         generateSelectedFiltersObject(
           CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.PRODUCT,
           CONSTANTS.FIELD_NAMES.FACILITY.TYPE,

--- a/portal/server/controllers/dashboard/filters/generate-keyword-query.js
+++ b/portal/server/controllers/dashboard/filters/generate-keyword-query.js
@@ -1,0 +1,30 @@
+/**
+ * Generates an object from given field name and keyword value
+ *
+ * @param {string} fieldName
+ * @param {string} keyword value
+ * @example ( 'submissionType', 'Automatic' )
+ * @returns { dealType: { $regex: 'Automatic', $options: 'i' } }
+ */
+const generateObject = (fieldName, keywordValue) => ({
+  [fieldName]: {
+    $regex: keywordValue, $options: 'i',
+  },
+});
+
+/**
+ * Generates an array of objects from given field names and keyword value
+ *
+ * @param {array} fields
+ * @param {string} keyword value
+ * @example ( ['dealType', 'submissionType' ], 'Automatic' )
+ * @returns [ { dealType: { $regex: 'Automatic', $options: 'i' } }, { submissionType: { $regex: 'Automatic', $options: 'i' } } ]
+ */
+const generateKeywordQuery = (fields, keywordValue) =>
+  fields.map((fieldName) =>
+    generateObject(fieldName, keywordValue));
+
+module.exports = {
+  generateObject,
+  generateKeywordQuery,
+};

--- a/portal/server/controllers/dashboard/filters/generate-keyword-query.test.js
+++ b/portal/server/controllers/dashboard/filters/generate-keyword-query.test.js
@@ -1,0 +1,56 @@
+import {
+  generateObject,
+  generateKeywordQuery,
+} from './generate-keyword-query';
+import CONSTANTS from '../../../constants';
+
+describe('controllers/dashboard/filters - generate-keyword-query', () => {
+  describe('generateObject', () => {
+    it('should return an object with given fieldName and keywordValue', () => {
+      const mockFieldName = CONSTANTS.FIELD_NAMES.DEAL_TYPE;
+      const mockKeywordValue = 'test';
+
+      const result = generateObject(
+        mockFieldName,
+        mockKeywordValue,
+      );
+
+      const expected = {
+        [mockFieldName]: {
+          $regex: mockKeywordValue, $options: 'i',
+        },
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('generateKeywordQuery', () => {
+    it('should return an array of objects with given fieldNames and keywordValue', () => {
+      const mockFieldNames = [
+        CONSTANTS.FIELD_NAMES.DEAL_TYPE,
+        CONSTANTS.FIELD_NAMES.DEAL.EXPORTER_COMPANY_NAME,
+      ];
+
+      const mockKeywordValue = 'test';
+
+      const result = generateKeywordQuery(
+        mockFieldNames,
+        mockKeywordValue,
+      );
+
+      const expected = [
+        generateObject(
+          mockFieldNames[0],
+          mockKeywordValue,
+        ),
+        generateObject(
+          mockFieldNames[1],
+          mockKeywordValue,
+        ),
+      ];
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/portal/templates/dashboard/facilities.njk
+++ b/portal/templates/dashboard/facilities.njk
@@ -13,6 +13,7 @@
     tab: tab,
     filters: filters,
     selectedFilters: selectedFilters,
+    keyword: keyword,
     renderCreatedByYou: false,
     table: facilitiesTable.render({
       facilities: facilities,


### PR DESCRIPTION
This adds the ability to filter by keyword in Dashboard facilities, just like deals, but with different fields.

Also as part of this - created a resuable `generateKeywordQuery` function(s) that is consumed by both deals and facilities. Just need to pass in an array of fields and the keyword value, and it'll generate an array of objects with correct format/regex that'll be sent to the API for MongoDB query. 🚀 