### PR TITLE
DTFS2-2970 : Autocomplete & Autocapitalize

### DIFF
--- a/portal/templates/_partials/password-create.njk
+++ b/portal/templates/_partials/password-create.njk
@@ -8,7 +8,8 @@
         text: "New password"
       },
       attributes: {
-        "data-cy": "password"
+        "data-cy": "password",
+        "autocomplete": "off"
       },
       id: "password",
       name: "password",
@@ -25,7 +26,8 @@
         text: "Confirm password"
       },
       attributes: {
-        "data-cy": "confirmPassword"
+        "data-cy": "confirmPassword",
+        "autocomplete": "off"
       },
       id: "passwordConfirm",
       name: "passwordConfirm",

--- a/portal/templates/admin/user-edit.njk
+++ b/portal/templates/admin/user-edit.njk
@@ -89,7 +89,10 @@
     {% else %}
 
       {{ govukInput({
-        attributes: {"data-cy": "username"},
+        attributes: {
+          "data-cy": "username",
+          "autocapitalize": "off"
+          },
         label: {
           text: "Email address"
         },
@@ -143,7 +146,10 @@
         {# {% include "../_partials/password-create.njk" %} #}
         <div class="govuk-form-group">
             {{ govukInput({
-              attributes: {"data-cy": "password"},
+              attributes: {
+                "data-cy": "password",
+                "autocomplete": "off"
+                },
               label: {
                 text: "New password"
               },
@@ -157,7 +163,10 @@
             }) }}
 
             {{ govukInput({
-              attributes: {"data-cy": "confirm-password"},
+              attributes: {
+                "data-cy": "confirm-password",
+                "autocomplete": "off"
+                },
               label: {
                 text: "Confirm password"
               },

--- a/portal/templates/login.njk
+++ b/portal/templates/login.njk
@@ -58,7 +58,8 @@
               }
             },
             attributes: {
-              "data-cy": "email"
+              "data-cy": "email",
+              "autocapitalize": "off"
             }
           }) }}
 
@@ -78,7 +79,8 @@
               }
             },
             attributes: {
-              "data-cy": "password"
+              "data-cy": "password",
+              "autocomplete": "off"
             }
           }) }}
 

--- a/portal/templates/reset-password.njk
+++ b/portal/templates/reset-password.njk
@@ -24,7 +24,7 @@
           <label class="govuk-label" for="email">
             Email
           </label>
-          <input data-cy="email" class="govuk-input" id="email" name="email" type="text">
+          <input data-cy="email" autocapitalize="off" class="govuk-input" id="email" name="email" type="text">
         </div>
 
         <p class="govuk-body">

--- a/trade-finance-manager-ui/templates/login.njk
+++ b/trade-finance-manager-ui/templates/login.njk
@@ -15,14 +15,14 @@
           <label class="govuk-label" for="email">
             Email
           </label>
-          <input class="govuk-input" id="email" name="email" type="text" data-cy="email">
+          <input class="govuk-input" id="email" name="email" type="text" autocapitalize="off" data-cy="email">
         </div>
 
         <div class="govuk-form-group">
           <label class="govuk-label" for="password">
             Password
           </label>
-          <input class="govuk-input" id="password" name="password" type="password" data-cy="password">
+          <input class="govuk-input" id="password" name="password" type="password" autocomplete="off" data-cy="password">
         </div>
 
 


### PR DESCRIPTION
### Introduction
Password fields are now set to `autocomplete=off`, this is a pen-test suggestion which prevents browsers from auto-filling the passwords. Currently not all browsers are equipped to do so and browsers which are they will autofill the password when authorised by the user.

However future browsers might implement this behaviour.

* `autocomplete=off` on all password fields
* `autocapitalize=off` on all email and username fields.