### PR TITLE
DTFS2-4615 - ability to remove dashboard facility filters

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-remove-all-filters.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-remove-all-filters.spec.js
@@ -1,0 +1,91 @@
+const relative = require('../../../relativeURL');
+const MOCK_USERS = require('../../../../fixtures/users');
+const { dashboardFacilities } = require('../../../pages');
+const { dashboardFilters } = require('../../../partials');
+const {
+  BSS_DEAL_AIN,
+  BSS_FACILITY_BOND_ISSUED,
+  BSS_FACILITY_BOND_UNISSUED,
+} = require('../fixtures');
+
+const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
+
+const filters = dashboardFilters;
+
+context('Dashboard Facilities filters - remove all filters', () => {
+  const ALL_FACILITIES = [];
+
+  before(() => {
+    cy.deleteGefApplications(ADMIN);
+    cy.deleteDeals(ADMIN);
+
+    cy.insertOneDeal(BSS_DEAL_AIN, BANK1_MAKER1).then((deal) => {
+      const dealId = deal._id;
+
+      const facilities = [
+        BSS_FACILITY_BOND_ISSUED,
+        BSS_FACILITY_BOND_UNISSUED,
+      ];
+
+      cy.createFacilities(dealId, facilities, BANK1_MAKER1).then((insertedFacilities) => {
+        insertedFacilities.forEach((facility) => {
+          ALL_FACILITIES.push(facility);
+        });
+      });
+    });
+  });
+
+  before(() => {
+    cy.login(BANK1_MAKER1);
+    dashboardFacilities.visit();
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+  });
+
+  it('removes all applied filters by clicking `clear filters` button', () => {
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // apply filter 1
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().click();
+
+    // apply filter 2
+    dashboardFacilities.filters.panel.form.type.bond.checkbox().click();
+
+    // submit filters
+    filters.panel.form.applyFiltersButton().click();
+
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // check filters are applied
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().should('be.checked');
+    dashboardFacilities.filters.panel.form.type.bond.checkbox().should('be.checked');
+
+    // click `clear all` button
+    filters.panel.selectedFilters.clearAllLink().should('be.visible');
+    filters.panel.selectedFilters.clearAllLink().click();
+
+    // should be redirected
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+    filters.panel.container().should('be.visible');
+
+    // should have empty panel applied filters
+    filters.panel.selectedFilters.container().should('not.exist');
+    filters.panel.selectedFilters.list().should('not.exist');
+
+    // should have empty main container applied filters
+    filters.mainContainer.selectedFilters.container().should('not.exist');
+
+    // checkbox should be NOT be checked
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().should('not.be.checked');
+    dashboardFacilities.filters.panel.form.type.bond.checkbox().should('not.be.checked');
+
+    // should render all facilities
+    dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
+  });
+});

--- a/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-main-container-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-main-container-filter-remove.spec.js
@@ -1,0 +1,97 @@
+const relative = require('../../../relativeURL');
+const MOCK_USERS = require('../../../../fixtures/users');
+const { dashboardFacilities } = require('../../../pages');
+const { dashboardFilters } = require('../../../partials');
+const {
+  BSS_DEAL_AIN,
+  BSS_FACILITY_BOND_ISSUED,
+} = require('../fixtures');
+
+const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
+
+const filters = dashboardFilters;
+
+context('Dashboard Facilities - main container selected filters - remove a filter', () => {
+  const ALL_FACILITIES = [];
+
+  before(() => {
+    cy.deleteGefApplications(ADMIN);
+    cy.deleteDeals(ADMIN);
+
+    cy.insertOneDeal(BSS_DEAL_AIN, BANK1_MAKER1).then((deal) => {
+      const dealId = deal._id;
+
+      const facilities = [BSS_FACILITY_BOND_ISSUED];
+
+      cy.createFacilities(dealId, facilities, BANK1_MAKER1).then((insertedFacilities) => {
+        insertedFacilities.forEach((facility) => {
+          ALL_FACILITIES.push(facility);
+        });
+      });
+    });
+
+    cy.login(BANK1_MAKER1);
+    dashboardFacilities.visit();
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+  });
+
+  it('applies and removes a filter', () => {
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // apply filter
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().click();
+    filters.panel.form.applyFiltersButton().click();
+
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // check the filter is in the applied filters section
+    dashboardFacilities.filters.mainContainer.selectedFilters.typeIssued().should('be.visible');
+
+    // click remove button
+    dashboardFacilities.filters.mainContainer.selectedFilters.typeIssued().click();
+
+    // should be redirected
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // should have empty applied filter
+    dashboardFacilities.filters.mainContainer.selectedFilters.typeIssued().should('not.exist');
+
+    // checkbox should be NOT be checked
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().should('not.be.checked');
+
+    // should render all facilities
+    dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
+  });
+
+  it('retains other filters when one is removed', () => {
+    cy.login(BANK1_MAKER1);
+    dashboardFacilities.visit();
+
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // apply filters
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().click();
+    dashboardFacilities.filters.panel.form.hasBeenIssued.unissued.checkbox().click();
+    filters.panel.form.applyFiltersButton().click();
+
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // remove one of the filters
+    dashboardFacilities.filters.mainContainer.selectedFilters.typeIssued().click();
+
+    // should have removed the filter
+    dashboardFacilities.filters.mainContainer.selectedFilters.typeIssued().should('not.exist');
+
+    // should NOT have removed the other filter
+    dashboardFacilities.filters.mainContainer.selectedFilters.typeUnissued().should('exist');
+
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // check checkboxes
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().should('not.be.checked');
+    dashboardFacilities.filters.panel.form.hasBeenIssued.unissued.checkbox().should('be.checked');
+  });
+});

--- a/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-panel-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-panel-filter-remove.spec.js
@@ -1,0 +1,75 @@
+const relative = require('../../../relativeURL');
+const MOCK_USERS = require('../../../../fixtures/users');
+const { dashboardFacilities } = require('../../../pages');
+const { dashboardFilters } = require('../../../partials');
+const {
+  BSS_DEAL_AIN,
+  BSS_FACILITY_BOND_ISSUED,
+} = require('../fixtures');
+
+const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
+
+const filters = dashboardFilters;
+
+context('Dashboard Facilities - panel selected filters - remove a filter', () => {
+  const ALL_FACILITIES = [];
+
+  before(() => {
+    cy.deleteGefApplications(ADMIN);
+    cy.deleteDeals(ADMIN);
+
+    cy.insertOneDeal(BSS_DEAL_AIN, BANK1_MAKER1).then((deal) => {
+      const dealId = deal._id;
+
+      const facilities = [ BSS_FACILITY_BOND_ISSUED ];
+
+      cy.createFacilities(dealId, facilities, BANK1_MAKER1).then((insertedFacilities) => {
+        insertedFacilities.forEach((facility) => {
+          ALL_FACILITIES.push(facility);
+        });
+      });
+    });
+
+    cy.login(BANK1_MAKER1);
+    dashboardFacilities.visit();
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+  });
+
+  it('applies and removes a filter', () => {
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // apply filter
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().click();
+    filters.panel.form.applyFiltersButton().click();
+
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+
+    // check the filter is in the applied filters section
+    const firstAppliedFilter = filters.panel.selectedFilters.listItem().first();
+    firstAppliedFilter.should('be.visible');
+
+    // click remove button
+    firstAppliedFilter.click();
+
+    // should be redirected
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+
+    // toggle to show filters (hidden by default)
+    filters.showHideButton().click();
+    filters.panel.container().should('be.visible');
+
+    // should have empty applied filters
+    filters.panel.selectedFilters.container().should('not.exist');
+    filters.panel.selectedFilters.list().should('not.exist');
+
+    // checkbox should be NOT be checked
+    dashboardFacilities.filters.panel.form.hasBeenIssued.issued.checkbox().should('not.be.checked');
+
+    // should render all facilities
+    dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
+  });
+});

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -26,7 +26,7 @@ RUN npm install --legacy-peer-deps
 COPY . .
 
 # Execute Script
-# ENTRYPOINT ["/bin/init.sh"]
+ENTRYPOINT ["/bin/init.sh"]
 
 # Hot reloading
-CMD node server/index.js
+# CMD node server/index.js

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -26,7 +26,7 @@ RUN npm install --legacy-peer-deps
 COPY . .
 
 # Execute Script
-ENTRYPOINT ["/bin/init.sh"]
+# ENTRYPOINT ["/bin/init.sh"]
 
 # Hot reloading
-# CMD node server/index.js
+CMD node server/index.js

--- a/portal/server/constants/dashboard-filters.js
+++ b/portal/server/constants/dashboard-filters.js
@@ -1,6 +1,0 @@
-const DASHBOARD_FILTERS_DEFAULT = {
-  createdByYou: null,
-  keyword: null,
-};
-
-module.exports = DASHBOARD_FILTERS_DEFAULT;

--- a/portal/server/constants/dashboard.js
+++ b/portal/server/constants/dashboard.js
@@ -1,0 +1,14 @@
+const DASHBOARD = {
+  PAGE_SIZE: 20,
+  PRIMARY_NAV: 'home',
+  TABS: {
+    DEALS: 'deals',
+    FACILITIES: 'facilities',
+  },
+  DEFAULT_FILTERS: {
+    createdByYou: null,
+    keyword: null,
+  },
+};
+
+module.exports = DASHBOARD;

--- a/portal/server/constants/index.js
+++ b/portal/server/constants/index.js
@@ -1,4 +1,4 @@
-const DASHBOARD_FILTERS_DEFAULT = require('./dashboard-filters');
+const DASHBOARD = require('./dashboard');
 const FACILITY_HAS_BEEN_ISSUED = require('./facility-has-been-issued');
 const FACILITY_TYPE = require('./facility-type');
 const FIELD_NAMES = require('./field-names');
@@ -9,7 +9,7 @@ const TRANSACTION_STAGE = require('./transaction-stage');
 const TRANSACTION_TYPE = require('./transaction-type');
 
 module.exports = {
-  DASHBOARD_FILTERS_DEFAULT,
+  DASHBOARD,
   FACILITY_HAS_BEEN_ISSUED,
   FACILITY_TYPE,
   FIELD_NAMES,

--- a/portal/server/controllers/dashboard/deals/index.js
+++ b/portal/server/controllers/dashboard/deals/index.js
@@ -14,9 +14,7 @@ const {
 } = require('../../../helpers');
 const CONSTANTS = require('../../../constants');
 
-const PAGESIZE = 20;
-const primaryNav = 'home';
-const tab = 'deals';
+const { PAGE_SIZE } = CONSTANTS.DASHBOARD;
 
 const getAllDealsData = async (
   userToken,
@@ -34,8 +32,8 @@ const getAllDealsData = async (
   );
 
   const { count, deals } = await getApiData(api.allDeals(
-    currentPage * PAGESIZE,
-    PAGESIZE,
+    currentPage * PAGE_SIZE,
+    PAGE_SIZE,
     filtersQuery,
     userToken,
   ), res);
@@ -57,7 +55,7 @@ const getTemplateVariables = (
   filtersArray,
 ) => {
   const pages = {
-    totalPages: Math.ceil(count / PAGESIZE),
+    totalPages: Math.ceil(count / PAGE_SIZE),
     currentPage: parseInt(currentPage, 10),
     totalItems: count,
   };
@@ -66,8 +64,8 @@ const getTemplateVariables = (
 
   const templateVariables = {
     user,
-    primaryNav,
-    tab,
+    primaryNav: CONSTANTS.DASHBOARD.PRIMARY_NAV,
+    tab: CONSTANTS.DASHBOARD.TABS.DEALS,
     deals,
     pages,
     filters: templateFilters(filtersObj),

--- a/portal/server/controllers/dashboard/deals/index.js
+++ b/portal/server/controllers/dashboard/deals/index.js
@@ -6,7 +6,7 @@ const {
   submittedFiltersArray,
   submittedFiltersObject,
 } = require('../filters/helpers');
-const removeSessionFilter = require('../filters/remove-filter-from-session');
+const { removeSessionFilter } = require('../filters/remove-filter-from-session');
 const {
   getApiData,
   requestParams,

--- a/portal/server/controllers/dashboard/deals/index.js
+++ b/portal/server/controllers/dashboard/deals/index.js
@@ -6,6 +6,7 @@ const {
   submittedFiltersArray,
   submittedFiltersObject,
 } = require('../filters/helpers');
+const removeSessionFilter = require('../filters/remove-filter-from-session');
 const {
   getApiData,
   requestParams,
@@ -131,26 +132,13 @@ exports.allDeals = async (req, res) => {
 };
 
 exports.removeSingleAllDealsFilter = async (req, res) => {
-  const currentFilters = req.session.dashboardFilters;
-
-  const filter = currentFilters[req.params.fieldName];
-
-  if (filter) {
-    if (Array.isArray(filter)) {
-      const modifiedFilter = currentFilters[req.params.fieldName].filter((value) =>
-        value !== req.params.fieldValue);
-
-      req.session.dashboardFilters[req.params.fieldName] = modifiedFilter;
-    } else {
-      delete req.session.dashboardFilters[req.params.fieldName];
-    }
-  }
+  removeSessionFilter(req);
 
   return res.redirect('/dashboard/deals/0');
 };
 
 exports.removeAllDealsFilters = (req, res) => {
-  req.session.dashboardFilters = CONSTANTS.DASHBOARD_FILTERS_DEFAULT;
+  req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
 
   return res.redirect('/dashboard/deals/0');
 };

--- a/portal/server/controllers/dashboard/deals/index.test.js
+++ b/portal/server/controllers/dashboard/deals/index.test.js
@@ -13,7 +13,7 @@ import {
   submittedFiltersArray,
   submittedFiltersObject,
 } from '../filters/helpers';
-import removeSessionFilter from '../filters/remove-filter-from-session';
+import { removeSessionFilter } from '../filters/remove-filter-from-session';
 import { dashboardDealsFiltersQuery } from './deals-filters-query';
 import { dealsTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';

--- a/portal/server/controllers/dashboard/deals/index.test.js
+++ b/portal/server/controllers/dashboard/deals/index.test.js
@@ -102,8 +102,8 @@ describe('controllers/dashboard/deals', () => {
       );
 
       expect(api.allDeals).toHaveBeenCalledWith(
-        20,
-        20,
+        CONSTANTS.DASHBOARD.PAGE_SIZE,
+        CONSTANTS.DASHBOARD.PAGE_SIZE,
         expectedFilters,
         'mock-token',
       );
@@ -146,15 +146,15 @@ describe('controllers/dashboard/deals', () => {
       const expectedFiltersObj = submittedFiltersObject(filtersArray);
 
       const expectedPages = {
-        totalPages: Math.ceil(mockDeals.length / 20),
+        totalPages: Math.ceil(mockDeals.length / CONSTANTS.DASHBOARD.PAGE_SIZE),
         currentPage: parseInt(mockReq.params.page, 10),
         totalItems: mockDeals.length,
       };
 
       const expected = {
         user: mockReq.session.user,
-        primaryNav: 'home',
-        tab: 'deals',
+        primaryNav: CONSTANTS.DASHBOARD.PRIMARY_NAV,
+        tab: CONSTANTS.DASHBOARD.TABS.DEALS,
         deals: mockDeals,
         pages: expectedPages,
         filters: templateFilters(expectedFiltersObj),
@@ -229,7 +229,7 @@ describe('controllers/dashboard/deals', () => {
   });
 
   describe('removeSingleAllDealsFilter', () => {
-    it('should remove a filter and redirect to `/dashboard/deals/0`', async () => {
+    it('should call removeSessionFilter and redirect to `/dashboard/deals/0`', async () => {
       mockReq = {
         ...mockReq,
         session: {

--- a/portal/server/controllers/dashboard/deals/index.test.js
+++ b/portal/server/controllers/dashboard/deals/index.test.js
@@ -13,6 +13,7 @@ import {
   submittedFiltersArray,
   submittedFiltersObject,
 } from '../filters/helpers';
+import removeSessionFilter from '../filters/remove-filter-from-session';
 import { dashboardDealsFiltersQuery } from './deals-filters-query';
 import { dealsTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
@@ -67,7 +68,7 @@ describe('controllers/dashboard/deals', () => {
       },
       params: { page: 1 },
       session: {
-        dashboardFilters: CONSTANTS.DASHBOARD_FILTERS_DEFAULT,
+        dashboardFilters: CONSTANTS.DASHBOARD.DEFAULT_FILTERS,
         userToken: '1234',
         user: {
           _id: 'mock-user',
@@ -228,7 +229,7 @@ describe('controllers/dashboard/deals', () => {
   });
 
   describe('removeSingleAllDealsFilter', () => {
-    it('should remove a single filter from mockReq.session.dashboardFilters', async () => {
+    it('should remove a filter and redirect to `/dashboard/deals/0`', async () => {
       mockReq = {
         ...mockReq,
         session: {
@@ -246,67 +247,15 @@ describe('controllers/dashboard/deals', () => {
 
       await removeSingleAllDealsFilter(mockReq, mockRes);
 
-      const expected = {
-        fieldA: ['valueA'],
-        fieldB: ['valueB2'],
-      };
+      const expected = removeSessionFilter(mockReq);
 
       expect(mockReq.session.dashboardFilters).toEqual(expected);
-    });
-
-    it('should remove a single filter from mockReq.session.dashboardFilters when value is NOT an array', async () => {
-      mockReq = {
-        ...mockReq,
-        session: {
-          ...mockReq.session,
-          dashboardFilters: {
-            fieldA: 'valueA',
-          },
-        },
-        params: {
-          fieldName: 'fieldA',
-          fieldValue: 'valueA',
-        },
-      };
-
-      await removeSingleAllDealsFilter(mockReq, mockRes);
-
-      const expected = {};
-
-      expect(mockReq.session.dashboardFilters).toEqual(expected);
-    });
-
-    it('should NOT remove a single filter if the filter/field name does not exist in the session', async () => {
-      mockReq = {
-        ...mockReq,
-        session: {
-          ...mockReq.session,
-          dashboardFilters: {
-            fieldA: ['valueA'],
-          },
-        },
-        params: {
-          fieldName: 'fieldX',
-          fieldValue: 'test',
-        },
-      };
-
-      const originalSession = mockReq.session.dashboardFilters;
-
-      await removeSingleAllDealsFilter(mockReq, mockRes);
-
-      expect(mockReq.session.dashboardFilters).toEqual(originalSession);
-    });
-
-    it('should redirect to `/dashboard/deals/0`', async () => {
-      await removeSingleAllDealsFilter(mockReq, mockRes);
-
       expect(mockRes.redirect).toHaveBeenCalledWith('/dashboard/deals/0');
     });
   });
 
   describe('removeAllDealsFilters', () => {
-    it('should reset all session filters', async () => {
+    it('should reset all session filters and redirect to `/dashboard/deals/0', async () => {
       mockReq = {
         ...mockReq,
         session: {
@@ -317,7 +266,7 @@ describe('controllers/dashboard/deals', () => {
 
       await removeAllDealsFilters(mockReq, mockRes);
 
-      expect(mockReq.session.dashboardFilters).toEqual(CONSTANTS.DASHBOARD_FILTERS_DEFAULT);
+      expect(mockReq.session.dashboardFilters).toEqual(CONSTANTS.DASHBOARD.DEFAULT_FILTERS);
     });
   });
 });

--- a/portal/server/controllers/dashboard/facilities/index.js
+++ b/portal/server/controllers/dashboard/facilities/index.js
@@ -6,7 +6,7 @@ const {
   submittedFiltersArray,
   submittedFiltersObject,
 } = require('../filters/helpers');
-const removeSessionFilter = require('../filters/remove-filter-from-session');
+const { removeSessionFilter } = require('../filters/remove-filter-from-session');
 const {
   getApiData,
   requestParams,

--- a/portal/server/controllers/dashboard/facilities/index.js
+++ b/portal/server/controllers/dashboard/facilities/index.js
@@ -6,12 +6,14 @@ const {
   submittedFiltersArray,
   submittedFiltersObject,
 } = require('../filters/helpers');
+const removeSessionFilter = require('../filters/remove-filter-from-session');
 const {
   getApiData,
   requestParams,
   getFlashSuccessMessage,
 } = require('../../../helpers');
 const { sanitiseBody } = require('./sanitise-body');
+const CONSTANTS = require('../../../constants');
 
 const PAGESIZE = 20;
 const primaryNav = 'home';
@@ -128,4 +130,16 @@ exports.allFacilities = async (req, res) => {
     ...templateVariables,
     successMessage: getFlashSuccessMessage(req),
   });
+};
+
+exports.removeSingleAllFacilitiesFilter = async (req, res) => {
+  removeSessionFilter(req);
+
+  return res.redirect('/dashboard/facilities/0');
+};
+
+exports.removeAllFacilitiesFilters = (req, res) => {
+  req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
+
+  return res.redirect('/dashboard/facilities/0');
 };

--- a/portal/server/controllers/dashboard/facilities/index.js
+++ b/portal/server/controllers/dashboard/facilities/index.js
@@ -15,9 +15,7 @@ const {
 const { sanitiseBody } = require('./sanitise-body');
 const CONSTANTS = require('../../../constants');
 
-const PAGESIZE = 20;
-const primaryNav = 'home';
-const tab = 'facilities';
+const { PAGE_SIZE } = CONSTANTS.DASHBOARD;
 
 const getAllFacilitiesData = async (
   userToken,
@@ -34,8 +32,8 @@ const getAllFacilitiesData = async (
   );
 
   const { count, facilities } = await getApiData(api.allFacilities(
-    currentPage * PAGESIZE,
-    PAGESIZE,
+    currentPage * PAGE_SIZE,
+    PAGE_SIZE,
     filtersQuery,
     userToken,
   ), res);
@@ -57,7 +55,7 @@ const getTemplateVariables = (
   filtersArray,
 ) => {
   const pages = {
-    totalPages: Math.ceil(count / PAGESIZE),
+    totalPages: Math.ceil(count / PAGE_SIZE),
     currentPage: parseInt(currentPage, 10),
     totalItems: count,
   };
@@ -66,8 +64,8 @@ const getTemplateVariables = (
 
   const templateVariables = {
     user,
-    primaryNav,
-    tab,
+    primaryNav: CONSTANTS.DASHBOARD.PRIMARY_NAV,
+    tab: CONSTANTS.DASHBOARD.TABS.FACILITIES,
     facilities,
     pages,
     filters: templateFilters(filtersObj),

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -14,7 +14,7 @@ import {
   submittedFiltersArray,
   submittedFiltersObject,
 } from '../filters/helpers';
-import removeSessionFilter from '../filters/remove-filter-from-session';
+import { removeSessionFilter } from '../filters/remove-filter-from-session';
 import { facilitiesTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
 import CONSTANTS from '../../../constants';

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -89,8 +89,8 @@ describe('controllers/dashboard/facilities', () => {
       );
 
       expect(api.allFacilities).toHaveBeenCalledWith(
-        20,
-        20,
+        CONSTANTS.DASHBOARD.PAGE_SIZE,
+        CONSTANTS.DASHBOARD.PAGE_SIZE,
         expectedFilters,
         'mock-token',
       );
@@ -131,7 +131,7 @@ describe('controllers/dashboard/facilities', () => {
       );
 
       const expectedPages = {
-        totalPages: Math.ceil(mockFacilities.length / 20),
+        totalPages: Math.ceil(mockFacilities.length / CONSTANTS.DASHBOARD.PAGE_SIZE),
         currentPage: parseInt(mockReq.params.page, 10),
         totalItems: mockFacilities.length,
       };
@@ -140,8 +140,8 @@ describe('controllers/dashboard/facilities', () => {
 
       const expected = {
         user: mockReq.session.user,
-        primaryNav: 'home',
-        tab: 'facilities',
+        primaryNav: CONSTANTS.DASHBOARD.PRIMARY_NAV,
+        tab: CONSTANTS.DASHBOARD.TABS.FACILITIES,
         facilities: mockFacilities,
         pages: expectedPages,
         filters: templateFilters(expectedFiltersObj),
@@ -215,7 +215,7 @@ describe('controllers/dashboard/facilities', () => {
   });
 
   describe('removeSingleAllFacilitiesFilter', () => {
-    it('should remove a filter and redirect to `/dashboard/facilities/0`', async () => {
+    it('should call removeSessionFilter and redirect to `/dashboard/facilities/0`', async () => {
       mockReq = {
         ...mockReq,
         session: {

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -3,6 +3,8 @@ import {
   getTemplateVariables,
   getDataAndTemplateVariables,
   allFacilities,
+  removeSingleAllFacilitiesFilter,
+  removeAllFacilitiesFilters,
 } from '.';
 import mockResponse from '../../../helpers/responseMock';
 import { getFlashSuccessMessage } from '../../../helpers';
@@ -12,6 +14,7 @@ import {
   submittedFiltersArray,
   submittedFiltersObject,
 } from '../filters/helpers';
+import removeSessionFilter from '../filters/remove-filter-from-session';
 import { facilitiesTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
 import CONSTANTS from '../../../constants';
@@ -53,7 +56,7 @@ describe('controllers/dashboard/facilities', () => {
       params: { page: 1 },
       body: {},
       session: {
-        dashboardFilters: CONSTANTS.DASHBOARD_FILTERS_DEFAULT,
+        dashboardFilters: CONSTANTS.DASHBOARD.DEFAULT_FILTERS,
         userToken: '1234',
         user: {
           _id: 'mock-user',
@@ -208,6 +211,48 @@ describe('controllers/dashboard/facilities', () => {
         ...expectedVariables,
         successMessage: getFlashSuccessMessage(mockReq),
       });
+    });
+  });
+
+  describe('removeSingleAllFacilitiesFilter', () => {
+    it('should remove a filter and redirect to `/dashboard/facilities/0`', async () => {
+      mockReq = {
+        ...mockReq,
+        session: {
+          ...mockReq.session,
+          dashboardFilters: {
+            fieldA: ['valueA'],
+            fieldB: ['valueB1', 'valueB2'],
+          },
+        },
+        params: {
+          fieldName: 'fieldB',
+          fieldValue: 'valueB1',
+        },
+      };
+
+      await removeSingleAllFacilitiesFilter(mockReq, mockRes);
+
+      const expected = removeSessionFilter(mockReq);
+
+      expect(mockReq.session.dashboardFilters).toEqual(expected);
+      expect(mockRes.redirect).toHaveBeenCalledWith('/dashboard/facilities/0');
+    });
+  });
+
+  describe('removeAllDealsFilters', () => {
+    it('should reset all session filters and redirect to `/dashboard/facilities/0', async () => {
+      mockReq = {
+        ...mockReq,
+        session: {
+          ...mockReq.session,
+          dashboardFilters: { fieldA: ['valueA'] },
+        },
+      };
+
+      await removeAllFacilitiesFilters(mockReq, mockRes);
+
+      expect(mockReq.session.dashboardFilters).toEqual(CONSTANTS.DASHBOARD.DEFAULT_FILTERS);
     });
   });
 });

--- a/portal/server/controllers/dashboard/facilities/selected-filters.js
+++ b/portal/server/controllers/dashboard/facilities/selected-filters.js
@@ -1,10 +1,54 @@
 const {
   generateSelectedFiltersObject,
+  generateSelectedFiltersObjectWithMappedValues,
   selectedSubmissionTypeFilters,
-  selectedHasBeenIssuedFilters,
 } = require('../filters/generate-selected-filters');
 const CONTENT_STRINGS = require('../../../content-strings');
 const CONSTANTS = require('../../../constants');
+
+/**
+ * Map true/false boolean to Issued/Unissued string.
+ *
+ * @param {boolean} the submitted filter value
+ * @example ( true )
+ * @returns 'Issued'
+ */
+const mapIssuedValueToText = (hasBeenIssued) => {
+  if (hasBeenIssued) {
+    return CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED;
+  }
+
+  return CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED;
+};
+
+/**
+ * Create an object for all selected hasBeenIssued filters.
+ * This will used in mojFilter component - selectedFilters.categories.
+ *
+ * @param {string} field heading
+ * @param {string} field name
+ * @param {object} submitted hasBeenIssued filters
+ * @example ( 'Bank facility stage', 'hasBeenIssued', [ true, false ] )
+ * @returns generateSelectedFiltersObjectWithMappedValues('Facility stage', 'hasBeenIssued', [ {value: true, mappedValue: 'Issued' }])
+ */
+const selectedHasBeenIssuedFilters = (
+  heading,
+  fieldName,
+  submittedFilters,
+) => {
+  const mappedFilters = submittedFilters.map((value) => ({
+    value,
+    mappedValue: mapIssuedValueToText(value),
+  }));
+
+  const selectedFiltersObj = generateSelectedFiltersObjectWithMappedValues(
+    heading,
+    fieldName,
+    mappedFilters,
+  );
+
+  return selectedFiltersObj;
+};
 
 /**
  * Create an array of objects for all selected filters.
@@ -54,5 +98,7 @@ const selectedFilters = (submittedFilters) => {
 };
 
 module.exports = {
+  mapIssuedValueToText,
   selectedFilters,
+  selectedHasBeenIssuedFilters,
 };

--- a/portal/server/controllers/dashboard/facilities/selected-filters.test.js
+++ b/portal/server/controllers/dashboard/facilities/selected-filters.test.js
@@ -1,13 +1,67 @@
 import {
   generateSelectedFiltersObject,
+  generateSelectedFiltersObjectWithMappedValues,
   selectedSubmissionTypeFilters,
-  selectedHasBeenIssuedFilters,
 } from '../filters/generate-selected-filters';
-import { selectedFilters } from './selected-filters';
+import {
+  mapIssuedValueToText,
+  selectedHasBeenIssuedFilters,
+  selectedFilters,
+} from './selected-filters';
 import CONTENT_STRINGS from '../../../content-strings';
 import CONSTANTS from '../../../constants';
 
 describe('controllers/dashboard/facilities - selected-filters', () => {
+  describe('mapIssuedValueToText', () => {
+    it(`should return ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED} when true string is passed`, () => {
+      const mockValue = true;
+
+      const result = mapIssuedValueToText(mockValue);
+
+      const expected = CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED;
+      expect(result).toEqual(expected);
+    });
+
+    it(`should return ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED} when false string is passed`, () => {
+      const mockValue = false;
+
+      const result = mapIssuedValueToText(mockValue);
+
+      const expected = CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED;
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('selectedHasBeenIssuedFilters', () => {
+    it('should return result of generateSelectedFiltersObject with mapped hasBeenIssuedValues', () => {
+      const mockHeading = CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.FACILITY_STAGE;
+      const mockFieldName = CONSTANTS.FIELD_NAMES.FACILITY.HAS_BEEN_ISSUED;
+      const mockSubmittedFieldFilters = [
+        'true',
+        'false',
+      ];
+
+      const result = selectedHasBeenIssuedFilters(
+        mockHeading,
+        mockFieldName,
+        mockSubmittedFieldFilters,
+      );
+
+      const mappedSubmittedFieldFilters = mockSubmittedFieldFilters.map((value) => ({
+        value,
+        mappedValue: mapIssuedValueToText(value),
+      }));
+
+      const expected = generateSelectedFiltersObjectWithMappedValues(
+        mockHeading,
+        mockFieldName,
+        mappedSubmittedFieldFilters,
+      );
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('selectedFilters', () => {
     it('should return an array of objects for all selected/submitted filters', () => {
       const mockSubmittedFilters = {

--- a/portal/server/controllers/dashboard/filters/generate-selected-filters.js
+++ b/portal/server/controllers/dashboard/filters/generate-selected-filters.js
@@ -8,8 +8,8 @@ const CONTENT_STRINGS = require('../../../content-strings');
  * @param {string} field heading
  * @param {string} field name
  * @param {array} submitted filters
- * @example ( 'Mock heading', 'dealType', [ 'BSS/EWCS', 'GEF' ] )
- * @returns { heading: { text: 'Mock heading' }, items: [ { text: 'BSS-EWCS', href: `filters/remove/dealType/BSS-EWCS`, value: 'BSS-EWCS' } ] }
+ * @example ( 'Deal type', 'dealType', ['BSS/EWCS', 'GEF'] )
+ * @returns { heading: { text: 'Deal type' }, items: [ { text: 'BSS-EWCS', href: `filters/remove/dealType/BSS-EWCS`, value: 'BSS-EWCS' } ] }
  */
 const generateSelectedFiltersObject = (
   heading,
@@ -20,12 +20,45 @@ const generateSelectedFiltersObject = (
     text: heading,
   },
   items: submittedFieldFilters.map((fieldValue) => {
-    const formattedFieldValue = formatFieldValue(fieldValue);
+    const formattedValue = formatFieldValue(fieldValue);
 
     return {
-      text: fieldValue,
-      href: `filters/remove/${fieldName}/${formattedFieldValue}`,
-      formattedFieldValue,
+      text: formattedValue,
+      href: `filters/remove/${fieldName}/${formattedValue}`,
+      formattedValue,
+    };
+  }),
+});
+
+/**
+ * Create an object for a single, selected filter
+ * With differentiation between text value and actual field value.
+ * This will used in mojFilter component - selectedFilters.categories.
+ *
+ * @param {string} field heading
+ * @param {string} field name
+ * @param {array} submitted filters
+ * @example ( 'Bank facility stage', 'hasBeenIssued', [true] )
+ * @returns { heading: { text: 'Deal type' }, items: [ { text: 'Issued', href: `filters/remove/hasBeenIssued/true`, value: true } ] }
+ */
+const generateSelectedFiltersObjectWithMappedValues = (
+  heading,
+  fieldName,
+  submittedFieldFilters,
+) => ({
+  heading: {
+    text: heading,
+  },
+  items: submittedFieldFilters.map(({
+    value,
+    mappedValue,
+  }) => {
+    const textValue = formatFieldValue(mappedValue);
+
+    return {
+      text: textValue,
+      href: `filters/remove/${fieldName}/${value}`,
+      formattedValue: textValue,
     };
   }),
 });
@@ -46,49 +79,8 @@ const selectedSubmissionTypeFilters = (fieldName, submittedFilters) =>
     submittedFilters,
   );
 
-/**
- * Map true/false boolean to Issued/Unissued string.
- *
- * @param {boolean} the submitted filter value
- * @example ( true )
- * @returns 'Issued'
- */
-const mapIssuedValueToText = (hasBeenIssued) => {
-  if (hasBeenIssued) {
-    return CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED;
-  }
-
-  return CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED;
-};
-
-/**
- * Create an object for all selected hasBeenIssued filters.
- * This will used in mojFilter component - selectedFilters.categories.
- *
- * @param {object} submitted hasBeenIssued filters
- * @example ( [true, false] )
- * @returns generateSelectedFiltersObject('Facility stage', 'hasBeenIssued', ['Issued', 'Unissued'])
- */
-const selectedHasBeenIssuedFilters = (
-  heading,
-  fieldName,
-  submittedFilters,
-) => {
-  const mappedFilters = submittedFilters.map((value) =>
-    mapIssuedValueToText(value));
-
-  const selectedFiltersObj = generateSelectedFiltersObject(
-    heading,
-    fieldName,
-    mappedFilters,
-  );
-
-  return selectedFiltersObj;
-};
-
 module.exports = {
   generateSelectedFiltersObject,
+  generateSelectedFiltersObjectWithMappedValues,
   selectedSubmissionTypeFilters,
-  mapIssuedValueToText,
-  selectedHasBeenIssuedFilters,
 };

--- a/portal/server/controllers/dashboard/filters/generate-selected-filters.js
+++ b/portal/server/controllers/dashboard/filters/generate-selected-filters.js
@@ -23,7 +23,7 @@ const generateSelectedFiltersObject = (
     const formattedValue = formatFieldValue(fieldValue);
 
     return {
-      text: formattedValue,
+      text: fieldValue,
       href: `filters/remove/${fieldName}/${formattedValue}`,
       formattedValue,
     };

--- a/portal/server/controllers/dashboard/filters/generate-selected-filters.test.js
+++ b/portal/server/controllers/dashboard/filters/generate-selected-filters.test.js
@@ -52,8 +52,14 @@ describe('controllers/dashboard/filters - ui-selected-filters', () => {
       const mockHeading = CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.FACILITY_STAGE;
       const mockFieldName = CONSTANTS.FIELD_NAMES.FACILITY_HAS_BEEN_ISSUED;
       const mockSubmittedFieldFilters = [
-        CONSTANTS.FACILITY_HAS_BEEN_ISSUED.ISSUED,
-        CONSTANTS.FACILITY_HAS_BEEN_ISSUED.UNISSUED,
+        {
+          value: CONSTANTS.FACILITY_HAS_BEEN_ISSUED.ISSUED,
+          mappedValue: CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED,
+        },
+        {
+          value: CONSTANTS.FACILITY_HAS_BEEN_ISSUED.UNISSUED,
+          mappedValue: CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED,
+        },
       ];
 
       const result = generateSelectedFiltersObjectWithMappedValues(
@@ -71,14 +77,14 @@ describe('controllers/dashboard/filters - ui-selected-filters', () => {
         },
         items: [
           {
-            text: expectedTextValue(mockSubmittedFieldFilters[0]),
-            href: expectedHref(mockFieldName, mockSubmittedFieldFilters[0]),
-            formattedValue: expectedTextValue(mockSubmittedFieldFilters[0]),
+            text: expectedTextValue(mockSubmittedFieldFilters[0].mappedValue),
+            href: expectedHref(mockFieldName, mockSubmittedFieldFilters[0].value),
+            formattedValue: expectedTextValue(mockSubmittedFieldFilters[0].mappedValue),
           },
           {
-            text: expectedTextValue(mockSubmittedFieldFilters[1]),
-            href: expectedHref(mockFieldName, mockSubmittedFieldFilters[1]),
-            formattedValue: expectedTextValue(mockSubmittedFieldFilters[1]),
+            text: expectedTextValue(mockSubmittedFieldFilters[1].mappedValue),
+            href: expectedHref(mockFieldName, mockSubmittedFieldFilters[1].value),
+            formattedValue: expectedTextValue(mockSubmittedFieldFilters[1].mappedValue),
           },
         ],
       };

--- a/portal/server/controllers/dashboard/filters/generate-selected-filters.test.js
+++ b/portal/server/controllers/dashboard/filters/generate-selected-filters.test.js
@@ -31,12 +31,12 @@ describe('controllers/dashboard/filters - ui-selected-filters', () => {
         },
         items: [
           {
-            text: formatFieldValue(mockSubmittedFieldFilters[0]),
+            text: mockSubmittedFieldFilters[0],
             href: expectedHref(mockFieldName, formatFieldValue(mockSubmittedFieldFilters[0])),
             formattedValue: formatFieldValue(mockSubmittedFieldFilters[0]),
           },
           {
-            text: formatFieldValue(mockSubmittedFieldFilters[1]),
+            text: mockSubmittedFieldFilters[1],
             href: expectedHref(mockFieldName, formatFieldValue(mockSubmittedFieldFilters[1])),
             formattedValue: formatFieldValue(mockSubmittedFieldFilters[1]),
           },

--- a/portal/server/controllers/dashboard/filters/generate-selected-filters.test.js
+++ b/portal/server/controllers/dashboard/filters/generate-selected-filters.test.js
@@ -1,8 +1,7 @@
 import {
   generateSelectedFiltersObject,
+  generateSelectedFiltersObjectWithMappedValues,
   selectedSubmissionTypeFilters,
-  mapIssuedValueToText,
-  selectedHasBeenIssuedFilters,
 } from './generate-selected-filters';
 import { formatFieldValue } from './helpers';
 import CONTENT_STRINGS from '../../../content-strings';
@@ -32,14 +31,54 @@ describe('controllers/dashboard/filters - ui-selected-filters', () => {
         },
         items: [
           {
-            text: mockSubmittedFieldFilters[0],
+            text: formatFieldValue(mockSubmittedFieldFilters[0]),
             href: expectedHref(mockFieldName, formatFieldValue(mockSubmittedFieldFilters[0])),
-            formattedFieldValue: formatFieldValue(mockSubmittedFieldFilters[0]),
+            formattedValue: formatFieldValue(mockSubmittedFieldFilters[0]),
           },
           {
-            text: mockSubmittedFieldFilters[1],
+            text: formatFieldValue(mockSubmittedFieldFilters[1]),
             href: expectedHref(mockFieldName, formatFieldValue(mockSubmittedFieldFilters[1])),
-            formattedFieldValue: formatFieldValue(mockSubmittedFieldFilters[1]),
+            formattedValue: formatFieldValue(mockSubmittedFieldFilters[1]),
+          },
+        ],
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('generateSelectedFiltersObjectWithMappedValues', () => {
+    it('should return mapped object', () => {
+      const mockHeading = CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.FACILITY_STAGE;
+      const mockFieldName = CONSTANTS.FIELD_NAMES.FACILITY_HAS_BEEN_ISSUED;
+      const mockSubmittedFieldFilters = [
+        CONSTANTS.FACILITY_HAS_BEEN_ISSUED.ISSUED,
+        CONSTANTS.FACILITY_HAS_BEEN_ISSUED.UNISSUED,
+      ];
+
+      const result = generateSelectedFiltersObjectWithMappedValues(
+        mockHeading,
+        mockFieldName,
+        mockSubmittedFieldFilters,
+      );
+
+      const expectedTextValue = (str) => formatFieldValue(str);
+      const expectedHref = (name, value) => `filters/remove/${name}/${value}`;
+
+      const expected = {
+        heading: {
+          text: mockHeading,
+        },
+        items: [
+          {
+            text: expectedTextValue(mockSubmittedFieldFilters[0]),
+            href: expectedHref(mockFieldName, mockSubmittedFieldFilters[0]),
+            formattedValue: expectedTextValue(mockSubmittedFieldFilters[0]),
+          },
+          {
+            text: expectedTextValue(mockSubmittedFieldFilters[1]),
+            href: expectedHref(mockFieldName, mockSubmittedFieldFilters[1]),
+            formattedValue: expectedTextValue(mockSubmittedFieldFilters[1]),
           },
         ],
       };
@@ -64,54 +103,6 @@ describe('controllers/dashboard/filters - ui-selected-filters', () => {
         CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.NOTICE_TYPE,
         CONSTANTS.FIELD_NAMES.DEAL.SUBMISSION_TYPE,
         mockSubmittedFieldFilters,
-      );
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('mapIssuedValueToText', () => {
-    it(`should return ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED} when true string is passed`, () => {
-      const mockValue = true;
-
-      const result = mapIssuedValueToText(mockValue);
-
-      const expected = CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.ISSUED;
-      expect(result).toEqual(expected);
-    });
-
-    it(`should return ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED} when false string is passed`, () => {
-      const mockValue = false;
-
-      const result = mapIssuedValueToText(mockValue);
-
-      const expected = CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.FACILITIES.UNISSUED;
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('selectedHasBeenIssuedFilters', () => {
-    it('should return result of generateSelectedFiltersObject with mapped hasBeenIssuedValues', () => {
-      const mockHeading = CONTENT_STRINGS.DASHBOARD_FILTERS.FILTER_HEADINGS.FACILITY_STAGE;
-      const mockFieldName = CONSTANTS.FIELD_NAMES.FACILITY.HAS_BEEN_ISSUED;
-      const mockSubmittedFieldFilters = [
-        'true',
-        'false',
-      ];
-
-      const result = selectedHasBeenIssuedFilters(
-        mockHeading,
-        mockFieldName,
-        mockSubmittedFieldFilters,
-      );
-
-      const mappedSubmittedFieldFilters = mockSubmittedFieldFilters.map((value) =>
-        mapIssuedValueToText(value));
-
-      const expected = generateSelectedFiltersObject(
-        mockHeading,
-        mockFieldName,
-        mappedSubmittedFieldFilters,
       );
 
       expect(result).toEqual(expected);

--- a/portal/server/controllers/dashboard/filters/remove-filter-from-session.js
+++ b/portal/server/controllers/dashboard/filters/remove-filter-from-session.js
@@ -1,8 +1,16 @@
+const sanitiseFieldValue = (value) => {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+
+  return value;
+};
+
 const removeSessionFilter = (req) => {
   const sessionFilters = req.session.dashboardFilters;
-
-  // console.log('---------removeSessionFilter - sessionFilters\n', sessionFilters);
-  // console.log('---------removeSessionFilter req.params\n', req.params);
 
   const {
     fieldName,
@@ -11,12 +19,18 @@ const removeSessionFilter = (req) => {
 
   const filter = sessionFilters[fieldName];
 
+  const sanitisedFieldValue = sanitiseFieldValue(fieldValue);
+
   if (filter) {
     if (Array.isArray(filter)) {
       const modifiedFilter = sessionFilters[fieldName].filter((value) =>
-        value !== fieldValue);
+        value !== sanitisedFieldValue);
 
-      req.session.dashboardFilters[fieldName] = modifiedFilter;
+      if (!modifiedFilter.length) {
+        delete req.session.dashboardFilters[fieldName];
+      } else {
+        req.session.dashboardFilters[fieldName] = modifiedFilter;
+      }
     } else {
       delete req.session.dashboardFilters[fieldName];
     }
@@ -25,4 +39,7 @@ const removeSessionFilter = (req) => {
   return req.session.dashboardFilters;
 };
 
-module.exports = removeSessionFilter;
+module.exports = {
+  sanitiseFieldValue,
+  removeSessionFilter,
+};

--- a/portal/server/controllers/dashboard/filters/remove-filter-from-session.js
+++ b/portal/server/controllers/dashboard/filters/remove-filter-from-session.js
@@ -1,0 +1,28 @@
+const removeSessionFilter = (req) => {
+  const sessionFilters = req.session.dashboardFilters;
+
+  // console.log('---------removeSessionFilter - sessionFilters\n', sessionFilters);
+  // console.log('---------removeSessionFilter req.params\n', req.params);
+
+  const {
+    fieldName,
+    fieldValue,
+  } = req.params;
+
+  const filter = sessionFilters[fieldName];
+
+  if (filter) {
+    if (Array.isArray(filter)) {
+      const modifiedFilter = sessionFilters[fieldName].filter((value) =>
+        value !== fieldValue);
+
+      req.session.dashboardFilters[fieldName] = modifiedFilter;
+    } else {
+      delete req.session.dashboardFilters[fieldName];
+    }
+  }
+
+  return req.session.dashboardFilters;
+};
+
+module.exports = removeSessionFilter;

--- a/portal/server/controllers/dashboard/filters/remove-filter-from-session.test.js
+++ b/portal/server/controllers/dashboard/filters/remove-filter-from-session.test.js
@@ -1,0 +1,74 @@
+import removeSessionFilter from './remove-filter-from-session';
+
+describe('controllers/dashboard/filters - remove-filter-from-session', () => {
+  it('should remove a filter from the session', () => {
+    const mockReq = {
+      session: {
+        dashboardFilters: {
+          fieldA: 'valueA',
+          fieldB: 'valueB',
+        },
+      },
+      params: {
+        fieldName: 'fieldA',
+        fieldValue: 'valueA',
+      },
+    };
+
+    const result = removeSessionFilter(mockReq);
+
+    const expected = {
+      fieldB: 'valueB',
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  describe('when a session filter is an array', () => {
+    it('should remove only one filter value from the array', () => {
+      const mockReq = {
+        session: {
+          dashboardFilters: {
+            fieldA: ['valueA', 'valueB'],
+            fieldC: 'valueC',
+          },
+        },
+        params: {
+          fieldName: 'fieldA',
+          fieldValue: 'valueB',
+        },
+      };
+
+      const result = removeSessionFilter(mockReq);
+
+      const expected = {
+        fieldA: ['valueA'],
+        fieldC: 'valueC',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a session filter does not exist', () => {
+    it('should return session filters without modifications', () => {
+      const mockReq = {
+        session: {
+          dashboardFilters: {
+            fieldA: 'valueA',
+          },
+        },
+        params: {
+          fieldName: 'fieldX',
+          fieldValue: 'valueY',
+        },
+      };
+
+      const result = removeSessionFilter(mockReq);
+
+      const expected = mockReq.session.dashboardFilters;
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/portal/server/controllers/dashboard/filters/remove-filter-from-session.test.js
+++ b/portal/server/controllers/dashboard/filters/remove-filter-from-session.test.js
@@ -1,74 +1,122 @@
-import removeSessionFilter from './remove-filter-from-session';
+import {
+  sanitiseFieldValue,
+  removeSessionFilter,
+} from './remove-filter-from-session';
 
 describe('controllers/dashboard/filters - remove-filter-from-session', () => {
-  it('should remove a filter from the session', () => {
-    const mockReq = {
-      session: {
-        dashboardFilters: {
-          fieldA: 'valueA',
-          fieldB: 'valueB',
-        },
-      },
-      params: {
-        fieldName: 'fieldA',
-        fieldValue: 'valueA',
-      },
-    };
+  describe('sanitiseFieldValue', () => {
+    describe('when a string boolean of true is passed', () => {
+      it('should return boolean', () => {
+        const result = sanitiseFieldValue('true');
 
-    const result = removeSessionFilter(mockReq);
+        expect(result).toEqual(true);
+      });
+    });
 
-    const expected = {
-      fieldB: 'valueB',
-    };
+    describe('when a string boolean of false is passed', () => {
+      it('should return boolean', () => {
+        const result = sanitiseFieldValue('false');
 
-    expect(result).toEqual(expected);
+        expect(result).toEqual(false);
+      });
+    });
   });
 
-  describe('when a session filter is an array', () => {
-    it('should remove only one filter value from the array', () => {
+  describe('removeSessionFilter', () => {
+    it('should remove a filter from the session', () => {
       const mockReq = {
         session: {
           dashboardFilters: {
-            fieldA: ['valueA', 'valueB'],
-            fieldC: 'valueC',
+            fieldA: 'valueA',
+            fieldB: 'valueB',
           },
         },
         params: {
           fieldName: 'fieldA',
-          fieldValue: 'valueB',
+          fieldValue: 'valueA',
         },
       };
 
       const result = removeSessionFilter(mockReq);
 
       const expected = {
-        fieldA: ['valueA'],
-        fieldC: 'valueC',
+        fieldB: 'valueB',
       };
 
       expect(result).toEqual(expected);
     });
-  });
 
-  describe('when a session filter does not exist', () => {
-    it('should return session filters without modifications', () => {
-      const mockReq = {
-        session: {
-          dashboardFilters: {
-            fieldA: 'valueA',
+    describe('when a session filter is an array', () => {
+      it('should remove only one filter value from the array', () => {
+        const mockReq = {
+          session: {
+            dashboardFilters: {
+              fieldA: ['valueA', 'valueB'],
+              fieldC: 'valueC',
+            },
           },
-        },
-        params: {
-          fieldName: 'fieldX',
-          fieldValue: 'valueY',
-        },
-      };
+          params: {
+            fieldName: 'fieldA',
+            fieldValue: 'valueB',
+          },
+        };
 
-      const result = removeSessionFilter(mockReq);
+        const result = removeSessionFilter(mockReq);
 
-      const expected = mockReq.session.dashboardFilters;
+        const expected = {
+          fieldA: ['valueA'],
+          fieldC: 'valueC',
+        };
 
-      expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
+      });
+
+      describe('when the session filter array has only one value that is being removed', () => {
+        it('should remove the filter array entirely', () => {
+          const mockReq = {
+            session: {
+              dashboardFilters: {
+                fieldA: ['valueA'],
+                fieldB: true,
+              },
+            },
+            params: {
+              fieldName: 'fieldA',
+              fieldValue: 'valueA',
+            },
+          };
+
+          const result = removeSessionFilter(mockReq);
+
+          const expected = {
+            fieldB: true,
+          };
+
+          expect(result).toEqual(expected);
+        });
+      });
+    });
+
+    describe('when a session filter does not exist', () => {
+      it('should return session filters without modifications', () => {
+        const mockReq = {
+          session: {
+            dashboardFilters: {
+              fieldA: 'valueA',
+            },
+          },
+          params: {
+            fieldName: 'fieldX',
+            fieldValue: 'valueY',
+          },
+        };
+
+        const result = removeSessionFilter(mockReq);
+
+        const expected = mockReq.session.dashboardFilters;
+
+        expect(result).toEqual(expected);
+      });
     });
   });
 });

--- a/portal/server/controllers/dashboard/index.js
+++ b/portal/server/controllers/dashboard/index.js
@@ -5,14 +5,17 @@ const {
 } = require('./deals');
 const {
   allFacilities,
+  removeSingleAllFacilitiesFilter,
+  removeAllFacilitiesFilters,
 } = require('./facilities');
-
 const reportsController = require('./reports.controller');
 
 module.exports = {
   allDeals,
-  allFacilities,
   removeSingleAllDealsFilter,
   removeAllDealsFilters,
+  allFacilities,
+  removeSingleAllFacilitiesFilter,
+  removeAllFacilitiesFilters,
   reportsController,
 };

--- a/portal/server/routes/dashboard.js
+++ b/portal/server/routes/dashboard.js
@@ -4,40 +4,49 @@ const {
   removeSingleAllDealsFilter,
   removeAllDealsFilters,
   allFacilities,
+  removeSingleAllFacilitiesFilter,
+  removeAllFacilitiesFilters,
 } = require('../controllers/dashboard');
 const CONSTANTS = require('../constants');
-
 const validateToken = require('./middleware/validate-token');
 
 const router = express.Router();
 
 router.use('/dashboard/*', validateToken);
-
-router.get('/', validateToken, (_, res) => res.redirect('/dashboard/deals'));
-
+router.get('/', validateToken, (req, res) => res.redirect('/dashboard/deals'));
 router.get('/dashboard', async (req, res) => res.redirect('/dashboard/deals'));
 
+/**
+ * Deals
+ */
 router.get('/dashboard/deals', async (req, res) => {
-  req.session.dashboardFilters = CONSTANTS.DASHBOARD_FILTERS_DEFAULT;
+  req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
 
   return res.redirect('/dashboard/deals/0');
 });
 
 router.get('/dashboard/deals/clear-all-filters', removeAllDealsFilters);
-
 router.get('/dashboard/deals/filters/remove/:fieldName/:fieldValue', removeSingleAllDealsFilter);
 
+/**
+ * Facilities
+ */
 router.get('/dashboard/facilities', async (req, res) => {
-  req.session.dashboardFilters = CONSTANTS.DASHBOARD_FILTERS_DEFAULT;
+  req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
 
   return res.redirect('/dashboard/facilities/0');
 });
 
-// needs to be ordered last to avoid issues with taking priority over transaction routes
-router.get('/dashboard/facilities/:page', allFacilities);
-router.post('/dashboard/facilities/:page', allFacilities);
+router.get('/dashboard/facilities/clear-all-filters', removeAllFacilitiesFilters);
+router.get('/dashboard/facilities/filters/remove/:fieldName/:fieldValue', removeSingleAllFacilitiesFilter);
 
+/**
+ * Deals and facilitiers - pagination
+ * - Needs to be ordered last to avoid priority issues
+ */
 router.get('/dashboard/deals/:page', allDeals);
 router.post('/dashboard/deals/:page', allDeals);
+router.get('/dashboard/facilities/:page', allFacilities);
+router.post('/dashboard/facilities/:page', allFacilities);
 
 module.exports = router;

--- a/portal/server/routes/login.js
+++ b/portal/server/routes/login.js
@@ -47,7 +47,7 @@ router.post('/login', async (req, res) => {
     if (success) {
       req.session.userToken = token;
       req.session.user = user;
-      req.session.dashboardFilters = CONSTANTS.DASHBOARD_FILTERS_DEFAULT;
+      req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
     } else {
       loginErrors.push(emailError);
       loginErrors.push(passwordError);

--- a/portal/templates/dashboard/_macros/dashboard-filters-action-bar.njk
+++ b/portal/templates/dashboard/_macros/dashboard-filters-action-bar.njk
@@ -59,7 +59,7 @@
               <a
                 class="govuk-link govuk-button--secondary moj-filter__tag"
                 href="{{ filterItem.href }}"
-                data-cy="main-container-selected-filter-{{ filterItem.formattedFieldValue}}"
+                data-cy="main-container-selected-filter-{{ filterItem.text }}"
               >
                 <span class="govuk-visually-hidden">Remove this filter</span>
                 {{ filterItem.text }}

--- a/portal/templates/dashboard/_macros/dashboard-filters-action-bar.njk
+++ b/portal/templates/dashboard/_macros/dashboard-filters-action-bar.njk
@@ -59,7 +59,7 @@
               <a
                 class="govuk-link govuk-button--secondary moj-filter__tag"
                 href="{{ filterItem.href }}"
-                data-cy="main-container-selected-filter-{{ filterItem.text }}"
+                data-cy="main-container-selected-filter-{{ filterItem.formattedValue }}"
               >
                 <span class="govuk-visually-hidden">Remove this filter</span>
                 {{ filterItem.text }}


### PR DESCRIPTION
## Summary
- Remove a single facility filter via filters panel, panel form, or main container 'selected filters' list.
- Remove all facility filters.


## How
- Add remove filter endpoints to facility UI routes.
- Create `removeSessionFilter` function to use in both deals and facilities when "remove a filter" endpoint is called. Sanitise any `req.params` that have string booleans (received from Nunjucks)

## Other necessities
- Move `selectedHasBeenIssuedFilters` and text/value mapping into facilities directory.
- Create `generateSelectedFiltersObjectWithMappedValues` so that a selected filter object will display the intended text value, but a different value to be sent to API. E.g, `hasBeenIssued` with `true` boolean, will have `Issued` text/value displayed, but the href/checkbox value will be `true`
  - Without this, any filters that have a true/false value, will not be removed when sent to the server, because the value will not match the actual value applied. In other words, if a value of "Issued" is passed to the "remove filter" endpoint, it won't work without this mapping - because the actual value (same as the actual data), is `true`, not `Issued`. So we display "Issued" to the user, but the actual value is `true`.


## Bonus
- Use constants for active tab, primary nav and page size for dashboard deals and facilities.