### PR TITLE
fix/DTFS2-5395 - wipe previousStatus when cloning a BSS/EWCS deal

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/maker/clone-deal/clone-deal.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/clone-deal/clone-deal.spec.js
@@ -112,6 +112,15 @@ context('Clone a deal', () => {
         expect(text.trim()).equal(`Copy of ${deal.additionalRefName}-cloned`);
       });
 
+      // confirm deal status and previous status are wiped
+      pages.contract.status().invoke('text').then((text) => {
+        expect(text.trim()).equal('Draft');
+      });
+
+      pages.contract.previousStatus().invoke('text').then((text) => {
+        expect(text.trim()).equal('-');
+      });
+
       // confirm About the Supply Contract is retained
       pages.contract.aboutSupplierDetailsStatus().invoke('text').then((text) => {
         expect(text.trim()).equal('Completed');

--- a/portal-api/api-tests/v1/deals/deal-clone.api-test.js
+++ b/portal-api/api-tests/v1/deals/deal-clone.api-test.js
@@ -94,7 +94,7 @@ describe('/v1/deals/:id/clone', () => {
         originalDeal = dealAfterCreation.deal;
       });
 
-      it('clones a deal with only specific properties in `details`, wipes `comments`, `editedBy` `ukefComments`, `ukefDecision`, changes `maker` to the user making the request, marks status `Draft`', async () => {
+      it('clones a deal with only specific properties in `details`. Wipes `previousStatus`, `comments`, `editedBy` `ukefComments`, `ukefDecision`, changes `maker` to the user making the request, marks status `Draft`', async () => {
         const clonePostBody = {
           bankInternalRefName: 'new-bank-deal-id',
           additionalRefName: 'new-bank-deal-name',
@@ -121,6 +121,7 @@ describe('/v1/deals/:id/clone', () => {
 
         expect(cloned.deal.bank).toEqual(aBarclaysMaker.bank);
         expect(cloned.deal.status).toEqual('Draft');
+        expect(cloned.deal.previousStatus).toBeUndefined();
         expect(cloned.deal.editedBy).toEqual([]);
         expect(cloned.deal.comments).toEqual([]);
         expect(cloned.deal.ukefComments).toEqual([]);

--- a/portal-api/src/v1/controllers/deal-clone.controller.js
+++ b/portal-api/src/v1/controllers/deal-clone.controller.js
@@ -69,10 +69,10 @@ exports.clone = async (req, res) => {
       cloneTransactions,
     } = req.body;
 
-    const { _id, tfm, ...existingDealWithoutId } = existingDeal;
+    const { _id, previousStatus, tfm, ...existingDealWithoutCertainFields } = existingDeal;
 
     const modifiedDeal = {
-      ...existingDealWithoutId,
+      ...existingDealWithoutCertainFields,
       status: DEFAULTS.DEAL.status,
       submissionType: existingDeal.submissionType,
       updatedAt: existingDeal.updatedAt,


### PR DESCRIPTION
Previously, the `previousStatus` would be retained when cloning a deal. Without this change, you could end up with a Draft deal status, with a previousStatus of e.g Ready for Checker, which should not be the case.