### PR TITLE
DTFS2-5357 - add line break to each facility in GEF confirmation email

### DIFF
--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.api-test.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.api-test.js
@@ -136,7 +136,7 @@ describe('generate AIN/MIN confirmation email facilities list email variable/str
       const expectedHeading = generateHeadingString(mockHeading);
       const expectedFacilityFields = generateFacilityFieldsListString(mockSimpleFacility);
 
-      const expectedFacilityString = `${expectedHeading}${expectedFacilityFields}`;
+      const expectedFacilityString = `\n\n${expectedHeading}${expectedFacilityFields}`;
 
       const expected = `${expectedFacilityString}${expectedFacilityString}`;
 

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.js
@@ -125,7 +125,7 @@ const generateFacilitiesListString = (heading, facilities) => {
   let listString = '';
 
   facilities.forEach((facility) => {
-    listString += formattedHeading;
+    listString += `\n\n${formattedHeading}`;
     listString += generateFacilityFieldsListString(facility);
   });
 


### PR DESCRIPTION
Without this change, if there are multiple facilities, each facility heading does not go to a new line.