### PR TITLE
fix/DTFS2-5417 - TFM all deals default sort order

### DIFF
--- a/trade-finance-manager-ui/server/constants/deals.js
+++ b/trade-finance-manager-ui/server/constants/deals.js
@@ -4,7 +4,7 @@ const TFM_SORT_BY = {
 };
 
 const TFM_SORT_BY_DEFAULT = {
-  field: 'dealSnapshot.details.submissionDate',
+  field: 'tfm.dateReceived',
   order: TFM_SORT_BY.DESCENDING,
 };
 

--- a/trade-finance-manager-ui/server/controllers/deals/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/deals/index.test.js
@@ -39,7 +39,7 @@ describe('controllers - deals', () => {
           activePrimaryNavigation: 'all deals',
           activeSubNavigation: 'deal',
           user: mockReq.session.user,
-          activeSortByField: 'dealSnapshot.details.submissionDate',
+          activeSortByField: 'tfm.dateReceived',
           activeSortByOrder: 'descending',
         });
       });


### PR DESCRIPTION
Order by `tfm.dateReceived`, not `submissionDate`.