### PR TITLE
fix/DTFS2-5410 - remove BSS/EWCS show header flags from TFM email variables

### DIFF
--- a/trade-finance-manager-api/src/v1/emails/MIA-confirmation/bss-email-variables.api-test.js
+++ b/trade-finance-manager-api/src/v1/emails/MIA-confirmation/bss-email-variables.api-test.js
@@ -28,9 +28,7 @@ describe('generate MIA confirmation email variables - BSS', () => {
 
     const expected = {
       bssList: facilityLists.bssList,
-      showBssHeader: 'yes',
       ewcsList: facilityLists.ewcsList,
-      showEwcsHeader: 'yes',
     };
 
     expect(result).toEqual(expected);
@@ -48,7 +46,6 @@ describe('generate MIA confirmation email variables - BSS', () => {
 
       const result = bssEmailVariables(mockSubmittedDeal);
 
-      expect(result.showBssHeader).toEqual('no');
       expect(result.showEwcsHeader).toEqual('no');
     });
   });

--- a/trade-finance-manager-api/src/v1/emails/MIA-confirmation/bss-email-variables.api-test.js
+++ b/trade-finance-manager-api/src/v1/emails/MIA-confirmation/bss-email-variables.api-test.js
@@ -33,20 +33,4 @@ describe('generate MIA confirmation email variables - BSS', () => {
 
     expect(result).toEqual(expected);
   });
-
-  describe('when there are no issued or unissued facilities', () => {
-    it('should return correct `show issued/unissued header` properties', () => {
-      const mockDealWithNoFacilities = {
-        ...MOCK_BSS_DEAL,
-        bondTransactions: { items: [] },
-        loanTransactions: { items: [] },
-      };
-
-      const mockSubmittedDeal = mapSubmittedDeal({ dealSnapshot: mockDealWithNoFacilities });
-
-      const result = bssEmailVariables(mockSubmittedDeal);
-
-      expect(result.showEwcsHeader).toEqual('no');
-    });
-  });
 });

--- a/trade-finance-manager-api/src/v1/emails/MIA-confirmation/bss-email-variables.js
+++ b/trade-finance-manager-api/src/v1/emails/MIA-confirmation/bss-email-variables.js
@@ -12,9 +12,7 @@ const bssEmailVariables = (deal) => {
 
   const emailVariables = {
     bssList: facilityLists.bssList,
-    showBssHeader: facilityLists.bssList ? 'yes' : 'no',
     ewcsList: facilityLists.ewcsList,
-    showEwcsHeader: facilityLists.ewcsList ? 'yes' : 'no',
   };
 
   return emailVariables;


### PR DESCRIPTION
Due to previous changes to "facility lists" email variable functions - BSS/EWCS facility headers would be generated twice. This was because the email template/variables generate a header, but the list also generates the header. Now the list just generates the header and the header variables are not required.