### PR TITLE
DTFS2-5417 - TFM - add dateReceivedTimestamp, fix Fee Record tests

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/deals/deals-search.spec.js
@@ -53,11 +53,8 @@ context('User can view and filter multiple deals', () => {
 
   // NOTE: searching by date queries multiple fields.
   // Therefore we need to set all of these fields to yesterday.
-  const DEAL_SUBMITTED_YESTERDAY = createMockDeal({
-    testId: 'DEAL_SUBMITTED_YESTERDAY',
-    details: {
-      submissionDate: yesterday.valueOf().toString(),
-    },
+  const DEAL_COMPLETED_YESTERDAY = createMockDeal({
+    testId: 'DEAL_COMPLETED_YESTERDAY',
     eligibility: {
       lastUpdated: yesterday.valueOf().toString(),
     },
@@ -71,7 +68,7 @@ context('User can view and filter multiple deals', () => {
     DEAL_WITH_TEST_MIA_SUBMISSION_TYPE,
     DEAL_WITH_ONLY_1_FACILITY_BOND,
     DEAL_WITH_ONLY_1_FACILITY_LOAN,
-    DEAL_SUBMITTED_YESTERDAY,
+    DEAL_COMPLETED_YESTERDAY,
   ];
 
   before(() => {
@@ -299,9 +296,9 @@ context('User can view and filter multiple deals', () => {
 
     const searchString = todayFormatted;
 
-    const ALL_DEALS_SUBMITTED_TODAY = MOCK_DEALS.filter((deal) => deal.testId !== 'DEAL_SUBMITTED_YESTERDAY');
-
-    const expectedResultsLength = ALL_DEALS_SUBMITTED_TODAY.length;
+    // Note: Date received is generated on submission.
+    // all deals in this test are submitted at the same time.
+    const expectedResultsLength = ALL_SUBMITTED_DEALS.length;
 
     pages.dealsPage.searchFormInput().type(searchString);
     pages.dealsPage.searchFormSubmitButton().click();
@@ -318,10 +315,9 @@ context('User can view and filter multiple deals', () => {
 
     const searchString = todayFormatted;
 
-    const ALL_DEALS_SUBMITTED_TODAY = MOCK_DEALS.filter((deal) =>
-      deal.testId !== 'DEAL_SUBMITTED_YESTERDAY');
-
-    const expectedResultsLength = ALL_DEALS_SUBMITTED_TODAY.length;
+    // Note: Date received is generated on submission.
+    // all deals in this test are submitted at the same time.
+    const expectedResultsLength = ALL_SUBMITTED_DEALS.length;
 
     pages.dealsPage.searchFormInput().type(searchString);
     pages.dealsPage.searchFormSubmitButton().click();

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -5,6 +5,7 @@ const submitDeal = require('../utils/submitDeal');
 const mapSubmittedDeal = require('../../../src/v1/mappings/map-submitted-deal');
 const addTfmDealData = require('../../../src/v1/controllers/deal-add-tfm-data');
 const { createDealTasks } = require('../../../src/v1/controllers/deal.tasks');
+const generateDateReceived = require('../../../src/v1/controllers/deal-add-tfm-data/dateReceived');
 
 const CONSTANTS = require('../../../src/constants');
 
@@ -200,17 +201,17 @@ describe('/v1/deals', () => {
       });
     });
 
-    it('adds dateReceived to deal.tfm from deal submissionDate', async () => {
+    it('adds dateReceived to deal.tfm', async () => {
       const { status, body } = await submitDeal(createSubmitBody(MOCK_DEAL_AIN_SUBMITTED));
 
       expect(status).toEqual(200);
 
-      const utc = moment(parseInt(MOCK_DEAL_AIN_SUBMITTED.details.submissionDate, 10));
-      const localisedTimestamp = utc.tz('Europe/London');
+      // const utc = moment(parseInt(MOCK_DEAL_AIN_SUBMITTED.details.submissionDate, 10));
+      // const localisedTimestamp = utc.tz('Europe/London');
 
-      const expectedDateReceived = localisedTimestamp.format('DD-MM-YYYY');
-
+      const expectedDateReceived = generateDateReceived().dateReceived;
       expect(body.tfm.dateReceived).toEqual(expectedDateReceived);
+      expect(body.tfm.dateReceivedTimestamp).toBeDefined();
     });
 
     it('adds empty TFM history to deal', async () => {

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -205,9 +205,6 @@ describe('/v1/deals', () => {
 
       expect(status).toEqual(200);
 
-      // const utc = moment(parseInt(MOCK_DEAL_AIN_SUBMITTED.details.submissionDate, 10));
-      // const localisedTimestamp = utc.tz('Europe/London');
-
       const expectedDateReceived = generateDateReceived().dateReceived;
       expect(body.tfm.dateReceived).toEqual(expectedDateReceived);
       expect(body.tfm.dateReceivedTimestamp).toBeDefined();

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.api-test.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const externalApis = require('../../../src/v1/api');
 const acbsController = require('../../../src/v1/controllers/acbs.controller');
 const submitDeal = require('../utils/submitDeal');

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -285,7 +285,7 @@ type TFMDealData {
   history: TFMDealHistory
   underwriterManagersDecision: TFMDealDecision
   dateReceived: String
-  dateReceivedTimestamp: Float
+  dateReceivedTimestamp: Int
   estore: TFMEstore
   leadUnderwriter: String
   activities: [TFMActivity]

--- a/trade-finance-manager-api/src/graphql/schemas/index.js
+++ b/trade-finance-manager-api/src/graphql/schemas/index.js
@@ -285,6 +285,7 @@ type TFMDealData {
   history: TFMDealHistory
   underwriterManagersDecision: TFMDealDecision
   dateReceived: String
+  dateReceivedTimestamp: Float
   estore: TFMEstore
   leadUnderwriter: String
   activities: [TFMActivity]

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -139,7 +139,7 @@ const findOneDeal = async (dealId) => {
     });
     return response.data.deal;
   } catch ({ response }) {
-    console.error(`TFM API - error finding BSS deal ${dealId}`);
+    console.error(`TFM API - error finding deal ${dealId}`);
 
     return false;
   }

--- a/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/dateReceived.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/dateReceived.api-test.js
@@ -1,34 +1,13 @@
-const moment = require('moment');
-require('moment-timezone'); // monkey-patch to provide moment().tz(;
-
-const {
-  generateDateFromSubmissionDate,
-  dateReceived,
-} = require('./dateReceived');
+const { format } = require('date-fns');
+const generateDateReceived = require('./dateReceived');
 
 describe('deal submit - add TFM data - date received', () => {
-  const mockSubmissionDate = '1623411666338';
+  it('should return a formatted date and timestamp', () => {
+    const result = generateDateReceived();
 
-  const expectedSubmissionDate = (date) => {
-    const utc = moment(parseInt(date, 10));
-    const localisedTimestamp = utc.tz('Europe/London');
+    const expectedDateReceived = format(new Date(), 'dd-MM-yyyy');
+    expect(result.dateReceived).toEqual(expectedDateReceived);
 
-    return localisedTimestamp.format('DD-MM-YYYY');
-  };
-
-  describe('generateDateFromSubmissionDate', () => {
-    it('should return formatted date', () => {
-      const result = generateDateFromSubmissionDate(mockSubmissionDate);
-
-      expect(result).toEqual(expectedSubmissionDate(mockSubmissionDate));
-    });
-  });
-
-  it('should return timestmap', async () => {
-    const result = await dateReceived(mockSubmissionDate);
-
-    const expected = generateDateFromSubmissionDate(mockSubmissionDate);
-
-    expect(result).toEqual(expected);
+    expect(typeof result.dateReceivedTimestamp).toEqual('number');
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/dateReceived.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/dateReceived.js
@@ -1,17 +1,8 @@
-const moment = require('moment');
-require('moment-timezone'); // monkey-patch to provide moment().tz()
+const { getUnixTime, format } = require('date-fns');
 
-const generateDateFromSubmissionDate = (submissionDate) => {
-  const utc = moment(parseInt(submissionDate, 10));
-  const localisedTimestamp = utc.tz('Europe/London');
+const generateDateReceived = () => ({
+  dateReceived: format(new Date(), 'dd-MM-yyyy'),
+  dateReceivedTimestamp: getUnixTime(new Date()),
+});
 
-  return localisedTimestamp.format('DD-MM-YYYY');
-};
-
-const dateReceived = (submissionDate) =>
-  generateDateFromSubmissionDate(submissionDate);
-
-module.exports = {
-  generateDateFromSubmissionDate,
-  dateReceived,
-};
+module.exports = generateDateReceived;

--- a/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/index.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/index.api-test.js
@@ -1,6 +1,6 @@
 const addTfmDealData = require('.');
 const mapSubmittedDeal = require('../../mappings/map-submitted-deal');
-const { dateReceived: addDateReceived } = require('./dateReceived');
+const generateDateReceived = require('./dateReceived');
 const addDealProduct = require('./dealProduct');
 const addDealPricingAndRisk = require('./dealPricingAndRisk');
 const addDealStage = require('./dealStage');
@@ -19,7 +19,7 @@ describe('deal submit - add TFM data', () => {
     const expected = {
       ...mockDeal,
       tfm: {
-        dateReceived: addDateReceived(mockDeal.submissionDate),
+        ...generateDateReceived(),
         history: DEFAULTS.HISTORY,
         parties: {},
         activities: [],

--- a/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/index.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/index.js
@@ -12,7 +12,6 @@ const addTfmDealData = async (deal) => {
 
   const {
     _id: dealId,
-    submissionDate,
     submissionType,
     status,
     tfm,

--- a/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/index.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/index.js
@@ -1,5 +1,5 @@
 const api = require('../../api');
-const { dateReceived: addDateReceived } = require('./dateReceived');
+const generateDateReceived = require('./dateReceived');
 const addDealProduct = require('./dealProduct');
 const addDealPricingAndRisk = require('./dealPricingAndRisk');
 const addDealStage = require('./dealStage');
@@ -21,7 +21,7 @@ const addTfmDealData = async (deal) => {
   const dealUpdate = {
     tfm: {
       ...tfm,
-      dateReceived: addDateReceived(submissionDate),
+      ...generateDateReceived(),
       history: DEFAULTS.HISTORY,
       parties: {},
       activities: [],

--- a/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.api-test.js
@@ -27,12 +27,7 @@ describe('calculate-gef-facility-fee-record', () => {
         mockInterestPercentage,
       );
 
-      const fractionalCoverPercentage = `0.${mockCoverPercentage}`;
-      const valueAndCover = (mockFacilityValue * fractionalCoverPercentage);
-
-      const drawnAmount = (valueAndCover * mockInterestPercentage);
-
-      const expected = drawnAmount;
+      const expected = (mockFacilityValue * (mockCoverPercentage / 100) * 0.1);
 
       expect(result).toEqual(expected);
     });
@@ -71,11 +66,10 @@ describe('calculate-gef-facility-fee-record', () => {
         drawnAmount,
         daysOfCover,
         mockDayBasis,
+        mockInterestPercentage,
       );
 
-      const drawnAmountAndDays = (drawnAmount * daysOfCover);
-
-      const expected = (drawnAmountAndDays * daysOfCover * (0.1 / mockDayBasis));
+      const expected = ((drawnAmount * daysOfCover * (mockInterestPercentage / 100)) / mockDayBasis);
 
       expect(result).toEqual(expected);
     });
@@ -110,6 +104,7 @@ describe('calculate-gef-facility-fee-record', () => {
         drawnAmount,
         daysOfCover,
         mockFacility.dayCountBasis,
+        mockInterestPercentage,
       );
 
       expect(result).toEqual(expected);

--- a/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.js
+++ b/trade-finance-manager-api/src/v1/helpers/calculate-gef-facility-fee-record.js
@@ -7,7 +7,10 @@ const { differenceInDays } = require('date-fns');
  */
 
 // NOTE: if the start date is passed first, we get a minus result.
-const calculateDaysOfCover = (coverStartDate, coverEndDate) => differenceInDays(new Date(Number(coverEndDate)), new Date(Number(coverStartDate)));
+const calculateDaysOfCover = (coverStartDate, coverEndDate) => differenceInDays(
+  new Date(Number(coverEndDate)),
+  new Date(Number(coverStartDate)),
+);
 
 /* Business logic:
  * (Facility Amount * UKEF Cover (fractional percentage)) * 10%
@@ -18,7 +21,8 @@ const calculateDrawnAmount = (facilityValue, coverPercentage) => (facilityValue 
  * (Drawn Amount * Days Of Cover * Interst rate) / day basis
  * Logic has been updated based on feedback from Mulesoft team (AV) - 10/02/2022
  */
-const calculateFeeAmount = (drawnAmount, daysOfCover, dayBasis, interestPercentage) => ((drawnAmount * daysOfCover * (interestPercentage / 100)) / dayBasis);
+const calculateFeeAmount = (drawnAmount, daysOfCover, dayBasis, interestPercentage) =>
+  ((drawnAmount * daysOfCover * (interestPercentage / 100)) / dayBasis);
 
 const calculateGefFacilityFeeRecord = (facility) => {
   if (facility.hasBeenIssued) {

--- a/trade-finance-manager-ui/server/constants/deals.js
+++ b/trade-finance-manager-ui/server/constants/deals.js
@@ -4,7 +4,7 @@ const TFM_SORT_BY = {
 };
 
 const TFM_SORT_BY_DEFAULT = {
-  field: 'tfm.dateReceived',
+  field: 'tfm.dateReceivedTimestamp',
   order: TFM_SORT_BY.DESCENDING,
 };
 

--- a/trade-finance-manager-ui/server/controllers/deals/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/deals/index.test.js
@@ -39,7 +39,7 @@ describe('controllers - deals', () => {
           activePrimaryNavigation: 'all deals',
           activeSubNavigation: 'deal',
           user: mockReq.session.user,
-          activeSortByField: 'tfm.dateReceived',
+          activeSortByField: 'tfm.dateReceivedTimestamp',
           activeSortByOrder: 'descending',
         });
       });


### PR DESCRIPTION
- DTFS2-5417: Add `dateReceivedTimestamp` to `deal.tfm`. Required to correctly sort TFM deals in the UI by date received
- DTFS2-5417: Update TFM UI to use `dateReceivedTimestamp` in default sort params sent to API/DB query
- Fix/update TFM GEF facility fee record calculation api tests
- Remove BSS from a `console.error` that would get thrown for a GEF deal