### PR TITLE
DTFS2-ACBS-Bug : Cover start date

### DIFF
--- a/azure-functions/acbs-function/mappings/deal/helpers/get-deal-effective-date.js
+++ b/azure-functions/acbs-function/mappings/deal/helpers/get-deal-effective-date.js
@@ -9,6 +9,7 @@ Issued (straight to Issued    Cover Start Date        Cover Start Date
 */
 const { formatTimestamp, formatDate } = require('../../../helpers/date');
 const getDealSubmissionDate = require('./get-deal-submission-date');
+const getCoverStartDate = require('../../facility/helpers/get-cover-start-date');
 
 const getDealEffectiveDate = (deal) => {
   const submissionDate = formatTimestamp(getDealSubmissionDate(deal));
@@ -16,7 +17,7 @@ const getDealEffectiveDate = (deal) => {
     let effectiveDate;
     if (facility.tfm.facilityGuaranteeDates) {
       effectiveDate = facility.facilitySnapshot.hasBeenIssued
-        ? formatDate(facility.facilitySnapshot.coverStartDate)
+        ? formatDate(getCoverStartDate(facility, true))
         : facility.tfm.facilityGuaranteeDates.effectiveDate;
     }
     if (earliestDate === submissionDate) {


### PR DESCRIPTION
* `EWCS/BSS` and `GEF` have different property name, `getCoverStartDate` helper function mitigates this issue.