### PR TITLE
fix BSS deal creation error with mandatory criteria API response

### DIFF
--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -581,7 +581,7 @@ const getLatestMandatoryCriteria = async (token) => {
     },
   });
 
-  return response;
+  return response.data;
 };
 
 const downloadFile = async (id, fieldname, filename, token) => {


### PR DESCRIPTION
BSS UI api call to Mandatory Criteria was not returning `response.data`. This caused BSS deal creation to break.