### PR TITLE
fix BSS Mandatory Criteria not displaying on before-you-start page

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/maker/before-you-start.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/before-you-start.spec.js
@@ -5,7 +5,30 @@ const MOCK_USERS = require('../../../fixtures/users');
 
 const { BANK1_MAKER1 } = MOCK_USERS;
 
-context('Red Line eligibility checking', () => {
+context('Red Line eligibility checking (`before you start` page)', () => {
+  it('should render headings, intro and mandatory criteria', () => {
+    cy.createBSSSubmission(BANK1_MAKER1);
+    cy.url().should('eq', relative('/before-you-start'));
+
+    pages.beforeYouStart.mandatoryCriteriaHeading().should('be.visible');
+    pages.beforeYouStart.mandatoryCriteriaHeading().invoke('text').then((text) => {
+      expect(text.trim()).to.equal('Mandatory criteria');
+    });
+
+    pages.beforeYouStart.mandatoryCriteriaSubHeading().should('be.visible');
+    pages.beforeYouStart.mandatoryCriteriaSubHeading().invoke('text').then((text) => {
+      expect(text.trim()).to.equal('Does this deal meet all UKEF\'s mandatory criteria?');
+    });
+
+    pages.beforeYouStart.mandatoryCriteriaIntro().should('be.visible');
+    pages.beforeYouStart.mandatoryCriteriaIntro().invoke('text').then((text) => {
+      expect(text.trim()).to.equal('To proceed with this submission, you need to be able to affirm that all the following mandatory criteria are or will be true for this deal on the date that cover starts.');
+    });
+
+    const LATEST_MANDATORY_CRITERIA_TOTAL_CRITERIONS = 5;
+    pages.beforeYouStart.mandatoryCriterion().should('have.length', LATEST_MANDATORY_CRITERIA_TOTAL_CRITERIONS);
+  });
+
   describe('When the `Mandatory criteria` form is submitted without confirming an answer', () => {
     it('should display validation error', () => {
       cy.createBSSSubmission(BANK1_MAKER1);
@@ -41,7 +64,7 @@ context('Red Line eligibility checking', () => {
     cy.url().should('eq', relative('/dashboard/deals/0'));
   });
 
-  it('A deal that passes red-line checks can progress to enter supply detaile', () => {
+  it('A deal that passes red-line checks can progress to enter supply contract details', () => {
     cy.createBSSSubmission(BANK1_MAKER1);
 
     pages.beforeYouStart.true().click();

--- a/e2e-tests/portal/cypress/integration/pages/beforeYouStart.js
+++ b/e2e-tests/portal/cypress/integration/pages/beforeYouStart.js
@@ -3,6 +3,11 @@ const page = {
   true: () => cy.get('[data-cy="criteriaMet-true"]'),
   false: () => cy.get('[data-cy="criteriaMet-false"]'),
   submit: () => cy.get('[data-cy="submit-button"]'),
+
+  mandatoryCriteriaHeading: () => cy.get('[data-cy="mandatory-criteria-heading"]'),
+  mandatoryCriteriaSubHeading: () => cy.get('[data-cy="mandatory-criteria-sub-heading"]'),
+  mandatoryCriteriaIntro: () => cy.get('[data-cy="mandatory-criteria-intro"]'),
+  mandatoryCriterion: () => cy.get('[data-cy="mandatory-criteria-criterion"]'),
 };
 
 module.exports = page;

--- a/portal/server/routes/start.js
+++ b/portal/server/routes/start.js
@@ -22,13 +22,14 @@ const userCanCreateADeal = (user) => user && user.roles.includes('maker');
 
 router.get('/before-you-start', provide([MANDATORY_CRITERIA]), async (req, res) => {
   const { mandatoryCriteria } = req.apiData;
+
   const { user } = req.session;
 
   if (!userCanCreateADeal(user)) {
     res.redirect('/');
   } else {
     res.render('before-you-start/before-you-start.njk', {
-      mandatoryCriteria: mandatoryCriteria.data,
+      mandatoryCriteria,
       user: req.session.user,
     });
   }

--- a/portal/templates/before-you-start/before-you-start.njk
+++ b/portal/templates/before-you-start/before-you-start.njk
@@ -15,16 +15,16 @@
     }}
   {% endif %}
 
-  <h1 class="govuk-heading-l">Mandatory criteria</h1>
+  <h1 class="govuk-heading-l" data-cy="mandatory-criteria-heading">Mandatory criteria</h1>
 
-  <h2 class="govuk-heading-m">Does this deal meet all UKEF’s mandatory criteria?</h2>
+  <h2 class="govuk-heading-m" data-cy="mandatory-criteria-sub-heading">Does this deal meet all UKEF's mandatory criteria?</h2>
 
-  <p class="govuk-body">To proceed with this submission, you need to be able to affirm that all the following mandatory criteria are or will be true for this deal on the date that cover starts.</p>
+  <p class="govuk-body" data-cy="mandatory-criteria-intro">To proceed with this submission, you need to be able to affirm that all the following mandatory criteria are or will be true for this deal on the date that cover starts.</p>
 
   {% for criterion in mandatoryCriteria.criteria %}
-    <h2 class="govuk-heading-m">{{ criterion.title }}</h2>
+    <h2 class="govuk-heading-m" data-cy="mandatory-criteria-criterion-{{ criterion.id }}-title">{{ criterion.title }}</h2>
 
-    <ol class="govuk-list govuk-list--number">
+    <ol class="govuk-list govuk-list--number" data-cy="mandatory-criteria-criterion">
       {% for item in criterion.items %}
         <li value="{{ item.id }}">{{ item.copy | safe}}</li>
       {% endfor %}


### PR DESCRIPTION
This fixes the criteria not displaying and adds e2e test coverage.

The template relied on `mandatoryCriteria.data` from the API, but it doesn't need the `.data`.