### PR TITLE
GEF smeType values as real values instead of uppercase values

### DIFF
--- a/azure-functions/acbs-function/constants/deal.js
+++ b/azure-functions/acbs-function/constants/deal.js
@@ -9,7 +9,7 @@ const SME_TYPE = {
   SMALL: 'small',
   MEDIUM: 'medium',
   NON_SME: 'non-sme',
-  NOT_SME: 'non-sme',
+  NOT_SME: 'not sme',
   NOT_KNOWN: 'not known',
 };
 

--- a/azure-functions/acbs-function/constants/deal.js
+++ b/azure-functions/acbs-function/constants/deal.js
@@ -9,6 +9,7 @@ const SME_TYPE = {
   SMALL: 'small',
   MEDIUM: 'medium',
   NON_SME: 'non-sme',
+  NOT_SME: 'non-sme',
   NOT_KNOWN: 'not known',
 };
 

--- a/azure-functions/acbs-function/mappings/party/helpers/get-sme-type.js
+++ b/azure-functions/acbs-function/mappings/party/helpers/get-sme-type.js
@@ -17,6 +17,9 @@ const getSmeType = (smeType) => {
     case CONSTANTS.DEAL.SME_TYPE.NON_SME:
       return '20';
 
+    case CONSTANTS.DEAL.SME_TYPE.NOT_SME:
+      return '20';
+
     default:
       return '70';
   }

--- a/dtfs-central-api/src/v1/swagger-definitions/portal/gef-exporter.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/portal/gef-exporter.js
@@ -70,7 +70,7 @@
  *           $ref: '#/definitions/GEFIndustry'
  *       smeType:
  *         type: string
- *         example: MICRO
+ *         example: Micro
  *       probabilityOfDefault:
  *         type: integer
  *         example: 45.5

--- a/e2e-tests/gef/cypress/fixtures/mocks/mock-deals.js
+++ b/e2e-tests/gef/cypress/fixtures/mocks/mock-deals.js
@@ -126,7 +126,7 @@ const commonApplicationDetails = {
         },
       },
     ],
-    smeType: 'MICRO',
+    smeType: 'Micro',
     probabilityOfDefault: 14,
     isFinanceIncreasing: true,
     status: 'COMPLETED',

--- a/e2e-tests/portal/cypress/fixtures/mockExporter.js
+++ b/e2e-tests/portal/cypress/fixtures/mockExporter.js
@@ -18,7 +18,7 @@ const exporterOne = {
     },
   },
   industries: [],
-  smeType: 'MICRO',
+  smeType: 'Micro',
   probabilityOfDefault: 45.5,
   isFinanceIncreasing: true,
 };
@@ -43,7 +43,7 @@ const exporterTwo = {
     },
   },
   industries: [],
-  smeType: 'MICRO',
+  smeType: 'Micro',
   probabilityOfDefault: 45.5,
   isFinanceIncreasing: true,
 };
@@ -68,7 +68,7 @@ const exporterThree = {
     },
   },
   industries: [],
-  smeType: 'MICRO',
+  smeType: 'Micro',
   probabilityOfDefault: 45.5,
   isFinanceIncreasing: true,
 };
@@ -93,7 +93,7 @@ const exporterFour = {
     },
   },
   industries: [],
-  smeType: 'MICRO',
+  smeType: 'Micro',
   probabilityOfDefault: 45.5,
   isFinanceIncreasing: true,
 };

--- a/e2e-tests/trade-finance-manager/cypress/fixtures/mock-gef-deals.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/mock-gef-deals.js
@@ -126,7 +126,7 @@ const commonApplicationDetails = {
         },
       },
     ],
-    smeType: 'MICRO',
+    smeType: 'Micro',
     probabilityOfDefault: 14,
     isFinanceIncreasing: true,
     status: 'Completed',

--- a/gef-ui/server/constants/index.js
+++ b/gef-ui/server/constants/index.js
@@ -35,13 +35,6 @@ const FACILITY_TYPE = {
   CONTINGENT: 'Contingent',
 };
 
-const SME_TYPE = {
-  MICRO: 'Micro',
-  SMALL: 'Small',
-  MEDIUM: 'Medium',
-  NOT_SME: 'Not an SME',
-};
-
 const BOOLEAN = {
   YES: 'Yes',
   NO: 'No',
@@ -86,7 +79,6 @@ module.exports = {
   DEAL_STATUS,
   DEAL_TYPE,
   FACILITY_TYPE,
-  SME_TYPE,
   BOOLEAN,
   STAGE,
   FACILITY_PROVIDED_DETAILS,

--- a/gef-ui/server/utils/display-items.js
+++ b/gef-ui/server/utils/display-items.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 const { isTrueSet } = require('./helpers');
 const {
-  SME_TYPE, BOOLEAN, STAGE, FACILITY_TYPE,
+  BOOLEAN, STAGE, FACILITY_TYPE,
 } = require('../constants');
 
 const exporterItems = (exporterUrl, options = {}) => [
@@ -33,7 +33,7 @@ const exporterItems = (exporterUrl, options = {}) => [
     label: 'SME type',
     id: 'smeType',
     href: `${exporterUrl}/about-exporter?status=change`,
-    method: (callback) => SME_TYPE[callback],
+    method: (callback) => callback,
   },
   {
     label: 'Probability of default',

--- a/gef-ui/templates/partials/about-exporter.njk
+++ b/gef-ui/templates/partials/about-exporter.njk
@@ -96,33 +96,33 @@
           },
           items: [
             {
-              value: "MICRO",
+              value: "Micro",
               text: "Micro",
-              checked: smeType === "MICRO",
+              checked: smeType === "Micro",
               attributes: {
                 'data-cy': 'micro-radio-button'
               }
             },
             {
-              value: "SMALL",
+              value: "Small",
               text: "Small",
-              checked: smeType === "SMALL",
+              checked: smeType === "Small",
               attributes: {
                 'data-cy': 'small-radio-button'
               }
             },
             {
-              value: "MEDIUM",
+              value: "Medium",
               text: "Medium",
-              checked: smeType === "MEDIUM",
+              checked: smeType === "Medium",
               attributes: {
                 'data-cy': 'medium-radio-button'
               }
             },
             {
-              value: "NOT_SME",
+              value: "Not SME",
               text: "They're not an SME",
-              checked: smeType === "NOT_SME",
+              checked: smeType === "Not SME",
               attributes: {
                 'data-cy': 'not-sme-radio-button'
               }

--- a/portal-api/api-tests/v1/gef/validation/exporter.api-test.js
+++ b/portal-api/api-tests/v1/gef/validation/exporter.api-test.js
@@ -5,7 +5,6 @@ const {
   exporterStatus,
 } = require('../../../../src/v1/gef/controllers/validation/exporter');
 const CONSTANTS = require('../../../../src/constants');
-const { SME_TYPE } = require('../../../../src/v1/gef/enums');
 
 describe('GEF controllers validation - exporter', () => {
   const mockAnswersValid = {
@@ -68,52 +67,6 @@ describe('GEF controllers validation - exporter', () => {
         const result = exporterStatus(mockAnswersValid);
 
         expect(result).toEqual(CONSTANTS.DEAL.DEAL_STATUS.COMPLETED);
-      });
-    });
-  });
-
-  describe('exporterCheckEnums', () => {
-    describe('when a valid smeType is passed', () => {
-      it('should return null', () => {
-        const result = exporterCheckEnums({
-          smeType: SME_TYPE.MICRO,
-        });
-
-        expect(result).toEqual(null);
-      });
-    });
-
-    describe('when a null smeType is passed', () => {
-      it('should return null', () => {
-        const result = exporterCheckEnums({
-          smeType: null,
-        });
-
-        expect(result).toEqual(null);
-      });
-    });
-
-    describe('when smeType is passed as undefined', () => {
-      it('should return null', () => {
-        const result = exporterCheckEnums({
-          smeType: undefined,
-        });
-
-        expect(result).toEqual(null);
-      });
-    });
-
-    describe('when an invalid smeType is passed', () => {
-      it('should return an error array', () => {
-        const result = exporterCheckEnums({
-          smeType: 'INVALID',
-        });
-
-        const expected = [
-          { errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'smeType' }
-        ];
-
-        expect(result).toEqual(expected);
       });
     });
   });

--- a/portal-api/src/v1/gef/controllers/validation/exporter.js
+++ b/portal-api/src/v1/gef/controllers/validation/exporter.js
@@ -1,7 +1,6 @@
 /* eslint-disable consistent-return */
 
 const CONSTANTS = require('../../../../constants');
-const { SME_TYPE } = require('../../enums');
 
 const TOTAL_REQUIRED = 8;
 
@@ -54,23 +53,6 @@ const exporterStatus = (answers) => {
   return CONSTANTS.DEAL.DEAL_STATUS.IN_PROGRESS;
 };
 
-const exporterCheckEnums = (doc) => {
-  const enumErrors = [];
-  switch (doc.smeType) {
-    case SME_TYPE.MICRO:
-    case SME_TYPE.SMALL:
-    case SME_TYPE.MEDIUM:
-    case SME_TYPE.NOT_SME:
-    case null:
-    case undefined:
-      break;
-    default:
-      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'smeType' });
-      break;
-  }
-  return enumErrors.length === 0 ? null : enumErrors;
-};
-
 const exporterValidation = (doc) => ({
   required: unansweredFields(doc),
 });
@@ -78,6 +60,5 @@ const exporterValidation = (doc) => ({
 module.exports = {
   unansweredFields,
   exporterStatus,
-  exporterCheckEnums,
   exporterValidation,
 };

--- a/portal-api/src/v1/gef/enums.js
+++ b/portal-api/src/v1/gef/enums.js
@@ -1,12 +1,5 @@
 const DEAL_TYPE = 'GEF';
 
-const SME_TYPE = {
-  MICRO: 'MICRO',
-  SMALL: 'SMALL',
-  MEDIUM: 'MEDIUM',
-  NOT_SME: 'NOT_SME',
-};
-
 const FACILITY_TYPE = {
   CASH: 'Cash',
   CONTINGENT: 'Contingent',
@@ -64,7 +57,6 @@ const CURRENCY = {
 
 module.exports = {
   DEAL_TYPE,
-  SME_TYPE,
   FACILITY_TYPE,
   DEAL_STATUS,
   ERROR,

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-TFM-deal-AIN-submitted.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-TFM-deal-AIN-submitted.js
@@ -53,7 +53,7 @@ const MOCK_TFM_DEAL_AIN_SUBMITTED = {
         code: '1005',
         name: 'Construction',
       },
-      smeType: 'MICRO',
+      smeType: 'Micro',
       status: 'Completed',
       updatedAt: 1643727452018,
     },

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-gef-deal.js
@@ -53,7 +53,7 @@ const MOCK_GEF_DEAL = {
         name: 'Information technology consultancy activities',
       },
     },
-    smeType: 'MEDIUM',
+    smeType: 'Medium',
     updatedAt: 162582748022,
   },
   bank: {

--- a/utils/mock-data-loader/gef/exporter.js
+++ b/utils/mock-data-loader/gef/exporter.js
@@ -25,7 +25,7 @@ const EXPORTER_HALF_COMPLETE = {
       },
     },
   ],
-  smeType: 'MEDIUM',
+  smeType: 'Medium',
   probabilityOfDefault: 10,
   isFinanceIncreasing: false,
 };
@@ -75,7 +75,7 @@ const EXPORTER_COMPLETED = {
       },
     },
   ],
-  smeType: 'MICRO',
+  smeType: 'Micro',
   probabilityOfDefault: 14,
   isFinanceIncreasing: true,
 };


### PR DESCRIPTION
Instead of mapping e.g "MICRO" to "Micro" in the GEF UI and (near future) data migration, just save the values in the DB as what they are.

Also for ACBS smeType mapping function - added another type because GEF and BSS have different values ("non sme", "not sme"). @abhi-markan 