### PR TITLE
DTFS2-5520 : Facility fee record

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/facility-fee.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-fee.js
@@ -16,12 +16,10 @@
 
 const helpers = require('./helpers');
 const CONSTANTS = require('../../constants');
+const getDealSubmissionDate = require('../deal/helpers/get-deal-submission-date');
 
 const constructFeeRecord = (deal, facility, premiumScheduleIndex = 0) => {
-  const { effectiveDate } = facility.tfm.facilityGuaranteeDates
-    ? facility.tfm.facilityGuaranteeDates
-    : facility.update;
-
+  const effectiveDate = helpers.getIssueDate(facility, getDealSubmissionDate(deal));
   const {
     expirationDate,
     nextDueDate,


### PR DESCRIPTION
Facility fixed fee record `effectiveDate` was being picked from facility `tfm` object, this approach will not always work especially when the facility cover start date is not same as the submission date.

`getIssueDate` helper function return the correct effective date.