### PR TITLE
Facility loan exchange rate

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/helpers/get-facility-currency-exchange-rate.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-facility-currency-exchange-rate.js
@@ -4,6 +4,6 @@
  * @param {Object} facility Facility object
  * @returns {Integer} Facility exchange rate
  */
-const getCurrencyExchangeRate = (facility) => Number(facility.tfm.exchangeRate);
+const getCurrencyExchangeRate = (facility) => Number(facility.tfm.exchangeRate.toFixed(4));
 
 module.exports = getCurrencyExchangeRate;


### PR DESCRIPTION
## Issue
Error while creating a **non-GBP** facility loan record, this was due to `exchangeRate` long decimal value.

## Resolution
`toFixed(4)` will round off the trailing digits to 4 decimal point exchange rate.