### PR TITLE
DTFS2-5528 : ACBS Facility issue

### DIFF
--- a/azure-functions/acbs-function/acbs-issue-facility/index.js
+++ b/azure-functions/acbs-function/acbs-issue-facility/index.js
@@ -49,7 +49,8 @@ module.exports = df.orchestrator(function* updateACBSfacility(context) {
 
     if (acbsFacility && etag) {
       // 2.1. Create updated facility master record object
-      const acbsFacilityMasterInput = mappings.facility.facilityUpdate(facility, acbsFacility, deal);
+      const acbsFacilityMasterInput = mappings.facility.facilityUpdate(facilitySnapshot, acbsFacility, deal);
+
       // 2.2. PUT updated facility master record object
       const issuedFacilityMaster = yield context.df.callActivityWithRetry(
         'activity-update-facility-master',

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -121,6 +121,7 @@ const issueAcbsFacilities = async (deal) => {
   /**
    * ACBS verification has been removed due to an ongoing bug of not receiving
    * the `acbs` object imperative data thus preventing maker from issuing the facility.
+   * TO-DO:
    * !isIssued(facilityStageInAcbs) && !facility.tfm.acbs.issuedFacilityMaster
    * const facilityStageInAcbs = facility.tfm.acbs && facility.tfm.acbs.facilityStage;
    */


### PR DESCRIPTION
## Issue
When a facility is issued on the following day since its creation, `getIssueDate` returns the submission date due to the absence of `facilitySnapshot` object.

## Resolution
`facilitySnapshot` object is passed as an argument instead of `facility` object which does not contains all the vital properties.

## Miscellaneous 
Documentation update