### PR TITLE
ReadOnly links for deals and facilities when a checker is logged in

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-filters.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-filters.spec.js
@@ -1,4 +1,3 @@
-const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
 const CONSTANTS = require('../../../../fixtures/constants');
 const { dashboardFacilities } = require('../../../pages');
@@ -10,7 +9,7 @@ const {
   GEF_FACILITY_CONTINGENT,
 } = require('../fixtures');
 
-const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
+const { BANK1_MAKER1, BANK1_CHECKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
 
@@ -21,16 +20,14 @@ context('Dashboard Deals filters', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      /// facility...
-    });
+    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1);
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       const { _id: dealId } = deal;
 
       const facilities = [
-        { ...GEF_FACILITY_CASH, dealId },
-        { ...GEF_FACILITY_CONTINGENT, dealId } ,
+        { ...GEF_FACILITY_CASH, dealId, name: 'Cash Facility name' },
+        { ...GEF_FACILITY_CONTINGENT, dealId, name: 'Contingent Facility name' },
       ];
 
       cy.insertManyGefFacilities(facilities, BANK1_MAKER1).then((insertedFacilities) => {
@@ -42,11 +39,20 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('by default', () => {
-    it('renders all facilities', () => {
+    it('renders all facilities (Checker)', () => {
+      cy.login(BANK1_CHECKER1);
+      dashboardFacilities.visit();
+      dashboardFacilities.rows().should('be.visible');
+      dashboardFacilities.row.nameText(ALL_FACILITIES[0]._id).should('exist');
+      dashboardFacilities.row.nameText(ALL_FACILITIES[1]._id).should('exist');
+      dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
+    });
+    it('renders all facilities (Maker)', () => {
       cy.login(BANK1_MAKER1);
       dashboardFacilities.visit();
-
       dashboardFacilities.rows().should('be.visible');
+      dashboardFacilities.row.nameLink(ALL_FACILITIES[0]._id).should('exist');
+      dashboardFacilities.row.nameLink(ALL_FACILITIES[1]._id).should('exist');
       dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
     });
 

--- a/e2e-tests/portal/cypress/integration/journeys/reports/review-ukef-decision.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/reports/review-ukef-decision.spec.js
@@ -6,7 +6,7 @@ const MOCK_USERS = require('../../../fixtures/users');
 const CONSTANTS = require('../../../fixtures/constants');
 const { reports } = require('../../pages');
 
-const { BANK1_MAKER1 } = MOCK_USERS;
+const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
 
 context('Dashboard: Review UKEF Decision report', () => {
   const todayAtMidnight = (new Date(parseInt(Date.now(), 10))).setHours(0, 0, 1, 0);
@@ -63,7 +63,7 @@ context('Dashboard: Review UKEF Decision report', () => {
     });
   });
 
-  describe('Review UKEF decision', () => {
+  describe('Review UKEF decision (Maker)', () => {
     beforeEach(() => {
       cy.login(BANK1_MAKER1);
       cy.visit(relative('/reports'));
@@ -82,6 +82,77 @@ context('Dashboard: Review UKEF Decision report', () => {
       reports.reportsUnconditionalDecisionDownload().should('exist');
 
       reports.reportsUkefDecisionTable().find('.govuk-table__row').eq(2).as('row2');
+      cy.get('@row2').find('[data-cy="deal__row--bankRef"]').should('contain', 'Draft GEF');
+      cy.get('@row2').find('[data-cy="reports-deal-link"]').should('exist');
+      cy.get('@row2').find('[data-cy="deal__row--product"]').should('contain', 'GEF');
+      cy.get('@row2').find('[data-cy="deal__row--exporter"]').should('contain', 'Delta');
+      cy.get('@row2').find('[data-cy="deal__row--date-created"]').should('contain', dateCreated);
+      cy.get('@row2').find('[data-cy="deal__row--submission-date"]').should('contain', submissionDate);
+      cy.get('@row2').find('[data-cy="deal__row--date-of-approval"]').should('contain', dateOfApproval);
+      cy.get('@row2').find('[data-cy="deal__row--days-to-review"]').should('contain', '10 days');
+
+      daysInThePast = sub(todayAtMidnight, { days: 25 });
+      submissionDate = format(parseInt(new Date(daysInThePast).valueOf().toString(), 10), 'dd LLL yyyy');
+      dateOfApproval = format(parseInt(new Date(daysInThePast).valueOf().toString(), 10), 'dd LLL yyyy');
+      reports.reportsUkefDecisionTable().find('.govuk-table__row').eq(1).as('row1');
+      cy.get('@row1').find('[data-cy="deal__row--bankRef"]').should('contain', 'Draft GEF');
+      cy.get('@row1').find('[data-cy="deal__row--product"]').should('contain', 'GEF');
+      cy.get('@row1').find('[data-cy="deal__row--exporter"]').should('contain', 'Delta');
+      cy.get('@row1').find('[data-cy="deal__row--date-created"]').should('contain', dateCreated);
+      cy.get('@row1').find('[data-cy="deal__row--submission-date"]').should('contain', submissionDate);
+      cy.get('@row1').find('[data-cy="deal__row--date-of-approval"]').should('contain', dateOfApproval);
+      cy.get('@row1').find('[data-cy="deal__row--days-to-review"]').should('contain', 'days overdue');
+    });
+
+    it('redirects to the `Manual inclusion application with conditions` reports page', () => {
+      reports.reportsConditionalDecision().click();
+      cy.url().should('eq', relative('/reports/review-conditional-decision'));
+      reports.reportsConditionalDecisionBreadcrumbs().should('exist');
+      reports.reportsConditionalDecisionDownload().should('exist');
+
+      submissionDate = format(todayAtMidnight, 'dd LLL yyyy');
+      dateOfApproval = format(todayAtMidnight, 'dd LLL yyyy');
+
+      reports.reportsUkefDecisionTable().find('.govuk-table__row').eq(2).as('row2');
+      cy.get('@row2').find('[data-cy="reports-deal-link"]').should('exist');
+      cy.get('@row2').find('[data-cy="deal__row--bankRef"]').should('contain', 'Draft GEF');
+      cy.get('@row2').find('[data-cy="deal__row--product"]').should('contain', 'GEF');
+      cy.get('@row2').find('[data-cy="deal__row--exporter"]').should('contain', 'Delta');
+      cy.get('@row2').find('[data-cy="deal__row--date-created"]').should('contain', dateCreated);
+      cy.get('@row2').find('[data-cy="deal__row--submission-date"]').should('contain', submissionDate);
+      cy.get('@row2').find('[data-cy="deal__row--date-of-approval"]').should('contain', dateOfApproval);
+      cy.get('@row2').find('[data-cy="deal__row--days-to-review"]').should('contain', '20 days');
+
+      daysInThePast = sub(todayAtMidnight, { days: 35 });
+      submissionDate = format(parseInt(new Date(daysInThePast).valueOf().toString(), 10), 'dd LLL yyyy');
+      dateOfApproval = format(parseInt(new Date(daysInThePast).valueOf().toString(), 10), 'dd LLL yyyy');
+      reports.reportsUkefDecisionTable().find('.govuk-table__row').eq(1).as('row1');
+      cy.get('@row1').find('[data-cy="deal__row--bankRef"]').should('contain', 'Draft GEF');
+      cy.get('@row1').find('[data-cy="deal__row--product"]').should('contain', 'GEF');
+      cy.get('@row1').find('[data-cy="deal__row--exporter"]').should('contain', 'Delta');
+      cy.get('@row1').find('[data-cy="deal__row--date-created"]').should('contain', dateCreated);
+      cy.get('@row1').find('[data-cy="deal__row--submission-date"]').should('contain', submissionDate);
+      cy.get('@row1').find('[data-cy="deal__row--date-of-approval"]').should('contain', dateOfApproval);
+      cy.get('@row1').find('[data-cy="deal__row--days-to-review"]').should('contain', 'days overdue');
+    });
+  });
+
+  describe('Review UKEF decision (Checker)', () => {
+    beforeEach(() => {
+      cy.login(BANK1_CHECKER1);
+      cy.visit(relative('/reports'));
+    });
+
+    it('redirects to the `Manual inclusion application without conditions` reports page', () => {
+      reports.reportsUnconditionalDecision().click();
+      cy.url().should('eq', relative('/reports/review-unconditional-decision'));
+      reports.reportsUnconditionalDecisionBreadcrumbs().should('exist');
+      reports.reportsUnconditionalDecisionDownload().should('exist');
+
+      submissionDate = format(todayAtMidnight, 'dd LLL yyyy');
+      dateOfApproval = format(todayAtMidnight, 'dd LLL yyyy');
+      reports.reportsUkefDecisionTable().find('.govuk-table__row').eq(2).as('row2');
+      cy.get('@row2').find('[data-cy="reports-deal-link-text"]').should('exist');
       cy.get('@row2').find('[data-cy="deal__row--bankRef"]').should('contain', 'Draft GEF');
       cy.get('@row2').find('[data-cy="deal__row--product"]').should('contain', 'GEF');
       cy.get('@row2').find('[data-cy="deal__row--exporter"]').should('contain', 'Delta');
@@ -113,6 +184,7 @@ context('Dashboard: Review UKEF Decision report', () => {
       dateOfApproval = format(todayAtMidnight, 'dd LLL yyyy');
 
       reports.reportsUkefDecisionTable().find('.govuk-table__row').eq(2).as('row2');
+      cy.get('@row2').find('[data-cy="reports-deal-link-text"]').should('exist');
       cy.get('@row2').find('[data-cy="deal__row--bankRef"]').should('contain', 'Draft GEF');
       cy.get('@row2').find('[data-cy="deal__row--product"]').should('contain', 'GEF');
       cy.get('@row2').find('[data-cy="deal__row--exporter"]').should('contain', 'Delta');

--- a/e2e-tests/portal/cypress/integration/pages/dashboardFacilities.js
+++ b/e2e-tests/portal/cypress/integration/pages/dashboardFacilities.js
@@ -2,6 +2,7 @@ const page = {
   visit: () => cy.visit('/dashboard/facilities'),
   rows: () => cy.get('.govuk-table__body .govuk-table__row'),
   row: {
+    nameText: (id) => cy.get(`[data-cy="facility__name--text--${id}"]`),
     nameLink: (id) => cy.get(`[data-cy="facility__name--link--${id}"]`),
     ukefFacilityId: (id) => cy.get(`[data-cy="facility__ukefId--${id}"]`),
     type: (id) => cy.get(`[data-cy="facility__type--${id}"]`),

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-EC-11-false.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks-MIA-EC-11-false.spec.js
@@ -4,28 +4,11 @@ import pages from '../../../pages';
 import MOCK_DEAL_MIA_EC_11_FALSE from '../../../../fixtures/deal-MIA-EC-11-false';
 import MOCK_USERS from '../../../../fixtures/users';
 import { MOCK_MAKER_TFM, ADMIN_LOGIN } from '../../../../fixtures/users-portal';
-import {
-  submitTaskInProgress,
-  submitTaskComplete,
-} from './tasks-helpers';
 
 context('Case tasks - MIA deal - EC 11 false', () => {
   let dealId;
   const dealFacilities = [];
   const businessSupportUser = MOCK_USERS.find((u) => u.teams.includes('BUSINESS_SUPPORT'));
-  const userFullName = `${businessSupportUser.firstName} ${businessSupportUser.lastName}`;
-  let userId;
-  let loggedInUserTeamName;
-  let usersInTeam;
-
-  before(() => {
-    cy.getUser(businessSupportUser.username).then((userObj) => {
-      userId = userObj._id;
-    });
-
-    [loggedInUserTeamName] = businessSupportUser.teams;
-    usersInTeam = MOCK_USERS.filter((u) => u.teams.includes(loggedInUserTeamName));
-  });
 
   beforeEach(() => {
     cy.insertOneDeal(MOCK_DEAL_MIA_EC_11_FALSE, MOCK_MAKER_TFM).then((insertedDeal) => {

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -147,6 +147,7 @@ describe('controllers/dashboard/facilities', () => {
         filters: templateFilters(expectedFiltersObj),
         selectedFilters: selectedFilters(expectedFiltersObj),
         keyword: mockReq.session.dashboardFilters.keyword,
+        isChecker: false,
       };
 
       expect(result).toEqual(expected);

--- a/portal/server/controllers/dashboard/reports.controller.js
+++ b/portal/server/controllers/dashboard/reports.controller.js
@@ -1,6 +1,7 @@
 const downloadCsv = require('../../utils/downloadCsv');
 const api = require('../../api');
 const CONSTANTS = require('../../constants');
+const { isChecker } = require('../../helpers/isChecker.helper');
 
 exports.getPortalReports = async (req, res) => {
   const { userToken } = req.session;
@@ -27,19 +28,37 @@ exports.getPortalReports = async (req, res) => {
 exports.getUnissuedFacilitiesReport = async (req, res) => {
   const { userToken } = req.session;
   const facilities = await api.getUnissuedFacilitiesReport(userToken) || [];
-  return res.render('reports/unissued-facilities.njk', { facilities, user: req.session.user, primaryNav: 'reports' });
+
+  return res.render('reports/unissued-facilities.njk', {
+    facilities,
+    user: req.session.user,
+    primaryNav: 'reports',
+    isChecker: isChecker(req?.session?.user?.roles),
+  });
 };
 
 exports.getUnconditionalDecisionReport = async (req, res) => {
   const { userToken } = req.session;
   const deals = await api.getUkefDecisionReport(userToken, { ukefDecision: CONSTANTS.STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS }) || [];
-  return res.render('reports/unconditional-decision.njk', { deals, user: req.session.user, primaryNav: 'reports' });
+
+  return res.render('reports/unconditional-decision.njk', {
+    deals,
+    user: req.session.user,
+    primaryNav: 'reports',
+    isChecker: isChecker(req?.session?.user?.roles),
+  });
 };
 
 exports.getConditionalDecisionReport = async (req, res) => {
   const { userToken } = req.session;
   const deals = await api.getUkefDecisionReport(userToken, { ukefDecision: CONSTANTS.STATUS.UKEF_APPROVED_WITH_CONDITIONS }) || [];
-  return res.render('reports/conditional-decision.njk', { deals, user: req.session.user, primaryNav: 'reports' });
+
+  return res.render('reports/conditional-decision.njk', {
+    deals,
+    user: req.session.user,
+    primaryNav: 'reports',
+    isChecker: isChecker(req?.session?.user?.roles),
+  });
 };
 
 exports.downloadUnissuedFacilitiesReport = async (req, res) => {

--- a/portal/server/controllers/dashboard/reports.test.js
+++ b/portal/server/controllers/dashboard/reports.test.js
@@ -65,7 +65,7 @@ const mockUkefUnconditionalDecisionReportResponse = [
 
 describe('controllers/reports.controller', () => {
   let res;
-  const req = { session: { token: 'mock-token', user: '' } };
+  const req = { session: { token: 'mock-token', user: { roles: ['maker'] } } };
   beforeEach(() => {
     res = mockResponse();
   });
@@ -153,7 +153,7 @@ describe('controllers/reports.controller', () => {
   });
 
   describe('getUnissuedFacilitiesReport', () => {
-    it('renders the unissued-facilities report page', async () => {
+    it('renders the unissued-facilities report page (Maker)', async () => {
       api.getUnissuedFacilitiesReport.mockResolvedValue([mockUnissuedFacilitiesReportResponse[1]]);
       await reportsController.getUnissuedFacilitiesReport(req, res);
 
@@ -161,12 +161,27 @@ describe('controllers/reports.controller', () => {
         facilities: [mockUnissuedFacilitiesReportResponse[1]],
         primaryNav: 'reports',
         user: req.session.user,
+        isChecker: false,
+      });
+    });
+
+    it('renders the unissued-facilities report page (Checker)', async () => {
+      req.session.user.roles = ['checker'];
+      api.getUnissuedFacilitiesReport.mockResolvedValue([mockUnissuedFacilitiesReportResponse[1]]);
+      await reportsController.getUnissuedFacilitiesReport(req, res);
+
+      expect(res.render).toHaveBeenCalledWith('reports/unissued-facilities.njk', {
+        facilities: [mockUnissuedFacilitiesReportResponse[1]],
+        primaryNav: 'reports',
+        user: req.session.user,
+        isChecker: true,
       });
     });
   });
 
   describe('getUnconditionalDecisionReport', () => {
-    it('renders the unconditional decision page', async () => {
+    it('renders the unconditional decision page (Maker)', async () => {
+      req.session.user.roles = ['maker'];
       api.getUkefDecisionReport.mockResolvedValue(mockUkefUnconditionalDecisionReportResponse);
       await reportsController.getUnconditionalDecisionReport(req, res);
 
@@ -174,12 +189,27 @@ describe('controllers/reports.controller', () => {
         deals: mockUkefUnconditionalDecisionReportResponse,
         primaryNav: 'reports',
         user: req.session.user,
+        isChecker: false,
+      });
+    });
+
+    it('renders the unconditional decision page (Checker)', async () => {
+      req.session.user.roles = ['checker'];
+      api.getUkefDecisionReport.mockResolvedValue(mockUkefUnconditionalDecisionReportResponse);
+      await reportsController.getUnconditionalDecisionReport(req, res);
+
+      expect(res.render).toHaveBeenCalledWith('reports/unconditional-decision.njk', {
+        deals: mockUkefUnconditionalDecisionReportResponse,
+        primaryNav: 'reports',
+        user: req.session.user,
+        isChecker: true,
       });
     });
   });
 
   describe('getConditionalDecisionReport', () => {
-    it('renders the conditional decision page', async () => {
+    it('renders the conditional decision page (Maker)', async () => {
+      req.session.user.roles = ['maker'];
       api.getUkefDecisionReport.mockResolvedValue(mockUkefConditionalDecisionReportResponse);
       await reportsController.getConditionalDecisionReport(req, res);
 
@@ -187,6 +217,20 @@ describe('controllers/reports.controller', () => {
         deals: mockUkefConditionalDecisionReportResponse,
         primaryNav: 'reports',
         user: req.session.user,
+        isChecker: false,
+      });
+    });
+
+    it('renders the conditional decision page (Checker)', async () => {
+      req.session.user.roles = ['checker'];
+      api.getUkefDecisionReport.mockResolvedValue(mockUkefConditionalDecisionReportResponse);
+      await reportsController.getConditionalDecisionReport(req, res);
+
+      expect(res.render).toHaveBeenCalledWith('reports/conditional-decision.njk', {
+        deals: mockUkefConditionalDecisionReportResponse,
+        primaryNav: 'reports',
+        user: req.session.user,
+        isChecker: true,
       });
     });
   });

--- a/portal/server/helpers/equalArrays.helper.js
+++ b/portal/server/helpers/equalArrays.helper.js
@@ -1,0 +1,3 @@
+const equalArrays = (array1, array2) => array1.length === array2.length && array1.every((element, index) => element === array2[index]);
+
+module.exports = { equalArrays };

--- a/portal/server/helpers/equalArrays.helper.js
+++ b/portal/server/helpers/equalArrays.helper.js
@@ -1,3 +1,6 @@
-const equalArrays = (array1, array2) => array1.length === array2.length && array1.every((element, index) => element === array2[index]);
+// Helper function that checks whether 2 arrays are exactly the same
+// 1. it checks if their length is the same
+// 2. it checks whether each element is the same
+const equalArrays = (arrayOne, arrayTwo) => arrayOne.length === arrayTwo.length && arrayOne.every((element, index) => element === arrayTwo[index]);
 
 module.exports = { equalArrays };

--- a/portal/server/helpers/equalArrays.test.js
+++ b/portal/server/helpers/equalArrays.test.js
@@ -1,0 +1,27 @@
+import { equalArrays } from './equalArrays.helper';
+
+describe('equalArrays', () => {
+  it('should return `true` when both arrays are the same', () => {
+    const array1 = ['abc'];
+    const array2 = ['abc'];
+    expect(equalArrays(array1, array2)).toEqual(true);
+  });
+
+  it('should return `true` when both arrays are empty', () => {
+    const array1 = [];
+    const array2 = [];
+    expect(equalArrays(array1, array2)).toEqual(true);
+  });
+
+  it('should return `false` when both arrays are the same', () => {
+    const array1 = ['abc'];
+    const array2 = ['abc', 'def'];
+    expect(equalArrays(array1, array2)).toEqual(false);
+  });
+
+  it('should return `false` when one array is empty', () => {
+    const array1 = [];
+    const array2 = ['abc', 'def'];
+    expect(equalArrays(array1, array2)).toEqual(false);
+  });
+});

--- a/portal/server/helpers/equalArrays.test.js
+++ b/portal/server/helpers/equalArrays.test.js
@@ -13,8 +13,13 @@ describe('equalArrays', () => {
     expect(equalArrays(array1, array2)).toEqual(true);
   });
 
-  it('should return `false` when both arrays are the same', () => {
+  it('should return `false` when one of the arrays has more items', () => {
     const array1 = ['abc'];
+    const array2 = ['abc', 'def'];
+    expect(equalArrays(array1, array2)).toEqual(false);
+  });
+  it('should return `false` when the array length is the same but the items are different', () => {
+    const array1 = ['abc', 'dee'];
     const array2 = ['abc', 'def'];
     expect(equalArrays(array1, array2)).toEqual(false);
   });

--- a/portal/server/helpers/isChecker.helper.js
+++ b/portal/server/helpers/isChecker.helper.js
@@ -1,0 +1,8 @@
+const { equalArrays } = require('./equalArrays.helper');
+
+const isChecker = (roles) => {
+  const checker = ['checker'];
+  return equalArrays(roles, checker);
+};
+
+module.exports = { isChecker };

--- a/portal/server/helpers/isChecker.test.js
+++ b/portal/server/helpers/isChecker.test.js
@@ -1,0 +1,28 @@
+import { isChecker } from './isChecker.helper';
+
+describe('isChecker', () => {
+  it('should return `true` when the role is `checker`', () => {
+    const roles = ['checker'];
+    expect(isChecker(roles)).toEqual(true);
+  });
+
+  it('should return `false` when the role is `maker`', () => {
+    const roles = ['maker'];
+    expect(isChecker(roles)).toEqual(false);
+  });
+
+  it('should return `false` when the role is `maker/checker`', () => {
+    const roles = ['maker', 'checker'];
+    expect(isChecker(roles)).toEqual(false);
+  });
+
+  it('should return `false` when the role is `admin`', () => {
+    const roles = ['admin'];
+    expect(isChecker(roles)).toEqual(false);
+  });
+
+  it('should return `false` when the role is `unknown`', () => {
+    const roles = ['unknown'];
+    expect(isChecker(roles)).toEqual(false);
+  });
+});

--- a/portal/templates/dashboard/_macros/dashboard-facilities-table.njk
+++ b/portal/templates/dashboard/_macros/dashboard-facilities-table.njk
@@ -3,38 +3,34 @@
 {% macro render(params) %}
   {% set facilities = params.facilities %}
   {% set userTimezone = params.userTimezone %}
+  {% set isChecker = params.isChecker %}
 
   {% set rows = [] %}
 
   {% for facility in facilities %}
-    
+
     {% if facility.type === 'Cash' or facility.type === 'Contingent' %}
-      {% set url = '/gef/application-details/' + facility.dealId %}
-
-      {% else %}
-
-      {% set url = '/contract/' + facility.dealId %}
+        {% set url = '/gef/application-details/' + facility.dealId %}
+    {% else %}
+        {% set url = '/contract/' + facility.dealId %}
     {% endif %}
 
     {% set linkHtml %}
-      <a
-        href="{{ url }}"
-        class="govuk-link"
-        data-cy="facility__name--link--{{ facility._id }}"
-      >
-        {{ facility.name }}
-      </a>
+      {% if not isChecker %}
+        <a href="{{ url }}" class="govuk-link" data-cy="facility__name--link--{{ facility._id }}">
+          {{ facility.name }}
+        </a>
+      {% else %}
+        <span data-cy="facility__name--text--{{ facility._id }}"> {{ facility.name }} </span>
+      {% endif %}
     {% endset %}
 
     {% if facility.hasBeenIssued %}
       {% set stage = 'Issued' %}
-
-      {% else %}
+    {% else %}
       {% set stage = 'Unissued' %}
     {% endif %}
 
-
-  
     {# {% if facility.currency.id and facility.value %}
       {% set currency = facility.currency.id %}
       {% set value = currency + ' ' + facility.value %}
@@ -138,5 +134,5 @@
     ],
     rows: rows
   })}}
-  
+
 {% endmacro %}

--- a/portal/templates/dashboard/facilities.njk
+++ b/portal/templates/dashboard/facilities.njk
@@ -17,7 +17,8 @@
     renderCreatedByYou: false,
     table: facilitiesTable.render({
       facilities: facilities,
-      userTimezone: user.timezone
+      userTimezone: user.timezone,
+      isChecker: isChecker
     }),
     pages: pages,
     route: '/facilities'

--- a/portal/templates/reports/_macros/ukefDecision.macro.njk
+++ b/portal/templates/reports/_macros/ukefDecision.macro.njk
@@ -1,25 +1,29 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% macro ukefDecisionTable(deals) %}
+{% macro ukefDecisionTable(deals, isChecker) %}
 
 {% set items = [] %}
   {% for deal in deals %}
     {% set bankRefLink %}
-      {% if deal.dealType === 'GEF' %}
-        <a
-          class="govuk-link"
-          href="/gef/application-details/{{ deal.dealId }}"
-          aria-label="View deal details"
-          data-cy="reports-deal-{{ deal.dealId }}-link">
-          {{ deal.bankInternalRefName }}
-        </a>
+    {% if not isChecker %}
+        {% if deal.dealType === 'GEF' %}
+          <a
+            class="govuk-link"
+            href="/gef/application-details/{{ deal.dealId }}"
+            aria-label="View deal details"
+            data-cy="reports-deal-link">
+            {{ deal.bankInternalRefName }}
+          </a>
+        {% else %}
+          <a
+            class="govuk-link"
+            href="/contract/{{ deal.dealId }}"
+            aria-label="View deal details"
+            data-cy="reports-deal-link">
+            {{ deal.bankInternalRefName }}
+          </a>
+        {% endif %}
       {% else %}
-        <a
-          class="govuk-link"
-          href="/contract/{{ deal.dealId }}"
-          aria-label="View deal details"
-          data-cy="reports-deal-{{ deal.dealId }}-link">
-          {{ deal.bankInternalRefName }}
-        </a>
+        <span data-cy="reports-deal-link-text"> {{ deal.bankInternalRefName }} </span>
       {% endif %}
     {% endset %}
 

--- a/portal/templates/reports/conditional-decision.njk
+++ b/portal/templates/reports/conditional-decision.njk
@@ -40,6 +40,6 @@
     </div>
   </div>
 
-  {{ ukefDecision.ukefDecisionTable(deals) }}
+  {{ ukefDecision.ukefDecisionTable(deals, isChecker) }}
 
 {% endblock %}

--- a/portal/templates/reports/unconditional-decision.njk
+++ b/portal/templates/reports/unconditional-decision.njk
@@ -40,6 +40,6 @@
     </div>
   </div>
 
-  {{ ukefDecision.ukefDecisionTable(deals) }}
+  {{ ukefDecision.ukefDecisionTable(deals, isChecker) }}
 
 {% endblock %}

--- a/portal/templates/reports/unissued-facilities.njk
+++ b/portal/templates/reports/unissued-facilities.njk
@@ -43,22 +43,26 @@
   {% set items = [] %}
   {% for facility in facilities %}
     {% set bankRefLink %}
-      {% if facility.dealType === 'GEF' %}
-        <a
-          class="govuk-link"
-          href="/gef/application-details/{{ facility.dealId }}"
-          aria-label="View deal details"
-          data-cy="reports-deal-{{ facility.dealId }}-link">
-          {{ facility.bankInternalRefName }}
-        </a>
+      {% if not isChecker %}
+        {% if facility.dealType === 'GEF' %}
+          <a
+            class="govuk-link"
+            href="/gef/application-details/{{ facility.dealId }}"
+            aria-label="View deal details"
+            data-cy="reports-deal-link">
+            {{ facility.bankInternalRefName }}
+          </a>
+        {% else %}
+          <a
+            class="govuk-link"
+            href="/contract/{{ facility.dealId }}"
+            aria-label="View deal details"
+            data-cy="reports-deal-link">
+            {{ facility.bankInternalRefName }}
+          </a>
+        {% endif %}
       {% else %}
-        <a
-          class="govuk-link"
-          href="/contract/{{ facility.dealId }}"
-          aria-label="View deal details"
-          data-cy="reports-deal-{{ facility.dealId }}-link">
-          {{ facility.bankInternalRefName }}
-        </a>
+        <span data-cy="reports-deal-link-text"> {{ facility.bankInternalRefName }} </span>
       {% endif %}
     {% endset %}
 


### PR DESCRIPTION
- Reports page: the rows in the table for GEF/BSS deals/facilities should be `readOnly` for Checkers. Makers should be able to click on them
- Facilities tab: the rows in the table for GEF/BSS facilities should be `readOnly` for checkers. Makers should be able to click on them as usual. 