### PR TITLE
DTFS2-5552-Facility-Amount

### DIFF
--- a/azure-functions/acbs-function/acbs-facility/index.js
+++ b/azure-functions/acbs-function/acbs-facility/index.js
@@ -96,6 +96,7 @@ module.exports = df.orchestrator(function* createACBSfacility(context) {
         facility,
         dealAcbsData,
       );
+
       facilityLoan = yield context.df.callActivityWithRetry(
         'activity-create-facility-loan',
         retryOptions,

--- a/azure-functions/acbs-function/mappings/facility/facility-covenant.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-covenant.js
@@ -10,6 +10,7 @@
   "effectiveDate"
   */
 
+const helpers = require('./helpers');
 const CONSTANTS = require('../../constants');
 
 const facilityCovenant = (deal, facility, covenantType) => {
@@ -25,7 +26,7 @@ const facilityCovenant = (deal, facility, covenantType) => {
     facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
     covenantType,
-    maximumLiability: Number(facility.facilitySnapshot.value),
+    maximumLiability: helpers.getMaximumLiability(facility),
     currency: facility.facilitySnapshot.currency.id,
     guaranteeCommencementDate,
     guaranteeExpiryDate,

--- a/azure-functions/acbs-function/mappings/facility/facility-guarantee.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-guarantee.js
@@ -27,7 +27,7 @@ const facilityGuarantee = (deal, facility, acbsData, guaranteeTypeCode) => {
     limitKey: acbsData.dealAcbsData.parties.exporter.partyIdentifier,
     guaranteeExpiryDate,
     effectiveDate,
-    maximumLiability: helpers.getMaximumLiability(facility.facilitySnapshot),
+    maximumLiability: helpers.getMaximumLiability(facility),
     guaranteeTypeCode,
   };
 };

--- a/azure-functions/acbs-function/mappings/facility/facility-investor.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-investor.js
@@ -22,7 +22,7 @@ const facilityInvestor = (deal, facility) => {
   return {
     facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
-    maximumLiability: helpers.getMaximumLiability(facility.facilitySnapshot),
+    maximumLiability: helpers.getMaximumLiability(facility),
     currency: facility.facilitySnapshot.currency.id,
     guaranteeCommencementDate,
     guaranteeExpiryDate,

--- a/azure-functions/acbs-function/mappings/facility/facility-loan.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-loan.js
@@ -31,6 +31,7 @@ const facilityLoan = (deal, facility, acbsData) => {
   const { guaranteeExpiryDate } = facility.tfm.facilityGuaranteeDates
     ? facility.tfm.facilityGuaranteeDates
     : facility.update;
+  const ukefExposure = helpers.getMaximumLiability(facility);
 
   let loanRecord = {
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
@@ -40,7 +41,7 @@ const facilityLoan = (deal, facility, acbsData) => {
     productTypeId: helpers.getProductTypeId(facility),
     productTypeGroup: helpers.getProductTypeGroup(facility, deal.dealSnapshot.dealType),
     currency: facility.facilitySnapshot.currency.id,
-    amount: facility.tfm.ukefExposure || facility.facilitySnapshot.ukefExposure,
+    amount: helpers.getLoanMaximumLiability(ukefExposure, deal.dealSnapshot.dealType),
     issueDate,
     expiryDate: guaranteeExpiryDate,
     spreadRate: facility.facilitySnapshot.guaranteeFee || Number(facility.facilitySnapshot.guaranteeFeePayableByBank),

--- a/azure-functions/acbs-function/mappings/facility/facility-master.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-master.js
@@ -56,7 +56,7 @@ const facilityMaster = (deal, facility, acbsData, acbsReference) => {
     facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
     dealBorrowerIdentifier: acbsData.parties.exporter.partyIdentifier,
-    maximumLiability: helpers.getMaximumLiability(facility.facilitySnapshot),
+    maximumLiability: helpers.getMaximumLiability(facility),
     productTypeId: helpers.getProductTypeId(facility),
     capitalConversionFactorCode: helpers.getCapitalConversionFactorCode(facility),
     productTypeName: deal.dealSnapshot.dealType,

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-loan-maximum-liability.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-loan-maximum-liability.js
@@ -1,0 +1,14 @@
+const CONSTANTS = require('../../../constants');
+
+/**
+ * Returns `10%` of amount, if the `GEF` deal.
+ * @param {Float} amount Facility UKEF exposure
+ * @param {Object} dealType Deal type
+ */
+const getLoanMaximumLiability = (amount, dealType) => (
+  dealType === CONSTANTS.PRODUCT.TYPE.GEF
+    ? amount * 0.10
+    : amount
+);
+
+module.exports = getLoanMaximumLiability;

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-maximum-liability.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-maximum-liability.js
@@ -1,7 +1,13 @@
-const getMaximumLiability = (facilitySnapshot) => {
-  if (typeof facilitySnapshot.ukefExposure !== 'number') {
-    return Number(facilitySnapshot.ukefExposure.replace(/,/g, ''));
-  }
-  return facilitySnapshot.ukefExposure;
+/**
+ * Returns facility UKEF exposure amount, if `loan` then 10% of the UKEF exposure amount.
+ * @param {Object} facility Facility object
+ * @returns {Float} Facility UKEF exposure amount
+ */
+const getMaximumLiability = (facility) => {
+  const ukefExposure = facility.tfm.ukefExposure || facility.facilitySnapshot.ukefExposure;
+
+  return typeof ukefExposure !== 'number'
+    ? Number(ukefExposure.replace(/,/g, ''))
+    : ukefExposure;
 };
 module.exports = getMaximumLiability;

--- a/azure-functions/acbs-function/mappings/facility/helpers/index.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/index.js
@@ -14,6 +14,7 @@ const getIssueDate = require('./get-issue-date');
 const getGuarantorParty = require('./get-guarantor-party');
 const getFacilityValue = require('./get-facility-value');
 const getMaximumLiability = require('./get-maximum-liability');
+const getLoanMaximumLiability = require('./get-loan-maximum-liability');
 const mapFeeFrequency = require('./map-fee-frequency');
 const getInsuredPercentage = require('./get-insured-percentage');
 const getBaseCurrency = require('./get-base-currency');
@@ -47,6 +48,7 @@ module.exports = {
   getGuarantorParty,
   getFacilityValue,
   getMaximumLiability,
+  getLoanMaximumLiability,
   mapFeeFrequency,
   getInsuredPercentage,
   getBaseCurrency,


### PR DESCRIPTION
## Introduction
When creating any facility record, the amount or the maximum liability should be set to the UKEF exposure rather than the total facility value. Following updates standardise this requirement.

* Improved `getMaximumLiability` helper function.
* Introduction of a new helper function `getLoanMaximumLiability`, responsible for calculating `GEF` facility loan amount (10% of UKEF exposure)