### PR TITLE
DTFS2-5465- Portal Bug - Name link not present if no name

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-name-link.spec.js
+++ b/e2e-tests/portal/cypress/integration/journeys/dashboard/dashboard-facilities/dashboard-facilities-name-link.spec.js
@@ -1,0 +1,61 @@
+const relative = require('../../../relativeURL');
+const MOCK_USERS = require('../../../../fixtures/users');
+const { dashboardFacilities } = require('../../../pages');
+const {
+  BSS_DEAL_AIN,
+  BSS_FACILITY_BOND_ISSUED,
+} = require('../fixtures');
+const contract = require('../../../pages/contract');
+const bondDetails = require('../../../pages/bondDetails');
+
+const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
+
+context('Dashboard Facilities - Name link', () => {
+  let facilityId;
+  let dealId;
+
+  before(() => {
+    cy.deleteGefApplications(ADMIN);
+    cy.deleteDeals(ADMIN);
+
+    cy.insertOneDeal(BSS_DEAL_AIN, BANK1_MAKER1).then((deal) => {
+      dealId = deal._id;
+
+      const facilities = [BSS_FACILITY_BOND_ISSUED];
+
+      cy.createFacilities(dealId, facilities, BANK1_MAKER1).then((insertedFacilities) => {
+        insertedFacilities.forEach((facility) => {
+          facilityId = facility._id;
+        });
+      });
+    });
+
+    cy.login(BANK1_MAKER1);
+    dashboardFacilities.visit();
+    cy.url().should('eq', relative('/dashboard/facilities/0'));
+  });
+
+  it('if facility name not entered, link shows Not entered', () => {
+    cy.get(`[data-cy="facility__name--link--${facilityId}"]`).contains('Not entered');
+    cy.get(`[data-cy="facility__name--link--${facilityId}"]`).invoke('attr', 'href').then((href) => {
+      expect(href).to.equal(`/contract/${dealId}`);
+    });
+  });
+
+  it('if facility name set, facility name is showed', () => {
+    cy.login(BANK1_MAKER1);
+    dashboardFacilities.visit();
+    cy.get(`[data-cy="facility__name--link--${facilityId}"]`).click();
+    // sets name to test
+    contract.bondTransactionsTable.row(facilityId).uniqueNumberLink().click();
+    bondDetails.facilityStageIssuedInput().click();
+    bondDetails.nameInput().type('Test');
+    bondDetails.saveGoBackButton().click();
+    // checks name is set
+    dashboardFacilities.visit();
+    cy.get(`[data-cy="facility__name--link--${facilityId}"]`).contains('Test');
+    cy.get(`[data-cy="facility__name--link--${facilityId}"]`).invoke('attr', 'href').then((href) => {
+      expect(href).to.equal(`/contract/${dealId}`);
+    });
+  });
+});

--- a/portal/templates/dashboard/_macros/dashboard-facilities-table.njk
+++ b/portal/templates/dashboard/_macros/dashboard-facilities-table.njk
@@ -18,7 +18,7 @@
     {% set linkHtml %}
       {% if not isChecker %}
         <a href="{{ url }}" class="govuk-link" data-cy="facility__name--link--{{ facility._id }}">
-          {{ facility.name }}
+          {{ facility.name if facility.name else 'Not entered'}}
         </a>
       {% else %}
         <span data-cy="facility__name--text--{{ facility._id }}"> {{ facility.name }} </span>


### PR DESCRIPTION
# Issue: 

* on portal facility table, name link is not there if facility name is not set

# Changes made: 

* added condition to check if name exists, else defaults to 'Not entered'
* Added e2e test