### PR TITLE
DTFS2-SEO : SEO Middleware

### DIFF
--- a/dtfs-central-api/src/createApp.js
+++ b/dtfs-central-api/src/createApp.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const compression = require('compression');
-// const helmet = require('helmet');
+const seo = require('./v1/routes/middleware/headers/seo');
 
 const {
   BANK_ROUTE,
@@ -22,11 +22,7 @@ const {
 
 const app = express();
 
-// Global middleware set headers
-app.use((req, res, next) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
+app.use(seo);
 
 app.use(healthcheck);
 app.use(express.json());

--- a/dtfs-central-api/src/v1/routes/middleware/headers/seo.js
+++ b/dtfs-central-api/src/v1/routes/middleware/headers/seo.js
@@ -1,0 +1,12 @@
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+const seo = (req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};
+
+module.exports = seo;

--- a/gef-ui/server/index.js
+++ b/gef-ui/server/index.js
@@ -16,12 +16,9 @@ const configureNunjucks = require('./nunjucks-configuration');
 
 const app = express();
 
-// Global middleware set headers
-app.use((req, res, next) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
+const seo = require('./middleware/headers/seo');
 
+app.use(seo);
 app.use(helmet());
 
 dotenv.config();

--- a/gef-ui/server/middleware/headers/seo.js
+++ b/gef-ui/server/middleware/headers/seo.js
@@ -1,0 +1,12 @@
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+const seo = (req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};
+
+module.exports = seo;

--- a/portal-api/src/createApp.js
+++ b/portal-api/src/createApp.js
@@ -20,15 +20,13 @@ const { CORS_ORIGIN } = process.env;
 const configurePassport = require('./v1/users/passport');
 const { authRouter, openRouter, authRouterAllowXss } = require('./v1/routes');
 
+const seo = require('./v1/middleware/headers/seo');
+
 configurePassport(passport);
 
 const app = express();
 
-// Global middleware set headers
-app.use((req, res, next) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
+app.use(seo);
 
 // TODO: re-enable Helmet (Jira - 4998)
 // app.use(

--- a/portal-api/src/v1/middleware/headers/seo.js
+++ b/portal-api/src/v1/middleware/headers/seo.js
@@ -1,0 +1,12 @@
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+const seo = (req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};
+
+module.exports = seo;

--- a/portal/server/index.js
+++ b/portal/server/index.js
@@ -14,14 +14,11 @@ const healthcheck = require('./healthcheck');
 const uploadTest = require('./upload-test');
 
 const configureNunjucks = require('./nunjucks-configuration');
+const seo = require('./routes/middleware/headers/seo');
 
 const app = express();
 
-// Global middleware set headers
-app.use((req, res, next) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
+app.use(seo);
 
 app.use(helmet({ contentSecurityPolicy: false }));
 

--- a/portal/server/routes/middleware/headers/seo.js
+++ b/portal/server/routes/middleware/headers/seo.js
@@ -1,0 +1,12 @@
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+const seo = (req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};
+
+module.exports = seo;

--- a/reference-data-proxy/src/createApp.ts
+++ b/reference-data-proxy/src/createApp.ts
@@ -2,14 +2,11 @@ import express from 'express';
 import compression from 'compression';
 import { apiRoutes, swaggerRoutes, healthcheck } from './v1/routes';
 
+import { seo } from './middleware/headers/seo';
+
 export const app: any = express();
 
-// Global middleware set headers
-app.use((req: any, res: any, next: any) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
-
+app.use(seo);
 app.use(express.json());
 app.use(compression());
 

--- a/reference-data-proxy/src/middleware/headers/seo.ts
+++ b/reference-data-proxy/src/middleware/headers/seo.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+export const seo = (req: Request, res: Response, next: NextFunction) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};

--- a/trade-finance-manager-api/src/createApp.js
+++ b/trade-finance-manager-api/src/createApp.js
@@ -18,17 +18,15 @@ const healthcheck = require('./healthcheck');
 const openRouter = require('./v1/routes');
 const initScheduler = require('./scheduler');
 
+const seo = require('./v1/middleware/headers/seo');
+
 dotenv.config();
 
 initScheduler();
 
 const app = express();
 
-// Global middleware set headers
-app.use((req, res, next) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
+app.use(seo);
 
 app.use(express.json());
 app.use(compression());

--- a/trade-finance-manager-api/src/v1/middleware/headers/seo.js
+++ b/trade-finance-manager-api/src/v1/middleware/headers/seo.js
@@ -1,0 +1,12 @@
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+const seo = (req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};
+
+module.exports = seo;

--- a/trade-finance-manager-ui/server/index.js
+++ b/trade-finance-manager-ui/server/index.js
@@ -10,17 +10,12 @@ require('./azure-env');
 
 const configureNunjucks = require('./nunjucks-configuration');
 const sessionOptions = require('./session-configuration');
-
 const healthcheck = require('./healthcheck');
+const seo = require('./middleware/headers/seo');
 
 const app = express();
 
-// Global middleware set headers
-app.use((req, res, next) => {
-  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
-  next();
-});
-
+app.use(seo);
 app.use(helmet({ contentSecurityPolicy: false }));
 
 const PORT = process.env.PORT || 5003;

--- a/trade-finance-manager-ui/server/middleware/headers/seo.js
+++ b/trade-finance-manager-ui/server/middleware/headers/seo.js
@@ -1,0 +1,12 @@
+/**
+ * Global middleware, ensures page cannot be indexed or followed when queried in a search engine.
+ * @param {Object} req Request object
+ * @param {Object} res Response object
+ * @param {String} next Callback function name
+ */
+const seo = (req, res, next) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, noimageindex, nosnippet');
+  next();
+};
+
+module.exports = seo;


### PR DESCRIPTION
## SEO Middleware
Due to various headers related tickets, a more formalised approach where middleware headers can be added in a standardised approach. `setHeaders` command have been moved to respective `seo` middleware across all the services. Thus setting a template for future headers to set as a global middleware.