### PR TITLE
DTFS2-5453 - add facility coverEndDate to TFM - GEF confirmation email

### DIFF
--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.api-test.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.api-test.js
@@ -72,6 +72,7 @@ describe('generate AIN/MIN confirmation email facilities list email variable/str
         bankReference: mockFacility.bankReference,
         hasBeenIssued: mapIssuedValue(mockFacility.hasBeenIssued),
         coverStartDate: format(Number(mockFacility.coverStartDate), 'do MMMM yyyy'),
+        coverEndDate: format(Number(mockFacility.coverEndDate), 'do MMMM yyyy'),
         value: mockFacility.value,
         currencyCode: mockFacility.currencyCode,
         interestPercentage: `${mockFacility.interestPercentage}%`,

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.js
@@ -29,6 +29,7 @@ const facilityFieldsObj = (facility) => {
     bankReference,
     hasBeenIssued,
     coverStartDate,
+    coverEndDate,
     value,
     currencyCode,
     coverPercentage,
@@ -43,6 +44,7 @@ const facilityFieldsObj = (facility) => {
     bankReference,
     hasBeenIssued,
     coverStartDate,
+    coverEndDate,
     value,
     currencyCode,
     coverPercentage,
@@ -61,6 +63,10 @@ const facilityFieldsObj = (facility) => {
 
   if (fields.coverStartDate) {
     fields.coverStartDate = format(Number(fields.coverStartDate), 'do MMMM yyyy');
+  }
+
+  if (fields.coverEndDate) {
+    fields.coverEndDate = format(Number(fields.coverEndDate), 'do MMMM yyyy');
   }
 
   if (fields.coverPercentage) {


### PR DESCRIPTION
Previously was only rendering `coverStartDate`.