### PR TITLE
Validate the `req.params._id` and `_id` property to ensure it's a valid ObjectId

### DIFF
--- a/dtfs-central-api/src/v1/controllers/portal/deal/add-deal-comment.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/add-deal-comment.controller.js
@@ -5,41 +5,47 @@ const { findOneDeal } = require('./get-deal.controller');
 const addDealComment = async (_id, commentType, comment) => {
   const collection = await db.getCollection('deals');
 
-  const findAndUpdateResponse = await collection.findOneAndUpdate(
-    { _id: ObjectId(_id) },
-    {
-      $push: {
-        [commentType]: {
-          $each: [{
-            ...comment,
-            timestamp: Date.now(),
-          }],
-          $position: 0,
+  if (ObjectId.isValid(_id)) {
+    const findAndUpdateResponse = await collection.findOneAndUpdate(
+      { _id: ObjectId(_id) },
+      {
+        $push: {
+          [commentType]: {
+            $each: [{
+              ...comment,
+              timestamp: Date.now(),
+            }],
+            $position: 0,
+          },
         },
       },
-    },
-    { returnOriginal: false },
-  );
+      { returnOriginal: false },
+    );
 
-  const { value } = findAndUpdateResponse;
+    const { value } = findAndUpdateResponse;
 
-  return value;
+    return value;
+  }
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 exports.addDealComment = addDealComment;
 
 exports.addDealCommentPost = async (req, res) => {
-  const dealId = req.params.id;
+  if (ObjectId.isValid(req.params.id)) {
+    const dealId = req.params.id;
 
-  await findOneDeal(dealId, async (deal) => {
-    if (!deal) res.status(404).send();
+    await findOneDeal(dealId, async (deal) => {
+      if (!deal) res.status(404).send({ status: 400, message: 'Deal not found' });
 
-    if (deal) {
-      const { commentType, comment } = req.body;
+      if (deal) {
+        const { commentType, comment } = req.body;
 
-      const updatedDeal = await addDealComment(dealId, commentType, comment);
+        const updatedDeal = await addDealComment(dealId, commentType, comment);
 
-      res.status(200).json(updatedDeal);
-    }
-    res.status(404).send();
-  });
+        res.status(200).json(updatedDeal);
+      }
+    });
+  } else {
+    res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
+  }
 };

--- a/dtfs-central-api/src/v1/controllers/portal/deal/delete-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/delete-deal.controller.js
@@ -4,12 +4,15 @@ const db = require('../../../../drivers/db-client');
 
 exports.deleteDeal = async (req, res) => {
   findOneDeal(req.params.id, async (deal) => {
-    if (deal) {
-      const collection = await db.getCollection('deals');
-      const status = await collection.deleteOne({ _id: ObjectId(req.params.id) });
-      return res.status(200).send(status);
-    }
+    if (ObjectId.isValid(req.params.id)) {
+      if (deal) {
+        const collection = await db.getCollection('deals');
+        const status = await collection.deleteOne({ _id: ObjectId(req.params.id) });
+        return res.status(200).send(status);
+      }
 
-    return res.status(404).send();
+      return res.status(404).send({ status: 404, message: 'Deal not found' });
+    }
+    return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
   });
 };

--- a/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/deal/get-deal.controller.js
@@ -67,32 +67,39 @@ const findOneDeal = async (_id, callback) => {
 exports.findOneDeal = findOneDeal;
 
 const findOneGefDeal = async (_id, callback) => {
-  const dealsCollection = await db.getCollection('deals');
+  if (ObjectId.isValid(_id)) {
+    const dealsCollection = await db.getCollection('deals');
 
-  const deal = await dealsCollection.findOne({ _id: ObjectId(_id) });
+    const deal = await dealsCollection.findOne({ _id: ObjectId(_id) });
 
-  if (deal) {
-    const facilities = await findAllGefFacilitiesByDealId(_id);
+    if (deal) {
+      const facilities = await findAllGefFacilitiesByDealId(_id);
 
-    deal.facilities = facilities;
+      deal.facilities = facilities;
+    }
+
+    if (callback) {
+      callback(deal);
+    }
+
+    return deal;
   }
-
-  if (callback) {
-    callback(deal);
-  }
-
-  return deal;
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 exports.findOneGefDeal = findOneGefDeal;
 
 exports.findOneDealGet = async (req, res) => {
-  const deal = await findOneDeal(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const deal = await findOneDeal(req.params.id);
 
-  if (deal) {
-    return res.status(200).send({
-      deal,
-    });
+    if (deal) {
+      return res.status(200).send({
+        deal,
+      });
+    }
+
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
 
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.js
@@ -4,28 +4,25 @@ const { removeFacilityIdFromDeal } = require('../deal/update-deal.controller');
 const db = require('../../../../drivers/db-client');
 
 exports.deleteFacility = async (req, res) => {
-  const facilityId = req.params.id;
+  if (ObjectId.isValid(req.params.id)) {
+    const facilityId = req.params.id;
 
-  await findOneFacility(facilityId, async (facility) => {
-    if (facility) {
-      const collection = await db.getCollection('facilities');
-      const status = await collection.deleteOne({ _id: ObjectId(facilityId) });
+    await findOneFacility(facilityId, async (facility) => {
+      if (facility) {
+        const collection = await db.getCollection('facilities');
+        const status = await collection.deleteOne({ _id: ObjectId(facilityId) });
 
-      // remove facility ID from the associated deal
-      const {
-        user,
-      } = req.body;
+        // remove facility ID from the associated deal
+        const { user } = req.body;
 
-      await removeFacilityIdFromDeal(
-        facility.dealId,
-        facilityId,
-        user,
-        req.routePath,
-      );
+        await removeFacilityIdFromDeal(facility.dealId, facilityId, user, req.routePath);
 
-      return res.status(200).send(status);
-    }
+        return res.status(200).send(status);
+      }
 
-    return res.status(404).send();
-  });
+      return res.status(404).send({ status: 400, message: 'Facility not found' });
+    });
+  } else {
+    return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
+  }
 };

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-facilities.controller.js
@@ -14,10 +14,13 @@ const findAll = async (_id, callback) => {
 exports.findAll = findAll;
 
 const findAllFacilitiesByDealId = async (dealId) => {
-  const collection = await db.getCollection('facilities');
-  // BSS facilities
-  const facilities = await collection.find({ dealId: ObjectId(dealId), $or: [{ type: 'Bond' }, { type: 'Loan' }] }).toArray();
-  return facilities;
+  if (ObjectId.isValid(dealId)) {
+    const collection = await db.getCollection('facilities');
+    // BSS facilities
+    const facilities = await collection.find({ dealId: ObjectId(dealId), $or: [{ type: 'Bond' }, { type: 'Loan' }] }).toArray();
+    return facilities;
+  }
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 exports.findAllFacilitiesByDealId = findAllFacilitiesByDealId;
 

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
@@ -2,23 +2,30 @@ const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 
 const findOneFacility = async (_id, callback) => {
-  const collection = await db.getCollection('facilities');
-  const facility = await collection.findOne({ _id: ObjectId(_id) });
+  if (ObjectId.isValid(_id)) {
+    const collection = await db.getCollection('facilities');
+    const facility = await collection.findOne({ _id: ObjectId(_id) });
 
-  if (callback) {
-    callback(facility);
+    if (callback) {
+      callback(facility);
+    }
+
+    return facility;
   }
-
-  return facility;
+  return { status: 400, message: 'Invalid Facility Id' };
 };
 exports.findOneFacility = findOneFacility;
 
 exports.findOneFacilityGet = async (req, res) => {
-  const facility = await findOneFacility(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const facility = await findOneFacility(req.params.id);
 
-  if (facility) {
-    return res.status(200).send(facility);
+    if (facility) {
+      return res.status(200).send(facility);
+    }
+
+    return res.status(404).send();
   }
 
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
@@ -12,63 +12,55 @@ const withoutId = (obj) => {
 };
 
 const updateFacility = async (facilityId, facilityBody, dealId, user, routePath) => {
-  const collection = await db.getCollection('facilities');
+  if (ObjectId.isValid(dealId) && ObjectId.isValid(facilityId)) {
+    const collection = await db.getCollection('facilities');
 
-  const update = {
-    ...facilityBody,
-    dealId: ObjectId(dealId),
-    updatedAt: Date.now(),
-  };
+    const update = { ...facilityBody, dealId: ObjectId(dealId), updatedAt: Date.now() };
 
-  const findAndUpdateResponse = await collection.findOneAndUpdate(
-    { _id: ObjectId(facilityId) },
-    $.flatten(withoutId(update)),
-    { returnOriginal: false },
-  );
+    const findAndUpdateResponse = await collection.findOneAndUpdate({ _id: ObjectId(facilityId) }, $.flatten(withoutId(update)), { returnOriginal: false });
 
-  const { value: updatedFacility } = findAndUpdateResponse;
+    const { value: updatedFacility } = findAndUpdateResponse;
 
-  if (routePath === PORTAL_ROUTE && user) {
-    // update the deal so that the user that has edited this facility,
-    // is also marked as editing the associated deal
+    if (routePath === PORTAL_ROUTE && user) {
+      // update the deal so that the user that has edited this facility,
+      // is also marked as editing the associated deal
 
-    await updateDealEditedByPortal(dealId, user);
+      await updateDealEditedByPortal(dealId, user);
+    }
+
+    return updatedFacility;
   }
-
-  return updatedFacility;
+  return { status: 400, message: 'Invalid Deal or Facility Id' };
 };
 exports.updateFacility = updateFacility;
 
 exports.updateFacilityPut = async (req, res) => {
-  const facilityId = req.params.id;
+  if (ObjectId.isValid(req.params.id)) {
+    const facilityId = req.params.id;
 
-  let facilityUpdate;
-  let user;
+    let facilityUpdate;
+    let user;
 
-  if (req.body.user) {
-    user = req.body.user;
+    if (req.body.user) {
+      user = req.body.user;
 
-    delete req.body.user;
-    facilityUpdate = req.body;
-  } else {
-    facilityUpdate = req.body;
+      delete req.body.user;
+      facilityUpdate = req.body;
+    } else {
+      facilityUpdate = req.body;
+    }
+
+    const facility = await findOneFacility(facilityId);
+
+    if (facility) {
+      const { dealId } = facility;
+
+      const updatedFacility = await updateFacility(facilityId, facilityUpdate, dealId, user, req.routePath);
+
+      return res.status(200).json(updatedFacility);
+    }
+
+    return res.status(404).send();
   }
-
-  const facility = await findOneFacility(facilityId);
-
-  if (facility) {
-    const { dealId } = facility;
-
-    const updatedFacility = await updateFacility(
-      facilityId,
-      facilityUpdate,
-      dealId,
-      user,
-      req.routePath,
-    );
-
-    return res.status(200).json(updatedFacility);
-  }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/portal/gef-deal/add-underwriter-comment-gef.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-deal/add-underwriter-comment-gef.controller.js
@@ -3,44 +3,51 @@ const { findOneDeal } = require('./get-gef-deal.controller');
 const db = require('../../../../drivers/db-client');
 
 const addComment = async (_id, commentType, comment) => {
+  if (ObjectId.isValid(_id)) {
   // get the deals collection
-  const collection = await db.getCollection('deals');
+    const collection = await db.getCollection('deals');
 
-  // add the comment to the matching deal (based on _id)
-  const addCommentToGefDeal = await collection.findOneAndUpdate(
-    { _id: { $eq: ObjectId(String(_id)) } },
-    {
-      $push: {
-        [commentType]: {
-          $each: [{
-            ...comment,
-            timestamp: Date.now(),
-          }],
-          $position: 0,
+    // add the comment to the matching deal (based on _id)
+    const addCommentToGefDeal = await collection.findOneAndUpdate(
+      { _id: { $eq: ObjectId(String(_id)) } },
+      {
+        $push: {
+          [commentType]: {
+            $each: [{
+              ...comment,
+              timestamp: Date.now(),
+            }],
+            $position: 0,
+          },
         },
       },
-    },
-  );
+    );
 
-  const { value } = addCommentToGefDeal;
+    const { value } = addCommentToGefDeal;
 
-  return value;
+    return value;
+  }
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 exports.addDealComment = addComment;
 
 exports.addUnderwriterCommentToGefDeal = async (req, res) => {
-  const dealId = req.params.id;
+  if (ObjectId.isValid(req.params.id)) {
+    const dealId = req.params.id;
 
-  await findOneDeal(dealId, async (deal) => {
-    if (!deal) res.status(404).send();
+    await findOneDeal(dealId, async (deal) => {
+      if (!deal) res.status(404).send();
 
-    if (deal) {
-      const { commentType, comment } = req.body;
+      if (deal) {
+        const { commentType, comment } = req.body;
 
-      const updatedDeal = await addComment(dealId, commentType, comment);
+        const updatedDeal = await addComment(dealId, commentType, comment);
 
-      res.status(200).json(updatedDeal);
-    }
-    res.status(404).send();
-  });
+        res.status(200).json(updatedDeal);
+      }
+      res.status(404).send();
+    });
+  } else {
+    res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
+  }
 };

--- a/dtfs-central-api/src/v1/controllers/portal/gef-deal/get-gef-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-deal/get-gef-deal.controller.js
@@ -2,24 +2,30 @@ const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 
 const findOneDeal = async (_id, callback) => {
-  const dealsCollection = await db.getCollection('deals');
+  if (ObjectId.isValid(_id)) {
+    const dealsCollection = await db.getCollection('deals');
 
-  const deal = await dealsCollection.findOne({ _id: ObjectId(_id) });
+    const deal = await dealsCollection.findOne({ _id: ObjectId(_id) });
 
-  if (callback) {
-    callback(deal);
+    if (callback) {
+      callback(deal);
+    }
+
+    return deal;
   }
-
-  return deal;
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 exports.findOneDeal = findOneDeal;
 
 exports.findOneDealGet = async (req, res) => {
-  const deal = await findOneDeal(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const deal = await findOneDeal(req.params.id);
 
-  if (deal) {
-    return res.status(200).send(deal);
+    if (deal) {
+      return res.status(200).send(deal);
+    }
+
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/portal/gef-deal/put-gef-deal.status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-deal/put-gef-deal.status.controller.js
@@ -1,51 +1,52 @@
-const { ObjectID } = require('mongodb');
+const { ObjectId } = require('mongodb');
 const { findOneDeal } = require('./get-gef-deal.controller');
 const db = require('../../../../drivers/db-client');
 
 const updateDealStatus = async (dealId, previousStatus, newStatus) => {
-  const collection = await db.getCollection('deals');
+  if (ObjectId.isValid(dealId)) {
+    const collection = await db.getCollection('deals');
 
-  console.info(`Updating Portal GEF deal status to ${newStatus}`);
+    console.info(`Updating Portal GEF deal status to ${newStatus}`);
 
-  const dealUpdate = {
-    previousStatus,
-    status: newStatus,
-    updatedAt: Date.now(),
-  };
+    const dealUpdate = {
+      previousStatus,
+      status: newStatus,
+      updatedAt: Date.now(),
+    };
 
-  const findAndUpdateResponse = await collection.findOneAndUpdate(
-    { _id: { $eq: ObjectID(String(dealId)) } },
-    {
-      $set: dealUpdate,
-    },
-    { returnOriginal: false },
-  );
+    const findAndUpdateResponse = await collection.findOneAndUpdate(
+      { _id: { $eq: ObjectId(String(dealId)) } },
+      { $set: dealUpdate },
+      { returnOriginal: false },
+    );
 
-  console.info(`Updated Portal GEF deal status from ${previousStatus} to ${newStatus}`);
+    console.info(`Updated Portal GEF deal status from ${previousStatus} to ${newStatus}`);
 
-  return findAndUpdateResponse.value;
+    return findAndUpdateResponse.value;
+  }
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 exports.updateDealStatus = updateDealStatus;
 
 exports.updateDealStatusPut = async (req, res) => {
-  const dealId = req.params.id;
+  if (ObjectId.isValid(req.params.id)) {
+    const dealId = req.params.id;
 
-  const { status: newStatus } = req.body;
+    const { status: newStatus } = req.body;
 
-  await findOneDeal(dealId, async (existingDeal) => {
-    if (existingDeal) {
-      if (existingDeal.status === newStatus) {
-        return res.status(400).send();
+    await findOneDeal(dealId, async (existingDeal) => {
+      if (existingDeal) {
+        if (existingDeal.status === newStatus) {
+          return res.status(400).send();
+        }
+
+        const updatedDeal = await updateDealStatus(dealId, existingDeal.status, newStatus);
+        return res.status(200).json(updatedDeal);
       }
 
-      const updatedDeal = await updateDealStatus(
-        dealId,
-        existingDeal.status,
-        newStatus,
-      );
-      return res.status(200).json(updatedDeal);
-    }
-
-    return res.status(404).send();
-  });
+      return res.status(404).send({ status: 404, message: 'Deal not found' });
+    });
+  } else {
+    return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
+  }
 };

--- a/dtfs-central-api/src/v1/controllers/portal/gef-facility/create-gef-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-facility/create-gef-facility.controller.js
@@ -11,9 +11,7 @@ const createFacility = async (newFacility) => {
   const response = await collection.insertOne(facility);
   const { insertedId } = response;
 
-  return {
-    _id: insertedId,
-  };
+  return { _id: insertedId };
 };
 
 exports.createFacilityPost = async (req, res) => {

--- a/dtfs-central-api/src/v1/controllers/portal/gef-facility/get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-facility/get-facilities.controller.js
@@ -3,19 +3,22 @@ const db = require('../../../../drivers/db-client');
 
 const facilitiesCollection = 'facilities';
 const findAllGefFacilitiesByDealId = async (dealId) => {
-  const collection = await db.getCollection(facilitiesCollection);
-
-  const facilities = await collection.find({ dealId: ObjectId(dealId) }).toArray();
-
-  return facilities;
+  if (ObjectId.isValid(dealId)) {
+    const collection = await db.getCollection(facilitiesCollection);
+    const facilities = await collection.find({ dealId: ObjectId(dealId) }).toArray();
+    return facilities;
+  }
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 
 exports.findAllGefFacilitiesByDealId = findAllGefFacilitiesByDealId;
 
 exports.findAllGet = async (req, res) => {
-  const facilities = await findAllGefFacilitiesByDealId(req.params.id);
-
-  return res.status(200).send(facilities);
+  if (ObjectId.isValid(req.params.id)) {
+    const facilities = await findAllGefFacilitiesByDealId(req.params.id);
+    return res.status(200).send(facilities);
+  }
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };
 
 exports.findAllFacilities = async (req, res) => {

--- a/dtfs-central-api/src/v1/controllers/portal/gef-facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-facility/update-facility.controller.js
@@ -16,10 +16,9 @@ const updateFacility = async (id, updateBody) => {
         // update facilitiesUpdated timestamp in the deal
         const dealUpdateObj = { facilitiesUpdated: new Date().valueOf() };
 
-        await dealsCollection.findOneAndUpdate(
+        await dealsCollection.updateOne(
           { _id: { $eq: ObjectId(existingFacility.dealId) } },
           { $set: dealUpdateObj },
-          { returnOriginal: false },
         );
       }
     }
@@ -33,14 +32,17 @@ const updateFacility = async (id, updateBody) => {
 exports.updateFacility = updateFacility;
 
 exports.updateFacilityPut = async (req, res) => {
-  const facilityId = req.params.id;
-  const facilityUpdate = req.body;
+  if (ObjectId.isValid(req.params.id)) {
+    const facilityId = req.params.id;
+    const facilityUpdate = req.body;
 
-  const updatedFacility = await updateFacility(facilityId, facilityUpdate);
+    const updatedFacility = await updateFacility(facilityId, facilityUpdate);
 
-  if (updatedFacility) {
-    return res.status(200).json(updatedFacility);
+    if (updatedFacility) {
+      return res.status(200).json(updatedFacility);
+    }
+
+    return res.status(404).send({ status: 404, message: 'The facility ID doesn\'t exist' });
   }
-
-  return res.status(404).send({ status: 404, message: 'The facility ID doesn\'t exist' });
+  return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-delete-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-delete-deal.controller.js
@@ -14,8 +14,9 @@ exports.deleteDeal = async (req, res) => {
         return res.status(200).send(status);
       }
 
-      return res.status(404).send();
+      return res.status(404).send({ status: 404, message: 'Deal not found' });
     });
+  } else {
+    return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
   }
-  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-delete-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-delete-deal.controller.js
@@ -3,16 +3,19 @@ const { findOneDeal } = require('./tfm-get-deal.controller');
 const db = require('../../../../drivers/db-client');
 
 exports.deleteDeal = async (req, res) => {
-  findOneDeal(req.params.id, async (deal) => {
-    if (deal) {
-      const collection = await db.getCollection('tfm-deals');
-      const facilitiesCollection = await db.getCollection('tfm-facilities');
-      const status = await collection.deleteOne({ _id: ObjectId(req.params.id) });
+  if (ObjectId.isValid(req.params.id)) {
+    findOneDeal(req.params.id, async (deal) => {
+      if (deal) {
+        const collection = await db.getCollection('tfm-deals');
+        const facilitiesCollection = await db.getCollection('tfm-facilities');
+        const status = await collection.deleteOne({ _id: ObjectId(req.params.id) });
 
-      await facilitiesCollection.deleteMany({ 'facilitySnapshot.dealId': { $eq: deal._id } });
-      return res.status(200).send(status);
-    }
+        await facilitiesCollection.deleteMany({ 'facilitySnapshot.dealId': { $eq: deal._id } });
+        return res.status(200).send(status);
+      }
 
-    return res.status(404).send();
-  });
+      return res.status(404).send();
+    });
+  }
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deal.controller.js
@@ -70,13 +70,16 @@ const findOneDeal = async (_id, callback) => {
 exports.findOneDeal = findOneDeal;
 
 exports.findOneDealGet = async (req, res) => {
-  const deal = await findOneDeal(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const deal = await findOneDeal(req.params.id);
 
-  if (deal) {
-    return res.status(200).send({
-      deal,
-    });
+    if (deal) {
+      return res.status(200).send({
+        deal,
+      });
+    }
+
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-update-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-update-deal.controller.js
@@ -11,132 +11,143 @@ const withoutId = (obj) => {
 };
 
 const updateDeal = async (dealId, dealChanges, existingDeal) => {
-  const collection = await db.getCollection('tfm-deals');
+  if (ObjectId.isValid(dealId)) {
+    const collection = await db.getCollection('tfm-deals');
 
-  /**
+    /**
    * Only use the tfm object. Remove anything else.
    * Only the tfm object should be updated.
    * - e.g dealSnapshot or any other root level data should not be updated.
    * */
-  const { tfm } = dealChanges;
+    const { tfm } = dealChanges;
 
-  const dealUpdate = { tfm };
-  const tfmUpdate = dealUpdate.tfm;
+    const dealUpdate = { tfm };
+    const tfmUpdate = dealUpdate.tfm;
 
-  /**
+    /**
    * Ensure that if a tfmUpdate with activities is an empty object,
    * we do not make activities an empty object.
    * */
-  if (tfmUpdate.activities && Object.keys(tfmUpdate.activities).length === 0) {
-    dealUpdate.tfm.activities = [];
-  }
+    if (tfmUpdate.activities && Object.keys(tfmUpdate.activities).length === 0) {
+      dealUpdate.tfm.activities = [];
+    }
 
-  /**
+    /**
    * Activities helper variables
    * */
-  const existingDealActivities = (existingDeal.tfm && existingDeal.tfm.activities);
-  const tfmUpdateHasActivities = (tfmUpdate.activities
+    const existingDealActivities = (existingDeal.tfm && existingDeal.tfm.activities);
+    const tfmUpdateHasActivities = (tfmUpdate.activities
                                   && Object.keys(tfmUpdate.activities).length > 0);
-  /**
+    /**
    * ACBS activities update is an array whereas TFM activity update is an object
    * Checks if array, then uses spread operator
    * else if not array, adds the object
    */
-  if (tfmUpdateHasActivities) {
-    if (Array.isArray(tfmUpdate.activities)) {
-      const updatedActivities = [
-        ...tfmUpdate.activities,
-        ...existingDealActivities,
-      ];
-      // ensures that duplicate entries are not added to activities by comparing timestamp and label
-      dealUpdate.tfm.activities = updatedActivities.filter((value, index, arr) =>
-        arr.findIndex((item) => ['timestamp', 'label'].every((key) => item[key] === value[key])) === index);
-    } else {
-      const updatedActivities = [
-        tfmUpdate.activities,
-        ...existingDealActivities,
-      ];
-      // ensures that duplicate entries are not added to activities by comparing timestamp and label
-      dealUpdate.tfm.activities = updatedActivities.filter((value, index, arr) =>
-        arr.findIndex((item) => ['timestamp', 'label'].every((key) => item[key] === value[key])) === index);
+    if (tfmUpdateHasActivities) {
+      if (Array.isArray(tfmUpdate.activities)) {
+        const updatedActivities = [
+          ...tfmUpdate.activities,
+          ...existingDealActivities,
+        ];
+        // ensures that duplicate entries are not added to activities by comparing timestamp and label
+        dealUpdate.tfm.activities = updatedActivities.filter((value, index, arr) =>
+          arr.findIndex((item) => ['timestamp', 'label'].every((key) => item[key] === value[key])) === index);
+      } else {
+        const updatedActivities = [
+          tfmUpdate.activities,
+          ...existingDealActivities,
+        ];
+        // ensures that duplicate entries are not added to activities by comparing timestamp and label
+        dealUpdate.tfm.activities = updatedActivities.filter((value, index, arr) =>
+          arr.findIndex((item) => ['timestamp', 'label'].every((key) => item[key] === value[key])) === index);
+      }
     }
-  }
 
-  dealUpdate.tfm.lastUpdated = new Date().valueOf();
-
-  const findAndUpdateResponse = await collection.findOneAndUpdate(
-    { _id: { $eq: ObjectId(dealId) } },
-    $.flatten(withoutId(dealUpdate)),
-    { returnOriginal: false },
-  );
-
-  return findAndUpdateResponse.value;
-};
-
-exports.updateDealPut = async (req, res) => {
-  const dealId = req.params.id;
-
-  const { dealUpdate } = req.body;
-
-  const deal = await findOneDeal(dealId, false, 'tfm');
-
-  if (deal) {
-    const updatedDeal = await updateDeal(
-      dealId,
-      dealUpdate,
-      deal,
-    );
-
-    return res.status(200).json(updatedDeal);
-  }
-  return res.status(404).send();
-};
-
-const updateDealSnapshot = async (deal, snapshotChanges) => {
-  try {
-    const collection = await db.getCollection('tfm-deals');
-
-    const update = {
-      ...deal,
-      dealSnapshot: {
-        ...deal.dealSnapshot,
-        ...snapshotChanges,
-      },
-    };
-
-    const dealId = deal._id;
+    dealUpdate.tfm.lastUpdated = new Date().valueOf();
 
     const findAndUpdateResponse = await collection.findOneAndUpdate(
-      { _id: { $eq: ObjectId(String(dealId)) } },
-      $.flatten(withoutId(update)),
-      { returnOriginal: false, upsert: true },
+      { _id: { $eq: ObjectId(dealId) } },
+      $.flatten(withoutId(dealUpdate)),
+      { returnOriginal: false },
     );
 
     return findAndUpdateResponse.value;
-  } catch (err) {
-    console.error('Error updating TFM dealSnapshot', { err });
-    return err;
   }
+  return { status: 400, message: 'Invalid Deal Id' };
+};
+
+exports.updateDealPut = async (req, res) => {
+  if (ObjectId.isValid(req.params.id)) {
+    const dealId = req.params.id;
+
+    const { dealUpdate } = req.body;
+
+    const deal = await findOneDeal(dealId, false, 'tfm');
+
+    if (deal) {
+      const updatedDeal = await updateDeal(
+        dealId,
+        dealUpdate,
+        deal,
+      );
+
+      return res.status(200).json(updatedDeal);
+    }
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
+  }
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
+};
+
+const updateDealSnapshot = async (deal, snapshotChanges) => {
+  if (ObjectId.isValid(deal._id)) {
+    try {
+      const collection = await db.getCollection('tfm-deals');
+
+      const update = {
+        ...deal,
+        dealSnapshot: {
+          ...deal.dealSnapshot,
+          ...snapshotChanges,
+        },
+      };
+
+      const dealId = deal._id;
+
+      const findAndUpdateResponse = await collection.findOneAndUpdate(
+        { _id: { $eq: ObjectId(String(dealId)) } },
+        $.flatten(withoutId(update)),
+        { returnOriginal: false, upsert: true },
+      );
+
+      return findAndUpdateResponse.value;
+    } catch (err) {
+      console.error('Error updating TFM dealSnapshot', { err });
+      return err;
+    }
+  }
+  return { status: 400, message: 'Invalid Deal Id' };
 };
 
 exports.updateDealSnapshotPut = async (req, res) => {
   const dealId = req.params.id;
+  if (ObjectId.isValid(dealId)) {
+    const deal = await findOneDeal(dealId, false, 'tfm');
 
-  const deal = await findOneDeal(dealId, false, 'tfm');
+    const snapshotUpdate = req.body;
 
-  const snapshotUpdate = req.body;
+    if (snapshotUpdate.dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
+      const dealFacilities = await findAllFacilitiesByDealId(dealId);
+      snapshotUpdate.facilities = dealFacilities;
+    }
 
-  if (snapshotUpdate.dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
-    const dealFacilities = await findAllFacilitiesByDealId(dealId);
-    snapshotUpdate.facilities = dealFacilities;
+    if (deal) {
+      const updatedDeal = await updateDealSnapshot(
+        deal,
+        snapshotUpdate,
+      );
+      return res.status(200).json(updatedDeal);
+    }
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
-
-  if (deal) {
-    const updatedDeal = await updateDealSnapshot(
-      deal,
-      snapshotUpdate,
-    );
-    return res.status(200).json(updatedDeal);
-  }
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
@@ -1,4 +1,4 @@
-const { ObjectID } = require('mongodb');
+const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
 
 const findFacilitiesByDealId = async (dealId) => {
@@ -7,16 +7,19 @@ const findFacilitiesByDealId = async (dealId) => {
   // NOTE: only GEF facilities have dealId.
   // this could be adapted so that we get the deal, check dealType,
   // then search for either dealId or dealId.
-  const facilities = await collection.find({ 'facilitySnapshot.dealId': { $eq: ObjectID(dealId) } }).toArray();
+  const facilities = await collection.find({ 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } }).toArray();
 
   return facilities;
 };
 exports.findFacilitiesByDealId = findFacilitiesByDealId;
 
 exports.findFacilitiesGet = async (req, res) => {
-  const facilities = await findFacilitiesByDealId(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const facilities = await findFacilitiesByDealId(req.params.id);
 
-  return res.status(200).send(facilities);
+    return res.status(200).send(facilities);
+  }
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };
 
 exports.getAllFacilities = async (req, res) => {

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facility.controller.js
@@ -14,11 +14,14 @@ const findOneFacility = async (_id, callback) => {
 exports.findOneFacility = findOneFacility;
 
 exports.findOneFacilityGet = async (req, res) => {
-  const facility = await findOneFacility(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const facility = await findOneFacility(req.params.id);
 
-  if (facility) {
-    return res.status(200).send(facility);
+    if (facility) {
+      return res.status(200).send(facility);
+    }
+
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Deal Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
@@ -31,20 +31,20 @@ const updateFacility = async (facilityId, tfmUpdate) => {
 exports.updateFacility = updateFacility;
 
 exports.updateFacilityPut = async (req, res) => {
-  const facilityId = req.params.id;
+  if (ObjectId.isValid(req.params.id)) {
+    const facilityId = req.params.id;
 
-  const { facilityUpdate } = req.body;
+    const { facilityUpdate } = req.body;
 
-  const facility = await findOneFacility(facilityId);
+    const facility = await findOneFacility(facilityId);
 
-  if (facility) {
-    const updatedFacility = await updateFacility(
-      facilityId,
-      facilityUpdate,
-    );
+    if (facility) {
+      const updatedFacility = await updateFacility(facilityId, facilityUpdate);
 
-    return res.status(200).json(updatedFacility);
+      return res.status(200).json(updatedFacility);
+    }
+
+    return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/users/tfm-users.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/users/tfm-users.controller.js
@@ -44,20 +44,26 @@ exports.findOneUserGET = async (req, res) => {
 };
 
 const findOneUserById = async (userId) => {
-  const collection = await db.getCollection(usersCollection);
-  const user = await collection.findOne({ _id: new ObjectId(userId) });
-  return user;
+  if (ObjectId.isValid(userId)) {
+    const collection = await db.getCollection(usersCollection);
+    const user = await collection.findOne({ _id: new ObjectId(userId) });
+    return user;
+  }
+  return { status: 400, message: 'Invalid User Id' };
 };
 exports.findOneUserById = findOneUserById;
 
 exports.findOneUserByIdGET = async (req, res) => {
-  const user = await findOneUserById(req.params.userId);
+  if (ObjectId.isValid(req.params.userId)) {
+    const user = await findOneUserById(req.params.userId);
 
-  if (user) {
-    return res.status(200).send(user);
+    if (user) {
+      return res.status(200).send(user);
+    }
+
+    return res.status(404).send({ status: 404, message: 'User not found' });
   }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid User Id' });
 };
 
 const findTeamUsers = async (teamId) => {

--- a/dtfs-central-api/src/v1/controllers/user/get-user.controller.js
+++ b/dtfs-central-api/src/v1/controllers/user/get-user.controller.js
@@ -2,22 +2,28 @@ const { ObjectId } = require('mongodb');
 const db = require('../../../drivers/db-client');
 
 const findOneUser = async (_id) => {
-  const usersCollection = await db.getCollection('users');
+  if (ObjectId.isValid(_id)) {
+    const usersCollection = await db.getCollection('users');
 
-  const user = await usersCollection.findOne({ _id: ObjectId(_id) });
+    const user = await usersCollection.findOne({ _id: ObjectId(_id) });
 
-  return user;
+    return user;
+  }
+  return { status: 400, message: 'Invalid User Id' };
 };
 exports.findOneUser = findOneUser;
 
 exports.findOneUserGet = async (req, res) => {
-  const user = await findOneUser(req.params.id);
+  if (ObjectId.isValid(req.params.id)) {
+    const user = await findOneUser(req.params.id);
 
-  if (user) {
-    return res.status(200).send(user);
+    if (user) {
+      return res.status(200).send(user);
+    }
+
+    return res.status(404).send({ status: 404, message: 'User not found' });
   }
-
-  return res.status(404).send();
+  return res.status(400).send({ status: 400, message: 'Invalid User Id' });
 };
 
 const sanitizeUser = (user) => ({


### PR DESCRIPTION
### Changelog:
- added a validation for `req.params.id` properties in central-api to check whether an `_id` is a valid Object Id. If it's not, then the server crashes because it tries to query the DB with an invalid _id