### PR TITLE
DTFS2-5452 - DTFS2-5387 - fix TFM GEF confirmation email not sending

### DIFF
--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.api-test.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.api-test.js
@@ -37,4 +37,16 @@ describe('generate AIN/MIN confirmation email variables - GEF', () => {
 
     expect(result).toEqual(expected);
   });
+
+  describe('when there is no additionalRefName', () => {
+    it('should return dealName as a dash', () => {
+      const mockDeal = MOCK_GEF_DEAL;
+      delete mockDeal.additionalRefName;
+
+      const mockSubmittedDeal = mapSubmittedDeal({ dealSnapshot: mockDeal });
+
+      const result = gefEmailVariables(mockSubmittedDeal, mockFacilityLists);
+      expect(result.dealName).toEqual('-');
+    });
+  });
 });

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-email-variables.js
@@ -21,7 +21,7 @@ const gefEmailVariables = (deal, facilityLists) => {
     exporterName: exporter.companyName,
     ukefDealId,
     bankGefDealId: bankInternalRefName,
-    dealName: additionalRefName,
+    dealName: additionalRefName || '-',
     submissionDate: format(getSubmissionDate(deal), 'do MMMM yyyy'),
     exporterCompaniesHouseRegistrationNumber: exporter.companiesHouseRegistrationNumber,
     exporterAddress: generateAddressString(exporter.registeredAddress),


### PR DESCRIPTION
This fixes an email confirmation not sending.

One of the email variables - `dealName`, uses `additionalRefName` which is an optional field. If this field is not provided, the email does not get sent because it's missing. Fixed by adding a default value of '-'.

