### PR TITLE
fix/DTFS2-5574 - ability to search TFM deals by GEF ukefDealId

### DIFF
--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-search-string.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-search-string.api-test.js
@@ -17,7 +17,7 @@ describe('/v1/tfm/deals', () => {
 
   describe('GET /v1/tfm/deals', () => {
     describe('filter by search string', () => {
-      it('returns deals filtered by ukefDealId', async () => {
+      it('returns deals filtered by deal.details.ukefDealId (BSS/EWCS)', async () => {
         const miaDeal = newDeal({
           details: {
             ukefDealId: 'test-1',
@@ -47,6 +47,38 @@ describe('/v1/tfm/deals', () => {
 
         const expectedDeals = submittedDeals.filter((deal) =>
           deal.dealSnapshot.details.ukefDealId === miaDeal.details.ukefDealId);
+
+        expect(body.deals.length).toEqual(expectedDeals.length);
+
+        expect(body.deals).toEqual(expectedDeals);
+      });
+
+      it('returns deals filtered by deal.ukefDealId (GEF)', async () => {
+        const miaDeal = newDeal({
+          ukefDealId: 'test-1',
+        });
+
+        const minDeal = newDeal({
+          ukefDealId: 'test-2',
+        });
+
+        const submittedDeals = await createAndSubmitDeals([
+          miaDeal,
+          minDeal,
+        ]);
+
+        const mockReqBody = {
+          queryParams: {
+            searchString: miaDeal.ukefDealId,
+          },
+        };
+
+        const { status, body } = await api.get('/v1/tfm/deals', mockReqBody);
+
+        expect(status).toEqual(200);
+
+        const expectedDeals = submittedDeals.filter((deal) =>
+          deal.dealSnapshot.ukefDealId === miaDeal.ukefDealId);
 
         expect(body.deals.length).toEqual(expectedDeals.length);
 

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
@@ -71,7 +71,8 @@ const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
 
     const query = {
       $or: [
-        { 'dealSnapshot.details.ukefDealId': { $regex: searchString, $options: 'i' } },
+        { 'dealSnapshot.details.ukefDealId': { $regex: searchString, $options: 'i' } }, // BSS
+        { 'dealSnapshot.ukefDealId': { $regex: searchString, $options: 'i' } }, // GEF
         { 'dealSnapshot.bank.name': { $regex: searchString, $options: 'i' } },
         { 'dealSnapshot.submissionDetails.supplier-name': { $regex: searchString, $options: 'i' } },
         { 'dealSnapshot.submissionType': { $regex: searchString, $options: 'i' } },


### PR DESCRIPTION
- BSS/EWCS has `deal.details.ukefDealId`
- GEF has `deal.ukefDealId`

This PR adds the GEF ukefDealId structure to central API query used for TFM deals search.

Would love to align the data, but not enough time.