### PR TITLE
fix TFM API tests

### DIFF
--- a/trade-finance-manager-api/graphql-query-tests/get-facility.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/get-facility.api-test.js
@@ -18,7 +18,6 @@ const facilityReducer = require('../src/graphql/reducers/facility');
 const mockFacilityTfm = {
   ukefExposure: '1,234.00',
   ukefExposureCalculationTimestamp: '1606900616651',
-  exchangeRate: 1.23,
   facilityValueInGBP: '123,45.00',
   bondIssuerPartyUrn: '456-test',
   bondBeneficiaryPartyUrn: '123-test',
@@ -34,49 +33,49 @@ const GET_FACILITY = gql`
       _id,
       facilitySnapshot {
         _id
-        ukefFacilityId,
-        dealId,
+        ukefFacilityId
+        ukefFacilityType
+        dealId
         facilityProduct {
-          code,
+          code
           name
-        },
-        type,
-        ukefFacilityType,
-        facilityStage,
-        hasBeenIssued,
-        facilityValueExportCurrency,
-        value,
-        currency,
-        ukefExposure,
-        coveredPercentage,
-        bankFacilityReference,
-        guaranteeFeePayableToUkef,
-        bondIssuer,
-        bondBeneficiary,
-        banksInterestMargin,
-        firstDrawdownAmountInExportCurrency,
-        feeType,
-        feeFrequency,
-        dayCountBasis,
-        providedOn,
-        providedOnOther,
+        }
+        hasBeenIssued
+        type
+        facilityStage
+        facilityValueExportCurrency
+        value
+        coveredPercentage
+        bankFacilityReference
+        guaranteeFeePayableToUkef
+        bondIssuer
+        bondBeneficiary
+        bankFacilityReference
+        ukefExposure
+        banksInterestMargin
+        firstDrawdownAmountInExportCurrency
+        currency
+        feeType
+        feeFrequency
+        dayCountBasis
+        providedOn
+        providedOnOther
         dates {
-          inclusionNoticeReceived,
-          bankIssueNoticeReceived,
-          coverStartDate,
-          coverEndDate,
+          inclusionNoticeReceived
+          bankIssueNoticeReceived
+          coverStartDate
+          coverEndDate
           tenor
         }
-      },
+      }
       tfm {
-        bondIssuerPartyUrn,
-        bondBeneficiaryPartyUrn,
-        facilityValueInGBP,
+        bondIssuerPartyUrn
+        bondBeneficiaryPartyUrn
+        facilityValueInGBP
         ukefExposure {
-          exposure,
+          exposure
           timestamp
-        },
-        creditRating
+        }
         premiumSchedule {
           id
           calculationDate
@@ -90,8 +89,9 @@ const GET_FACILITY = gql`
           created
           updated
           isAtive
-        },
+        }
         premiumTotals
+        creditRating
       }
     }
   }
@@ -131,13 +131,22 @@ describe('graphql query - get facility', () => {
       tfm: mockFacility.tfm,
     };
 
-    const reducerResult = facilityReducer(initFacilityShape, MOCK_DEAL, mockDealTfm);
+    const mockDeal = {
+      dealSnapshot: MOCK_DEAL,
+      tfm: {},
+    };
+
+    const reducerResult = facilityReducer(
+      initFacilityShape,
+      MOCK_DEAL,
+      mockDealTfm,
+    );
 
     expect(data.facility._id).toEqual(MOCK_FACILITIES[0]._id);
 
     const expectedSnapshot = {
       ...reducerResult.facilitySnapshot,
-      // providedOn is in the query, but only specific to GEF facilities.
+      // these fields are in the query, but only specific to GEF facilities.
       providedOn: null,
       providedOnOther: null,
     };

--- a/trade-finance-manager-api/graphql-query-tests/graphql-authentication.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/graphql-authentication.api-test.js
@@ -5,6 +5,7 @@ const { makeExecutableSchema } = require('@graphql-tools/schema');
 const gql = require('graphql-tag');
 const graphqlPermissions = require('../src/graphql/middleware/graphql-permissions');
 const graphqlKeyAuthentication = require('../src/graphql/key-authentication');
+const MOCK_DEAL = require('../src/v1/__mocks__/mock-deal');
 
 const apiToken = process.env.UKEF_TFM_API_SYSTEM_KEY;
 
@@ -72,7 +73,7 @@ describe('graphql query - authentication', () => {
     it('GET - should return not authorised if missing auth key', async () => {
       const { data, errors } = await query({
         query: GET_DEAL,
-        variables: { _id: '123456789' },
+        variables: { _id: MOCK_DEAL._id },
       });
 
       expect(data.deal).toEqual(null);
@@ -119,7 +120,7 @@ describe('graphql query - authentication', () => {
     it('GET - should return result', async () => {
       const { data, errors } = await query({
         query: GET_DEAL,
-        variables: { _id: '123456789' },
+        variables: { _id: MOCK_DEAL._id },
         context: {
           headers: {
             Authorization: apiToken,
@@ -127,7 +128,7 @@ describe('graphql query - authentication', () => {
         },
       });
 
-      expect(data.deal.dealSnapshot._id).toEqual('123456789');
+      expect(data.deal.dealSnapshot._id).toEqual(MOCK_DEAL._id);
       expect(errors).toEqual(undefined);
     });
 
@@ -135,7 +136,7 @@ describe('graphql query - authentication', () => {
       const { data, errors } = await query({
         query: UPDATE_PARTIES,
         variables: {
-          id: '123456789',
+          id: MOCK_DEAL._id,
           partyUpdate,
         },
       });
@@ -173,7 +174,7 @@ describe('graphql query - authentication', () => {
     it('GET - should return result', async () => {
       const { data, errors } = await query({
         query: GET_DEAL,
-        variables: { _id: '123456789' },
+        variables: { _id: MOCK_DEAL._id },
         context: {
           headers: {
             Authorization: apiToken,
@@ -181,7 +182,7 @@ describe('graphql query - authentication', () => {
         },
       });
 
-      expect(data.deal.dealSnapshot._id).toEqual('123456789');
+      expect(data.deal.dealSnapshot._id).toEqual(MOCK_DEAL._id);
       expect(errors).toEqual(undefined);
     });
 
@@ -189,7 +190,7 @@ describe('graphql query - authentication', () => {
       const { data, errors } = await query({
         query: UPDATE_PARTIES,
         variables: {
-          id: '123456789',
+          id: MOCK_DEAL._id,
           partyUpdate,
         },
       });

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-deal.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-deal.js
@@ -1,7 +1,7 @@
 const { MOCK_FACILITIES } = require('./mock-facilities');
 
 const MOCK_DEAL = {
-  _id: '61f7a4edcf809301e78fbq43',
+  _id: 'AIN_DEAL',
   dealType: 'BSS/EWCS',
   submissionType: 'Automatic Inclusion Notice',
   bankInternalRefName: 'Mock supply contract ID',

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-facilities.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-facilities.js
@@ -1,7 +1,7 @@
 const MOCK_FACILITIES = [
   {
     _id: '61f7a4edcf809301e78fbe53',
-    dealId: '61f7a4edcf809301e78fbe41',
+    dealId: 'AIN_DEAL',
     type: 'Bond',
     bondIssuer: 'Issuer',
     bondType: 'Advance payment guarantee',

--- a/trade-finance-manager-api/src/v1/controllers/tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/tasks.api-test.js
@@ -177,7 +177,7 @@ describe('tasks controller', () => {
         })),
       };
 
-      it('should unlock all tasks in the Underwriting group', async () => {
+      it('should unlock all tasks in the Underwriting group and send an email for every unlocked task in the Underwriting group', async () => {
         const tfmTaskUpdate = createTaskUpdateObj(2, 1);
 
         const result = await updateAllTasks(
@@ -200,24 +200,8 @@ describe('tasks controller', () => {
 
         expect(underwritingGroup.groupTasks[2].status).toEqual(CONSTANTS.TASKS.STATUS.TO_DO);
         expect(underwritingGroup.groupTasks[2].canEdit).toEqual(true);
-      });
-
-      it('should send an email for every unlocked task in the Underwriting group', async () => {
-        const tfmTaskUpdate = createTaskUpdateObj(2, 1);
-
-        const result = await updateAllTasks(
-          tasksWithAdverseHistoryTaskComplete,
-          tfmTaskUpdate.groupId,
-          tfmTaskUpdate,
-          CONSTANTS.TASKS.STATUS.TO_DO,
-          MOCK_DEAL_MIA_SUBMITTED,
-          mockUrlOrigin,
-        );
 
         expect(api.sendEmail).toHaveBeenCalled();
-
-        const underwritingGroup = result.find((group) =>
-          group.groupTitle === CONSTANTS.TASKS.GROUP_TITLES.UNDERWRITING);
 
         const underwritingTeamEmail = MOCK_TEAMS.find((team) => team.id === CONSTANTS.TEAMS.UNDERWRITERS.id).email;
 


### PR DESCRIPTION
- make sure that the failing TFM tests do not have hard coded deal ids. API endpoints are mocked in the tests, any deal/facility queries must match a mock ID.
- move "TFM tasks should unlock" API tests into one test This was causing an issue where the first test would update the mock tasks so the proceeding email test would fail.