### PR TITLE
DTFS2-5532 - GEF Bug - Keep correspondence address visible

### DIFF
--- a/e2e-tests/gef/cypress/integration/exporter-correspondence-address.spec.js
+++ b/e2e-tests/gef/cypress/integration/exporter-correspondence-address.spec.js
@@ -1,7 +1,10 @@
+import relative from './relativeURL';
 import applicationDetails from './pages/application-details';
 import dashboardPage from './pages/dashboard-page';
 import companiesHouse from './pages/companies-house';
 import automaticCover from './pages/exporters-address';
+import aboutExporter from './pages/about-exporter';
+import selectExportersCorAddress from './pages/select-exporters-corr-address';
 
 import CREDENTIALS from '../fixtures/credentials.json';
 
@@ -29,18 +32,20 @@ context('Incomplete exporter section - application details page', () => {
       });
     });
 
-    it('add the exporter', () => {
+    it('completes the exporter section', () => {
       cy.visit(url);
       applicationDetails.exporterDetailsLink().click();
       companiesHouse.regNumberField().type('8989898');
       companiesHouse.continueButton().click();
       automaticCover.noRadioButton().click();
       automaticCover.continueButton().click();
-      // exits without saving, to ensure does not bug and hide fields
-      dashboardPage.dashboardHome().click();
+      aboutExporter.microRadioButton().click();
+      aboutExporter.probabilityOfDefaultInput().type('10');
+      aboutExporter.isFinancingIncreasingRadioYes().click();
+      aboutExporter.doneButton().click();
     });
 
-    it('should show add on the fields not completed yet', () => {
+    it('should show add on correspondence address with a dash', () => {
       cy.visit(url);
       applicationDetails.exporterSummaryListRowKey(0, 0).contains('Companies House registration number');
       applicationDetails.exporterSummaryListRowAction(0, 0).contains('Change');
@@ -55,29 +60,66 @@ context('Incomplete exporter section - application details page', () => {
       applicationDetails.exporterSummaryListRowKey(0, 2).contains('Registered Address');
       applicationDetails.exporterSummaryListRowAction(0, 2).should('not.exist');
 
+      applicationDetails.exporterSummaryListRowKey(0, 3).contains('Correspondence address, if different');
+      applicationDetails.exporterSummaryListRowValue(0, 3).contains('—');
+      applicationDetails.exporterSummaryListRowAction(0, 3).contains('Add');
+      applicationDetails.exporterSummaryListRowAction(0, 3).find('.govuk-link').invoke('attr', 'href').then((href) => {
+        expect(href).to.equal(`/gef/application-details/${dealId}/exporters-address`);
+      });
+
       applicationDetails.exporterSummaryListRowKey(0, 4).contains('Industry');
       applicationDetails.exporterSummaryListRowAction(0, 4).should('not.exist');
 
       // should be - and be add as not yet added
       applicationDetails.exporterSummaryListRowKey(0, 5).contains('SME type');
-      applicationDetails.exporterSummaryListRowValue(0, 5).contains('—');
-      applicationDetails.exporterSummaryListRowAction(0, 5).contains('Add');
+      applicationDetails.exporterSummaryListRowValue(0, 5).contains('Micro');
+      applicationDetails.exporterSummaryListRowAction(0, 5).contains('Change');
       applicationDetails.exporterSummaryListRowAction(0, 5).find('.govuk-link').invoke('attr', 'href').then((href) => {
         expect(href).to.equal(`/gef/application-details/${dealId}/about-exporter?status=change`);
       });
 
       applicationDetails.exporterSummaryListRowKey(0, 6).contains('Probability of default');
-      applicationDetails.exporterSummaryListRowValue(0, 6).contains('—');
-      applicationDetails.exporterSummaryListRowAction(0, 6).contains('Add');
+      applicationDetails.exporterSummaryListRowValue(0, 6).contains('10%');
+      applicationDetails.exporterSummaryListRowAction(0, 6).contains('Change');
       applicationDetails.exporterSummaryListRowAction(0, 6).find('.govuk-link').invoke('attr', 'href').then((href) => {
         expect(href).to.equal(`/gef/application-details/${dealId}/about-exporter?status=change`);
       });
 
       applicationDetails.exporterSummaryListRowKey(0, 7).contains('Is finance for this exporter increasing?');
-      applicationDetails.exporterSummaryListRowValue(0, 7).contains('—');
-      applicationDetails.exporterSummaryListRowAction(0, 7).contains('Add');
+      applicationDetails.exporterSummaryListRowValue(0, 7).contains('Yes');
+      applicationDetails.exporterSummaryListRowAction(0, 7).contains('Change');
       applicationDetails.exporterSummaryListRowAction(0, 7).find('.govuk-link').invoke('attr', 'href').then((href) => {
         expect(href).to.equal(`/gef/application-details/${dealId}/about-exporter?status=change`);
+      });
+    });
+
+    it('add a correspondence address', () => {
+      cy.visit(url);
+
+      applicationDetails.exporterSummaryListRowAction(0, 3).find('.govuk-link').click();
+
+      cy.url().should('eq', relative(`/gef/application-details/${dealId}/exporters-address`));
+
+      automaticCover.yesRadioButton().click();
+      automaticCover.correspondenceAddress().type('SW1A 2AA');
+      automaticCover.continueButton().click();
+
+      selectExportersCorAddress.selectAddress().select('0');
+      selectExportersCorAddress.continueButton().click();
+
+      automaticCover.saveAndReturn().click();
+    });
+
+    it('link for correspondence address should be changed and redirect to correspondence address page', () => {
+      cy.visit(relative(`/gef/application-details/${dealId}`));
+
+      applicationDetails.exporterSummaryListRowKey(0, 3).contains('Correspondence address, if different');
+      applicationDetails.exporterSummaryListRowValue(0, 3).should('not.contain', '—');
+      applicationDetails.exporterSummaryListRowValue(0, 3).contains('SW1A 2AA');
+      applicationDetails.exporterSummaryListRowValue(0, 3).contains('United Kingdom');
+      applicationDetails.exporterSummaryListRowAction(0, 3).contains('Change');
+      applicationDetails.exporterSummaryListRowAction(0, 3).find('.govuk-link').invoke('attr', 'href').then((href) => {
+        expect(href).to.equal(`/gef/application-details/${dealId}/enter-exporters-correspondence-address?status=change`);
       });
     });
   });

--- a/e2e-tests/gef/cypress/integration/pages/exporters-address.js
+++ b/e2e-tests/gef/cypress/integration/pages/exporters-address.js
@@ -7,6 +7,7 @@ const automaticCover = {
   registeredCompanyAddressTitle: () => cy.get('[data-cy="registered-company-address-title"]'),
   changeDetails: () => cy.get('[data-cy="change-details"]'),
   continueButton: () => cy.get('[data-cy="continue-button"]'),
+  saveAndReturn: () => cy.get('[data-cy="save-and-return-button"]'),
   errorSummary: () => cy.get('[data-cy="error-summary"]'),
   postcodeError: () => cy.get('[data-cy="postcode-error"]'),
   fieldError: () => cy.get('[data-cy="correspondence-error"]'),

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -90,6 +90,7 @@ function buildBody(app, previewMode, user) {
         { details: app.exporter }, // wrap in details because mapSummaryList relies this.
         exporterItems(exporterUrl, {
           showIndustryChangeLink: app.exporter?.industries?.length > 1,
+          correspondenceAddressLink: !app.exporter.correspondenceAddress,
         }),
         mapSummaryParams,
         previewMode,

--- a/gef-ui/server/controllers/companies-house/index.js
+++ b/gef-ui/server/controllers/companies-house/index.js
@@ -71,6 +71,7 @@ const validateCompaniesHouse = async (req, res) => {
       exporter: {
         ...exporter,
         ...companiesHouseDetails,
+        correspondenceAddress: null,
         smeType: '',
         probabilityOfDefault: '',
         isFinanceIncreasing: null,

--- a/gef-ui/server/controllers/companies-house/index.test.js
+++ b/gef-ui/server/controllers/companies-house/index.test.js
@@ -141,6 +141,7 @@ describe('controllers/about-exporter', () => {
       const expectedUpdateObj = {
         editorId: '12345',
         exporter: {
+          correspondenceAddress: null,
           isFinanceIncreasing: null,
           probabilityOfDefault: '',
           smeType: '',

--- a/gef-ui/server/controllers/enter-exporters-correspondence-address/index.js
+++ b/gef-ui/server/controllers/enter-exporters-correspondence-address/index.js
@@ -49,6 +49,8 @@ const enterExportersCorrespondenceAddress = async (req, res) => {
 };
 
 const validateEnterExportersCorrespondenceAddress = async (req, res) => {
+  delete req.body._csrf;
+
   const {
     params, body, query, session,
   } = req;
@@ -85,7 +87,9 @@ const validateEnterExportersCorrespondenceAddress = async (req, res) => {
 
   // always default to UK (this is not entered in the UI)
   // https://ukef-dtfs.atlassian.net/browse/DTFS2-4456?focusedCommentId=15031
-  body.country = DEFAULT_COUNTRY;
+  if (body.addressLine1 && body.postalCode) {
+    body.country = DEFAULT_COUNTRY;
+  }
 
   try {
     const { exporter } = await api.getApplication(dealId);

--- a/gef-ui/server/utils/display-items.js
+++ b/gef-ui/server/utils/display-items.js
@@ -21,7 +21,7 @@ const exporterItems = (exporterUrl, options = {}) => [
   {
     label: 'Correspondence address, if different',
     id: 'correspondenceAddress',
-    href: `${exporterUrl}/enter-exporters-correspondence-address?status=change`,
+    href: options.correspondenceAddressLink ? `${exporterUrl}/exporters-address` : `${exporterUrl}/enter-exporters-correspondence-address?status=change`,
   },
   {
     label: 'Industry',


### PR DESCRIPTION
# Issue: 

* If select no for correspondence address, then can never be changed even on cloning deal
* if save and return on correspondence address, then it added United Kingdom

# Changes made:

* set correspondenceAddress to null once entering company house number
* changed add html link to registered address if correspondenceAddress is not set
* updated e2e tests
* only set country to United kingdom if 1st line and postcode set