### PR TITLE
DTFS2 : Dash if empty

### DIFF
--- a/gef-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
+++ b/gef-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
@@ -5,7 +5,7 @@ const dashIfEmpty = (text) => {
 
   const textStr = String(text);
 
-  const isEmpty = !(textStr && textStr.trim().length > 0);
+  const isEmpty = !(textStr && textStr.trim().length > 0 && textStr !== 'NaN');
   return isEmpty ? '-' : textStr;
 };
 

--- a/gef-ui/server/nunjucks-configuration/filter-dashIfEmpty.test.js
+++ b/gef-ui/server/nunjucks-configuration/filter-dashIfEmpty.test.js
@@ -25,4 +25,10 @@ describe('nunjuck filters - dashIfEmpty', () => {
 
     expect(result).toEqual('-');
   });
+
+  it('should return dash if NaN', () => {
+    const result = dashIfEmpty('NaN');
+
+    expect(result).toEqual('-');
+  });
 });

--- a/portal/server/nunjucks-configuration/filter-dashIfEmpty.js
+++ b/portal/server/nunjucks-configuration/filter-dashIfEmpty.js
@@ -5,7 +5,7 @@ const dashIfEmpty = (text) => {
 
   const textStr = String(text);
 
-  const isEmpty = !(textStr && textStr.trim().length > 0);
+  const isEmpty = !(textStr && textStr.trim().length > 0 && textStr !== 'NaN');
   return isEmpty ? '-' : textStr;
 };
 

--- a/portal/server/nunjucks-configuration/filter-dashIfEmpty.test.js
+++ b/portal/server/nunjucks-configuration/filter-dashIfEmpty.test.js
@@ -25,4 +25,10 @@ describe('nunjuck filters - dashIfEmpty', () => {
 
     expect(result).toEqual('-');
   });
+
+  it('should return dash if NaN', () => {
+    const result = dashIfEmpty('NaN');
+
+    expect(result).toEqual('-');
+  });
 });

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
@@ -5,7 +5,7 @@ const dashIfEmpty = (text) => {
 
   const textStr = String(text);
 
-  const isEmpty = !(textStr && textStr.trim().length > 0);
+  const isEmpty = !(textStr && textStr.trim().length > 0 && textStr !== 'NaN');
   return isEmpty ? '-' : textStr;
 };
 

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.test.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.test.js
@@ -25,4 +25,10 @@ describe('nunjuck filters - dashIfEmpty', () => {
 
     expect(result).toEqual('-');
   });
+
+  it('should return dash if NaN', () => {
+    const result = dashIfEmpty('NaN');
+
+    expect(result).toEqual('-');
+  });
 });

--- a/trade-finance-manager-ui/templates/case/facility/_macros/premium_schedule.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/premium_schedule.njk
@@ -53,6 +53,7 @@
             <span class="govuk-!-font-size-16" data-cy="total-to-be-paid-to-ukef">
 
             {% if isGefFacility %}
+            
               {{ facilityTfm.feeRecord | formatAsCurrency | dashIfEmpty }}
 
               {% else %}


### PR DESCRIPTION
## Introduction
Upon an application of a plugin or a function which will return `NaN` as an output `dashIfEmpty` plugin considers it as a valid text thus prevents it from displaying `-`.

* Filter function has been updated to consider `NaN` as an empty value.
* Jest tests cases updates.