### PR TITLE
DTFS2-5710 : Cover start date validation

### DIFF
--- a/e2e-tests/gef/cypress/integration/unissued-facility-to-issued-cover-start-date.spec.js
+++ b/e2e-tests/gef/cypress/integration/unissued-facility-to-issued-cover-start-date.spec.js
@@ -1,0 +1,142 @@
+import { format } from 'date-fns';
+
+import relative from './relativeURL';
+
+import CONSTANTS from '../fixtures/constants';
+
+import dateConstants from '../fixtures/dateConstants';
+
+import { MOCK_APPLICATION_AIN } from '../fixtures/mocks/mock-deals';
+import { MOCK_USER_MAKER } from '../fixtures/mocks/mock-user-maker';
+import {
+  MOCK_FACILITY_ONE,
+} from '../fixtures/mocks/mock-facilities';
+import applicationPreview from './pages/application-preview';
+import unissuedFacilityTable from './pages/unissued-facilities';
+import aboutFacilityUnissued from './pages/unissued-facilities-about-facility';
+import CREDENTIALS from '../fixtures/credentials.json';
+import statusBanner from './pages/application-status-banner';
+
+let dealId;
+let token;
+let facilityOneId;
+
+const unissuedFacilitiesArray = [
+  MOCK_FACILITY_ONE,
+];
+
+context('Unissued Facilities AIN - change all to issued from unissued table', () => {
+  before(() => {
+    cy.apiLogin(CREDENTIALS.MAKER).then((t) => {
+      token = t;
+    }).then(() => {
+      // creates application and inserts facilities and changes status
+      cy.apiCreateApplication(MOCK_USER_MAKER, token).then(({ body }) => {
+        dealId = body._id;
+        cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
+            facilityOneId = facility.body.details._id;
+            cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+          });
+          cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+        });
+      });
+    });
+  });
+
+  describe('Change facility to issued from unissued table', () => {
+    beforeEach(() => {
+      Cypress.Cookies.preserveOnce('connect.sid');
+      cy.login(CREDENTIALS.MAKER);
+      cy.visit(relative(`/gef/application-details/${dealId}`));
+    });
+
+    // ensures the task comment box exists with correct headers and link
+    it('task comment box exists with correct header and unissued facilities link', () => {
+      applicationPreview.unissuedFacilitiesHeader().contains('Update facility stage for unissued facilities');
+      applicationPreview.unissuedFacilitiesReviewLink().contains('View unissued facilities');
+      applicationPreview.submitButtonPostApproval().should('not.exist');
+      applicationPreview.mainHeading().contains(CONSTANTS.DEAL_SUBMISSION_TYPE.AIN);
+      applicationPreview.automaticCoverSummaryList().contains('Yes - submit as an automatic inclusion notice');
+      applicationPreview.automaticCoverCriteria().should('exist');
+    });
+
+    it('clicking unissued facilities link takes you to unissued facility list page', () => {
+      applicationPreview.unissuedFacilitiesReviewLink().click();
+      cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
+      unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
+      unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
+      unissuedFacilityTable.rows().contains(format(dateConstants.threeDaysAgoPlusMonth, 'dd MMM yyyy'));
+      statusBanner.applicationBanner().should('exist');
+    });
+
+    it('clicking back or update later takes you back to application preview', () => {
+      applicationPreview.unissuedFacilitiesReviewLink().click();
+      unissuedFacilityTable.backLink().click();
+      cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
+
+      applicationPreview.unissuedFacilitiesReviewLink().click();
+      // ensures that nothing has changed
+      unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
+      unissuedFacilityTable.backLink().click();
+      cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
+    });
+
+    // clicking update on unissued-facilities table
+    it('clicking on update should take you to the update facility page with correct url', () => {
+      applicationPreview.unissuedFacilitiesReviewLink().click();
+      unissuedFacilityTable.updateIndividualFacilityButton(0).click();
+      cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/about`));
+    });
+
+    it('update facility page should have correct titles and text', () => {
+      applicationPreview.unissuedFacilitiesReviewLink().click();
+      unissuedFacilityTable.updateIndividualFacilityButton(0).click();
+
+      aboutFacilityUnissued.mainHeading().contains('Tell us you\'ve issued this facility');
+      aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
+      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+
+      aboutFacilityUnissued.issueDateDay().should('have.value', '');
+      aboutFacilityUnissued.issueDateMonth().should('have.value', '');
+      aboutFacilityUnissued.issueDateMonth().should('have.value', '');
+
+      aboutFacilityUnissued.coverStartDateDay().should('have.value', '');
+      aboutFacilityUnissued.coverStartDateMonth().should('have.value', '');
+      aboutFacilityUnissued.coverStartDateYear().should('have.value', '');
+
+      aboutFacilityUnissued.coverEndDateDay().should('have.value', '');
+      aboutFacilityUnissued.coverEndDateMonth().should('have.value', '');
+      aboutFacilityUnissued.coverEndDateYear().should('have.value', '');
+    });
+
+    it('Should not throw error upon user defined cover start date input when cover start date is set to issuance date', () => {
+      // Navigate to the unissued facility
+      applicationPreview.unissuedFacilitiesReviewLink().click();
+      unissuedFacilityTable.updateIndividualFacilityButton(0).click();
+
+      // Issue date set to today's date
+      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
+      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
+      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+
+      // Cover start date to user defined date - Three days in the past
+      aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
+      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
+      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
+      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+
+      // Cover end date to user defined date
+      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
+      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
+      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+
+      // Changing cover start date to issuance date
+      aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
+      aboutFacilityUnissued.continueButton().click();
+
+      // Success banner
+      unissuedFacilityTable.allUnissuedUpdatedSuccess().contains('Facility stages are now updated');
+    });
+  });
+});

--- a/gef-ui/server/controllers/unissued-facilities/index.test.js
+++ b/gef-ui/server/controllers/unissued-facilities/index.test.js
@@ -189,6 +189,8 @@ describe('postChangeUnissuedFacility()', () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
     mockRequest.query.saveAndReturn = 'true';
+    mockRequest.body.shouldCoverStartOnSubmission = 'false';
+
     mockRequest.body['issue-date-day'] = format(now, 'd');
     mockRequest.body['issue-date-month'] = format(now, 'M');
     mockRequest.body['issue-date-year'] = format(now, 'yyyy');
@@ -209,7 +211,7 @@ describe('postChangeUnissuedFacility()', () => {
         coverEndDate: format(tomorrow, 'MMMM d, yyyy'),
         coverStartDate: format(tomorrow, 'MMMM d, yyyy'),
         issueDate: format(now, 'MMMM d, yyyy'),
-        shouldCoverStartOnSubmission: null,
+        shouldCoverStartOnSubmission: false,
         monthsOfCover: 30,
         name: 'UKEF123',
         hasBeenIssued: true,
@@ -302,6 +304,8 @@ describe('postChangeUnissuedFacility()', () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
     mockRequest.query.saveAndReturn = 'true';
+    mockRequest.body.shouldCoverStartOnSubmission = 'false';
+
     mockRequest.body['issue-date-day'] = format(yesterday, 'd');
     mockRequest.body['issue-date-month'] = format(yesterday, 'M');
     mockRequest.body['issue-date-year'] = format(yesterday, 'yyyy');
@@ -322,7 +326,7 @@ describe('postChangeUnissuedFacility()', () => {
         coverEndDate: format(tomorrow, 'MMMM d, yyyy'),
         coverStartDate: format(yesterday, 'MMMM d, yyyy'),
         issueDate: format(yesterday, 'MMMM d, yyyy'),
-        shouldCoverStartOnSubmission: null,
+        shouldCoverStartOnSubmission: false,
         monthsOfCover: 30,
         name: 'UKEF123',
         hasBeenIssued: true,
@@ -439,6 +443,7 @@ describe('postChangeUnissuedFacilityPreview()', () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
     mockRequest.query.saveAndReturn = 'true';
+    mockRequest.body.shouldCoverStartOnSubmission = 'false';
 
     mockRequest.body['issue-date-day'] = format(now, 'd');
     mockRequest.body['issue-date-month'] = format(now, 'M');
@@ -460,7 +465,7 @@ describe('postChangeUnissuedFacilityPreview()', () => {
         coverEndDate: format(tomorrow, 'MMMM d, yyyy'),
         coverStartDate: format(tomorrow, 'MMMM d, yyyy'),
         issueDate: format(now, 'MMMM d, yyyy'),
-        shouldCoverStartOnSubmission: null,
+        shouldCoverStartOnSubmission: false,
         monthsOfCover: 30,
         name: 'UKEF123',
         hasBeenIssued: true,

--- a/gef-ui/server/controllers/unissued-facilities/validation.js
+++ b/gef-ui/server/controllers/unissued-facilities/validation.js
@@ -222,9 +222,21 @@ const facilityValidation = async (body, query, params) => {
   }
 
   if (coverStartDateIsFullyComplete) {
-    const value = shouldCoverStartOnSubmission
-      ? { year: issueDateYear, month: issueDateMonth - 1, date: issueDateDay }
-      : { year: coverStartDateYear, month: coverStartDateMonth - 1, date: coverStartDateDay };
+    let value;
+    if (shouldCoverStartOnSubmission) {
+      value = {
+        year: issueDateYear,
+        month: issueDateMonth - 1,
+        date: issueDateDay,
+      };
+    } else {
+      value = {
+        year: coverStartDateYear,
+        month: coverStartDateMonth - 1,
+        date: coverStartDateDay,
+      };
+    }
+
     coverStartDate = set(new Date(), value);
   }
 

--- a/gef-ui/server/controllers/unissued-facilities/validation.js
+++ b/gef-ui/server/controllers/unissued-facilities/validation.js
@@ -37,8 +37,8 @@ const facilityValidation = async (body, query, params) => {
   const issueDateIsFullyComplete = issueDateDay && issueDateMonth && issueDateYear;
   const issueDateIsPartiallyComplete = !issueDateIsFullyComplete && (issueDateDay || issueDateMonth || issueDateYear);
   const issueDateIsBlank = !issueDateDay && !issueDateMonth && !issueDateYear;
-  const coverStartDateIsFullyComplete = (coverStartDateDay && coverStartDateMonth && coverStartDateYear && !shouldCoverStartOnSubmission)
-  || shouldCoverStartOnSubmission;
+  const coverStartDateIsFullyComplete = (coverStartDateDay && coverStartDateMonth && coverStartDateYear && shouldCoverStartOnSubmission === 'false')
+  || shouldCoverStartOnSubmission === 'true';
   const coverStartDateIsPartiallyComplete = !coverStartDateIsFullyComplete && (coverStartDateDay || coverStartDateMonth || coverStartDateYear);
   const coverStartDateIsBlank = !coverStartDateDay && !coverStartDateMonth && !coverStartDateYear;
   const coverEndDateIsFullyComplete = coverEndDateDay && coverEndDateMonth && coverEndDateYear;
@@ -223,7 +223,7 @@ const facilityValidation = async (body, query, params) => {
 
   if (coverStartDateIsFullyComplete) {
     let value;
-    if (shouldCoverStartOnSubmission) {
+    if (shouldCoverStartOnSubmission === 'true') {
       value = {
         year: issueDateYear,
         month: issueDateMonth - 1,
@@ -236,7 +236,6 @@ const facilityValidation = async (body, query, params) => {
         date: coverStartDateDay,
       };
     }
-
     coverStartDate = set(new Date(), value);
   }
 

--- a/gef-ui/server/controllers/unissued-facilities/validation.test.js
+++ b/gef-ui/server/controllers/unissued-facilities/validation.test.js
@@ -68,6 +68,55 @@ describe('validation()', () => {
     expect(result.aboutFacilityErrors).toEqual(expected.aboutFacilityErrors);
   });
 
+  it('Should return no error when cover start date is pre-populated from previous submission but cover start date is now same as issuance date', async () => {
+    mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
+    mockRequest.body.facilityName = 'UKEF123';
+    mockRequest.query.saveAndReturn = 'true';
+
+    // Issue date set to submission date
+    mockRequest.body['issue-date-day'] = format(now, 'd');
+    mockRequest.body['issue-date-month'] = format(now, 'M');
+    mockRequest.body['issue-date-year'] = format(now, 'yyyy');
+
+    // Cover start date to be set as issue date (today)
+    mockRequest.body.shouldCoverStartOnSubmission = 'true';
+
+    // Cover start date set to yesterday - should be ignored due to cover start date set to issue date
+    mockRequest.body['cover-start-date-day'] = format(yesterday, 'd');
+    mockRequest.body['cover-start-date-month'] = format(yesterday, 'M');
+    mockRequest.body['cover-start-date-year'] = format(yesterday, 'yyyy');
+
+    // Cover end date set to tomorrow
+    mockRequest.body['cover-end-date-day'] = format(tomorrow, 'd');
+    mockRequest.body['cover-end-date-month'] = format(tomorrow, 'M');
+    mockRequest.body['cover-end-date-year'] = format(tomorrow, 'yyyy');
+
+    // Validate
+    const result = await facilityValidation(mockRequest.body, mockRequest.query, mockRequest.params);
+
+    // Compare
+    const expected = {
+      coverStartDate: now,
+      coverEndDate: tomorrow,
+      aboutFacilityErrors: [],
+      facilityId: 'xyz',
+      dealId: '123',
+    };
+
+    // formatted to remove the millisecond mismatch (lag)
+    const resultCoverStartFormatted = format(result.coverStartDate, 'dd mm yyyy');
+    const resultCoverEndFormatted = format(result.coverEndDate, 'dd mm yyyy');
+    const expectedCoverStartFormatted = format(expected.coverStartDate, 'dd mm yyyy');
+    const expectedCoverEndFormatted = format(expected.coverEndDate, 'dd mm yyyy');
+
+    // as no errors expected, compare objects being passed back
+    expect(resultCoverStartFormatted).toEqual(expectedCoverStartFormatted);
+    expect(resultCoverEndFormatted).toEqual(expectedCoverEndFormatted);
+    expect(result.facilityId).toEqual('xyz');
+    expect(result.dealId).toEqual('123');
+    expect(result.aboutFacilityErrors).toEqual(expected.aboutFacilityErrors);
+  });
+
   it('should return object with errors populated if end date before start date', async () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';

--- a/gef-ui/server/controllers/unissued-facilities/validation.test.js
+++ b/gef-ui/server/controllers/unissued-facilities/validation.test.js
@@ -36,6 +36,8 @@ describe('validation()', () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
     mockRequest.query.saveAndReturn = 'true';
+    mockRequest.body.shouldCoverStartOnSubmission = 'false';
+
     mockRequest.body['cover-start-date-day'] = format(now, 'd');
     mockRequest.body['cover-start-date-month'] = format(now, 'M');
     mockRequest.body['cover-start-date-year'] = format(now, 'yyyy');
@@ -45,7 +47,6 @@ describe('validation()', () => {
     mockRequest.body['cover-end-date-year'] = format(tomorrow, 'yyyy');
 
     const result = await facilityValidation(mockRequest.body, mockRequest.query, mockRequest.params);
-
     const expected = {
       coverStartDate: now,
       coverEndDate: tomorrow,
@@ -120,6 +121,7 @@ describe('validation()', () => {
   it('should return object with errors populated if end date before start date', async () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
+    mockRequest.body.shouldCoverStartOnSubmission = 'false';
     mockRequest.query.saveAndReturn = 'true';
 
     mockRequest.body['issue-date-day'] = '';
@@ -165,6 +167,7 @@ describe('validation()', () => {
   it('should return object with errors populated if start date before issue date', async () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
+    mockRequest.body.shouldCoverStartOnSubmission = 'false';
     mockRequest.query.saveAndReturn = 'true';
 
     mockRequest.body['issue-date-day'] = format(now, 'd');
@@ -206,6 +209,7 @@ describe('validation()', () => {
   it('should return object with errors populated if end date before issue date', async () => {
     mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
     mockRequest.body.facilityName = 'UKEF123';
+    mockRequest.body.shouldCoverStartOnSubmission = 'true';
     mockRequest.query.saveAndReturn = 'true';
 
     mockRequest.body['issue-date-day'] = format(now, 'd');


### PR DESCRIPTION
## Bug
Upon facility issuance, if the facility cover start date was previously saved but not submitted an error message is thrown stating **cover start date cannot precede issue date** despite the fact that the cover start date is set to the issuance date.

This was due to cover start date selection was being ignored.

## Resolution
* `shouldCoverStartOnSubmission` is added to compound conditions.
* `coverStartDate` property in the return object returns issue date if `shouldCoverStartOnSubmission` is true otherwise user defined cover start date.
* Added Jest unit test.
* E2E test introducted.