### PR TITLE
fix: prevent test deals from reaching eStore. + updated the notifications email

### DIFF
--- a/reference-data-proxy/src/v1/controllers/estore/eStore.controller.ts
+++ b/reference-data-proxy/src/v1/controllers/estore/eStore.controller.ts
@@ -33,6 +33,10 @@ export const createEstore = async (req: Request, res: Response) => {
 
   // check if the body is not empty
   if (Object.keys(eStoreData).length) {
+    // prevent test deals from triggering calls to eStore
+    if (eStoreData.dealIdentifier.includes('100000')) {
+      return res.status(200).send();
+    }
     // send a 200 response back to tfm-api
     // this is because we are not waiting for the cron-jobs to finish
     res.status(200).send();

--- a/reference-data-proxy/src/v1/controllers/estore/eStoreApi.ts
+++ b/reference-data-proxy/src/v1/controllers/estore/eStoreApi.ts
@@ -45,9 +45,9 @@ const postToEstore = async (
   }).catch(async (error: any) => {
     console.error(`Error calling eStore API %O`, { apiEndpoint, data: error?.response?.data, status: error?.response?.status });
     const tfmUserCollection = await getCollection('tfm-users');
-    const tfmDevUser = await tfmUserCollection.aggregate([{ $match: { teams: { $in: ['ESTORE'] } } }, { $project: { _id: 0, email: 1 } }]).toArray();
+    const tfmDevUser = await tfmUserCollection.aggregate([{ $match: { hasEstoreAccess: true } }, { $project: { _id: 0, email: 1 } }]).toArray();
 
-    if (tfmDevUser && error?.response?.status !== 404) {
+    if (tfmDevUser.length && error?.response?.status !== 404) {
       const data = {
         apiEndpoint,
         apiPayload,


### PR DESCRIPTION
- added a check in place to prevent `dealIdentifiers` that are used in tests from triggering eStore calls
- added a flag to identify eStore users