### PR TITLE
Bug - BSS - mock data loader eligibility 

### DIFF
--- a/utils/mock-data-loader/bss/deals/1.js
+++ b/utils/mock-data-loader/bss/deals/1.js
@@ -97,6 +97,7 @@ module.exports = {
         answer: true,
       },
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/10.js
+++ b/utils/mock-data-loader/bss/deals/10.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/11.js
+++ b/utils/mock-data-loader/bss/deals/11.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/2.js
+++ b/utils/mock-data-loader/bss/deals/2.js
@@ -97,6 +97,7 @@ module.exports = {
         answer: true,
       },
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/3.js
+++ b/utils/mock-data-loader/bss/deals/3.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/4.js
+++ b/utils/mock-data-loader/bss/deals/4.js
@@ -90,6 +90,7 @@ module.exports = {
         answer: true,
       },
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/5.js
+++ b/utils/mock-data-loader/bss/deals/5.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/6.js
+++ b/utils/mock-data-loader/bss/deals/6.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/7.js
+++ b/utils/mock-data-loader/bss/deals/7.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/8.js
+++ b/utils/mock-data-loader/bss/deals/8.js
@@ -96,6 +96,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',

--- a/utils/mock-data-loader/bss/deals/9.js
+++ b/utils/mock-data-loader/bss/deals/9.js
@@ -97,6 +97,7 @@ module.exports = {
         answer: true
       }
     ],
+    version: 5,
     agentName: '',
     agentAddressCountry: '',
     agentAddressLine1: '',


### PR DESCRIPTION
# Issue: 
* Mock data loader crashed reference data proxy when submitting BSS deals

# Changes made: 

* added eligibility version to criteria for BSS deals in mock data loader