### PR TITLE
DTFS2-5498 : Facility product code

### DIFF
--- a/azure-functions/acbs-function/constants/facility.js
+++ b/azure-functions/acbs-function/constants/facility.js
@@ -9,7 +9,7 @@ const FACILITY_TYPE_CODE = {
   BSS: '250',
   EWCS: '260',
   CASH: '280',
-  CONTINGENT: '280',
+  CONTINGENT: '281',
 };
 
 const PRODUCT_TYPE_GROUP = {

--- a/azure-functions/acbs-function/mappings/facility/facility-master.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-master.js
@@ -57,7 +57,7 @@ const facilityMaster = (deal, facility, acbsData, acbsReference) => {
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
     dealBorrowerIdentifier: acbsData.parties.exporter.partyIdentifier,
     maximumLiability: helpers.getMaximumLiability(facility),
-    productTypeId: helpers.getProductTypeId(facility),
+    productTypeId: helpers.getProductTypeId(facility, true),
     capitalConversionFactorCode: helpers.getCapitalConversionFactorCode(facility),
     productTypeName: deal.dealSnapshot.dealType,
     currency: facility.facilitySnapshot.currency.id,

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-product-type-id.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-product-type-id.js
@@ -1,11 +1,12 @@
 const CONSTANTS = require('../../../constants');
 
 /**
- * Return ACBS facility type code
+ * Return facility product ACBS compliant code.
  * @param {Object} facility Facility object
- * @returns {String} ACBS facility type code
+ * @param {Boolean} facilityMasterRecord Set to `true` if creating facility master record
+ * @returns {String} Facility product ACBS comliant code, GEF facility master record will return `280`.
  */
-const getProductTypeId = (facility) => {
+const getProductTypeId = (facility, facilityMasterRecord = false) => {
   switch (facility.type || facility.facilitySnapshot.type) {
     case CONSTANTS.FACILITY.FACILITY_TYPE.BOND:
       return CONSTANTS.FACILITY.FACILITY_TYPE_CODE.BSS;
@@ -17,10 +18,12 @@ const getProductTypeId = (facility) => {
       return CONSTANTS.FACILITY.FACILITY_TYPE_CODE.CASH;
 
     case CONSTANTS.FACILITY.FACILITY_TYPE.CONTINGENT:
-      return CONSTANTS.FACILITY.FACILITY_TYPE_CODE.CONTINGENT;
+      return facilityMasterRecord
+        ? CONSTANTS.FACILITY.FACILITY_TYPE_CODE.CASH
+        : CONSTANTS.FACILITY.FACILITY_TYPE_CODE.CONTINGENT;
 
     default:
-      return '';
+      return CONSTANTS.FACILITY.FACILITY_TYPE_CODE.CASH;
   }
 };
 


### PR DESCRIPTION
## Introduction
Facility master and loan records have `productTypeId` field which specifies facility product type.
Upon a contingent facility record creation, it was being set to cash due to code `280` set for contingent facility type.

## Resolution
* Contingent ACBS code updated to `281`.
* `getProductTypeId` helper function will return `280` for contingent facility upon master record creation for a GEF deal and `281` on facility loan creation.
* Default return set to `280`