### PR TITLE
fix(DTFS2-5817): TFM - Missing price risk info

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress.json
+++ b/e2e-tests/trade-finance-manager/cypress.json
@@ -17,7 +17,7 @@
   "responseTimeout": 100000,
   "pageLoadTimeout": 120000,
   "redirectionLimit": 60,
-  "numTestsKeptInMemory": 100,
+  "numTestsKeptInMemory": 1,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/e2e-tests/trade-finance-manager/cypress.json
+++ b/e2e-tests/trade-finance-manager/cypress.json
@@ -17,7 +17,7 @@
   "responseTimeout": 100000,
   "pageLoadTimeout": 120000,
   "redirectionLimit": 60,
-  "numTestsKeptInMemory": 1,
+  "numTestsKeptInMemory": 100,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/e2e-tests/trade-finance-manager/cypress/fixtures/deal-MIA.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/deal-MIA.js
@@ -182,6 +182,7 @@ const MOCK_DEAL = {
       ukefGuaranteeInMonths: '10',
       bondBeneficiary: 'test',
       guaranteeFeePayableByBank: '9.0000',
+      banksInterestMargin: '10',
       value: '12345.00',
       currencySameAsSupplyContractCurrency: 'true',
       riskMarginFee: '10',

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/underwriting/change-facility-risk-profile.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/underwriting/change-facility-risk-profile.spec.js
@@ -54,6 +54,21 @@ context('Case Underwriting - Pricing and risk - Facility Risk Profile', () => {
     });
   });
 
+  it('should show Guarantee fee, interest margin and risk profile correctly', () => {
+    cy.login(UNDERWRITER_MANAGER_1);
+    cy.visit(relative(`/case/${dealId}/deal`));
+
+    // go to pricing and risk page
+    partials.caseSubNavigation.underwritingLink().click();
+    cy.url().should('eq', relative(`/case/${dealId}/underwriting/pricing-and-risk`));
+
+    const facilityRow = pages.underwritingPricingAndRiskPage.facilityTable(facilityId);
+
+    facilityRow.bankInterestMargin().contains(`${dealFacilities[0].banksInterestMargin}%`);
+    facilityRow.guaranteeFee().contains(`${dealFacilities[0].guaranteeFeePayableByBank}%`);
+    facilityRow.changeRiskProfileLink().should('be.visible');
+  });
+
   it('clicking `Change` link in facilities table goes to Facility Risk profile page', () => {
     cy.login(UNDERWRITER_MANAGER_1);
     cy.visit(relative(`/case/${dealId}/deal`));

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/underwriting/pricingAndRiskPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/underwriting/pricingAndRiskPage.js
@@ -13,6 +13,8 @@ const pricingAndRiskPage = {
     return {
       facilityLink: () => cy.get('@table').get(`[data-cy="facility-${facilityId}-ukef-facility-id-link"]`),
       riskProfile: () => cy.get('@table').get(`[data-cy="facility-${facilityId}-risk-profile-value"]`),
+      guaranteeFee: () => cy.get('@table').get(`[data-cy="facility-${facilityId}-bank-guarantee-fee-value"]`),
+      bankInterestMargin: () => cy.get('@table').get(`[data-cy="facility-${facilityId}-bank-interest-value"]`),
       changeRiskProfileLink: () => cy.get('@table').get(`[data-cy="facility-${facilityId}-change-risk-profile-link"]`),
     };
   },

--- a/trade-finance-manager-ui/server/graphql/queries/deal-query.js
+++ b/trade-finance-manager-ui/server/graphql/queries/deal-query.js
@@ -124,6 +124,7 @@ const dealQuery = gql`
             bankFacilityReference,
             ukefExposure,
             banksInterestMargin,
+            guaranteeFeePayableToUkef,
             firstDrawdownAmountInExportCurrency,
             dates {
               inclusionNoticeReceived,

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -18,13 +18,13 @@
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header govuk-body-s width-half govuk-table__cell--border-top">Guarantee fee % payable to UKEF</th>
-        <td class="govuk-table__cell govuk-table__cell--border-top">-</td>
+        <td class="govuk-table__cell govuk-table__cell--border-top" data-cy="facility-{{ facility._id}}-bank-guarantee-fee-value">{{ facility.facilitySnapshot.guaranteeFeePayableToUkef | dashIfEmpty}}</td>
         <td class="govuk-table__cell govuk-table__cell--border-top"></td>
       </tr>
 
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header govuk-body-s width-half">Bank’s interest margin</th>
-        <td class="govuk-table__cell">-</td>
+        <td class="govuk-table__cell" data-cy="facility-{{ facility._id}}-bank-interest-value">{{ facility.facilitySnapshot.banksInterestMargin | dashIfEmpty}}</td>
         <td class="govuk-table__cell"></td>
       </tr>
 


### PR DESCRIPTION
# Issue: 
* pricing and risk page had '-' by interest margin and guarantee value

# Changes made:
* added guaranteeFeePayableToUkef to graphql query
* changed from '-' to value for relevant fields
* updated e2e test