### PR TITLE
DTFS2-5870 : Moment `utc()` calls removed.

### DIFF
--- a/azure-functions/acbs-function/helpers/date.js
+++ b/azure-functions/acbs-function/helpers/date.js
@@ -7,7 +7,7 @@ const now = () => moment().format('YYYY-MM-DD');
 
 const formatYear = (year) => (year < 1000 ? (2000 + parseInt(year, 10)).toString() : year && year.toString());
 const formatDate = (dateStr) => moment(isDate(dateStr) || isString(dateStr) ? dateStr : Number(dateStr)).format('YYYY-MM-DD');
-const formatTimestamp = (dateStr) => moment.utc(isDate(dateStr) || isString(dateStr) ? dateStr : Number(dateStr)).format('YYYY-MM-DD');
+const formatTimestamp = (dateStr) => moment(isDate(dateStr) || isString(dateStr) ? dateStr : Number(dateStr)).format('YYYY-MM-DD');
 
 const addDay = (date, day) => moment(date).add({ day }).format('YYYY-MM-DD');
 const addMonth = (date, months) => moment(date).add({ months }).format('YYYY-MM-DD');

--- a/trade-finance-manager-api/src/utils/date.js
+++ b/trade-finance-manager-api/src/utils/date.js
@@ -2,8 +2,8 @@ const moment = require('moment');
 
 const formatYear = (year) => (year < 1000 ? (2000 + parseInt(year, 10)).toString() : year && year.toString());
 const formatDate = (dateStr) => moment(dateStr).format('YYYY-MM-DD');
-const formatTimestamp = (dateStr) => moment.utc(Number(dateStr)).format('YYYY-MM-DD');
-const convertDateToTimestamp = (dateStr) => moment(dateStr).utc().valueOf().toString();
+const formatTimestamp = (dateStr) => moment(Number(dateStr)).format('YYYY-MM-DD');
+const convertDateToTimestamp = (dateStr) => moment(dateStr).valueOf().toString();
 
 module.exports = {
   formatYear,

--- a/trade-finance-manager-api/src/v1/helpers/get-guarantee-dates.js
+++ b/trade-finance-manager-api/src/v1/helpers/get-guarantee-dates.js
@@ -35,11 +35,11 @@ const getGuaranteeDates = (facility, dealSubmissionDate) => {
     guaranteeExpiryDate = dateHelpers.formatDate(coverEndDate);
   } else {
     guaranteeCommencementDate = dateHelpers.formatTimestamp(
-      moment.utc(Number(dealSubmissionDate)).add(3, 'months').valueOf(),
+      moment(Number(dealSubmissionDate)).add(3, 'months').valueOf(),
     );
 
     guaranteeExpiryDate = dateHelpers.formatTimestamp(
-      moment.utc(guaranteeCommencementDate).add(ukefGuaranteeInMonths, 'months').valueOf(),
+      moment(guaranteeCommencementDate).add(ukefGuaranteeInMonths, 'months').valueOf(),
     );
   }
 


### PR DESCRIPTION
## Introduction
Date specified by the bank is converted into `UTC` by moment if date is set to `00:0:00 +01:00` then UTC conversion can take the converted date back a day. This PR aims to mitigate this issue.

## Resolution
* Removal of `utc()` calls.
* Date in string or EPOCH provided will be treated as it is.