### PR TITLE
.gitignore - Added `actionsheets` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dtfs-submissions-data-volume*
 **/cypress/videos
 **/cypress/screenshots
+**/actionsheets/*
 
 trade-finance-manager/salesforce.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .npm
 .idea
 .env
+.env.prod
 **/.env
+**/.env.prod
 pipeline.log
 dist
 node_modules


### PR DESCRIPTION
`**/actionsheets/*` directory has been added to `.gitignore` to avoid to tracking Action Sheets and accidentally adding them to the repo due to data sensitivity.