### PR TITLE
DTFS2-5882 : TZ=Europe/London added to docker-compose.yml

### DIFF
--- a/azure-functions/acbs-function/docker-compose.yml
+++ b/azure-functions/acbs-function/docker-compose.yml
@@ -16,3 +16,4 @@ services:
       - MULESOFT_API_UKEF_MDM_EA_URL
       - MULESOFT_API_UKEF_MDM_EA_KEY
       - MULESOFT_API_UKEF_MDM_EA_SECRET
+      - TZ=Europe/London

--- a/azure-functions/number-generator-function/docker-compose.yml
+++ b/azure-functions/number-generator-function/docker-compose.yml
@@ -16,3 +16,4 @@ services:
       - MULESOFT_API_KEY
       - MULESOFT_API_SECRET
       - MULESOFT_API_NUMBER_GENERATOR_URL
+      - TZ=Europe/London


### PR DESCRIPTION
# Introduction
`moment().utc()` calls have been updated to `moment()` calls due to this change default TZ now needs to be explicitly specified.

# Resolution
`TZ=Europe/London` has been added to ACBS and NumGen `docker-compose.yml` files.