### PR TITLE
DTFS2-5582 : disbursementAmount undefined - FLR

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/helpers/get-loan-maximum-liability.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-loan-maximum-liability.js
@@ -17,11 +17,11 @@ const getLoanMaximumLiability = (amount, facility, dealType) => {
   } else {
     let { disbursementAmount, coveredPercentage } = facility.facilitySnapshot;
 
-    if (typeof disbursementAmount !== 'number') {
+    if (disbursementAmount && typeof disbursementAmount === 'string') {
       disbursementAmount = disbursementAmount.replace(/,/g, '');
     }
 
-    if (typeof coveredPercentage !== 'number') {
+    if (coveredPercentage && typeof coveredPercentage === 'string') {
       coveredPercentage = coveredPercentage.replace(/,/g, '');
     }
 


### PR DESCRIPTION
## Facility Loan Record
`disbursementAmount` is not present as expected and due to datatype being `undefined` replace function is being executed which only exists for string datatype.

## Resolution
* Property null check
* Type of `string` comparison