### PR TITLE
DTFS2-ACBS-Bug : Facility loan amount  property

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/helpers/get-loan-maximum-liability.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-loan-maximum-liability.js
@@ -15,7 +15,7 @@ const getLoanMaximumLiability = (amount, facility, dealType) => {
   if (dealType === CONSTANTS.PRODUCT.TYPE.GEF) {
     ukefExposure = amount * 0.10;
   } else {
-    let { disbursementAmount, coveredPercentage } = facility.facilitySnapshot;
+    let { disbursementAmount, coverPercentage, coveredPercentage } = facility.facilitySnapshot;
 
     if (disbursementAmount && typeof disbursementAmount === 'string') {
       disbursementAmount = disbursementAmount.replace(/,/g, '');
@@ -23,6 +23,10 @@ const getLoanMaximumLiability = (amount, facility, dealType) => {
 
     if (coveredPercentage && typeof coveredPercentage === 'string') {
       coveredPercentage = coveredPercentage.replace(/,/g, '');
+    }
+
+    if (coverPercentage && !coveredPercentage) {
+      coveredPercentage = coverPercentage;
     }
 
     // BSS/EWCS


### PR DESCRIPTION
## Introduction
A discrepancy on `coveredPercentage` property for the facility has been causing facility loan record's `amount` property to be retuned `NaN`. 

## Resolution
* Ascertain whether `coveredPercentage` is a valid property or not.
* If above is true and in any case above does not exists then `coverPercentage` property value will be assigned only if above is undefined and `coverPercentage` property is not undefined.