### PR TITLE
fix(DTFS2-5930): Facility fixed fee income class code

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/facility-fee.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-fee.js
@@ -37,7 +37,7 @@ const constructFeeRecord = (deal, facility, premiumScheduleIndex = 0) => {
       period: helpers.getFeeRecordPeriod(facility, deal.dealSnapshot.dealType, premiumScheduleIndex),
       currency: facility.facilitySnapshot.currency.id,
       lenderTypeCode: CONSTANTS.FACILITY.LENDER_TYPE.TYPE1,
-      incomeClassCode: helpers.getIncomeClassCode(deal.dealSnapshot.dealType),
+      incomeClassCode: helpers.getIncomeClassCode(facility),
       spreadToInvestorsIndicator: true,
     };
   } catch (e) {

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-income-class-code.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-income-class-code.js
@@ -1,21 +1,33 @@
 const CONSTANTS = require('../../../constants');
 
 /**
- * Return facility income class code
- * @param {String} dealType Deal type i.e. GEF, BSS, EWCS
- * @returns {String} Facility income class code
+ * Return facility income class code as per
+ * facility type. Same is used for reconciliation with CODA.
+ * @param {String} facility Facility object
+ * @returns {String} Facility income class code or `null` upon a failure.
  */
-const getIncomeClassCode = (dealType) => {
-  switch (dealType) {
-    case CONSTANTS.PRODUCT.TYPE.BSS:
-      return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.BSS;
-    case CONSTANTS.PRODUCT.TYPE.EWCS:
-      return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.EWCS;
-    case CONSTANTS.PRODUCT.TYPE.GEF:
-      return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.GEF;
-    default:
-      return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.BSS;
+const getIncomeClassCode = (facility) => {
+  if (facility.facilitySnapshot) {
+    const { type } = facility.facilitySnapshot;
+
+    switch (type) {
+      // GEF
+      case CONSTANTS.FACILITY.FACILITY_TYPE.CASH:
+        return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.GEF;
+      // GEF
+      case CONSTANTS.FACILITY.FACILITY_TYPE.CONTINGENT:
+        return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.GEF;
+      // EWCS
+      case CONSTANTS.FACILITY.FACILITY_TYPE.LOAN:
+        return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.EWCS;
+      // BSS
+      case CONSTANTS.FACILITY.FACILITY_TYPE.BOND:
+        return CONSTANTS.FACILITY.ACBS_INCOME_CLASS_CODE.BSS;
+      default:
+        return null;
+    }
   }
+  return null;
 };
 
 module.exports = getIncomeClassCode;


### PR DESCRIPTION
## Introduction
Facility fixed fee record / premium schedule has `incomeClassCode` field which was being set as per the deal type due to lack of clarity in the user story. Due to deal type for BSS and EWCS and set in unison i.e. `BSS/EWCS` rather individually this has caused the helper function to reset to the default case which was set to BSS, thus supplying `BPM` for EWCS facility.

This bug has caused issue with three production EWCS deals which have been set as `BPM` instead of `EPM` hence causing issues with reconciliation with CODA.

## Resolution
* Facility type evaluation for setting the correct income class code.
* Improved function documentation.