### PR TITLE
fix(Deployment) : Staging GitHub secret name update

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -16,8 +16,7 @@ on:
   
 env:
   environment: staging
-  #TODO: Update AZURE_DIGITAL_TEST -> AZURE_DIGITAL_STAGING upon permissions
-  credentials: ${{ secrets.AZURE_DIGITAL_TEST }}
+  credentials: ${{ secrets.AZURE_DIGITAL_STAGING }}
   from: latest
   acr: ${{ secrets.ACR_REGISTRY_STAGING }}
   acr_username: ${{ secrets.ACR_USERNAME_STAGING }}


### PR DESCRIPTION
## Introduction
`Staging` environment was consuming GH secret as per an old naming convention.
This has been updated to reflect an updated naming convention.

`AZURE_DIGITAL_TEST ` -> `AZURE_DIGITAL_STAGING `