### PR TITLE
fix(ACBS) : Inclusion of payload and status in logs

### DIFF
--- a/azure-functions/acbs-function/activity-create-code-value-transaction/index.js
+++ b/azure-functions/acbs-function/activity-create-code-value-transaction/index.js
@@ -45,6 +45,8 @@ const createCodeValueTransaction = async (context) => {
   }
 
   return {
+    status,
+    dataSent: acbsCodeValueTransactionInput,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-deal-guarantee/index.js
+++ b/azure-functions/acbs-function/activity-create-deal-guarantee/index.js
@@ -48,6 +48,8 @@ const createDealGuarantee = async (context) => {
   }
 
   return {
+    status,
+    dataSent: guarantee,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-deal-investor/index.js
+++ b/azure-functions/acbs-function/activity-create-deal-investor/index.js
@@ -46,6 +46,8 @@ const createDealInvestor = async (context) => {
   }
 
   return {
+    status,
+    dataSent: investor,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-deal/index.js
+++ b/azure-functions/acbs-function/activity-create-deal/index.js
@@ -49,6 +49,8 @@ const createDeal = async (context) => {
   }
 
   return {
+    status,
+    dataSent: deal,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-facility-covenant/index.js
+++ b/azure-functions/acbs-function/activity-create-facility-covenant/index.js
@@ -64,6 +64,8 @@ const createFacilityCovenant = async (context) => {
   }
 
   return {
+    status,
+    dataSent: acbsFacilityCovenantInput,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-facility-fee/index.js
+++ b/azure-functions/acbs-function/activity-create-facility-fee/index.js
@@ -52,6 +52,8 @@ const createFacilityFee = async (context) => {
     }
 
     return {
+      status,
+      dataSent: acbsFacilityFeeInput,
       submittedToACBS,
       receivedFromACBS: moment().format(),
       ...data,

--- a/azure-functions/acbs-function/activity-create-facility-guarantee/index.js
+++ b/azure-functions/acbs-function/activity-create-facility-guarantee/index.js
@@ -50,6 +50,8 @@ const createFacilityGuarantee = async (context) => {
   }
 
   return {
+    status,
+    dataSent: acbsFacilityGuaranteeInput,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-facility-investor/index.js
+++ b/azure-functions/acbs-function/activity-create-facility-investor/index.js
@@ -49,6 +49,8 @@ const createFacilityInvestor = async (context) => {
   }
 
   return {
+    status,
+    dataSent: acbsFacilityInvestorInput,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-facility-loan/index.js
+++ b/azure-functions/acbs-function/activity-create-facility-loan/index.js
@@ -56,6 +56,8 @@ const createFacilityLoan = async (context) => {
     }
 
     return {
+      status,
+      dataSent: acbsFacilityLoanInput,
       submittedToACBS,
       receivedFromACBS: moment().format(),
       ...data,

--- a/azure-functions/acbs-function/activity-create-facility-master/index.js
+++ b/azure-functions/acbs-function/activity-create-facility-master/index.js
@@ -70,6 +70,8 @@ const createFacilityMaster = async (context) => {
   }
 
   return {
+    status,
+    dataSent: acbsFacilityMasterInput,
     submittedToACBS,
     receivedFromACBS: moment().format(),
     ...data,

--- a/azure-functions/acbs-function/activity-create-party/index.js
+++ b/azure-functions/acbs-function/activity-create-party/index.js
@@ -49,6 +49,8 @@ const createParty = async (context) => {
     }
 
     return {
+      status,
+      dataSent: party,
       submittedToACBS,
       receivedFromACBS: moment().format(),
       ...data,


### PR DESCRIPTION
## Introduction
Mulesoft compatible payload has never been stored anywhere in the system. Payload storage is providing pivotal for quick debugging and manual intervention thus saving hours when necessary.

## Resolution
Return responses are saving in Azure storage, keeping this in mind following have been added to return statements across various Azure Durable Activity Functions (DAF).

* Inclusion of `status` in the return statement.
* Inclusion of `dataSent` in the return statement.