### PR TITLE
fix(DTFS2-gitignore) : Added json directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dtfs-submissions-data-volume*
 **/cypress/videos
 **/cypress/screenshots
 **/actionsheets/*
+**/json/*
 
 trade-finance-manager/salesforce.json
 


### PR DESCRIPTION
##Introduction

`json` directory used for storing raw JSON files for data migration.
This has now been added to `.gitignore` to avoid accidental inclusion of high PII files.