### PR TITLE
fix(DTFS2-5964) : Deal expiry date set to 2050-12-31

### DIFF
--- a/azure-functions/acbs-function/constants/deal.js
+++ b/azure-functions/acbs-function/constants/deal.js
@@ -14,7 +14,7 @@ const SME_TYPE = {
 };
 
 const EXPIRATION_DATE = {
-  NONE: '9999-12-31',
+  NONE: '2050-12-31',
 };
 
 const PARTY = {

--- a/azure-functions/acbs-function/mappings/deal/deal-investor.js
+++ b/azure-functions/acbs-function/mappings/deal/deal-investor.js
@@ -11,7 +11,7 @@ const CONSTANTS = require('../../constants');
 "effectiveDate":      As per deal Commencement date
 "currency":           Deal Currency,
 "maximumLiability":   Contract Value,
-"expiryDate":     99/99/99
+"expiryDate":     2050-12-31
 */
 
 const dealInvestor = (deal) => ({


### PR DESCRIPTION
## Introduction
Due to latest patch applied to ACBS `dev` and `QA` environments deal creation has been unsuccessful.
A remedial action requires deal investor expiry date to be updated from `9999-99-99` to `2050-12-31`.

## Resolution
* Updated constant - Deal investor record's expiryDate payload property.
 