### PR TITLE
feat(DTFS2-5965) : TFM API  field support

### DIFF
--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-query-field.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-query-field.api-test.js
@@ -2,7 +2,11 @@ const { getTime, format } = require('date-fns');
 const wipeDB = require('../../../wipeDB');
 const app = require('../../../../src/createApp');
 const api = require('../../../api')(app);
-const { newDeal, createAndSubmitDeals, updateDealsTfm } = require('./tfm-deals-get.api-test');
+const {
+  newDeal,
+  createAndSubmitDeals,
+  updateDealsTfm,
+} = require('./tfm-deals-get.api-test');
 
 describe('/v1/tfm/deals', () => {
   beforeEach(async () => {
@@ -27,7 +31,13 @@ describe('/v1/tfm/deals', () => {
           },
         });
 
-        const [submittedMIADeal, submittedMINDeal] = await createAndSubmitDeals([miaDeal, minDeal]);
+        const [
+          submittedMIADeal,
+          submittedMINDeal,
+        ] = await createAndSubmitDeals([
+          miaDeal,
+          minDeal,
+        ]);
 
         await updateDealsTfm([
           {
@@ -105,7 +115,9 @@ describe('/v1/tfm/deals', () => {
 
         expect(status).toEqual(200);
 
-        const expectedDeals = [submittedMIADeal];
+        const expectedDeals = [
+          submittedMIADeal,
+        ];
 
         expect(body.deals.length).toEqual(expectedDeals.length);
 

--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-query-field.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-query-field.api-test.js
@@ -1,4 +1,4 @@
-const { getTime, format, getUnixTime } = require('date-fns');
+const { getTime, format } = require('date-fns');
 const wipeDB = require('../../../wipeDB');
 const app = require('../../../../src/createApp');
 const api = require('../../../api')(app);

--- a/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-query-field.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/deal/tfm-deals-get-query-field.api-test.js
@@ -128,7 +128,7 @@ describe('/v1/tfm/deals', () => {
         const todayFormatted = format(new Date(), 'dd-MM-yyyy');
 
         // Create Mock AIN deals
-
+        // Today date
         const ainDealToday = newDeal({
           details: {
             ukefDealId: 'ain-1',
@@ -162,7 +162,7 @@ describe('/v1/tfm/deals', () => {
             {
               _id: deals[0]._id,
               tfm: {
-                lastUpdated: 0,
+                lastUpdated: todayFormatted,
               },
             },
             {

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals-date-helpers.js
@@ -14,6 +14,7 @@ const TIMESTAMP_FIELDS = [
   'dealSnapshot.eligibility.lastUpdated',
   'dealSnapshot.details.submissionDate',
   'dealSnapshot.facilitiesUpdated',
+  'tfm.lastUpdated',
 ];
 
 const isTimestampField = (fieldName) =>
@@ -31,12 +32,10 @@ const dayStartAndEndTimestamps = (dateString) => {
   const dayEnd = endOfDay(new Date(day));
   const dayEndTimestamp = getTime(dayEnd);
 
-  const dates = {
+  return {
     dayStartTimestamp,
     dayEndTimestamp,
   };
-
-  return dates;
 };
 
 module.exports = {


### PR DESCRIPTION
## Introduction
When querying `v1/tfm/deals` with below sample body, TFM API returns empty data set.
This was due to `lastUpdated` field was missed out from array of acceptable fields.

```{
    "queryParams": {
        "byField": [
            {
                "name": "tfm.lastUpdated",
                "value": "02-08-2022"
            }
        ]
    }
}
```

## Resolution
* `tfm.lastUpdated` has been added to `TIMESTAMP_FIELDS`.
* API Unit test case.
* Lint fix.