### PR TITLE
fix(DTFS2-5966): Amendment facility time value fix

### DIFF
--- a/e2e-tests/e2e-fixtures/dateConstants.js
+++ b/e2e-tests/e2e-fixtures/dateConstants.js
@@ -53,6 +53,7 @@ const todayUnixMonth = format(threeDaysAgo, 'M');
 const todayUnixYear = format(threeDaysAgo, 'yyyy');
 
 const todayFormattedFull = format(today, 'dd MMMM yyyy');
+const todayFormatted = format(today, 'd MMMM yyyy');
 const tomorrowFormattedFull = format(tomorrow, 'd MMMM yyyy');
 const todayFormattedTimeHours = format(today, 'h');
 const todayFormattedTimeAmPm = format(today, 'aaa');
@@ -102,6 +103,7 @@ export default {
   threeDaysAgoPlusMonth,
   todayTaskFormat,
   todayFormattedFull,
+  todayFormatted,
   tomorrowFormattedFull,
   todayFormattedTimeHours,
   todayFormattedTimeAmPm,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-cannot-edit-issued-facilities-after-submit-to-ukef/deal-multiple-facility-types-ready-to-submit-to-ukef.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/facilities/maker-cannot-edit-issued-facilities-after-submit-to-ukef/deal-multiple-facility-types-ready-to-submit-to-ukef.js
@@ -35,6 +35,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/7. amendment-details-automatic-approval.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/7. amendment-details-automatic-approval.spec.js
@@ -499,7 +499,7 @@ context('Amendments - automatic approval journey', () => {
 
       facilityPage.facilityValueExportCurrency().contains(`${CURRENCY.GBP} 123.00`);
       facilityPage.facilityValueGbp().contains(`${CURRENCY.GBP} 123.00`);
-      facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60`);
+      facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60 as at ${dateConstants.todayFormatted}`);
 
       facilityPage.facilityCoverEndDate().contains('20 October 2022');
       facilityPage.facilityTenor().contains('23 months');

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/add-bank-decision-proceed.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/add-bank-decision-proceed.spec.js
@@ -433,7 +433,7 @@ context('Amendments underwriting - add banks decision - proceed', () => {
 
     facilityPage.facilityValueExportCurrency().contains(`${CURRENCY.GBP} 123.00`);
     facilityPage.facilityValueGbp().contains(`${CURRENCY.GBP} 123.00`);
-    facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60`);
+    facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60 as at ${dateConstants.todayFormatted}`);
 
     facilityPage.facilityCoverEndDate().contains('20 October 2022');
     facilityPage.facilityTenor().contains('23 months');

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.js
@@ -1,4 +1,3 @@
-const { fromUnixTime } = require('date-fns');
 const { formattedNumber } = require('../../../../utils/number');
 const api = require('../../../../v1/api');
 const { calculateNewFacilityValue, calculateUkefExposure, isValidCompletedValueAmendment } = require('../../../helpers/amendment.helpers');
@@ -26,7 +25,7 @@ const mapUkefExposure = async (facilityTfm, facility) => {
         const { coverPercentage, coveredPercentage } = facility.facilitySnapshot;
         const { requireUkefApproval, submittedAt, bankDecision } = latestCompletedAmendment;
         // value of ukefExposureCalculationTime from automatic amendment submission time or manual amendment bankDecision submission time
-        const ukefExposureCalculationTime = requireUkefApproval ? bankDecision.submittedAt : submittedAt;
+        const ukefExposureTimestamp = requireUkefApproval ? bankDecision.submittedAt : submittedAt;
 
         // BSS is coveredPercentage while GEF is coverPercentage
         const coverPercentageValue = coverPercentage || coveredPercentage;
@@ -37,7 +36,7 @@ const mapUkefExposure = async (facilityTfm, facility) => {
         // sets new exposure value based on amendment value
         formattedUkefExposure = formattedNumber(ukefExposureValue);
         // converts from seconds unix timestamp to one with milliseconds
-        ukefExposureCalculationTimestampValue = fromUnixTime(ukefExposureCalculationTime).valueOf();
+        ukefExposureCalculationTimestampValue = new Date(ukefExposureTimestamp * 1000).valueOf();
       }
     }
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.js
@@ -1,4 +1,4 @@
-const { getUnixTime } = require('date-fns');
+const { fromUnixTime } = require('date-fns');
 const { formattedNumber } = require('../../../../utils/number');
 const api = require('../../../../v1/api');
 const { calculateNewFacilityValue, calculateUkefExposure, isValidCompletedValueAmendment } = require('../../../helpers/amendment.helpers');
@@ -24,6 +24,9 @@ const mapUkefExposure = async (facilityTfm, facility) => {
 
       if (isValidCompletedValueAmendment(latestCompletedAmendment)) {
         const { coverPercentage, coveredPercentage } = facility.facilitySnapshot;
+        const { requireUkefApproval, submittedAt, bankDecision } = latestCompletedAmendment;
+        // value of ukefExposureCalculationTime from automatic amendment submission time or manual amendment bankDecision submission time
+        const ukefExposureCalculationTime = requireUkefApproval ? bankDecision.submittedAt : submittedAt;
 
         // BSS is coveredPercentage while GEF is coverPercentage
         const coverPercentageValue = coverPercentage || coveredPercentage;
@@ -33,7 +36,8 @@ const mapUkefExposure = async (facilityTfm, facility) => {
 
         // sets new exposure value based on amendment value
         formattedUkefExposure = formattedNumber(ukefExposureValue);
-        ukefExposureCalculationTimestampValue = getUnixTime(new Date());
+        // converts from seconds unix timestamp to one with milliseconds
+        ukefExposureCalculationTimestampValue = fromUnixTime(ukefExposureCalculationTime).valueOf();
       }
     }
 


### PR DESCRIPTION
# Issue: 
* TFM facility page showed maximum facility  exposure timestamp as January 1970 as value was mapped using date-fns in epoch seconds rather than milliseconds

# Changes made: 
* converted from date-fns timestamp to native epoch timestamp with ms
* Linked to amendment submission date
* added to existing e2e tests