### PR TITLE
fix(DTFS2-5968): Added eligibility criteria versions to e2e tests for portal

### DIFF
--- a/e2e-tests/portal/cypress/fixtures/deal-dashboard-data.js
+++ b/e2e-tests/portal/cypress/fixtures/deal-dashboard-data.js
@@ -19,6 +19,7 @@ module.exports = [
     },
     eligibility: {
       status: 'Incomplete',
+      version: 5,
     },
   }, {
     submissionType: 'Automatic Inclusion Notice',

--- a/e2e-tests/portal/cypress/fixtures/deal.js
+++ b/e2e-tests/portal/cypress/fixtures/deal.js
@@ -110,6 +110,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         _id: '5f3bd4c19b84262f37a97fdc',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/cannot-submit-a-deal-with-newly-issued-facilities-that-have-cover-start-dates-before-min-submission-date/deal.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/cannot-submit-a-deal-with-newly-issued-facilities-that-have-cover-start-dates-before-min-submission-date/deal.js
@@ -109,6 +109,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         _id: '5f3bd4c19b84262f37a97fdc',

--- a/e2e-tests/portal/cypress/integration/journeys/checker/currency-conversion-date/deal-first-submission.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/currency-conversion-date/deal-first-submission.js
@@ -21,6 +21,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/MIA-deal-with-unissued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/MIA-deal-with-unissued-facilities.js
@@ -40,6 +40,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/submit-MIN-deal-with-issued-facility/MIN-deal-accepted-status-with-unissued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/issued-specs-new/submit-MIN-deal-with-issued-facility/MIN-deal-accepted-status-with-unissued-facilities.js
@@ -61,6 +61,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/checker/return-a-deal-to-maker/dealWithSomeIssuedFacilitiesReadyForReview.js
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/return-a-deal-to-maker/dealWithSomeIssuedFacilitiesReadyForReview.js
@@ -21,6 +21,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/checker/submit-a-deal/test-data/template.json
+++ b/e2e-tests/portal/cypress/integration/journeys/checker/submit-a-deal/test-data/template.json
@@ -84,7 +84,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/dealWithFirstPageComplete.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/dealWithFirstPageComplete.json
@@ -30,6 +30,7 @@
     },
     "eligibility" : {
         "status" : "Incomplete",
+        "version": 5,
         "criteria" : [
             {
                 "id" : 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/dealWithSecondPageComplete.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/about-supply-contract/dealWithSecondPageComplete.json
@@ -30,6 +30,7 @@
     },
     "eligibility" : {
         "status" : "Incomplete",
+        "version": 5,
         "criteria" : [
             {
                 "id" : 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/fixtures/dealFullyCompleted.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/fixtures/dealFullyCompleted.js
@@ -140,6 +140,7 @@ const deal = {
     },
   ],
   eligibility: {
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
@@ -18,6 +18,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealThatJustNeedsConversionDate.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealThatJustNeedsConversionDate.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteAbout.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteAbout.json
@@ -17,7 +17,7 @@
   },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteAbout.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteAbout.json
@@ -17,6 +17,7 @@
   },
     "eligibility": {
       "status": "Completed",
+      "version": 4,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteBonds.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteBonds.json
@@ -16,7 +16,7 @@
   },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteBonds.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteBonds.json
@@ -16,6 +16,7 @@
   },
     "eligibility": {
       "status": "Completed",
+      "version": 4,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteEligibility.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteEligibility.json
@@ -76,6 +76,7 @@
 },
     "eligibility": {
       "status": "Incomplete",
+      "version": 4,
       "criteria": [
       { "id": 11, "answer": false
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteEligibility.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteEligibility.json
@@ -76,7 +76,7 @@
 },
     "eligibility": {
       "status": "Incomplete",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": false
       },

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteLoans.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteLoans.json
@@ -16,7 +16,7 @@
   },
   "eligibility": {
     "status": "Completed",
-    "version": 4,
+    "version": 5,
     "criteria": [
       {
         "id": 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteLoans.json
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review/dealWithIncompleteLoans.json
@@ -16,6 +16,7 @@
   },
   "eligibility": {
     "status": "Completed",
+    "version": 4,
     "criteria": [
       {
         "id": 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/dealWithNotStartedFacilityStatuses.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/dealWithNotStartedFacilityStatuses.js
@@ -12,6 +12,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-MIN-deal-with-issued-facilities-for-review-without-cover-start-dates/MINDealWithNotStartedFacilityStatuses.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-issued-facilities-for-review/submit-MIN-deal-with-issued-facilities-for-review-without-cover-start-dates/MINDealWithNotStartedFacilityStatuses.js
@@ -12,6 +12,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/portal/cypress/integration/journeys/number-generator/test-data/MIA-deal-ready-to-submit-with-already-submitted-issued-facilities.js
+++ b/e2e-tests/portal/cypress/integration/journeys/number-generator/test-data/MIA-deal-ready-to-submit-with-already-submitted-issued-facilities.js
@@ -42,6 +42,7 @@ const deal = {
   },
   eligibility: {
     status: 'Completed',
+    version: 5,
     criteria: [
       {
         id: 11,

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/test-data/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/test-data/dealThatJustNeedsDates.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-non-gbp-facilities/test-data/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-non-gbp-facilities/test-data/dealThatJustNeedsDates.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/AIN-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/AIN-deal/dealThatJustNeedsDates.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIA-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIA-deal/dealThatJustNeedsDates.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal-unissued-facilities/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal-unissued-facilities/dealThatJustNeedsDates.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal/dealThatJustNeedsDates.json
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/test-data/MIN-deal/dealThatJustNeedsDates.json
@@ -89,7 +89,7 @@
 },
     "eligibility": {
       "status": "Completed",
-      "version": 4,
+      "version": 5,
       "criteria": [
       { "id": 11, "answer": true
       },

--- a/utils/mock-data-loader/bss/eligibilityCriteria.js
+++ b/utils/mock-data-loader/bss/eligibilityCriteria.js
@@ -179,7 +179,7 @@ module.exports = [
     ],
   },
   {
-    version: 4,
+    version: 5,
     criteria: [
       {
         id: 11,


### PR DESCRIPTION
# Issue:
* portal e2e tests were missing eligibility criteria versions which crashed tfm-api

# Changes made: 
* Added versions to all required e2e deal files