### PR TITLE
fix(DTFS2-5963): Amendments details reverting when multiple single amendment changes

### DIFF
--- a/dtfs-central-api/src/constants/amendments.constant.js
+++ b/dtfs-central-api/src/constants/amendments.constant.js
@@ -11,7 +11,14 @@ const AMENDMENT_BANK_DECISION = {
   AWAITING_DECISION: 'Awaiting decision',
 };
 
+const AMENDMENT_MANAGER_DECISIONS = {
+  APPROVED_WITH_CONDITIONS: 'Approved with conditions',
+  APPROVED_WITHOUT_CONDITIONS: 'Approved without conditions',
+  DECLINED: 'Declined',
+};
+
 module.exports = {
   AMENDMENT_STATUS,
-  AMENDMENT_BANK_DECISION
+  AMENDMENT_BANK_DECISION,
+  AMENDMENT_MANAGER_DECISIONS
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -284,7 +284,7 @@ exports.getCompletedAmendmentByDealId = async (req, res) => {
 };
 
 /**
- *  returns an number containing the latest completed amendment value based on a given facilityId:
+ *  returns an object containing the latest completed amendment value, currency and amendmentId based on a given facilityId:
  *  {
  *    "amendmentId": "62692866ce546902bfcd9168",
  *    "createdAt": 1651058790,
@@ -337,7 +337,7 @@ const findLatestCompletedValueAmendmentByFacilityId = async (facilityId) => {
 exports.findLatestCompletedValueAmendmentByFacilityId = findLatestCompletedValueAmendmentByFacilityId;
 
 /**
- *  returns an number containing the latest completed amendment coverEndDate based on a given facilityId:
+ *  returns an object containing the latest completed amendment coverEndDate and amendmentId based on a given facilityId:
  *  {
  *    "amendmentId": "62692866ce546902bfcd9168",
  *    "createdAt": 1651058790,

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -296,6 +296,7 @@ const findLatestCompletedValueAmendmentByFacilityId = async (facilityId) => {
   if (ObjectId.isValid(facilityId)) {
     const { PROCEED } = CONSTANTS.AMENDMENT.AMENDMENT_BANK_DECISION;
     const { COMPLETED } = CONSTANTS.AMENDMENT.AMENDMENT_STATUS;
+    const { APPROVED_WITH_CONDITIONS, APPROVED_WITHOUT_CONDITIONS } = CONSTANTS.AMENDMENT.AMENDMENT_MANAGER_DECISIONS;
 
     try {
       const collection = await db.getCollection('tfm-facilities');
@@ -306,10 +307,24 @@ const findLatestCompletedValueAmendmentByFacilityId = async (facilityId) => {
           $match: {
             $or: [
               {
-                'amendments.status': COMPLETED, 'amendments.submittedByPim': true, 'amendments.requireUkefApproval': false, 'amendments.changeFacilityValue': true
+                'amendments.status': COMPLETED,
+                'amendments.submittedByPim': true,
+                'amendments.requireUkefApproval': false,
+                'amendments.changeFacilityValue': true
               },
               {
-                'amendments.status': COMPLETED, 'amendments.bankDecision.decision': PROCEED, 'amendments.bankDecision.submitted': true, 'amendments.changeFacilityValue': true
+                'amendments.status': COMPLETED,
+                'amendments.bankDecision.decision': PROCEED,
+                'amendments.bankDecision.submitted': true,
+                'amendments.ukefDecision.value': APPROVED_WITH_CONDITIONS,
+                'amendments.changeFacilityValue': true
+              },
+              {
+                'amendments.status': COMPLETED,
+                'amendments.bankDecision.decision': PROCEED,
+                'amendments.bankDecision.submitted': true,
+                'amendments.ukefDecision.value': APPROVED_WITHOUT_CONDITIONS,
+                'amendments.changeFacilityValue': true
               }
             ]
           }
@@ -349,6 +364,7 @@ const findLatestCompletedDateAmendmentByFacilityId = async (facilityId) => {
   if (ObjectId.isValid(facilityId)) {
     const { PROCEED } = CONSTANTS.AMENDMENT.AMENDMENT_BANK_DECISION;
     const { COMPLETED } = CONSTANTS.AMENDMENT.AMENDMENT_STATUS;
+    const { APPROVED_WITH_CONDITIONS, APPROVED_WITHOUT_CONDITIONS } = CONSTANTS.AMENDMENT.AMENDMENT_MANAGER_DECISIONS;
 
     try {
       const collection = await db.getCollection('tfm-facilities');
@@ -359,10 +375,24 @@ const findLatestCompletedDateAmendmentByFacilityId = async (facilityId) => {
           $match: {
             $or: [
               {
-                'amendments.status': COMPLETED, 'amendments.submittedByPim': true, 'amendments.requireUkefApproval': false, 'amendments.changeCoverEndDate': true
+                'amendments.status': COMPLETED,
+                'amendments.submittedByPim': true,
+                'amendments.requireUkefApproval': false,
+                'amendments.changeCoverEndDate': true
               },
               {
-                'amendments.status': COMPLETED, 'amendments.bankDecision.decision': PROCEED, 'amendments.bankDecision.submitted': true, 'amendments.changeCoverEndDate': true
+                'amendments.status': COMPLETED,
+                'amendments.bankDecision.decision': PROCEED,
+                'amendments.bankDecision.submitted': true,
+                'amendments.ukefDecision.coverEndDate': APPROVED_WITH_CONDITIONS,
+                'amendments.changeCoverEndDate': true
+              },
+              {
+                'amendments.status': COMPLETED,
+                'amendments.bankDecision.decision': PROCEED,
+                'amendments.bankDecision.submitted': true,
+                'amendments.ukefDecision.coverEndDate': APPROVED_WITHOUT_CONDITIONS,
+                'amendments.changeCoverEndDate': true
               }
             ]
           }

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -284,7 +284,7 @@ exports.getCompletedAmendmentByDealId = async (req, res) => {
 };
 
 /**
- *  returns an object containing the latest completed amendment based on a given facilityId:
+ *  returns an number containing the latest completed amendment value based on a given facilityId:
  *  {
  *    "amendmentId": "62692866ce546902bfcd9168",
  *    "createdAt": 1651058790,
@@ -292,7 +292,7 @@ exports.getCompletedAmendmentByDealId = async (req, res) => {
  *    "status": "Completed",
  *  }
  */
-const findLatestCompletedAmendmentByFacilityId = async (facilityId) => {
+const findLatestCompletedValueAmendmentByFacilityId = async (facilityId) => {
   if (ObjectId.isValid(facilityId)) {
     const { PROCEED } = CONSTANTS.AMENDMENT.AMENDMENT_BANK_DECISION;
     const { COMPLETED } = CONSTANTS.AMENDMENT.AMENDMENT_STATUS;
@@ -305,8 +305,12 @@ const findLatestCompletedAmendmentByFacilityId = async (facilityId) => {
         {
           $match: {
             $or: [
-              { 'amendments.status': COMPLETED, 'amendments.submittedByPim': true, 'amendments.requireUkefApproval': false },
-              { 'amendments.status': COMPLETED, 'amendments.bankDecision.decision': PROCEED, 'amendments.bankDecision.submitted': true }
+              {
+                'amendments.status': COMPLETED, 'amendments.submittedByPim': true, 'amendments.requireUkefApproval': false, 'amendments.changeFacilityValue': true
+              },
+              {
+                'amendments.status': COMPLETED, 'amendments.bankDecision.decision': PROCEED, 'amendments.bankDecision.submitted': true, 'amendments.changeFacilityValue': true
+              }
             ]
           }
         },
@@ -314,15 +318,75 @@ const findLatestCompletedAmendmentByFacilityId = async (facilityId) => {
         { $project: { _id: 0, amendments: 1 } },
         { $limit: 1 }
       ]).toArray();
-      return amendment[0]?.amendments ?? null;
+
+      if (amendment[0]?.amendments?.value) {
+        return {
+          amendmentId: amendment[0].amendments.amendmentId,
+          value: amendment[0].amendments.value,
+          currency: amendment[0].amendments.currency
+        };
+      }
+      return null;
     } catch (err) {
-      console.error('Unable to find amendments object %O', { err });
+      console.error('Unable to find latest completed amendments value %O', { err });
       return null;
     }
   }
   return null;
 };
-exports.findLatestCompletedAmendmentByFacilityId = findLatestCompletedAmendmentByFacilityId;
+exports.findLatestCompletedValueAmendmentByFacilityId = findLatestCompletedValueAmendmentByFacilityId;
+
+/**
+ *  returns an number containing the latest completed amendment coverEndDate based on a given facilityId:
+ *  {
+ *    "amendmentId": "62692866ce546902bfcd9168",
+ *    "createdAt": 1651058790,
+ *    "updatedAt": 1651059653,
+ *    "status": "Completed",
+ *  }
+ */
+const findLatestCompletedDateAmendmentByFacilityId = async (facilityId) => {
+  if (ObjectId.isValid(facilityId)) {
+    const { PROCEED } = CONSTANTS.AMENDMENT.AMENDMENT_BANK_DECISION;
+    const { COMPLETED } = CONSTANTS.AMENDMENT.AMENDMENT_STATUS;
+
+    try {
+      const collection = await db.getCollection('tfm-facilities');
+      const amendment = await collection.aggregate([
+        { $match: { _id: ObjectId(facilityId) } },
+        { $unwind: '$amendments' },
+        {
+          $match: {
+            $or: [
+              {
+                'amendments.status': COMPLETED, 'amendments.submittedByPim': true, 'amendments.requireUkefApproval': false, 'amendments.changeCoverEndDate': true
+              },
+              {
+                'amendments.status': COMPLETED, 'amendments.bankDecision.decision': PROCEED, 'amendments.bankDecision.submitted': true, 'amendments.changeCoverEndDate': true
+              }
+            ]
+          }
+        },
+        { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+        { $project: { _id: 0, amendments: 1 } },
+        { $limit: 1 }
+      ]).toArray();
+
+      if (amendment[0]?.amendments?.coverEndDate) {
+        return {
+          amendmentId: amendment[0].amendments.amendmentId,
+          coverEndDate: amendment[0].amendments.coverEndDate
+        };
+      }
+      return null;
+    } catch (err) {
+      console.error('Unable to find latest completed amendments coverEndDate %O', { err });
+      return null;
+    }
+  }
+  return null;
+};
+exports.findLatestCompletedDateAmendmentByFacilityId = findLatestCompletedDateAmendmentByFacilityId;
 
 // finds the latest completed amendment and returns the version
 const findLatestCompletedAmendmentByFacilityIdVersion = async (facilityId) => {
@@ -349,11 +413,20 @@ const findLatestCompletedAmendmentByFacilityIdVersion = async (facilityId) => {
 };
 exports.findLatestCompletedAmendmentByFacilityIdVersion = findLatestCompletedAmendmentByFacilityIdVersion;
 
-exports.getLatestCompletedAmendment = async (req, res) => {
+exports.getLatestCompletedValueAmendment = async (req, res) => {
   const { facilityId } = req.params;
   if (ObjectId.isValid(facilityId)) {
-    const amendment = await findLatestCompletedAmendmentByFacilityId(facilityId) ?? {};
-    return res.status(200).send(amendment);
+    const newValue = await findLatestCompletedValueAmendmentByFacilityId(facilityId) ?? {};
+    return res.status(200).send(newValue);
+  }
+  return res.status(400).send({ status: 400, message: 'Invalid facility Id' });
+};
+
+exports.getLatestCompletedDateAmendment = async (req, res) => {
+  const { facilityId } = req.params;
+  if (ObjectId.isValid(facilityId)) {
+    const coverEndDate = await findLatestCompletedDateAmendmentByFacilityId(facilityId) ?? {};
+    return res.status(200).send(coverEndDate);
   }
   return res.status(400).send({ status: 400, message: 'Invalid facility Id' });
 };

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -414,7 +414,7 @@ tfmRouter.route('/facilities/:facilityId/amendment').get(tfmGetAmendmentControll
 tfmRouter.route('/facilities/:facilityId/amendment/status/in-progress').get(tfmGetAmendmentController.getAmendmentInProgress);
 tfmRouter.route('/facilities/:facilityId/amendment/status/completed').get(tfmGetAmendmentController.getAllCompletedAmendmentsByFacilityId);
 tfmRouter.route('/facilities/:facilityId/amendment/status/completed/latest-value').get(tfmGetAmendmentController.getLatestCompletedValueAmendment);
-tfmRouter.route('/facilities/:facilityId/amendment/status/completed/latest-date').get(tfmGetAmendmentController.getLatestCompletedDateAmendment);
+tfmRouter.route('/facilities/:facilityId/amendment/status/completed/latest-cover-end-date').get(tfmGetAmendmentController.getLatestCompletedDateAmendment);
 tfmRouter.route('/facilities/:facilityId/amendment/:amendmentId').get(tfmGetAmendmentController.getAmendmentById);
 tfmRouter.route('/deals/:dealId/amendments').get(tfmGetAmendmentController.getAmendmentsByDealId);
 tfmRouter.route('/deals/:dealId/amendment/status/in-progress').get(tfmGetAmendmentController.getAmendmentInProgressByDealId);

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -413,7 +413,8 @@ tfmRouter.route('/amendments/status/in-progress').get(tfmGetAmendmentController.
 tfmRouter.route('/facilities/:facilityId/amendment').get(tfmGetAmendmentController.getAllAmendmentsByFacilityId);
 tfmRouter.route('/facilities/:facilityId/amendment/status/in-progress').get(tfmGetAmendmentController.getAmendmentInProgress);
 tfmRouter.route('/facilities/:facilityId/amendment/status/completed').get(tfmGetAmendmentController.getAllCompletedAmendmentsByFacilityId);
-tfmRouter.route('/facilities/:facilityId/amendment/status/completed/latest').get(tfmGetAmendmentController.getLatestCompletedAmendment);
+tfmRouter.route('/facilities/:facilityId/amendment/status/completed/latest-value').get(tfmGetAmendmentController.getLatestCompletedValueAmendment);
+tfmRouter.route('/facilities/:facilityId/amendment/status/completed/latest-date').get(tfmGetAmendmentController.getLatestCompletedDateAmendment);
 tfmRouter.route('/facilities/:facilityId/amendment/:amendmentId').get(tfmGetAmendmentController.getAmendmentById);
 tfmRouter.route('/deals/:dealId/amendments').get(tfmGetAmendmentController.getAmendmentsByDealId);
 tfmRouter.route('/deals/:dealId/amendment/status/in-progress').get(tfmGetAmendmentController.getAmendmentInProgressByDealId);

--- a/e2e-tests/trade-finance-manager/cypress.json
+++ b/e2e-tests/trade-finance-manager/cypress.json
@@ -17,7 +17,7 @@
   "responseTimeout": 100000,
   "pageLoadTimeout": 120000,
   "redirectionLimit": 60,
-  "numTestsKeptInMemory": 100,
+  "numTestsKeptInMemory": 1,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/e2e-tests/trade-finance-manager/cypress.json
+++ b/e2e-tests/trade-finance-manager/cypress.json
@@ -17,7 +17,7 @@
   "responseTimeout": 100000,
   "pageLoadTimeout": 120000,
   "redirectionLimit": 60,
-  "numTestsKeptInMemory": 1,
+  "numTestsKeptInMemory": 100,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/add-amendment-request-check-previous.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/add-amendment-request-check-previous.spec.js
@@ -147,7 +147,7 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     amendmentsPage.continueAmendment().click();
   });
 
-  it('should accept the coverEndDate and decline facility value and bank should proceed', () => {
+  it('should accept the facility value and decline cover end date and bank should proceed', () => {
     cy.login(UNDERWRITER_MANAGER_1);
     cy.visit(relative(`/case/${dealId}/underwriting`));
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/amendment-changes-multiple-single-amendments.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/amendment-changes-multiple-single-amendments.spec.js
@@ -1,0 +1,149 @@
+import relative from '../../../relativeURL';
+import facilityPage from '../../../pages/facilityPage';
+import amendmentsPage from '../../../pages/amendments/amendmentsPage';
+import MOCK_DEAL_AIN from '../../../../fixtures/deal-AIN';
+import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
+import { PIM_USER_1 } from '../../../../../../e2e-fixtures';
+import { MOCK_MAKER_TFM, ADMIN_LOGIN } from '../../../../fixtures/users-portal';
+import { CURRENCY } from '../../../../../../e2e-fixtures/constants.fixture';
+import caseDealPage from '../../../pages/caseDealPage';
+
+context('Amendments changes displayed - multiple single change amendments', () => {
+  let dealId;
+  const dealFacilities = [];
+
+  before(() => {
+    cy.insertOneDeal(MOCK_DEAL_AIN, MOCK_MAKER_TFM).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      const { dealType, mockFacilities } = MOCK_DEAL_AIN;
+
+      cy.createFacilities(dealId, [mockFacilities[0]], MOCK_MAKER_TFM).then((createdFacilities) => {
+        dealFacilities.push(...createdFacilities);
+      });
+
+      cy.submitDeal(dealId, dealType);
+    });
+  });
+
+  after(() => {
+    cy.deleteDeals(dealId, ADMIN_LOGIN);
+    dealFacilities.forEach((facility) => {
+      cy.deleteFacility(facility._id, MOCK_MAKER_TFM);
+    });
+  });
+
+  it('should submit an automatic amendment request for coverEndDate', () => {
+    cy.login(PIM_USER_1);
+    const facilityId = dealFacilities[0]._id;
+    cy.visit(relative(`/case/${dealId}/facility/${facilityId}`));
+
+    facilityPage.facilityTabAmendments().click();
+    amendmentsPage.addAmendmentButton().should('exist');
+    amendmentsPage.addAmendmentButton().contains('Add an amendment request');
+    amendmentsPage.addAmendmentButton().click();
+    cy.url().should('contain', 'request-date');
+
+    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
+    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
+    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'request-approval');
+    // automatic approval
+    amendmentsPage.amendmentRequestApprovalNo().click();
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'amendment-effective-date');
+
+    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
+    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
+    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'amendment-options');
+    amendmentsPage.amendmentCoverEndDateCheckbox().should('not.be.checked');
+    amendmentsPage.amendmentFacilityValueCheckbox().should('not.be.checked');
+
+    // update both the cover end date and the facility value
+    amendmentsPage.amendmentCoverEndDateCheckbox().click();
+    amendmentsPage.amendmentCoverEndDateCheckbox().should('be.checked');
+    amendmentsPage.continueAmendment().click();
+    cy.url().should('contain', 'cover-end-date');
+
+    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
+    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
+    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'check-answers');
+    amendmentsPage.continueAmendment().click();
+  });
+
+  it('should submit an automatic amendment request for facilityValue', () => {
+    cy.login(PIM_USER_1);
+    const facilityId = dealFacilities[0]._id;
+    cy.visit(relative(`/case/${dealId}/facility/${facilityId}`));
+
+    facilityPage.facilityTabAmendments().click();
+    amendmentsPage.addAmendmentButton().should('exist');
+    amendmentsPage.addAmendmentButton().contains('Add an amendment request');
+    amendmentsPage.addAmendmentButton().click();
+    cy.url().should('contain', 'request-date');
+
+    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
+    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
+    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'request-approval');
+    // automatic approval
+    amendmentsPage.amendmentRequestApprovalNo().click();
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'amendment-effective-date');
+
+    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
+    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
+    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'amendment-options');
+    amendmentsPage.amendmentCoverEndDateCheckbox().should('not.be.checked');
+    amendmentsPage.amendmentFacilityValueCheckbox().should('not.be.checked');
+
+    // update both the cover end date and the facility value
+    amendmentsPage.amendmentFacilityValueCheckbox().click();
+    amendmentsPage.amendmentFacilityValueCheckbox().should('be.checked');
+    amendmentsPage.continueAmendment().click();
+
+    cy.url().should('contain', 'facility-value');
+    amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
+    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+
+    amendmentsPage.continueAmendment().click();
+    cy.url().should('contain', 'check-answers');
+    amendmentsPage.continueAmendment().click();
+  });
+
+  it('should display amendment changed values on deal and facility page', () => {
+    cy.login(PIM_USER_1);
+    const facilityId = dealFacilities[0]._id;
+
+    cy.visit(relative(`/case/${dealId}/deal`));
+    caseDealPage.dealFacilitiesTable.row(facilityId).facilityTenor().should('not.contain', '23 months');
+    caseDealPage.dealFacilitiesTable.row(facilityId).facilityEndDate().contains(dateConstants.tomorrowFormattedFull);
+    caseDealPage.dealFacilitiesTable.row(facilityId).exportCurrency().contains(`${CURRENCY.GBP} 123.00`);
+    caseDealPage.dealFacilitiesTable.row(facilityId).valueGBP().contains(`${CURRENCY.GBP} 123.00`);
+    caseDealPage.dealFacilitiesTable.row(facilityId).exposure().contains(`${CURRENCY.GBP} 24.60`);
+
+    cy.visit(relative(`/case/${dealId}/facility/${facilityId}`));
+
+    facilityPage.facilityValueExportCurrency().contains(`${CURRENCY.GBP} 123.00`);
+    facilityPage.facilityValueGbp().contains(`${CURRENCY.GBP} 123.00`);
+    facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60 as at ${dateConstants.todayFormatted}`);
+
+    facilityPage.facilityCoverEndDate().contains(dateConstants.tomorrowFormattedFull);
+    facilityPage.facilityTenor().should('not.contain', '23 months');
+  });
+});

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/amendment-changes-multiple-single-amendments.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/amendment-changes-multiple-single-amendments.spec.js
@@ -15,9 +15,7 @@ context('Amendments changes displayed - multiple single change amendments', () =
   before(() => {
     cy.insertOneDeal(MOCK_DEAL_AIN, MOCK_MAKER_TFM).then((insertedDeal) => {
       dealId = insertedDeal._id;
-
       const { dealType, mockFacilities } = MOCK_DEAL_AIN;
-
       cy.createFacilities(dealId, [mockFacilities[0]], MOCK_MAKER_TFM).then((createdFacilities) => {
         dealFacilities.push(...createdFacilities);
       });
@@ -48,23 +46,21 @@ context('Amendments changes displayed - multiple single change amendments', () =
     amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
     amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'request-approval');
+
     // automatic approval
     amendmentsPage.amendmentRequestApprovalNo().click();
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'amendment-effective-date');
 
     amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
     amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
     amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'amendment-options');
+
     amendmentsPage.amendmentCoverEndDateCheckbox().should('not.be.checked');
     amendmentsPage.amendmentFacilityValueCheckbox().should('not.be.checked');
-
     // update both the cover end date and the facility value
     amendmentsPage.amendmentCoverEndDateCheckbox().click();
     amendmentsPage.amendmentCoverEndDateCheckbox().should('be.checked');
@@ -75,7 +71,6 @@ context('Amendments changes displayed - multiple single change amendments', () =
     amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
     amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'check-answers');
     amendmentsPage.continueAmendment().click();
   });
@@ -95,32 +90,29 @@ context('Amendments changes displayed - multiple single change amendments', () =
     amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
     amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'request-approval');
+
     // automatic approval
     amendmentsPage.amendmentRequestApprovalNo().click();
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'amendment-effective-date');
 
     amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
     amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
     amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'amendment-options');
+
     amendmentsPage.amendmentCoverEndDateCheckbox().should('not.be.checked');
     amendmentsPage.amendmentFacilityValueCheckbox().should('not.be.checked');
-
     // update both the cover end date and the facility value
     amendmentsPage.amendmentFacilityValueCheckbox().click();
     amendmentsPage.amendmentFacilityValueCheckbox().should('be.checked');
     amendmentsPage.continueAmendment().click();
-
     cy.url().should('contain', 'facility-value');
+
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
     amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
-
     amendmentsPage.continueAmendment().click();
     cy.url().should('contain', 'check-answers');
     amendmentsPage.continueAmendment().click();
@@ -138,11 +130,9 @@ context('Amendments changes displayed - multiple single change amendments', () =
     caseDealPage.dealFacilitiesTable.row(facilityId).exposure().contains(`${CURRENCY.GBP} 24.60`);
 
     cy.visit(relative(`/case/${dealId}/facility/${facilityId}`));
-
     facilityPage.facilityValueExportCurrency().contains(`${CURRENCY.GBP} 123.00`);
     facilityPage.facilityValueGbp().contains(`${CURRENCY.GBP} 123.00`);
     facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60 as at ${dateConstants.todayFormatted}`);
-
     facilityPage.facilityCoverEndDate().contains(dateConstants.tomorrowFormattedFull);
     facilityPage.facilityTenor().should('not.contain', '23 months');
   });

--- a/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/get-deal.api-test.js
@@ -266,7 +266,8 @@ describe('graphql query - get deal', () => {
   });
 
   it('should return a mapped deal via dealReducer', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const mappedDeal = await mapDeal(MOCK_DEAL);
 

--- a/trade-finance-manager-api/graphql-query-tests/get-facility.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/get-facility.api-test.js
@@ -117,7 +117,8 @@ describe('graphql query - get facility', () => {
   });
 
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
   });
 
   it('should return a BSS/EWCS facility via facilityReducer', async () => {

--- a/trade-finance-manager-api/graphql-query-tests/graphql-authentication.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/graphql-authentication.api-test.js
@@ -72,7 +72,9 @@ describe('graphql query - authentication', () => {
     });
 
     beforeEach(() => {
-      api.getLatestCompletedAmendment = () => Promise.resolve({});
+      api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+      api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+      api.getAmendmentById = () => Promise.resolve({});
     });
 
     it('GET - should return not authorised if missing auth key', async () => {

--- a/trade-finance-manager-api/graphql-query-tests/mutation-update-underwriting-managers-decision.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/mutation-update-underwriting-managers-decision.api-test.js
@@ -46,7 +46,9 @@ describe('graphql mutation - update underwriting managers decision', () => {
   });
 
   beforeEach(() => {
-    externalApis.getLatestCompletedAmendment = () => Promise.resolve({});
+    externalApis.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    externalApis.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    externalApis.getAmendmentById = () => Promise.resolve({});
   });
 
   it('should return updated decision with timestamp', async () => {

--- a/trade-finance-manager-api/src/graphql/helpers/amendment.helpers.api-test.js
+++ b/trade-finance-manager-api/src/graphql/helpers/amendment.helpers.api-test.js
@@ -1,7 +1,6 @@
 const amendmentHelpers = require('./amendment.helpers');
 const { CURRENCY } = require('../../constants/currency.constant');
 const { FACILITY_TYPE } = require('../../constants/facilities');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../constants/deals');
 const api = require('../../v1/api');
 
 describe('amendmentChangeValueExportCurrency()', () => {
@@ -187,19 +186,10 @@ describe('calculateAmendmentTenor()', () => {
 });
 
 describe('calculateAmendmentTotalExposure()', () => {
-  const mockAmendment = {
+  const mockAmendmentValueResponse = {
     value: 5000,
     currency: CURRENCY.GBP,
     amendmentId: '1234',
-    requireUkefApproval: true,
-    ukefDecision: {
-      submitted: true,
-      value: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-    },
-    bankDecision: {
-      submitted: true,
-      decision: AMENDMENT_BANK_DECISION.PROCEED,
-    },
   };
 
   const mockFacility = {
@@ -215,16 +205,15 @@ describe('calculateAmendmentTotalExposure()', () => {
   };
 
   it('should return exposure value when amendment in progress ', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
 
     const result = await amendmentHelpers.calculateAmendmentTotalExposure(mockFacility);
-    const expected = mockAmendment.value * (mockFacility.facilitySnapshot.coverPercentage / 100);
+    const expected = mockAmendmentValueResponse.value * (mockFacility.facilitySnapshot.coverPercentage / 100);
     expect(result).toEqual(expected);
   });
 
   it('should null if amendment not completed', async () => {
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.null };
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
 
     const result = await amendmentHelpers.calculateAmendmentTotalExposure(mockFacility);
     expect(result).toBeNull();

--- a/trade-finance-manager-api/src/graphql/reducers/deal-with-amendment-bss.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deal-with-amendment-bss.api-test.js
@@ -24,8 +24,22 @@ describe('gef deal with amendments', () => {
     },
   };
 
+  const mockAmendmentValueResponse = {
+    value: 5000,
+    currency: CURRENCY.GBP,
+    amendmentId: '1234',
+  };
+
+  const mockAmendmentDateResponse = {
+    coverEndDate: coverEndDateUnix,
+    amendmentId: '1234',
+
+  };
+
   it('should return original deal as amendment not fully complete', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockBSSDeal = {
       _id: MOCK_DEAL_AIN_SUBMITTED._id,
@@ -58,7 +72,9 @@ describe('gef deal with amendments', () => {
     MOCK_DEAL_AIN_SUBMITTED.loanTransactions.items[0]['requestedCoverStartDate-month'] = '01';
     MOCK_DEAL_AIN_SUBMITTED.loanTransactions.items[0]['requestedCoverStartDate-day'] = '01';
 
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockBSSDeal = {
       _id: MOCK_DEAL_AIN_SUBMITTED._id,
@@ -76,7 +92,9 @@ describe('gef deal with amendments', () => {
 
     const originalResult = await dealReducer(mockBSSDeal);
 
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
+    api.getLatestCompletedDateAmendment = () => Promise.resolve(mockAmendmentDateResponse);
+    api.getAmendmentById = () => Promise.resolve(mockAmendment);
 
     const amendmentResult = {
       _id: mockBSSDeal._id,
@@ -102,7 +120,9 @@ describe('gef deal with amendments', () => {
     mockAmendment.ukefDecision.coverEndDate = AMENDMENT_UW_DECISION.DECLINED;
     mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
 
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockBSSDeal = {
       _id: MOCK_DEAL_AIN_SUBMITTED._id,
@@ -121,7 +141,9 @@ describe('gef deal with amendments', () => {
 
     const originalResult = await dealReducer(mockBSSDeal);
 
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve(mockAmendment);
 
     const amendmentResult = {
       _id: mockBSSDeal._id,

--- a/trade-finance-manager-api/src/graphql/reducers/deal-with-amendment-gef.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deal-with-amendment-gef.api-test.js
@@ -3,7 +3,6 @@ const dealReducer = require('./deal');
 const mapGefDeal = require('./mappings/gef-deal/mapGefDeal');
 const api = require('../../v1/api');
 const { CURRENCY } = require('../../constants/currency.constant');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../constants/deals');
 
 const MOCK_GEF_DEAL = require('../../v1/__mocks__/mock-gef-deal');
 const MOCK_CASH_CONTINGENT_FACILIIES = require('../../v1/__mocks__/mock-cash-contingent-facilities');
@@ -11,21 +10,20 @@ const MOCK_CASH_CONTINGENT_FACILIIES = require('../../v1/__mocks__/mock-cash-con
 describe('gef deal with amendments', () => {
   const coverEndDateUnix = 1658403289;
 
-  const mockAmendment = {
-    coverEndDate: coverEndDateUnix,
+  const mockAmendmentValueResponse = {
     value: 5000,
     currency: CURRENCY.GBP,
     amendmentId: '1234',
-    requireUkefApproval: true,
-    ukefDecision: {
-      submitted: true,
-      value: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-      coverEndDate: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-    },
+  };
+
+  const mockAmendmentDateResponse = {
+    coverEndDate: coverEndDateUnix,
+    amendmentId: '1234',
   };
 
   it('should return original deal as amendment not fully complete', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const mockGefDeal = {
       _id: MOCK_GEF_DEAL._id,
@@ -49,9 +47,8 @@ describe('gef deal with amendments', () => {
   });
 
   it('should return updated deal with completed amendment with 2 changes', async () => {
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const mockGefDeal = {
       _id: MOCK_GEF_DEAL._id,
@@ -69,7 +66,8 @@ describe('gef deal with amendments', () => {
 
     const originalResult = await dealReducer(mockGefDeal);
 
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
+    api.getLatestCompletedDateAmendment = () => Promise.resolve(mockAmendmentDateResponse);
 
     const amendmentResult = await mapGefDeal(mockGefDeal);
 
@@ -85,10 +83,8 @@ describe('gef deal with amendments', () => {
   });
 
   it('should return updated deal with completed amendment with 1 changes if 1 accepted and 1 rejected', async () => {
-    mockAmendment.ukefDecision.coverEndDate = AMENDMENT_UW_DECISION.DECLINED;
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const mockGefDeal = {
       _id: MOCK_GEF_DEAL._id,
@@ -105,8 +101,8 @@ describe('gef deal with amendments', () => {
     };
 
     const originalResult = await dealReducer(mockGefDeal);
-
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const amendmentResult = await mapGefDeal(mockGefDeal);
 

--- a/trade-finance-manager-api/src/graphql/reducers/deal.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deal.api-test.js
@@ -10,7 +10,8 @@ const MOCK_CASH_CONTINGENT_FACILIIES = require('../../v1/__mocks__/mock-cash-con
 
 describe('reducer - deal', () => {
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
   });
 
   it('should return mapped object', async () => {

--- a/trade-finance-manager-api/src/graphql/reducers/deals.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/deals.api-test.js
@@ -54,7 +54,8 @@ const mockGefDeal = {
 
 describe('reducer - deals', () => {
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
   });
 
   describe('mapBssDeal', () => {
@@ -131,5 +132,3 @@ describe('reducer - deals', () => {
     });
   });
 });
-
-/* eslint-enable no-underscore-dangle */

--- a/trade-finance-manager-api/src/graphql/reducers/facility.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/facility.api-test.js
@@ -10,7 +10,9 @@ const MOCK_CASH_CONTINGENT_FACILIIES = require('../../v1/__mocks__/mock-cash-con
 
 describe('reducer - facility', () => {
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
   });
 
   it('should return mapped object', async () => {

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapDealSnapshot.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapDealSnapshot.api-test.js
@@ -8,7 +8,9 @@ const api = require('../../../../v1/api');
 
 describe('mapDealSnapshot', () => {
   it('should return mapped object', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockFacilities = [
       {

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.api-test.js
@@ -2,7 +2,6 @@ const mapTotals = require('./mapTotals');
 const { formattedNumber } = require('../../../../utils/number');
 const api = require('../../../../v1/api');
 const { CURRENCY } = require('../../../../constants/currency.constant');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../../../constants/deals');
 
 describe('mapTotals', () => {
   const mockBondAndLoanFacilities = [
@@ -88,19 +87,16 @@ describe('mapTotals', () => {
     },
   ];
 
-  const mockAmendment = {
+  const mockAmendmentValueResponse = {
     value: 5000,
     currency: CURRENCY.GBP,
     amendmentId: '1234',
-    requireUkefApproval: true,
-    ukefDecision: {
-      submitted: true,
-      value: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-    },
   };
 
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
   });
 
   describe('with bond & loan facilities', () => {
@@ -117,7 +113,7 @@ describe('mapTotals', () => {
     });
 
     it('should return formatted total of all facility values when amendment not complete', async () => {
-      api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+      api.getLatestCompletedValueAmendment = () => Promise.resolve({});
 
       const result = await mapTotals(mockBondAndLoanFacilities);
 
@@ -131,9 +127,7 @@ describe('mapTotals', () => {
     });
 
     it('should return formatted total of all amended values when amendment completed', async () => {
-      mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-      api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+      api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
 
       const result = await mapTotals(mockBondAndLoanFacilities);
 
@@ -145,7 +139,7 @@ describe('mapTotals', () => {
       const notExpected = `${CURRENCY.GBP} ${formattedNumber(totalValue)}`;
       expect(result.facilitiesValueInGBP).not.toEqual(notExpected);
 
-      const newTotal = mockAmendment.value * mockBondAndLoanFacilities.length;
+      const newTotal = mockAmendmentValueResponse.value * mockBondAndLoanFacilities.length;
       const expected = `${CURRENCY.GBP} ${formattedNumber(newTotal)}`;
       expect(result.facilitiesValueInGBP).toEqual(expected);
     });
@@ -164,9 +158,7 @@ describe('mapTotals', () => {
     });
 
     it('should return formatted total of all facility values when amendment not complete', async () => {
-      mockAmendment.bankDecision = { decision: null };
-
-      api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+      api.getLatestCompletedValueAmendment = () => Promise.resolve({});
       const result = await mapTotals(mockCashAndContingentFacilities);
 
       const totalValue = Number(mockCashAndContingentFacilities[0].facilitySnapshot.value)
@@ -178,9 +170,7 @@ describe('mapTotals', () => {
     });
 
     it('should return formatted total of all amended values when amendment is complete', async () => {
-      mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-      api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+      api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
       const result = await mapTotals(mockCashAndContingentFacilities);
 
       const totalValue = Number(mockCashAndContingentFacilities[0].facilitySnapshot.value)
@@ -190,7 +180,7 @@ describe('mapTotals', () => {
       const notExpected = `${CURRENCY.GBP} ${formattedNumber(totalValue)}`;
       expect(result.facilitiesValueInGBP).not.toEqual(notExpected);
 
-      const newTotal = mockAmendment.value * mockCashAndContingentFacilities.length;
+      const newTotal = mockAmendmentValueResponse.value * mockCashAndContingentFacilities.length;
       const expected = `${CURRENCY.GBP} ${formattedNumber(newTotal)}`;
       expect(result.facilitiesValueInGBP).toEqual(expected);
     });
@@ -209,9 +199,7 @@ describe('mapTotals', () => {
   });
 
   it('should return formatted total of all facilities ukefExposure when amendment not complete', async () => {
-    mockAmendment.bankDecision = { decision: null };
-
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
     const result = await mapTotals(mockBondAndLoanFacilities);
 
     const totalUkefExposure = mockBondAndLoanFacilities[0].tfm.ukefExposure
@@ -224,9 +212,7 @@ describe('mapTotals', () => {
   });
 
   it('should return formatted total of all amended ukefExposure when amendment complete', async () => {
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
     const result = await mapTotals(mockBondAndLoanFacilities);
 
     const totalUkefExposure = 5000;

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.js
@@ -1,5 +1,5 @@
 const { formattedNumber } = require('../../../../utils/number');
-const { calculateNewFacilityValue, calculateAmendmentTotalExposure, isValidCompletedValueAmendment } = require('../../../helpers/amendment.helpers');
+const { calculateNewFacilityValue, calculateAmendmentTotalExposure } = require('../../../helpers/amendment.helpers');
 const isValidFacility = require('../../../helpers/isValidFacility.helper');
 const api = require('../../../../v1/api');
 const { CURRENCY } = require('../../../../constants/currency.constant');
@@ -12,13 +12,13 @@ const mapTotals = async (facilities) => {
     if (isValidFacility(facility)) {
       const { facilitySnapshot, tfm, _id } = facility;
 
-      const latestCompletedAmendment = await api.getLatestCompletedAmendment(_id);
+      const latestCompletedAmendmentValue = await api.getLatestCompletedValueAmendment(_id);
 
       // if latest amendment then returns value of new amendment
-      if (isValidCompletedValueAmendment(latestCompletedAmendment)) {
+      if (latestCompletedAmendmentValue?.value) {
         const { exchangeRate } = tfm;
 
-        const valueInGBP = calculateNewFacilityValue(exchangeRate, latestCompletedAmendment);
+        const valueInGBP = calculateNewFacilityValue(exchangeRate, latestCompletedAmendmentValue);
         return Number(valueInGBP);
       }
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapCoverEndDate.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapCoverEndDate.api-test.js
@@ -3,7 +3,6 @@ const { format, fromUnixTime } = require('date-fns');
 const mapCoverEndDate = require('./mapCoverEndDate');
 const { formatYear } = require('../../../../utils/date');
 const api = require('../../../../v1/api');
-const { DEALS } = require('../../../../constants');
 
 describe('mapCoverEndDate', () => {
   it('should return formatted cover end date', async () => {
@@ -56,7 +55,7 @@ describe('mapCoverEndDate', () => {
 
   describe('when facility provided but no latest completed amendment', () => {
     it('should return 4 digit year provided', async () => {
-      api.getLatestCompletedAmendment = () => Promise.resolve({});
+      api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
       const facilitySnapshot = {
         _id: '123',
@@ -90,17 +89,9 @@ describe('mapCoverEndDate', () => {
     it('should return modified coverEndDate', async () => {
       const coverEndDateUnix = 1658403289;
 
-      api.getLatestCompletedAmendment = () => Promise.resolve({
+      api.getLatestCompletedDateAmendment = () => Promise.resolve({
         coverEndDate: coverEndDateUnix,
         amendmentId: '1234',
-        bankDecision: {
-          submitted: true,
-          decision: DEALS.AMENDMENT_BANK_DECISION.PROCEED,
-        },
-        ukefDecision: {
-          submitted: true,
-          coverEndDate: DEALS.AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-        },
       });
 
       const facilitySnapshot = {

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapCoverEndDate.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapCoverEndDate.js
@@ -2,7 +2,6 @@ const { fromUnixTime, format } = require('date-fns');
 const { hasValue } = require('../../../../utils/string');
 const { formatYear } = require('../../../../utils/date');
 const api = require('../../../../v1/api');
-const { isValidCompletedCoverEndDateAmendment } = require('../../../helpers/amendment.helpers');
 
 const mapCoverEndDate = async (day, month, year, facilitySnapshot) => {
   const hasCoverEndDate = (hasValue(day) && hasValue(month) && hasValue(year));
@@ -15,10 +14,10 @@ const mapCoverEndDate = async (day, month, year, facilitySnapshot) => {
     if (facilitySnapshot) {
       const { _id } = facilitySnapshot;
 
-      const latestCompletedAmendment = await api.getLatestCompletedAmendment(_id);
+      const latestCompletedAmendmentCoverEndDate = await api.getLatestCompletedDateAmendment(_id);
 
-      if (isValidCompletedCoverEndDateAmendment(latestCompletedAmendment)) {
-        const { coverEndDate } = latestCompletedAmendment;
+      if (latestCompletedAmendmentCoverEndDate?.coverEndDate) {
+        const { coverEndDate } = latestCompletedAmendmentCoverEndDate;
         // maps new coverEndDate from unix timestamp in amendment
         dayToUse = format(fromUnixTime(coverEndDate), 'dd');
         monthToUse = format(fromUnixTime(coverEndDate), 'MM');

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilities.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilities.api-test.js
@@ -105,7 +105,9 @@ describe('mapFacilities', () => {
   ];
 
   it('should map and format correct fields/values', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const result = await mapFacilities(mockFacilities, mockDealDetails, MOCK_DEAL_TFM);
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacility.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacility.api-test.js
@@ -79,7 +79,8 @@ describe('mapFacility', () => {
   };
 
   it('should map and format correct fields/values', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const result = await mapFacility(mockFacility, mockTfmFacility, mockDealDetails, mockFacilityFull);
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValue.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValue.api-test.js
@@ -5,7 +5,7 @@ const { CURRENCY } = require('../../../../constants/currency.constant');
 
 describe('mapFacilityValue', () => {
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
   });
 
   describe('when no facility provided', () => {

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValue.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValue.js
@@ -1,7 +1,7 @@
 const { formattedNumber } = require('../../../../utils/number');
 const api = require('../../../../v1/api');
 const { CURRENCY } = require('../../../../constants/currency.constant');
-const { calculateNewFacilityValue, isValidCompletedValueAmendment } = require('../../../helpers/amendment.helpers');
+const { calculateNewFacilityValue } = require('../../../helpers/amendment.helpers');
 
 const mapFacilityValue = async (currencyId, value, facility) => {
   if (facility) {
@@ -10,12 +10,12 @@ const mapFacilityValue = async (currencyId, value, facility) => {
       tfm: facilityTfm,
     } = facility;
 
-    const latestCompletedAmendment = await api.getLatestCompletedAmendment(_id);
+    const latestCompletedAmendmentValue = await api.getLatestCompletedValueAmendment(_id);
 
-    if (isValidCompletedValueAmendment(latestCompletedAmendment)) {
+    if (latestCompletedAmendmentValue?.value) {
       const { exchangeRate } = facilityTfm;
 
-      const valueInGBP = calculateNewFacilityValue(exchangeRate, latestCompletedAmendment);
+      const valueInGBP = calculateNewFacilityValue(exchangeRate, latestCompletedAmendmentValue);
       return `${CURRENCY.GBP} ${formattedNumber(valueInGBP)}`;
     }
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValueExportCurrency.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValueExportCurrency.js
@@ -1,6 +1,6 @@
 const api = require('../../../../v1/api');
 const { formattedNumber } = require('../../../../utils/number');
-const { amendmentChangeValueExportCurrency, isValidCompletedValueAmendment } = require('../../../helpers/amendment.helpers');
+const { amendmentChangeValueExportCurrency } = require('../../../helpers/amendment.helpers');
 
 // maps facility value (in original currency) and checks if amendment change on that value
 const mapFacilityValueExportCurrency = async (facility) => {
@@ -10,11 +10,11 @@ const mapFacilityValueExportCurrency = async (facility) => {
     const { currency, value } = facilitySnapshot;
 
     // checks if completed amendment which is accepted
-    const latestCompletedAmendment = await api.getLatestCompletedAmendment(_id);
+    const latestCompletedAmendmentValue = await api.getLatestCompletedValueAmendment(_id);
 
-    if (isValidCompletedValueAmendment(latestCompletedAmendment)) {
+    if (latestCompletedAmendmentValue?.value) {
       // returns the new value from amendment if completed and accepted by bank and UKEF
-      return amendmentChangeValueExportCurrency(latestCompletedAmendment);
+      return amendmentChangeValueExportCurrency(latestCompletedAmendmentValue);
     }
     const formattedFacilityValue = formattedNumber(value);
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValueExporterCurrency.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilityValueExporterCurrency.api-test.js
@@ -1,6 +1,5 @@
 const mapFacilityValueExportCurrency = require('./mapFacilityValueExportCurrency');
 const { CURRENCY } = require('../../../../constants/currency.constant');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../../../constants/deals');
 const api = require('../../../../v1/api');
 
 describe('mapFacilityValueExportCurrency()', () => {
@@ -14,18 +13,14 @@ describe('mapFacilityValueExportCurrency()', () => {
     },
   };
 
-  const mockAmendment = {
+  const mockAmendmentValueResponse = {
     amendmentId: '123',
-    requireUkefApproval: true,
     value: 4000,
     currency: CURRENCY.GBP,
-    ukefDecision: {
-      value: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-    },
   };
 
   it('should return the facilitySnapshot currency and value when no latest amendment', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
 
     const result = await mapFacilityValueExportCurrency(mockFacility);
     const expected = `${CURRENCY.GBP} 1,000.00`;
@@ -33,7 +28,7 @@ describe('mapFacilityValueExportCurrency()', () => {
   });
 
   it('should return the facilitySnapshot currency and value when latest amendment is not complete', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
 
     const result = await mapFacilityValueExportCurrency(mockFacility);
     const expected = `${CURRENCY.GBP} 1,000.00`;
@@ -41,8 +36,7 @@ describe('mapFacilityValueExportCurrency()', () => {
   });
 
   it('should return the new amendment value when latest amendment is complete', async () => {
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
 
     const result = await mapFacilityValueExportCurrency(mockFacility);
     const expected = `${CURRENCY.GBP} 4,000.00`;
@@ -50,7 +44,7 @@ describe('mapFacilityValueExportCurrency()', () => {
   });
 
   it('should return null when there is no facility provided', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
 
     const result = await mapFacilityValueExportCurrency(null);
     expect(result).toBeNull();

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.api-test.js
@@ -1,6 +1,5 @@
 const api = require('../../../../v1/api');
 const mapTenor = require('./mapTenor');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../../../constants/deals');
 const { FACILITY_TYPE } = require('../../../../constants/facilities');
 
 describe('mapTenor()', () => {
@@ -33,18 +32,13 @@ describe('mapTenor()', () => {
     },
   };
 
-  const mockAmendment = {
+  const mockAmendmentDateResponse = {
     coverEndDate: coverEndDateUnix,
     amendmentId: '1234',
-    requireUkefApproval: true,
-    ukefDecision: {
-      submitted: true,
-      coverEndDate: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
-    },
   };
 
   it('should return tenor from facility when no amendment exists', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const result = await mapTenor(mockFacility.facilitySnapshot, mockFacility.tfm);
 
@@ -54,7 +48,7 @@ describe('mapTenor()', () => {
   });
 
   it('should return tenor from facility when no completed amendment exists', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
 
     const result = await mapTenor(mockFacility.facilitySnapshot, mockFacility.tfm);
 
@@ -64,9 +58,7 @@ describe('mapTenor()', () => {
   });
 
   it('should return tenor from amendment when completed amendment exists', async () => {
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedDateAmendment = () => Promise.resolve(mockAmendmentDateResponse);
     api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
 
     const result = await mapTenor(mockFacility.facilitySnapshot, mockFacility.tfm);

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.js
@@ -1,6 +1,6 @@
 const api = require('../../../../v1/api');
 const mapTenorDate = require('./mapTenorDate');
-const { calculateAmendmentTenor, isValidCompletedCoverEndDateAmendment } = require('../../../helpers/amendment.helpers');
+const { calculateAmendmentTenor } = require('../../../helpers/amendment.helpers');
 
 // maps tenor from new amendment coverEndDate or from original facility
 const mapTenor = async (facilitySnapshot, facilityTfm) => {
@@ -12,10 +12,10 @@ const mapTenor = async (facilitySnapshot, facilityTfm) => {
 
   if (facilitySnapshot?._id) {
     const { _id } = facilitySnapshot;
-    const latestCompletedAmendment = await api.getLatestCompletedAmendment(_id);
-    if (isValidCompletedCoverEndDateAmendment(latestCompletedAmendment)) {
+    const latestCompletedAmendmentCoverEndDate = await api.getLatestCompletedDateAmendment(_id);
+    if (latestCompletedAmendmentCoverEndDate?.coverEndDate) {
       // if amendment coverEndDate change, then calculates new tenor period
-      updatedExposurePeriodInMonths = await calculateAmendmentTenor(facilitySnapshot, latestCompletedAmendment);
+      updatedExposurePeriodInMonths = await calculateAmendmentTenor(facilitySnapshot, latestCompletedAmendmentCoverEndDate);
     }
   }
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.api-test.js
@@ -10,10 +10,20 @@ describe('mapUkefExposure()', () => {
     currency: CURRENCY.GBP,
     amendmentId: '1234',
     requireUkefApproval: true,
+    submittedAt: 1660047717,
     ukefDecision: {
       submitted: true,
       value: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
     },
+    bankDecision: {
+      decision: AMENDMENT_BANK_DECISION.PROCEED,
+      submittedAt: 1660047717,
+    },
+  };
+  const mockAmendmentValueResponse = {
+    value: 5000,
+    currency: CURRENCY.GBP,
+    amendmentId: '1234',
   };
 
   const facilitySnapshot = {
@@ -50,7 +60,7 @@ describe('mapUkefExposure()', () => {
       ukefExposureCalculationTimestamp: '1606900616651',
     };
 
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
 
     const mockFacility = {
       _id: '12',
@@ -78,7 +88,8 @@ describe('mapUkefExposure()', () => {
       ukefExposureCalculationTimestamp: '1606900616651',
     };
 
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
+    api.getAmendmentById = () => Promise.resolve(mockAmendment);
 
     const mockFacility = {
       _id: '12',

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposure.js
@@ -1,6 +1,6 @@
 const { formattedNumber } = require('../../../../utils/number');
 const api = require('../../../../v1/api');
-const { calculateNewFacilityValue, calculateUkefExposure, isValidCompletedValueAmendment } = require('../../../helpers/amendment.helpers');
+const { calculateNewFacilityValue, calculateUkefExposure } = require('../../../helpers/amendment.helpers');
 const { CURRENCY } = require('../../../../constants/currency.constant');
 
 // maps ukef exposure on original value or latest amended value
@@ -19,18 +19,24 @@ const mapUkefExposure = async (facilityTfm, facility) => {
     if (facility?._id) {
       const { _id } = facility;
 
-      const latestCompletedAmendment = await api.getLatestCompletedAmendment(_id);
+      // gets the latest value, amendmentId and currency from latest completed amendment with value change
+      const latestCompletedAmendmentValue = await api.getLatestCompletedValueAmendment(_id);
 
-      if (isValidCompletedValueAmendment(latestCompletedAmendment)) {
+      // if value exists - else there is no completed amendment with value changed
+      if (latestCompletedAmendmentValue?.value) {
+        const { amendmentId } = latestCompletedAmendmentValue;
         const { coverPercentage, coveredPercentage } = facility.facilitySnapshot;
-        const { requireUkefApproval, submittedAt, bankDecision } = latestCompletedAmendment;
+        // gets full amendment
+        const fullAmendment = await api.getAmendmentById(_id, amendmentId);
+
+        const { requireUkefApproval, submittedAt, bankDecision } = fullAmendment;
         // value of ukefExposureCalculationTime from automatic amendment submission time or manual amendment bankDecision submission time
         const ukefExposureTimestamp = requireUkefApproval ? bankDecision.submittedAt : submittedAt;
 
         // BSS is coveredPercentage while GEF is coverPercentage
         const coverPercentageValue = coverPercentage || coveredPercentage;
 
-        const valueInGBP = calculateNewFacilityValue(exchangeRate, latestCompletedAmendment);
+        const valueInGBP = calculateNewFacilityValue(exchangeRate, latestCompletedAmendmentValue);
         const ukefExposureValue = calculateUkefExposure(valueInGBP, coverPercentageValue);
 
         // sets new exposure value based on amendment value

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposureValue.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapUkefExposureValue.api-test.js
@@ -1,7 +1,7 @@
 const mapUkefExposureValue = require('./mapUkefExposureValue');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../../../constants/deals');
 const { formattedNumber } = require('../../../../utils/number');
 const { CURRENCY } = require('../../../../constants/currency.constant');
+const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../../../constants/deals');
 const api = require('../../../../v1/api');
 
 describe('mapUkefExposureValue()', () => {
@@ -14,6 +14,12 @@ describe('mapUkefExposureValue()', () => {
       submitted: true,
       value: AMENDMENT_UW_DECISION.APPROVED_WITHOUT_CONDITIONS,
     },
+  };
+
+  const mockAmendmentValueResponse = {
+    value: 5000,
+    currency: CURRENCY.GBP,
+    amendmentId: '1234',
   };
 
   const facilitySnapshot = {
@@ -33,7 +39,8 @@ describe('mapUkefExposureValue()', () => {
   };
 
   it('should return exposure from facility if no amendment completed', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const result = await mapUkefExposureValue(mockFacilityTfm, mockFacility);
 
@@ -43,7 +50,8 @@ describe('mapUkefExposureValue()', () => {
   });
 
   it('should return exposure from facility if no amendment completed', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const result = await mapUkefExposureValue(mockFacilityTfm, mockFacility);
 
@@ -55,7 +63,8 @@ describe('mapUkefExposureValue()', () => {
   it('should return exposure from amendment if amendment completed', async () => {
     mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
 
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
+    api.getAmendmentById = () => Promise.resolve(mockAmendment);
 
     const result = await mapUkefExposureValue(mockFacilityTfm, mockFacility);
 
@@ -67,9 +76,7 @@ describe('mapUkefExposureValue()', () => {
   });
 
   it('should return undefined if no facilityTfm', async () => {
-    mockAmendment.bankDecision = { decision: AMENDMENT_BANK_DECISION.PROCEED };
-
-    api.getLatestCompletedAmendment = () => Promise.resolve(mockAmendment);
+    api.getLatestCompletedValueAmendment = () => Promise.resolve(mockAmendmentValueResponse);
 
     const result = await mapUkefExposureValue(null, mockFacility);
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDeal.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDeal.api-test.js
@@ -8,7 +8,9 @@ const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-ca
 
 describe('mapGefDeal', () => {
   it('should return mapped deal', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockDeal = {
       _id: MOCK_GEF_DEAL._id,

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealSnapshot.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-deal/mapGefDealSnapshot.api-test.js
@@ -27,7 +27,9 @@ describe('mapGefDealSnapshot', () => {
   };
 
   it('should return mapped deal', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const result = await mapGefDealSnapshot(mockDeal.dealSnapshot, mockDeal.tfm);
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilities.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilities.api-test.js
@@ -5,7 +5,9 @@ const api = require('../../../../v1/api');
 
 describe('mapGefFacilities', () => {
   it('should return mapped GEF facilities', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockDealSnapshot = {
       facilities: [

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacility.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacility.api-test.js
@@ -16,7 +16,9 @@ const MOCK_CASH_CONTINGENT_FACILIIES = require('../../../../v1/__mocks__/mock-ca
 
 describe('mapGefFacility', () => {
   it('should return mapped GEF facility', async () => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
+    api.getAmendmentById = () => Promise.resolve({});
 
     const mockFacility = {
       _id: MOCK_CASH_CONTINGENT_FACILIIES[0]._id,

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityDates.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/gef-facilities/mapGefFacilityDates.api-test.js
@@ -20,7 +20,8 @@ describe('mapGefFacilityDates', () => {
   };
 
   beforeEach(() => {
-    api.getLatestCompletedAmendment = () => Promise.resolve({});
+    api.getLatestCompletedValueAmendment = () => Promise.resolve({});
+    api.getLatestCompletedDateAmendment = () => Promise.resolve({});
   });
 
   it('should return inclusionNoticeReceived as deal submissionDate if manualInclusionNoticeSubmissionDate is empty', async () => {

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -369,7 +369,7 @@ const getLatestCompletedDateAmendment = async (facilityId) => {
     try {
       const response = await axios({
         method: 'get',
-        url: `${centralApiUrl}/v1/tfm/facilities/${facilityId}/amendment/status/completed/latest-date`,
+        url: `${centralApiUrl}/v1/tfm/facilities/${facilityId}/amendment/status/completed/latest-cover-end-date`,
         headers: { 'Content-Type': 'application/json' },
       });
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -342,19 +342,40 @@ const getCompletedAmendment = async (facilityId) => {
   }
 };
 
-const getLatestCompletedAmendment = async (facilityId) => {
+const getLatestCompletedValueAmendment = async (facilityId) => {
   const isValid = hasValidObjectId(facilityId) && hasValidUri(centralApiUrl);
   if (isValid) {
     try {
       const response = await axios({
         method: 'get',
-        url: `${centralApiUrl}/v1/tfm/facilities/${facilityId}/amendment/status/completed/latest`,
+        url: `${centralApiUrl}/v1/tfm/facilities/${facilityId}/amendment/status/completed/latest-value`,
         headers: { 'Content-Type': 'application/json' },
       });
 
       return response.data;
     } catch (err) {
-      console.error('Unable to get the latest completed amendment %O', { response: err?.response?.data });
+      console.error('Unable to get the latest completed value amendment %O', { response: err?.response?.data });
+      return { status: 500, data: err?.response?.data };
+    }
+  } else {
+    console.error('Invalid facility Id');
+    return { status: 400, data: 'Invalid facility Id amendment Id provided' };
+  }
+};
+
+const getLatestCompletedDateAmendment = async (facilityId) => {
+  const isValid = hasValidObjectId(facilityId) && hasValidUri(centralApiUrl);
+  if (isValid) {
+    try {
+      const response = await axios({
+        method: 'get',
+        url: `${centralApiUrl}/v1/tfm/facilities/${facilityId}/amendment/status/completed/latest-date`,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      return response.data;
+    } catch (err) {
+      console.error('Unable to get the latest completed coverEndDate amendment %O', { response: err?.response?.data });
       return { status: 500, data: err?.response?.data };
     }
   } else {
@@ -998,7 +1019,8 @@ module.exports = {
   updateFacilityAmendment,
   getAmendmentInProgress,
   getCompletedAmendment,
-  getLatestCompletedAmendment,
+  getLatestCompletedValueAmendment,
+  getLatestCompletedDateAmendment,
   getAmendmentById,
   getAmendmentByFacilityId,
   getAmendmentsByDealId,

--- a/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
@@ -137,13 +137,22 @@ const getCompletedAmendment = async (req, res) => {
   return res.status(422).send({ data: 'Unable to get the completed amendment' });
 };
 
-const getLatestCompletedAmendment = async (req, res) => {
+const getLatestCompletedValueAmendment = async (req, res) => {
   const { facilityId } = req.params;
-  const amendment = await api.getLatestCompletedAmendment(facilityId);
+  const amendment = await api.getLatestCompletedValueAmendment(facilityId);
   if (amendment) {
     return res.status(200).send(amendment);
   }
-  return res.status(422).send({ data: 'Unable to get the latest completed amendment' });
+  return res.status(422).send({ data: 'Unable to get the latest completed value amendment' });
+};
+
+const getLatestCompletedDateAmendment = async (req, res) => {
+  const { facilityId } = req.params;
+  const amendment = await api.getLatestCompletedDateAmendment(facilityId);
+  if (amendment) {
+    return res.status(200).send(amendment);
+  }
+  return res.status(422).send({ data: 'Unable to get the latest completed coverEndDate amendment' });
 };
 
 const getAmendmentById = async (req, res) => {
@@ -213,7 +222,6 @@ module.exports = {
   updateFacilityAmendment,
   getAmendmentInProgress,
   getCompletedAmendment,
-  getLatestCompletedAmendment,
   getAmendmentById,
   getAmendmentByFacilityId,
   getAmendmentsByDealId,
@@ -223,4 +231,6 @@ module.exports = {
   getAllAmendmentsInProgress,
   sendAmendmentEmail,
   updateTFMDealLastUpdated,
+  getLatestCompletedValueAmendment,
+  getLatestCompletedDateAmendment,
 };

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -144,7 +144,8 @@ openRouter.route('/facility/:facilityId/amendment/:amendmentId').put(amendmentCo
 openRouter.route('/facility/:facilityId/amendment/:amendmentId').get(amendmentController.getAmendmentById);
 openRouter.route('/facility/:facilityId/amendment/status/in-progress').get(amendmentController.getAmendmentInProgress);
 openRouter.route('/facility/:facilityId/amendment/status/completed').get(amendmentController.getCompletedAmendment);
-openRouter.route('/facility/:facilityId/amendment/status/completed/latest').get(amendmentController.getLatestCompletedAmendment);
+openRouter.route('/facility/:facilityId/amendment/status/completed/latest-value').get(amendmentController.getLatestCompletedValueAmendment);
+openRouter.route('/facility/:facilityId/amendment/status/completed/latest-cover-end-date').get(amendmentController.getLatestCompletedDateAmendment);
 openRouter.route('/deal/:dealId/amendments/').get(amendmentController.getAmendmentsByDealId);
 openRouter.route('/deal/:dealId/amendment/status/in-progress').get(amendmentController.getAmendmentInProgressByDealId);
 openRouter.route('/deal/:dealId/amendment/status/completed').get(amendmentController.getCompletedAmendmentByDealId);

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -337,17 +337,32 @@ const getCompletedAmendment = async (facilityId) => {
   }
 };
 
-const getLatestCompletedAmendment = async (facilityId) => {
+const getLatestCompletedValueAmendment = async (facilityId) => {
   try {
     const response = await axios({
       method: 'get',
-      url: `${tfmAPIurl}/v1/facility/${facilityId}/amendment/status/completed/latest`,
+      url: `${tfmAPIurl}/v1/facility/${facilityId}/amendment/status/completed/latest-value`,
       headers: { 'Content-Type': 'application/json' },
     });
 
     return { status: 200, data: response.data };
   } catch (err) {
-    console.error('Unable to get the latest completed amendment %O', { response: err?.response?.data });
+    console.error('Unable to get the latest completed value amendment %O', { response: err?.response?.data });
+    return { status: err?.response?.status, data: err?.response?.data };
+  }
+};
+
+const getLatestCompletedDateAmendment = async (facilityId) => {
+  try {
+    const response = await axios({
+      method: 'get',
+      url: `${tfmAPIurl}/v1/facility/${facilityId}/amendment/status/completed/latest-cover-end-date`,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    return { status: 200, data: response.data };
+  } catch (err) {
+    console.error('Unable to get the latest completed coverEndDate amendment %O', { response: err?.response?.data });
     return { status: err?.response?.status, data: err?.response?.data };
   }
 };
@@ -466,7 +481,6 @@ module.exports = {
   createFacilityAmendment,
   getAmendmentInProgress,
   getCompletedAmendment,
-  getLatestCompletedAmendment,
   getAmendmentById,
   getAmendmentsByFacilityId,
   getAmendmentsByDealId,
@@ -474,4 +488,6 @@ module.exports = {
   getCompletedAmendmentByDealId,
   getLatestCompletedAmendmentByDealId,
   getAllAmendmentsInProgress,
+  getLatestCompletedValueAmendment,
+  getLatestCompletedDateAmendment,
 };

--- a/trade-finance-manager-ui/server/controllers/case/amendments/amendCoverEndDate.controller.js
+++ b/trade-finance-manager-ui/server/controllers/case/amendments/amendCoverEndDate.controller.js
@@ -2,7 +2,6 @@ const { format, fromUnixTime, getUnixTime } = require('date-fns');
 const api = require('../../../api');
 const { coverEndDateValidation } = require('./validation/amendCoverEndDateDate.validate');
 const { AMENDMENT_STATUS } = require('../../../constants/amendments');
-const { latestAmendmentCoverEndDateAccepted } = require('../../helpers/amendments.helper');
 
 const getAmendCoverEndDate = async (req, res) => {
   const { facilityId, amendmentId } = req.params;
@@ -25,16 +24,12 @@ const getAmendCoverEndDate = async (req, res) => {
   }
 
   const facility = await api.getFacility(facilityId);
-  const { data: latestAmendment } = await api.getLatestCompletedAmendment(facilityId, amendmentId);
+  const { data: latestAmendmentCoverEndDate } = await api.getLatestCompletedDateAmendment(facilityId, amendmentId);
+
   let currentCoverEndDate = format(new Date(facility.facilitySnapshot.dates.coverEndDate), 'dd MMMM yyyy');
 
-  // if currentCoverEndDate exists, then use it
-  if (latestAmendment.currentCoverEndDate) {
-    currentCoverEndDate = format(fromUnixTime(latestAmendment.currentCoverEndDate), 'dd MMMM yyyy');
-  }
-
-  if (latestAmendmentCoverEndDateAccepted(latestAmendment)) {
-    currentCoverEndDate = format(fromUnixTime(latestAmendment.coverEndDate), 'dd MMMM yyyy');
+  if (latestAmendmentCoverEndDate?.coverEndDate) {
+    currentCoverEndDate = format(fromUnixTime(latestAmendmentCoverEndDate.coverEndDate), 'dd MMMM yyyy');
   }
 
   return res.render('case/amendments/amendment-cover-end-date.njk', {
@@ -54,17 +49,12 @@ const postAmendCoverEndDate = async (req, res) => {
   const { data: amendment } = await api.getAmendmentById(facilityId, amendmentId);
   const { dealId } = amendment;
   const facility = await api.getFacility(facilityId);
-  const { data: latestAmendment } = await api.getLatestCompletedAmendment(facilityId);
+  const { data: latestAmendmentCoverEndDate } = await api.getLatestCompletedDateAmendment(facilityId, amendmentId);
 
   let currentCoverEndDate = format(new Date(facility.facilitySnapshot.dates.coverEndDate), 'dd MMMM yyyy');
 
-  // if currentCoverEndDate exists, then use it
-  if (latestAmendment.currentCoverEndDate) {
-    currentCoverEndDate = format(fromUnixTime(latestAmendment.currentCoverEndDate), 'dd MMMM yyyy');
-  }
-
-  if (latestAmendmentCoverEndDateAccepted(latestAmendment)) {
-    currentCoverEndDate = format(fromUnixTime(latestAmendment.coverEndDate), 'dd MMMM yyyy');
+  if (latestAmendmentCoverEndDate?.coverEndDate) {
+    currentCoverEndDate = format(fromUnixTime(latestAmendmentCoverEndDate.coverEndDate), 'dd MMMM yyyy');
   }
 
   const { coverEndDate, errorsObject, coverEndDateErrors } = await coverEndDateValidation(req.body, currentCoverEndDate);

--- a/trade-finance-manager-ui/server/controllers/case/amendments/amendFacilityValue.controller.js
+++ b/trade-finance-manager-ui/server/controllers/case/amendments/amendFacilityValue.controller.js
@@ -2,7 +2,6 @@ const api = require('../../../api');
 const { AMENDMENT_STATUS } = require('../../../constants/amendments');
 const { amendFacilityValueValidation } = require('./validation/amendFacilityValue.validate');
 const { formattedNumber } = require('../../../helpers/number');
-const { latestAmendmentValueAccepted } = require('../../helpers/amendments.helper');
 
 const getAmendFacilityValue = async (req, res) => {
   const { facilityId, amendmentId } = req.params;
@@ -13,19 +12,15 @@ const getAmendFacilityValue = async (req, res) => {
   }
 
   const facility = await api.getFacility(facilityId);
-  const { data: latestAmendment } = await api.getLatestCompletedAmendment(facilityId);
+  const { data: latestAmendmentValue } = await api.getLatestCompletedValueAmendment(facilityId);
 
   const { dealId, value } = amendment;
   const isEditable = amendment.status === AMENDMENT_STATUS.IN_PROGRESS && amendment.changeFacilityValue;
   const { currency } = facility.facilitySnapshot;
   let currentFacilityValue = facility.facilitySnapshot.facilityValueExportCurrency;
 
-  // if currentValue exists, then use it, else use from snapshot
-  if (latestAmendment.currentValue) {
-    currentFacilityValue = `${currency} ${formattedNumber(latestAmendment.currentValue)}`;
-  }
-  if (latestAmendmentValueAccepted(latestAmendment)) {
-    currentFacilityValue = `${currency} ${formattedNumber(latestAmendment.value)}`;
+  if (latestAmendmentValue?.value) {
+    currentFacilityValue = `${currency} ${formattedNumber(latestAmendmentValue.value)}`;
   }
 
   return res.render('case/amendments/amendment-facility-value.njk', {
@@ -45,17 +40,12 @@ const postAmendFacilityValue = async (req, res) => {
 
   const facility = await api.getFacility(facilityId);
 
-  const { data: latestAmendment } = await api.getLatestCompletedAmendment(facilityId);
+  const { data: latestAmendmentValue } = await api.getLatestCompletedValueAmendment(facilityId);
   const { currency } = facility.facilitySnapshot;
   let currentFacilityValue = facility.facilitySnapshot.facilityValueExportCurrency;
 
-  // if currentValue exists, then use it, else use from snapshot
-  if (latestAmendment.currentValue) {
-    currentFacilityValue = `${currency} ${formattedNumber(latestAmendment.currentValue)}`;
-  }
-
-  if (latestAmendmentValueAccepted(latestAmendment)) {
-    currentFacilityValue = `${currency} ${formattedNumber(latestAmendment.value)}`;
+  if (latestAmendmentValue?.value) {
+    currentFacilityValue = `${currency} ${formattedNumber(latestAmendmentValue.value)}`;
   }
 
   const { errorsObject, amendFacilityValueErrors } = amendFacilityValueValidation(currentFacilityValue, value, currency);

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
@@ -1,7 +1,7 @@
 const CONSTANTS = require('../../constants');
 const { userIsInTeam } = require('../../helpers/user');
 
-const { AMENDMENTS, DECISIONS } = CONSTANTS;
+const { AMENDMENTS } = CONSTANTS;
 
 /**
  * @param {Object} deal
@@ -91,46 +91,6 @@ const amendmentsInProgressByDeal = async (amendments) => {
   return [];
 };
 
-const latestAmendmentValueAccepted = (amendment) => {
-  const { ukefDecision, bankDecision, value, requireUkefApproval } = amendment;
-  const { APPROVED_WITH_CONDITIONS } = DECISIONS.UNDERWRITER_MANAGER_DECISIONS;
-  const { APPROVED_WITHOUT_CONDITIONS } = DECISIONS.UNDERWRITER_MANAGER_DECISIONS;
-  const { PROCEED } = AMENDMENTS.AMENDMENT_BANK_DECISION;
-
-  const ukefDecisionApproved = ukefDecision?.value === APPROVED_WITH_CONDITIONS || ukefDecision?.value === APPROVED_WITHOUT_CONDITIONS;
-  const bankProceed = bankDecision?.decision === PROCEED;
-
-  if (!requireUkefApproval && value) {
-    return true;
-  }
-
-  if (value && ukefDecisionApproved && bankProceed) {
-    return true;
-  }
-
-  return false;
-};
-
-const latestAmendmentCoverEndDateAccepted = (amendment) => {
-  const { ukefDecision, bankDecision, coverEndDate, requireUkefApproval } = amendment;
-  const { APPROVED_WITH_CONDITIONS } = DECISIONS.UNDERWRITER_MANAGER_DECISIONS;
-  const { APPROVED_WITHOUT_CONDITIONS } = DECISIONS.UNDERWRITER_MANAGER_DECISIONS;
-  const { PROCEED } = AMENDMENTS.AMENDMENT_BANK_DECISION;
-
-  const ukefDecisionApproved = ukefDecision?.coverEndDate === APPROVED_WITH_CONDITIONS || ukefDecision?.coverEndDate === APPROVED_WITHOUT_CONDITIONS;
-  const bankProceed = bankDecision?.decision === PROCEED;
-
-  if (!requireUkefApproval && coverEndDate) {
-    return true;
-  }
-
-  if (coverEndDate && ukefDecisionApproved && bankProceed) {
-    return true;
-  }
-
-  return false;
-};
-
 module.exports = {
   showAmendmentButton,
   userCanEditManagersDecision,
@@ -139,6 +99,4 @@ module.exports = {
   validateUkefDecision,
   hasAmendmentInProgressDealStage,
   amendmentsInProgressByDeal,
-  latestAmendmentValueAccepted,
-  latestAmendmentCoverEndDateAccepted,
 };

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.test.js
@@ -4,8 +4,6 @@ import {
   userCanEditManagersDecision,
   ukefDecisionRejected,
   validateUkefDecision,
-  latestAmendmentValueAccepted,
-  latestAmendmentCoverEndDateAccepted,
 } from '.';
 
 import MOCKS from '../../test-mocks/amendment-test-mocks';
@@ -248,70 +246,6 @@ describe('validateUkefDecision()', () => {
   it('should return `false` when only facility value is approved', () => {
     MOCKS.MOCK_AMENDMENT_FACILITYVALUE.ukefDecision.value = CONSTANTS.DECISIONS.UNDERWRITER_MANAGER_DECISIONS.APPROVED_WITHOUT_CONDITIONS;
     const result = validateUkefDecision(MOCKS.MOCK_AMENDMENT_FACILITYVALUE.ukefDecision, CONSTANTS.DECISIONS.UNDERWRITER_MANAGER_DECISIONS.DECLINED);
-    expect(result).toEqual(false);
-  });
-});
-
-describe('latestAmendmentValueAccepted()', () => {
-  it('should return `true` when automatic amendment and value was set', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_AUTOMATIC_VALUE);
-    expect(result).toEqual(true);
-  });
-
-  it('should return `false` when automatic amendment and coverEndDate was set', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_AUTOMATIC_COVERENDDATE);
-    expect(result).toEqual(false);
-  });
-
-  it('should return `true` when manual amendment and value was set, approved and proceed', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_BANK_DECISION_PROCEED_VALUE);
-    expect(result).toEqual(true);
-  });
-
-  it('should return `false` when manual amendment and coverEndDate was set, approved and proceed', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_BANK_DECISION_PROCEED_COVERENDDATE);
-    expect(result).toEqual(false);
-  });
-
-  it('should return `false` when manual amendment and value was set, approved and no bank decision', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_BANK_DECISION_PROCEED_COVERENDDATE);
-    expect(result).toEqual(false);
-  });
-
-  it('should return `false` when manual amendment and value was set, approved and declined', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_TWO_AMENDMENTS_ONE_DECLINED_COVERENDDATE);
-    expect(result).toEqual(false);
-  });
-});
-
-describe('latestAmendmentCoverEndDateAccepted()', () => {
-  it('should return `true` when automatic amendment and coverEndDate was set', () => {
-    const result = latestAmendmentCoverEndDateAccepted(MOCKS.MOCK_AMENDMENT_AUTOMATIC_COVERENDDATE);
-    expect(result).toEqual(true);
-  });
-
-  it('should return `false` when automatic amendment and coverEndDate was set', () => {
-    const result = latestAmendmentCoverEndDateAccepted(MOCKS.MOCK_AMENDMENT_AUTOMATIC_VALUE);
-    expect(result).toEqual(false);
-  });
-
-  it('should return `true` when manual amendment and coverEndDate was set, approved and proceed', () => {
-    const result = latestAmendmentCoverEndDateAccepted(MOCKS.MOCK_AMENDMENT_BANK_DECISION_PROCEED_COVERENDDATE);
-    expect(result).toEqual(true);
-  });
-
-  it('should return `false` when manual amendment and value was set, approved and proceed', () => {
-    const result = latestAmendmentCoverEndDateAccepted(MOCKS.MOCK_AMENDMENT_BANK_DECISION_PROCEED_VALUE);
-    expect(result).toEqual(false);
-  });
-
-  it('should return `false` when manual amendment and coverEndDate was set, approved and no bank decision', () => {
-    const result = latestAmendmentCoverEndDateAccepted(MOCKS.MOCK_AMENDMENT_TWO_AMENDMENTS_ONE_DECLINED_WITH_COVERENDDATE_SET);
-    expect(result).toEqual(false);
-  });
-
-  it('should return `false` when manual amendment and coverEndDate was set, approved and declined', () => {
-    const result = latestAmendmentValueAccepted(MOCKS.MOCK_AMENDMENT_BANK_DECISION_WITHDRAW_COVERENDDATE);
     expect(result).toEqual(false);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/helpers/index.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/index.js
@@ -4,8 +4,6 @@ const {
   userCanEditBankDecision,
   ukefDecisionRejected,
   validateUkefDecision,
-  latestAmendmentValueAccepted,
-  latestAmendmentCoverEndDateAccepted,
 } = require('./amendments.helper');
 const { generateHeadingText } = require('./generateHeadingText.helper');
 const { mapDecisionObject, mapDecisionValue } = require('./mapDecisionObject.helper');
@@ -27,6 +25,4 @@ module.exports = {
   ukefDecisionRejected,
   validateUkefDecision,
   probabilityOfDefaultValidation,
-  latestAmendmentValueAccepted,
-  latestAmendmentCoverEndDateAccepted,
 };


### PR DESCRIPTION
# Issue:
* When having multiple single change amendments, if latest amendment was only value, coverEndDate would revert to facility submission value

# Changes made:
* 2 new endpoints for getting latest amendment value and coverEndDate
* Modified mapping to take new object instead
* Updated api-tests
* Added e2e test 