### PR TITLE
fix(DTFS2-6009): Remove effective date validation for automatic amendments

### DIFF
--- a/e2e-tests/e2e-fixtures/dateConstants.js
+++ b/e2e-tests/e2e-fixtures/dateConstants.js
@@ -13,6 +13,7 @@ const fourDaysAgo = sub(today, { days: 4 });
 const fourDaysAgoDay = format(fourDaysAgo, 'dd');
 const fourDaysAgoMonth = format(fourDaysAgo, 'M');
 const fourDaysAgoYear = format(fourDaysAgo, 'yyyy');
+const fourDaysAgoFull = format(fourDaysAgo, 'd MMMM yyyy');
 const oneMonth = add(today, { months: 1 });
 const oneMonthDay = format(oneMonth, 'dd');
 const oneMonthMonth = format(oneMonth, 'M');
@@ -71,6 +72,7 @@ export default {
   fourDaysAgoDay,
   fourDaysAgoMonth,
   fourDaysAgoYear,
+  fourDaysAgoFull,
   oneMonth,
   oneMonthDay,
   oneMonthMonth,

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/7. amendment-details-automatic-approval.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/amendments/7. amendment-details-automatic-approval.spec.js
@@ -79,9 +79,9 @@ context('Amendments - automatic approval journey', () => {
       amendmentsPage.continueAmendment().click();
       cy.url().should('contain', 'amendment-effective-date');
 
-      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.fourDaysAgoDay);
+      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.fourDaysAgoMonth);
+      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.fourDaysAgoYear);
       amendmentsPage.continueAmendment().click();
 
       cy.url().should('contain', 'amendment-options');
@@ -134,7 +134,7 @@ context('Amendments - automatic approval journey', () => {
 
       amendmentsPage.amendmentAnswerBankRequestDate().should('contain', dateConstants.todayDay);
       amendmentsPage.amendmentAnswerRequireApproval().should('contain', 'No');
-      amendmentsPage.amendmentAnswerEffectiveDate().should('contain', dateConstants.todayDay);
+      amendmentsPage.amendmentAnswerEffectiveDate().should('contain', dateConstants.fourDaysAgoDay);
       amendmentsPage.amendmentAnswerCoverEndDate().should('contain', dateConstants.tomorrowDay);
       amendmentsPage.amendmentAnswerFacilityValue().should('contain', 'GBP 123.00');
 
@@ -150,7 +150,7 @@ context('Amendments - automatic approval journey', () => {
 
       facilityPage.facilityTabAmendments().click();
       amendmentsPage.amendmentDetails.row(1).heading().should('contain', 'Amendment 1');
-      amendmentsPage.amendmentDetails.row(1).effectiveDate().should('contain', dateConstants.todayFormattedFull);
+      amendmentsPage.amendmentDetails.row(1).effectiveDate().should('contain', dateConstants.fourDaysAgoFull);
       amendmentsPage.amendmentDetails.row(1).currentCoverEndDate().should('contain', '20 October 2022');
       amendmentsPage.amendmentDetails.row(1).newCoverEndDate().should('contain', dateConstants.tomorrowDay);
       amendmentsPage.amendmentDetails.row(1).ukefDecisionCoverEndDate().should('contain', UNDERWRITER_MANAGER_DECISIONS.AUTOMATIC_APPROVAL);
@@ -299,7 +299,7 @@ context('Amendments - automatic approval journey', () => {
 
       amendmentsPage.amendmentAnswerBankRequestDate().should('contain', dateConstants.todayDay);
       amendmentsPage.amendmentAnswerRequireApproval().should('contain', 'No');
-      amendmentsPage.amendmentAnswerEffectiveDate().should('contain', dateConstants.todayDay);
+      amendmentsPage.amendmentAnswerEffectiveDate().should('contain', dateConstants.fourDaysAgoDay);
       amendmentsPage.amendmentAnswerCoverEndDate().should('contain', dateConstants.tomorrowDay);
 
       amendmentsPage.continueAmendment().click();

--- a/trade-finance-manager-ui/server/controllers/case/amendments/validation/amendmentEffectiveDate.validate.js
+++ b/trade-finance-manager-ui/server/controllers/case/amendments/validation/amendmentEffectiveDate.validate.js
@@ -1,4 +1,4 @@
-const { isBefore, set, getUnixTime } = require('date-fns');
+const { set, getUnixTime } = require('date-fns');
 const { validationErrorHandler } = require('../../../../helpers/validationErrorHandler.helper');
 
 /**
@@ -51,18 +51,6 @@ const effectiveDateValidation = async (body) => {
       errMsg: msg,
       subFieldErrorRefs: dateFieldsInError,
     });
-  } else if (amendmentEffectiveIsFullyComplete) {
-    const today = (new Date()).setHours(2, 2, 2, 2);
-    let effectiveDateSet = set(new Date(), { year: effectiveDateYear, month: effectiveDateMonth - 1, date: effectiveDateDay });
-    effectiveDateSet = effectiveDateSet.setHours(2, 2, 2, 2);
-
-    // checks amendment date is not in the future
-    if (isBefore(effectiveDateSet, today)) {
-      effectiveDateErrors.push({
-        errRef: 'effectiveDate',
-        errMsg: 'The date the amendment is effective from must be today or in the future',
-      });
-    }
   }
 
   if (amendmentEffectiveIsFullyComplete) {


### PR DESCRIPTION
# Issue: 
* Automatic amendments could only have effective date today or in the future

# Changes made:
* Removed validation for effective date not being in the past
* Added to automatic amendment e2e test with past effective date