### PR TITLE
fix(DTFS2-6013): Two decimal point format - Facility Records

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/helpers/get-interest-or-fee-rate.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-interest-or-fee-rate.js
@@ -1,11 +1,24 @@
 const CONSTANTS = require('../../../constants');
 
+/**
+ * Formats an amount with trailing two decimal points integer
+ * @param {Integer} amount Amount with or without decimal points integers
+ * @returns {Integer} Two decimal points formatted integer
+ */
+const decimalPoint = (amount) => {
+  if (amount) {
+    return Number(Number(amount).toFixed(2));
+  }
+
+  return amount;
+};
+
 const getInterestOrFeeRate = (facility) => {
   /**
    * Facility record update
    */
   if (facility.update) {
-    return facility.update.intrestOrFeeRate;
+    return decimalPoint(facility.update.intrestOrFeeRate);
   }
 
   /**
@@ -13,19 +26,19 @@ const getInterestOrFeeRate = (facility) => {
    */
   // GEF
   if (facility.facilitySnapshot.interestPercentage) {
-    return facility.facilitySnapshot.interestPercentage;
+    return decimalPoint(facility.facilitySnapshot.interestPercentage);
   }
 
   // EWCS/BSS
   switch (facility.facilitySnapshot.type) {
     case CONSTANTS.FACILITY.FACILITY_TYPE.BOND:
-      return Number(facility.facilitySnapshot.riskMarginFee);
+      return decimalPoint(facility.facilitySnapshot.riskMarginFee);
 
     case CONSTANTS.FACILITY.FACILITY_TYPE.LOAN:
-      return Number(facility.facilitySnapshot.interestMarginFee);
+      return decimalPoint(facility.facilitySnapshot.interestMarginFee);
 
     default:
-      return '';
+      return 0;
   }
 };
 


### PR DESCRIPTION
## Introduction
Amid recent ACBS facility master records creation failure, a two decimal point formatting is required.
Despite this has never been an issue before (Deals submitted prior to 24/08/2022) but nevertheless a back-end level decimal point formatting is a necessity. 

## Resolution
* Introduction of `decimalPoint` function responsible for trailing two decimal point formatting.
* Default value set to `0`.