### PR TITLE
fix(DTFS2-5970): BSS exposure rounded off

### DIFF
--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
@@ -89,6 +89,9 @@ context('Portal to TFM deal submission', () => {
     const issuedBondId = issuedBond._id;
     facilityRow = tfmPages.caseDealPage.dealFacilitiesTable.row(issuedBondId);
 
+    // contains exposure to 2 decimal places (not rounded)
+    facilityRow.facilityExposure().contains('486.14');
+
     facilityRow.facilityId().click();
 
     cy.url().should('eq', `${TFM_URL}/case/${dealId}/facility/${issuedBondId}`);
@@ -113,6 +116,9 @@ context('Portal to TFM deal submission', () => {
 
     const issuedLoanId = issuedLoan._id;
     facilityRow = tfmPages.caseDealPage.dealFacilitiesTable.row(issuedLoanId);
+
+    // contains exposure to 2 decimal places (not rounded)
+    facilityRow.facilityExposure().contains('87.27');
 
     facilityRow.facilityId().click();
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/caseDealPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/caseDealPage.js
@@ -18,6 +18,7 @@ const caseDealPage = {
         facilityId: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-facility-id-link"]`),
         facilityTenor: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-tenor"]`),
         facilityEndDate: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-cover-end-date"]`),
+        facilityExposure: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-exposure"]`),
       };
     },
   },

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.api-test.js
@@ -65,7 +65,7 @@ describe('mappings - map submitted deal - mapBssEwcsFacility', () => {
         currencyCode: currency.id,
         value: Number(value.replace(/,/g, '')),
         coverPercentage: Number(coveredPercentage),
-        ukefExposure: Number(ukefExposure.split('.')[0].replace(/,/g, '')),
+        ukefExposure: Number(ukefExposure.replace(/,/g, '')),
         ukefGuaranteeInMonths,
         hasBeenIssued: isIssued(facilityStage),
         hasBeenAcknowledged,

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-facility.js
@@ -52,7 +52,7 @@ const mapBssEwcsFacility = (facility) => {
     hasBeenIssuedAndAcknowledged,
   } = facility;
 
-  const cleanUkefExposure = Number(ukefExposure.split('.')[0].replace(/,/g, ''));
+  const cleanUkefExposure = Number(ukefExposure.replace(/,/g, ''));
 
   return {
     _id,


### PR DESCRIPTION
# Issue:
* Exposure values for BSS facilities were rounded to the nearest number so decimal places were always 00

# Changes made:
* Removed split which cut off decimal places in mapping function for BSS
* Added to tests