### PR TITLE
fix(DTFS2-5829): Match parties task non-conditional

### DIFF
--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
@@ -89,8 +89,17 @@ context('Portal to TFM deal submission', () => {
     const issuedBondId = issuedBond._id;
     facilityRow = tfmPages.caseDealPage.dealFacilitiesTable.row(issuedBondId);
 
+    // calculate ukef exposure from value in GBP
+    facilityRow.facilityValueGBP().then((value) => {
+      facilityRow = tfmPages.caseDealPage.dealFacilitiesTable.row(issuedBondId);
+      // removes GBP before
+      const valueinGBP = value.text().split(' ');
+      // removes commas
+      const exposureValue = parseFloat(valueinGBP[1].replace(/,/g, '')) * (issuedBond.coveredPercentage / 100);
+      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(2)}`);
+    });
+
     // contains exposure to 2 decimal places (not rounded)
-    facilityRow.facilityExposure().contains('486.14');
 
     facilityRow.facilityId().click();
 
@@ -117,8 +126,15 @@ context('Portal to TFM deal submission', () => {
     const issuedLoanId = issuedLoan._id;
     facilityRow = tfmPages.caseDealPage.dealFacilitiesTable.row(issuedLoanId);
 
-    // contains exposure to 2 decimal places (not rounded)
-    facilityRow.facilityExposure().contains('87.27');
+    // calculate ukef exposure from value in GBP
+    facilityRow.facilityValueGBP().then((value) => {
+      facilityRow = tfmPages.caseDealPage.dealFacilitiesTable.row(issuedLoanId);
+      // removes GBP before
+      const valueinGBP = value.text().split(' ');
+      // removes commas
+      const exposureValue = parseFloat(valueinGBP[1].replace(/,/g, '')) * (issuedLoan.coveredPercentage / 100);
+      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(2)}`);
+    });
 
     facilityRow.facilityId().click();
 

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/test-data/dealReadyToSubmit.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/test-data/dealReadyToSubmit.js
@@ -23,7 +23,7 @@ module.exports = () => {
   deal.mockFacilities[1]['coverEndDate-month'] = (aMonthInTheFuture.getMonth() + 1).toString();
   deal.mockFacilities[1]['coverEndDate-year'] = (aMonthInTheFuture.getFullYear()).toString();
 
-  deal.mockFacilities[0]['conversionRateDate-day'] = aMonthInTheFuture.getDate();
+  deal.mockFacilities[0]['conversionRateDate-day'] = now.getDate();
   deal.mockFacilities[0]['conversionRateDate-month'] = now.getMonth() + 1;
   deal.mockFacilities[0]['conversionRateDate-year'] = now.getFullYear();
 

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/caseDealPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/caseDealPage.js
@@ -18,6 +18,7 @@ const caseDealPage = {
         facilityId: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-facility-id-link"]`),
         facilityTenor: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-tenor"]`),
         facilityEndDate: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-cover-end-date"]`),
+        facilityValueGBP: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-value-gbp"]`),
         facilityExposure: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-exposure"]`),
       };
     },

--- a/trade-finance-manager-api/src/constants/tasks.js
+++ b/trade-finance-manager-api/src/constants/tasks.js
@@ -29,7 +29,6 @@ const AIN = {
       {
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
         team: TEAMS.BUSINESS_SUPPORT,
-        isConditional: true,
       },
       {
         title: AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE,
@@ -72,7 +71,6 @@ const MIA = {
         groupId: 1,
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
         team: TEAMS.BUSINESS_SUPPORT,
-        isConditional: true,
       },
       {
         groupId: 1,

--- a/trade-finance-manager-api/src/constants/tasks.js
+++ b/trade-finance-manager-api/src/constants/tasks.js
@@ -29,6 +29,7 @@ const AIN = {
       {
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
         team: TEAMS.BUSINESS_SUPPORT,
+        isConditional: true,
       },
       {
         title: AIN_AND_MIA.GROUP_1.CREATE_OR_LINK_SALESFORCE,
@@ -71,6 +72,7 @@ const MIA = {
         groupId: 1,
         title: AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
         team: TEAMS.BUSINESS_SUPPORT,
+        isConditional: true,
       },
       {
         groupId: 1,

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
@@ -57,6 +57,15 @@ describe('createDealTasks', () => {
       });
     });
 
+    describe('when a deal has empty string tfm.exporter.partyUrn but has tfm.buyer.partyUrn and deal is BSS', () => {
+      it('should return true', () => {
+        mockDealWithPartyUrn.tfm.parties.buyer = { partyUrn: '1234' };
+        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: ' ' };
+        const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
+        expect(result).toEqual(true);
+      });
+    });
+
     describe('when a deal has tfm.exporter.partyUrn and has tfm.buyer.partyUrn and deal is BSS', () => {
       it('should return true', () => {
         mockDealWithPartyUrn.tfm.parties.buyer = { partyUrn: '1234' };

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
@@ -32,7 +32,7 @@ describe('createDealTasks', () => {
   const mockDealWithPartyUrn = {
     ...mockSubmittedDeal,
     tfm: {
-      parties: { exporter: { partyUrn: 'test' } },
+      parties: { exporter: { partyUrn: '1234' } },
     },
   };
 
@@ -50,8 +50,8 @@ describe('createDealTasks', () => {
 
     describe('when a deal does NOT have tfm.exporter.partyUrn but has tfm.buyer.partyUrn and deal is BSS', () => {
       it('should return true', () => {
-        mockDealWithPartyUrn.tfm.parties.buyer = { partyUrn: 'Test' };
-        mockDealWithPartyUrn.tfm.parties.exporter = null;
+        mockDealWithPartyUrn.tfm.parties.buyer = { partyUrn: '1234' };
+        mockDealWithPartyUrn.tfm.parties.exporter = '';
         const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
         expect(result).toEqual(true);
       });
@@ -66,8 +66,7 @@ describe('createDealTasks', () => {
 
     describe('when a deal has tfm.exporter.partyUrn and deal is GEF', () => {
       it('should return false', () => {
-        mockDealWithPartyUrn.tfm.parties.buyer = null;
-        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: 'Test' };
+        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: '1234' };
         mockDealWithPartyUrn.dealType = CONSTANTS.DEALS.DEAL_TYPE.GEF;
         const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
         expect(result).toEqual(false);
@@ -76,8 +75,16 @@ describe('createDealTasks', () => {
 
     describe('when a deal does NOT have tfm.exporter.partyUrn and deal is GEF', () => {
       it('should return true', () => {
-        mockDealWithPartyUrn.tfm.parties.buyer = null;
-        mockDealWithPartyUrn.tfm.parties.exporter = null;
+        mockDealWithPartyUrn.tfm.parties.exporter = '';
+        mockDealWithPartyUrn.dealType = CONSTANTS.DEALS.DEAL_TYPE.GEF;
+        const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
+        expect(result).toEqual(true);
+      });
+    });
+
+    describe('when a deal has a blank partyURN with a space in it', () => {
+      it('should return true', () => {
+        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: ' ' };
         mockDealWithPartyUrn.dealType = CONSTANTS.DEALS.DEAL_TYPE.GEF;
         const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
         expect(result).toEqual(true);
@@ -137,8 +144,7 @@ describe('createDealTasks', () => {
 
     describe('when no additional tasks should be added', () => {
       it('should return empty array', () => {
-        mockDealWithPartyUrn.tfm.parties.buyer = null;
-        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: 'Test ' };
+        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: '1234' };
         mockDealWithPartyUrn.dealType = CONSTANTS.DEALS.DEAL_TYPE.GEF;
         const result = listAdditionalTasks(mockDealWithPartyUrn);
 

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
@@ -1,5 +1,4 @@
 const {
-  shouldCreatePartiesTask,
   shouldCreateAgentCheckTask,
   listAdditionalTasks,
   createDealTasks,
@@ -38,22 +37,6 @@ describe('createDealTasks', () => {
 
   beforeEach(() => {
     externalApis.updateDeal = updateDealSpy;
-  });
-
-  describe('shouldCreatePartiesTask', () => {
-    describe('when a deal has tfm.exporter.partyUrn', () => {
-      it('should return false', () => {
-        const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
-        expect(result).toEqual(false);
-      });
-    });
-
-    describe('when a deal does NOT have tfm.exporter.partyUrn', () => {
-      it('should return true', () => {
-        const result = shouldCreatePartiesTask(mockSubmittedDeal);
-        expect(result).toEqual(true);
-      });
-    });
   });
 
   describe('shouldCreateAgentCheckTask', () => {
@@ -98,7 +81,6 @@ describe('createDealTasks', () => {
         const result = listAdditionalTasks(mockDealEligibilityCriteria11False);
 
         const expected = [
-          CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES,
           CONSTANTS.TASKS.MIA_GROUP_1_TASKS.COMPLETE_AGENT_CHECK,
         ];
 

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.api-test.js
@@ -57,6 +57,15 @@ describe('createDealTasks', () => {
       });
     });
 
+    describe('when a deal has tfm.exporter.partyUrn and has tfm.buyer.partyUrn and deal is BSS', () => {
+      it('should return true', () => {
+        mockDealWithPartyUrn.tfm.parties.buyer = { partyUrn: '1234' };
+        mockDealWithPartyUrn.tfm.parties.exporter = { partyUrn: '1234' };
+        const result = shouldCreatePartiesTask(mockDealWithPartyUrn);
+        expect(result).toEqual(false);
+      });
+    });
+
     describe('when a deal does NOT have tfm.exporter.partyUrn and NO tfm.buyer.partyUrn and deal is BSS', () => {
       it('should return true', () => {
         const result = shouldCreatePartiesTask(mockSubmittedDeal);

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.js
@@ -3,22 +3,6 @@ const CONSTANTS = require('../../constants');
 const { createTasks } = require('../helpers/create-tasks');
 
 /**
- * Check if the "create or match parties" task should be created
- * @param {Object} deal
- * @returns {Boolean}
- */
-const shouldCreatePartiesTask = (deal) => {
-  const { tfm } = deal;
-  const exporterPartyUrn = tfm.parties.exporter.partyUrn;
-
-  if (exporterPartyUrn && exporterPartyUrn.length) {
-    return false;
-  }
-
-  return true;
-};
-
-/**
  * Check if the "check agent" task should be created
  * @param {Object} deal
  * @returns {Boolean}
@@ -53,10 +37,6 @@ const shouldCreateAgentCheckTask = (deal) => {
  */
 const listAdditionalTasks = (deal) => {
   const additionalTasks = [];
-
-  if (shouldCreatePartiesTask(deal)) {
-    additionalTasks.push(CONSTANTS.TASKS.AIN_AND_MIA.GROUP_1.MATCH_OR_CREATE_PARTIES);
-  }
 
   if (shouldCreateAgentCheckTask(deal)) {
     additionalTasks.push(CONSTANTS.TASKS.MIA_GROUP_1_TASKS.COMPLETE_AGENT_CHECK);
@@ -104,7 +84,6 @@ const createDealTasks = async (deal) => {
 };
 
 module.exports = {
-  shouldCreatePartiesTask,
   shouldCreateAgentCheckTask,
   listAdditionalTasks,
   createDealTasks,

--- a/trade-finance-manager-api/src/v1/controllers/deal.tasks.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.tasks.js
@@ -17,12 +17,12 @@ const shouldCreatePartiesTask = (deal) => {
   // buyer party URN
   const buyerPartyUrn = tfm.parties?.buyer?.partyUrn;
   // boolean if exporter party URN exists and is not empty
-  const exporterPartyUrnExists = exporterPartyUrn && exporterPartyUrn.length;
+  const exporterPartyUrnExists = exporterPartyUrn && exporterPartyUrn.trim().length;
 
   // if BSS, then need to check buyer party URN and exporter party URN
   if (dealType === BSS_EWCS) {
     // boolean if buyer party URN exists and is not empty
-    const buyerPartyUrnExists = buyerPartyUrn && buyerPartyUrn.length;
+    const buyerPartyUrnExists = buyerPartyUrn && buyerPartyUrn.trim().length;
     // if either does not exist, then show task
     return !buyerPartyUrnExists || !exporterPartyUrnExists;
   }


### PR DESCRIPTION
# Issue: 
* Match or create the parties in this deal task was only conditionally showing for BSS
* submit-to-tfm e2e facilities test failing

# Changes made:
* Added check for BSS and to add parties task if either buyer or exporter URN is blank
* Added more api-tests to check all conditions
* Changed submit-to-tfm e2e facilities test to calculate exposure from column value