### PR TITLE
fix(DTFS2-gitignore): Added sensitive directories

### DIFF
--- a/utils/data-migration/.gitignore
+++ b/utils/data-migration/.gitignore
@@ -4,3 +4,8 @@ bss-ewcs/dump/
 bss-ewcs/data/
 gef/dump/
 gef/data/
+exports/
+actionsheets/
+json/
+tfm/amendments
+tfm/actionsheets


### PR DESCRIPTION
## Introduction
`utils` directory have various I/O scripts which could produce sensitive information.
This data should never make it to any VCS, in order to prevent such scenarios following paths have been added to utils `.gitignore`.

## Resolution
* exports/
* actionsheets/
* json/
* tfm/amendments