### PR TITLE
fix: EC - Criterion existence check

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks.spec.js
@@ -347,7 +347,6 @@ context('Case tasks - AIN deal', () => {
 
     pages.tasksPage.filterRadioYourTeam().click();
 
-    // const secondTask = pages.tasksPage.tasks.row(1, 2);
     let firstTask = pages.tasksPage.tasks.row(1, 1);
 
     //---------------------------------------------------------------
@@ -378,7 +377,13 @@ context('Case tasks - AIN deal', () => {
 
     firstTask = pages.tasksPage.tasks.row(1, 1);
 
-    const expectedDate = new Date().toLocaleString('en-GB', { year: 'numeric', month: 'short', day: '2-digit' });
+    const now = new Date();
+    let expectedDate = [
+      now.toLocaleDateString('en-GB', { day: '2-digit' }),
+      now.toLocaleDateString('en-GB', { month: 'short' }).substr(0, 3),
+      now.toLocaleDateString('en-GB', { year: 'numeric' }),
+    ];
+    expectedDate = expectedDate.join(' ');
 
     firstTask.dateStarted().invoke('text').then((text) => {
       expect(text.trim()).to.equal(expectedDate);

--- a/trade-finance-manager-api/src/v1/mappings/map-eligibility-criteria-content-strings.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-eligibility-criteria-content-strings.js
@@ -9,10 +9,14 @@ const mapEligibilityCriteriaContentStrings = (eligibility, dealType) => {
 
   return mappedCriteria.map((criterion) => {
     const mappedCriterion = criterion;
+    const id = Number(criterion.id);
 
-    const contentObj = versionContentStrings[Number(criterion.id)];
-    mappedCriterion.text = contentObj.text;
-    mappedCriterion.textList = contentObj.textList;
+    // Ensure Criterion exists in applicable EC
+    if (id in versionContentStrings) {
+      const contentObj = versionContentStrings[id];
+      mappedCriterion.text = contentObj.text;
+      mappedCriterion.textList = contentObj.textList;
+    }
 
     return mappedCriterion;
   });


### PR DESCRIPTION
## Introduction
Migrated deals especially `BSS/EWCS` have various criterions which do not exists in pre-defined ECs.
Upon accessing a void criterion GQL resolver does not gets the expected data thus returning `null` data back to `TFM UI`.

## Resolution
* Criterion `id` existence check in `versionContentStrings` (pre-defined ECs)