### PR TITLE
fix(DTFS2-5967): TFM facilities decimal places

### DIFF
--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
@@ -96,7 +96,7 @@ context('Portal to TFM deal submission', () => {
       const valueinGBP = value.text().split(' ');
       // removes commas
       const exposureValue = parseFloat(valueinGBP[1].replace(/,/g, '')) * (issuedBond.coveredPercentage / 100);
-      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(2)}`);
+      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(0)}`);
     });
 
     // contains exposure to 2 decimal places (not rounded)
@@ -133,7 +133,7 @@ context('Portal to TFM deal submission', () => {
       const valueinGBP = value.text().split(' ');
       // removes commas
       const exposureValue = parseFloat(valueinGBP[1].replace(/,/g, '')) * (issuedLoan.coveredPercentage / 100);
-      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(2)}`);
+      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(0)}`);
     });
 
     facilityRow.facilityId().click();

--- a/trade-finance-manager-api/src/graphql/helpers/facilityValueFormatted.helper.api-test.js
+++ b/trade-finance-manager-api/src/graphql/helpers/facilityValueFormatted.helper.api-test.js
@@ -1,0 +1,31 @@
+const facilityValueFormatted = require('./facilityValueFormatted.helper');
+
+describe('facilityValueFormatted()', () => {
+  it('should return BSS value as string unformatted', () => {
+    const value = '30000.00';
+    const result = facilityValueFormatted(value);
+
+    expect(result).toEqual(value);
+  });
+
+  it('should return GEF value which already with 2 decimal places', () => {
+    const value = 30000.00;
+    const result = facilityValueFormatted(value.toFixed(2));
+
+    expect(result).toEqual(value.toFixed(2));
+  });
+
+  it('should return GEF value with 2 decimal places when original did not have any decimal places', () => {
+    const value = 30000;
+    const result = facilityValueFormatted(value.toFixed(2));
+
+    expect(result).toEqual(value.toFixed(2));
+  });
+
+  it('should return unformatted GEF value with 2 decimal places when original has 2 decimal places', () => {
+    const value = 30000.53;
+    const result = facilityValueFormatted(value);
+
+    expect(result).toEqual(value);
+  });
+});

--- a/trade-finance-manager-api/src/graphql/helpers/facilityValueFormatted.helper.js
+++ b/trade-finance-manager-api/src/graphql/helpers/facilityValueFormatted.helper.js
@@ -1,0 +1,21 @@
+const { decimalsCount } = require('../../v1/helpers/number');
+
+/**
+ * formats facility value based on type
+ * BSS - string and already formatted with 2 decimal places
+ * GEF - number so needs to have 2 decimal places
+ */
+const facilityValueFormatted = (value) => {
+  // BSS is string and formatted so can be returned
+  if (typeof value === 'string') {
+    return value;
+  }
+  // checks number of decimal places
+  const totalDecimals = decimalsCount(value);
+  // if not 2 decimal places, then set 2 decimal places
+  const newValue = totalDecimals !== 2 ? value.toFixed(2) : value;
+
+  return newValue;
+};
+
+module.exports = facilityValueFormatted;

--- a/trade-finance-manager-api/src/graphql/resolvers/query-facilities.js
+++ b/trade-finance-manager-api/src/graphql/resolvers/query-facilities.js
@@ -2,6 +2,7 @@
 const { format, getUnixTime } = require('date-fns');
 const commaNumber = require('comma-number');
 const { findLatestCompletedAmendment } = require('../helpers/amendment.helpers');
+const facilityValueFormatted = require('../helpers/facilityValueFormatted.helper');
 const { getAllFacilities } = require('../../v1/controllers/facility.controller');
 
 // list all facilities from the database
@@ -19,7 +20,7 @@ exports.queryAllFacilities = async (queryParams) => {
     // finds latest completed amendment tfm object with mapped values
     const latestCompletedAmendment = findLatestCompletedAmendment(item?.amendments);
 
-    const defaultFacilityValue = facility.value;
+    const defaultFacilityValue = facilityValueFormatted(facility.value);
     const defaultCoverEndDate = facility.coverEndDate;
     const formatCoverEndDate = format(new Date(defaultCoverEndDate), 'dd LLL yyyy'); // 11 Aug 2021
 

--- a/trade-finance-manager-api/src/graphql/resolvers/query-facilities.js
+++ b/trade-finance-manager-api/src/graphql/resolvers/query-facilities.js
@@ -33,7 +33,8 @@ exports.queryAllFacilities = async (queryParams) => {
     // if amendment, then willset relevant values based on amendment
     if (latestCompletedAmendment?.value) {
       const { value, currency } = latestCompletedAmendment.value;
-      currencyAndValue = `${currency} ${commaNumber(value)}`;
+      const formattedValue = facilityValueFormatted(value);
+      currencyAndValue = `${currency} ${commaNumber(formattedValue)}`;
       facilityValue = parseInt(value, 10);
     }
 


### PR DESCRIPTION
# Issue: 
* GEF facilities are displayed without decimal places on TFM all facilities page
* Amendment values were showing without 2 decimal places if .00

# Changes made:
* Added helper to return number as 2 decimal places if is a number and is not already 2 decimal place
* (BSS has string formatted to 2 decimal places so is untouched)