### PR TITLE
fix(DTFS2-6024): BSS date validation

### DIFF
--- a/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
+++ b/e2e-tests/portal/cypress/integration/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
@@ -1,6 +1,7 @@
 const { nowPlusMonths } = require('../../../../support/utils/dateFuncs');
 
 const now = new Date().valueOf;
+const nowFormatted = new Date();
 const nowPlusMonth = nowPlusMonths(1);
 
 const deal = {
@@ -198,9 +199,10 @@ const deal = {
       bondType: 'Bid bond',
       facilityStage: 'Issued',
       hasBeenIssued: true,
-      'requestedCoverStartDate-day': '',
-      'requestedCoverStartDate-month': '',
-      'requestedCoverStartDate-year': '',
+      requestedCoverStartDate: nowFormatted.valueOf().toString(),
+      'requestedCoverStartDate-day': nowFormatted.getDate().toString(),
+      'requestedCoverStartDate-month': (nowFormatted.getMonth() + 1).toString(),
+      'requestedCoverStartDate-year': nowFormatted.getFullYear().toString(),
       'coverEndDate-day': (nowPlusMonth.getDate()).toString(),
       'coverEndDate-month': (nowPlusMonth.getMonth() + 1).toString(),
       'coverEndDate-year': (nowPlusMonth.getFullYear()).toString(),
@@ -240,9 +242,10 @@ const deal = {
       createdDate: now,
       facilityStage: 'Unconditional',
       hasBeenIssued: true,
-      'requestedCoverStartDate-day': '',
-      'requestedCoverStartDate-month': '',
-      'requestedCoverStartDate-year': '',
+      requestedCoverStartDate: nowFormatted.valueOf().toString(),
+      'requestedCoverStartDate-day': nowFormatted.getDate().toString(),
+      'requestedCoverStartDate-month': (nowFormatted.getMonth() + 1).toString(),
+      'requestedCoverStartDate-year': nowFormatted.getFullYear().toString(),
       'coverEndDate-day': (nowPlusMonth.getDate()).toString(),
       'coverEndDate-month': (nowPlusMonth.getMonth() + 1).toString(),
       'coverEndDate-year': (nowPlusMonth.getFullYear()).toString(),

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-issued-facilities/submit-deal-with-issued-facilities.spec.js
@@ -96,7 +96,8 @@ context('Portal to TFM deal submission', () => {
       const valueinGBP = value.text().split(' ');
       // removes commas
       const exposureValue = parseFloat(valueinGBP[1].replace(/,/g, '')) * (issuedBond.coveredPercentage / 100);
-      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(2)}`);
+      // Math.trunc() as we need the value of exposure before the decimal point (no rounding)
+      facilityRow.facilityExposure().contains(`GBP ${Math.trunc(exposureValue)}`);
     });
 
     // contains exposure to 2 decimal places (not rounded)
@@ -133,7 +134,8 @@ context('Portal to TFM deal submission', () => {
       const valueinGBP = value.text().split(' ');
       // removes commas
       const exposureValue = parseFloat(valueinGBP[1].replace(/,/g, '')) * (issuedLoan.coveredPercentage / 100);
-      facilityRow.facilityExposure().contains(`GBP ${exposureValue.toFixed(2)}`);
+      // Math.trunc() as we need the value of exposure before the decimal point (no rounding)
+      facilityRow.facilityExposure().contains(`GBP ${Math.trunc(exposureValue)}`);
     });
 
     facilityRow.facilityId().click();

--- a/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/journeys/case/tasks/tasks.spec.js
@@ -378,7 +378,13 @@ context('Case tasks - AIN deal', () => {
 
     firstTask = pages.tasksPage.tasks.row(1, 1);
 
-    const expectedDate = new Date().toLocaleString('en-GB', { year: 'numeric', month: 'short', day: '2-digit' });
+    const now = new Date();
+    let expectedDate = [
+      now.toLocaleDateString('en-GB', { day: '2-digit' }),
+      now.toLocaleDateString('en-GB', { month: 'short' }).substr(0, 3),
+      now.toLocaleDateString('en-GB', { year: 'numeric' }),
+    ];
+    expectedDate = expectedDate.join(' ');
 
     firstTask.dateStarted().invoke('text').then((text) => {
       expect(text.trim()).to.equal(expectedDate);

--- a/portal-api/api-tests/v1/bonds/bond-change-cover-start-date-validation.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bond-change-cover-start-date-validation.api-test.js
@@ -172,6 +172,22 @@ describe('/v1/deals/:id/bond/:bondId/change-cover-start-date', () => {
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
       });
 
       describe('when deal is MIA with approved deal status', () => {
@@ -239,6 +255,22 @@ describe('/v1/deals/:id/bond/:bondId/change-cover-start-date', () => {
           });
         });
 
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
         describe('when eligibility criteria 15 answer is `false`', () => {
           it('should NOT return validationError when date is greater than 3 months', async () => {
             const dealWithEligibilityCriteria15False = {
@@ -299,6 +331,22 @@ describe('/v1/deals/:id/bond/:bondId/change-cover-start-date', () => {
 
             const formattedManualInclusionNoticeSubmissionDate = moment(formattedTimestamp(updatedDeal.details.manualInclusionNoticeSubmissionDate)).format('Do MMMM YYYY');
             const expectedText = `Requested Cover Start Date must be after ${formattedManualInclusionNoticeSubmissionDate}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });

--- a/portal-api/api-tests/v1/bonds/bond-issue-facility-validation.api-test.js
+++ b/portal-api/api-tests/v1/bonds/bond-issue-facility-validation.api-test.js
@@ -198,6 +198,22 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
           );
           expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
         });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
       });
 
       describe('when deal is AIN', () => {
@@ -232,6 +248,22 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
 
             const formattedSubmissionDate = moment(formattedTimestamp(updatedDeal.details.submissionDate)).format('Do MMMM YYYY');
             const expectedText = `Requested Cover Start Date must be after ${formattedSubmissionDate}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });
@@ -297,6 +329,22 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
             const todayPlus3MonthsFormatted = moment(todayPlus3Months).format('Do MMMM YYYY');
 
             const expectedText = `Requested Cover Start Date must be between ${todayFormatted} and ${todayPlus3MonthsFormatted}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });
@@ -383,6 +431,22 @@ describe('/v1/deals/:id/bond/:bondId/issue-facility', () => {
 
             const formattedManualInclusionNoticeSubmissionDate = moment(formattedTimestamp(updatedDeal.details.manualInclusionNoticeSubmissionDate)).format('Do MMMM YYYY');
             const expectedText = `Requested Cover Start Date must be after ${formattedManualInclusionNoticeSubmissionDate}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });

--- a/portal-api/api-tests/v1/loan/loan-change-cover-start-date-validation.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan-change-cover-start-date-validation.api-test.js
@@ -152,6 +152,22 @@ describe('/v1/deals/:id/loan/:loanId', () => {
           });
         });
 
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
         describe('when requestedCoverStartDate is after 3 months from today', () => {
           it('should return validationError', async () => {
             const todayPlus3Months = moment().add(3, 'month');
@@ -213,6 +229,22 @@ describe('/v1/deals/:id/loan/:loanId', () => {
             const todayPlus3MonthsFormatted = moment(todayPlus3Months).format('Do MMMM YYYY');
 
             const expectedText = `Requested Cover Start Date must be between ${todayFormatted} and ${todayPlus3MonthsFormatted}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });
@@ -300,6 +332,22 @@ describe('/v1/deals/:id/loan/:loanId', () => {
             const formattedManualInclusionNoticeSubmissionDate = moment(formattedTimestamp(updatedDeal.details.manualInclusionNoticeSubmissionDate)).format('Do MMMM YYYY');
             const expectedText = `Requested Cover Start Date must be after ${formattedManualInclusionNoticeSubmissionDate}`;
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+
+          describe('when requestedCoverStartDate year is not 4 numbers', () => {
+            it('should return validationError', async () => {
+              const requestedCoverStartDateFields = {
+                'requestedCoverStartDate-day': '23',
+                'requestedCoverStartDate-month': '09',
+                'requestedCoverStartDate-year': '22',
+              };
+
+              const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+              expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+              const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
+              expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+            });
           });
         });
 

--- a/portal-api/api-tests/v1/loan/loan-issue-facility-validation.api-test.js
+++ b/portal-api/api-tests/v1/loan/loan-issue-facility-validation.api-test.js
@@ -202,6 +202,22 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
           );
           expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
         });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
       });
 
       describe('when deal is AIN', () => {
@@ -236,6 +252,22 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
 
             const formattedSubmissionDate = moment(formattedTimestamp(updatedDeal.details.submissionDate)).format('Do MMMM YYYY');
             const expectedText = `Requested Cover Start Date must be after ${formattedSubmissionDate}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });
@@ -301,6 +333,22 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
             const todayPlus3MonthsFormatted = moment(todayPlus3Months).format('Do MMMM YYYY');
 
             const expectedText = `Requested Cover Start Date must be between ${todayFormatted} and ${todayPlus3MonthsFormatted}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });
@@ -387,6 +435,22 @@ describe('/v1/deals/:id/loan/:loanId/issue-facility', () => {
 
             const formattedManualInclusionNoticeSubmissionDate = moment(formattedTimestamp(updatedDeal.details.manualInclusionNoticeSubmissionDate)).format('Do MMMM YYYY');
             const expectedText = `Requested Cover Start Date must be after ${formattedManualInclusionNoticeSubmissionDate}`;
+            expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
+          });
+        });
+
+        describe('when requestedCoverStartDate year is not 4 numbers', () => {
+          it('should return validationError', async () => {
+            const requestedCoverStartDateFields = {
+              'requestedCoverStartDate-day': '23',
+              'requestedCoverStartDate-month': '09',
+              'requestedCoverStartDate-year': '22',
+            };
+
+            const { validationErrors } = await updateRequestedCoverStartDate(requestedCoverStartDateFields);
+            expect(validationErrors.errorList.requestedCoverStartDate.order).toBeDefined();
+
+            const expectedText = 'The year for the requested Cover Start Date must include 4 numbers';
             expect(validationErrors.errorList.requestedCoverStartDate.text).toEqual(expectedText);
           });
         });

--- a/portal-api/api-tests/v1/validation/cover-end-date.api-test.js
+++ b/portal-api/api-tests/v1/validation/cover-end-date.api-test.js
@@ -46,6 +46,40 @@ describe('validation - coverEndDate on ready for checkers approval', () => {
 
       expect(errors).toEqual({});
     });
+
+    it('should throw validation error if coverEndDate is 2 numbers long', () => {
+      const errorList = {};
+
+      const deal = {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.AIN,
+      };
+      const submittedValues = {
+        'coverEndDate-day': '23',
+        'coverEndDate-month': '03',
+        'coverEndDate-year': '23',
+      };
+
+      const errors = checkCoverStartDate(submittedValues, deal, errorList);
+
+      expect(errors.coverEndDate.text).toEqual('The year for the Cover End Date must include 4 numbers');
+    });
+
+    it('should throw validation error if coverEndDate is has letters in it', () => {
+      const errorList = {};
+
+      const deal = {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.AIN,
+      };
+      const submittedValues = {
+        'coverEndDate-day': '23',
+        'coverEndDate-month': '03',
+        'coverEndDate-year': '2O23',
+      };
+
+      const errors = checkCoverStartDate(submittedValues, deal, errorList);
+
+      expect(errors.coverEndDate.text).toEqual('The year for the Cover End Date must include 4 numbers');
+    });
   });
 
   describe('MIN', () => {
@@ -88,6 +122,40 @@ describe('validation - coverEndDate on ready for checkers approval', () => {
 
       expect(errors).toEqual({});
     });
+
+    it('should throw validation error if coverEndDate is 2 numbers long', () => {
+      const errorList = {};
+
+      const deal = {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      };
+      const submittedValues = {
+        'coverEndDate-day': '23',
+        'coverEndDate-month': '03',
+        'coverEndDate-year': '23',
+      };
+
+      const errors = checkCoverStartDate(submittedValues, deal, errorList);
+
+      expect(errors.coverEndDate.text).toEqual('The year for the Cover End Date must include 4 numbers');
+    });
+
+    it('should throw validation error if coverEndDate contains non numerical characters', () => {
+      const errorList = {};
+
+      const deal = {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIN,
+      };
+      const submittedValues = {
+        'coverEndDate-day': '23',
+        'coverEndDate-month': '03',
+        'coverEndDate-year': '2O23',
+      };
+
+      const errors = checkCoverStartDate(submittedValues, deal, errorList);
+
+      expect(errors.coverEndDate.text).toEqual('The year for the Cover End Date must include 4 numbers');
+    });
   });
 
   describe('MIA', () => {
@@ -129,6 +197,40 @@ describe('validation - coverEndDate on ready for checkers approval', () => {
       const errors = checkCoverStartDate(submittedValues, deal, errorList);
 
       expect(errors.coverEndDate.text).toEqual(errorMessage);
+    });
+
+    it('should throw validation error if coverEndDate is 2 numbers long', () => {
+      const errorList = {};
+
+      const deal = {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIA,
+      };
+      const submittedValues = {
+        'coverEndDate-day': '23',
+        'coverEndDate-month': '03',
+        'coverEndDate-year': '23',
+      };
+
+      const errors = checkCoverStartDate(submittedValues, deal, errorList);
+
+      expect(errors.coverEndDate.text).toEqual('The year for the Cover End Date must include 4 numbers');
+    });
+
+    it('should throw validation error if coverEndDate contains non numerical characters', () => {
+      const errorList = {};
+
+      const deal = {
+        submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIA,
+      };
+      const submittedValues = {
+        'coverEndDate-day': '23',
+        'coverEndDate-month': '03',
+        'coverEndDate-year': '2O23',
+      };
+
+      const errors = checkCoverStartDate(submittedValues, deal, errorList);
+
+      expect(errors.coverEndDate.text).toEqual('The year for the Cover End Date must include 4 numbers');
     });
   });
 });

--- a/portal-api/package-lock.json
+++ b/portal-api/package-lock.json
@@ -23,6 +23,7 @@
         "filesize": "^8.0.7",
         "graphql": "^15.8.0",
         "graphql-middleware": "^4.0.2",
+        "joi": "^17.6.0",
         "jsonwebtoken": "8.5.1",
         "moment": "2.29.4",
         "moment-timezone": "0.5.34",
@@ -859,6 +860,19 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -1397,6 +1411,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.20",
@@ -5434,6 +5466,18 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8778,6 +8822,19 @@
         "tslib": "^2.4.0"
       }
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -9213,6 +9270,24 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sinclair/typebox": {
       "version": "0.24.20",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.20.tgz",
@@ -9570,7 +9645,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -9750,7 +9826,8 @@
     "apollo-server-errors": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
+      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
+      "requires": {}
     },
     "apollo-server-express": {
       "version": "2.18.2",
@@ -12109,7 +12186,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -12328,6 +12406,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {
@@ -14264,7 +14354,8 @@
     "ws": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "requires": {}
     },
     "xml2js": {
       "version": "0.4.23",

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -47,6 +47,7 @@
     "filesize": "^8.0.7",
     "graphql": "^15.8.0",
     "graphql-middleware": "^4.0.2",
+    "joi": "^17.6.0",
     "jsonwebtoken": "8.5.1",
     "moment": "2.29.4",
     "moment-timezone": "0.5.34",

--- a/portal-api/src/v1/validation/bond-rules/facility-stage-issued-rules/requested-cover-start-date.js
+++ b/portal-api/src/v1/validation/bond-rules/facility-stage-issued-rules/requested-cover-start-date.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const Joi = require('joi');
 const { orderNumber } = require('../../../../utils/error-list-order-number');
 const {
   dateHasSomeValues,
@@ -28,9 +29,18 @@ module.exports = (submittedValues, deal, errorList) => {
     const nowDate = moment().startOf('day');
 
     if (!dealHasBeenSubmitted) {
+      const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
+      const validation = schema.validate(requestedCoverStartDateYear);
+
       if (moment(requestedCoverStartDateTimestamp).isBefore(nowDate)) {
         newErrorList.requestedCoverStartDate = {
           text: 'Requested Cover Start Date must be on the application submission date or in the future',
+          order: orderNumber(newErrorList),
+        };
+      } else if (validation.error) {
+        // error object does not exist if no errors in validation
+        newErrorList.requestedCoverStartDate = {
+          text: 'The year for the requested Cover Start Date must include 4 numbers',
           order: orderNumber(newErrorList),
         };
       } else if (!canEnterDateGreaterThan3Months) {

--- a/portal-api/src/v1/validation/bond-rules/facility-stage-issued-rules/requested-cover-start-date.js
+++ b/portal-api/src/v1/validation/bond-rules/facility-stage-issued-rules/requested-cover-start-date.js
@@ -29,18 +29,13 @@ module.exports = (submittedValues, deal, errorList) => {
     const nowDate = moment().startOf('day');
 
     if (!dealHasBeenSubmitted) {
+      // validates the coverStartDateYear is 4 digits long and only numbers and returns error in validation if not
       const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
       const validation = schema.validate(requestedCoverStartDateYear);
 
       if (moment(requestedCoverStartDateTimestamp).isBefore(nowDate)) {
         newErrorList.requestedCoverStartDate = {
           text: 'Requested Cover Start Date must be on the application submission date or in the future',
-          order: orderNumber(newErrorList),
-        };
-      } else if (validation.error) {
-        // error object does not exist if no errors in validation
-        newErrorList.requestedCoverStartDate = {
-          text: 'The year for the requested Cover Start Date must include 4 numbers',
           order: orderNumber(newErrorList),
         };
       } else if (!canEnterDateGreaterThan3Months) {
@@ -62,6 +57,13 @@ module.exports = (submittedValues, deal, errorList) => {
             order: orderNumber(newErrorList),
           };
         }
+      }
+      if (validation.error && requestedCoverStartDateYear) {
+        // error object does not exist if no errors in validation
+        newErrorList.requestedCoverStartDate = {
+          text: 'The year for the requested Cover Start Date must include 4 numbers',
+          order: orderNumber(newErrorList),
+        };
       }
     }
   } else if (!requestedCoverStartDateTimestamp && dateHasSomeValues(

--- a/portal-api/src/v1/validation/fields/cover-end-date.js
+++ b/portal-api/src/v1/validation/fields/cover-end-date.js
@@ -21,19 +21,19 @@ module.exports = (submittedValues, deal, errorList) => {
       const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
       const validation = schema.validate(coverEndDateYear);
 
-      // error object does not exist if no errors in validation
-      if (validation.error) {
-        newErrorList.coverEndDate = {
-          text: 'The year for the Cover End Date must include 4 numbers',
-          order: orderNumber(newErrorList),
-        };
-      }
-
       const formattedDate = `${coverEndDateYear}-${coverEndDateMonth}-${coverEndDateDay}`;
       const nowDate = moment().format('YYYY-MM-DD');
       if (moment(formattedDate).isBefore(nowDate)) {
         newErrorList.coverEndDate = {
           text: 'Cover End Date must be today or in the future',
+          order: orderNumber(newErrorList),
+        };
+      }
+
+      // error object does not exist if no errors in validation
+      if (validation.error) {
+        newErrorList.coverEndDate = {
+          text: 'The year for the Cover End Date must include 4 numbers',
           order: orderNumber(newErrorList),
         };
       }

--- a/portal-api/src/v1/validation/fields/cover-end-date.js
+++ b/portal-api/src/v1/validation/fields/cover-end-date.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const Joi = require('joi');
 const { orderNumber } = require('../../../utils/error-list-order-number');
 const {
   dateHasAllValues,
@@ -16,9 +17,20 @@ module.exports = (submittedValues, deal, errorList) => {
 
   if (isReadyForValidation(deal, submittedValues)) {
     if (dateHasAllValues(coverEndDateDay, coverEndDateMonth, coverEndDateYear)) {
+      // schema to validate that the year is 4 digits long and only numbers
+      const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
+      const validation = schema.validate(coverEndDateYear);
+
+      // error object does not exist if no errors in validation
+      if (validation.error) {
+        newErrorList.coverEndDate = {
+          text: 'The year for the Cover End Date must include 4 numbers',
+          order: orderNumber(newErrorList),
+        };
+      }
+
       const formattedDate = `${coverEndDateYear}-${coverEndDateMonth}-${coverEndDateDay}`;
       const nowDate = moment().format('YYYY-MM-DD');
-
       if (moment(formattedDate).isBefore(nowDate)) {
         newErrorList.coverEndDate = {
           text: 'Cover End Date must be today or in the future',

--- a/portal-api/src/v1/validation/fields/issue-facility/requested-cover-start-date.js
+++ b/portal-api/src/v1/validation/fields/issue-facility/requested-cover-start-date.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const Joi = require('joi');
 const { orderNumber } = require('../../../../utils/error-list-order-number');
 const {
   dateHasSomeValues,
@@ -104,6 +105,16 @@ module.exports = (
           order: orderNumber(newErrorList),
         };
       }
+    }
+    const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
+    const validation = schema.validate(requestedCoverStartDateYear);
+
+    // error object does not exist if no errors in validation
+    if (validation.error) {
+      newErrorList.requestedCoverStartDate = {
+        text: 'The year for the requested Cover Start Date must include 4 numbers',
+        order: orderNumber(newErrorList),
+      };
     }
   } else if (dateHasSomeValues(
     requestedCoverStartDateDay,

--- a/portal-api/src/v1/validation/fields/issue-facility/requested-cover-start-date.js
+++ b/portal-api/src/v1/validation/fields/issue-facility/requested-cover-start-date.js
@@ -106,11 +106,12 @@ module.exports = (
         };
       }
     }
+    // validates the coverStartDateYear is 4 digits long and only numbers and returns error in validation if not
     const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
     const validation = schema.validate(requestedCoverStartDateYear);
 
     // error object does not exist if no errors in validation
-    if (validation.error) {
+    if (validation.error && requestedCoverStartDateYear) {
       newErrorList.requestedCoverStartDate = {
         text: 'The year for the requested Cover Start Date must include 4 numbers',
         order: orderNumber(newErrorList),

--- a/portal-api/src/v1/validation/loan-rules/facility-stage-unconditional/requested-cover-start-date.js
+++ b/portal-api/src/v1/validation/loan-rules/facility-stage-unconditional/requested-cover-start-date.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const Joi = require('joi');
 const { orderNumber } = require('../../../../utils/error-list-order-number');
 const {
   dateHasSomeValues,
@@ -33,6 +34,17 @@ module.exports = (submittedValues, deal, errorList) => {
           text: 'Requested Cover Start Date must be on the application submission date or in the future',
           order: orderNumber(newErrorList),
         };
+
+        const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
+        const validation = schema.validate(requestedCoverStartDateYear);
+
+        // error object does not exist if no errors in validation
+        if (validation.error) {
+          newErrorList.requestedCoverStartDate = {
+            text: 'The year for the requested Cover Start Date must include 4 numbers',
+            order: orderNumber(newErrorList),
+          };
+        }
       } else if (!canEnterDateGreaterThan3Months) {
         const MAX_MONTHS_FROM_NOW = 3;
 

--- a/portal-api/src/v1/validation/loan-rules/facility-stage-unconditional/requested-cover-start-date.js
+++ b/portal-api/src/v1/validation/loan-rules/facility-stage-unconditional/requested-cover-start-date.js
@@ -27,6 +27,9 @@ module.exports = (submittedValues, deal, errorList) => {
 
   if (requestedCoverStartDateTimestamp) {
     const nowDate = moment().startOf('day');
+    // validates the coverStartDateYear is 4 digits long and only numbers and returns error in validation if not
+    const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
+    const validation = schema.validate(requestedCoverStartDateYear);
 
     if (!dealHasBeenSubmitted) {
       if (moment(requestedCoverStartDateTimestamp).isBefore(nowDate)) {
@@ -34,17 +37,6 @@ module.exports = (submittedValues, deal, errorList) => {
           text: 'Requested Cover Start Date must be on the application submission date or in the future',
           order: orderNumber(newErrorList),
         };
-
-        const schema = Joi.string().length(4).pattern(/^[0-9]+$/).required();
-        const validation = schema.validate(requestedCoverStartDateYear);
-
-        // error object does not exist if no errors in validation
-        if (validation.error) {
-          newErrorList.requestedCoverStartDate = {
-            text: 'The year for the requested Cover Start Date must include 4 numbers',
-            order: orderNumber(newErrorList),
-          };
-        }
       } else if (!canEnterDateGreaterThan3Months) {
         const MAX_MONTHS_FROM_NOW = 3;
 
@@ -64,6 +56,12 @@ module.exports = (submittedValues, deal, errorList) => {
             order: orderNumber(newErrorList),
           };
         }
+      }
+      if (validation.error && requestedCoverStartDateYear) {
+        newErrorList.requestedCoverStartDate = {
+          text: 'The year for the requested Cover Start Date must include 4 numbers',
+          order: orderNumber(newErrorList),
+        };
       }
     }
   } else if (!requestedCoverStartDateTimestamp && dateHasSomeValues(


### PR DESCRIPTION
# Issue:
* BSS allowed for the year to be 2 numbers (eg 22 instead of 2022) which caused some functions to assume the year 0022

# Changes made:
* Added validation using joi to check length is 4 and only digits entered for the number
* Updated tests