### PR TITLE
fix(DTFS2-6043): security.txt protocol conformance

### DIFF
--- a/portal/server/routes/static.js
+++ b/portal/server/routes/static.js
@@ -5,21 +5,13 @@ const router = express.Router();
 router.get('/.well-known/security.txt', (req, res) => {
   res.type('text/plain');
 
-  res.write('# DTFS Portal 2.0');
-  res.write('\n');
-  res.write('Policy: https://www.gov.uk/guidance/report-a-vulnerability-on-a-ukef-system');
-  res.write('\n');
-  res.write('Contact: https://hackerone.com/7af14fd9-fe4e-4f39-bea1-8f8a364061b8/embedded_submissions/new');
-  res.write('\n\n');
-  res.write('Contact: https://get-a-guarantee-for-export-finance.service.gov.uk/feedback');
-  res.write('\n');
-  res.write('Contact: https://www.gov.uk/contact/govuk');
-  res.write('\n\n');
-  res.write('Acknowledgments: https://get-a-guarantee-for-export-finance.service.gov.uk/thanks.txt');
-  res.write('\n');
-  res.write('Hiring: https://www.civilservicejobs.service.gov.uk/');
-  res.write('\n\n');
-  res.write('Last-Updated: 03-05-2022 10:31:01 UTC');
+  res.write('Contact: https://www.gov.uk/contact/govuk\n');
+  res.write('Expires: 2022-12-09T00:00:00.000Z\n');
+  res.write('Acknowledgments: https://get-a-guarantee-for-export-finance.service.gov.uk/thanks.txt\n');
+  res.write('Preferred-Languages: en\n');
+  res.write('Canonical: https://get-a-guarantee-for-export-finance.service.gov.uk/.well-known/security.txt\n');
+  res.write('Policy: https://www.gov.uk/guidance/report-a-vulnerability-on-a-ukef-system\n');
+  res.write('Hiring: https://www.civilservicejobs.service.gov.uk/\n');
 
   res.send();
 });


### PR DESCRIPTION
## Introduction
`https://get-a-guarantee-for-export-finance.service.gov.uk/.well-known/security.txt` was not adhering to `https://securitytxt.org/` standards. This was flagged by NCSC scanner.

## Resolution
`security.txt` generated using `https://securitytxt.org/`