### PR TITLE
fix: GQL resolver exceptional handling and optional chaining

### DIFF
--- a/trade-finance-manager-api/src/graphql/resolvers/query-deal.js
+++ b/trade-finance-manager-api/src/graphql/resolvers/query-deal.js
@@ -4,20 +4,25 @@ const { filterTasks } = require('./filters/filterTasks');
 const { filterActivities } = require('./filters/filterActivities');
 
 const queryDeal = async ({ params }) => {
-  const { _id, tasksFilters, activityFilters } = params;
+  try {
+    const { _id, tasksFilters, activityFilters } = params;
 
-  const deal = await findOneTfmDeal(_id);
+    const deal = await findOneTfmDeal(_id);
 
-  const filtered = {
-    ...deal,
-    tfm: {
-      ...deal.tfm,
-      tasks: filterTasks(deal.tfm.tasks, tasksFilters),
-      activities: filterActivities(deal.tfm.activities, activityFilters),
-    },
-  };
+    const filtered = {
+      ...deal,
+      tfm: {
+        ...deal.tfm,
+        tasks: filterTasks(deal.tfm.tasks, tasksFilters),
+        activities: filterActivities(deal.tfm.activities, activityFilters),
+      },
+    };
 
-  return dealReducer(filtered);
+    return dealReducer(filtered);
+  } catch (e) {
+    console.error('Unable to resolve GQL queryDeal: ', { e });
+    return null;
+  }
 };
 
 module.exports = queryDeal;

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -33,7 +33,7 @@ const getDeal = async (id, tasksFilters, activityFilters) => {
     console.error('TFM UI - GraphQL error querying deal ', response.errors || response.networkError.result.errors);
   }
 
-  return response.data.deal;
+  return response?.data?.deal;
 };
 
 const getFacilities = async (queryParams) => {


### PR DESCRIPTION
## Introduction
Upon an unsuccessful resolution of a GQL in `TFM-API` no `deal` object is returned.
TFM-UI crashes when accessing void property.

## Resolution
* Exceptional handling TFM-API GQL resolver.
* Optional chaining of `response?.data?.deal`