### PR TITLE
fix(DTFS2-6035): TFM UI - Indemnifier address overlap

### DIFF
--- a/trade-finance-manager-ui/templates/case/parties/_macros/parties-indemnifier-area.njk
+++ b/trade-finance-manager-ui/templates/case/parties/_macros/parties-indemnifier-area.njk
@@ -102,10 +102,7 @@
             key: 'Approval level required',
             value: ''
           }) }}
-        {% if not userCanEdit %}
-          </div>
-          <div class="govuk-grid-column-one-half">
-        {% endif %}
+
           {{ keyValueArrayGridRow.render({
             key: 'Correspondence Address',
             values:  [ deal.submissionDetails.indemnifierCorrespondenceAddressLine1,


### PR DESCRIPTION
## Introduction

When an `indemnifier` is present with its correspondence address and country and when logged in as a non-editable user address overlaps with the heading on the left this was due to a child DOM element with class `govuk-grid-column-one-half` exists inside a parent DOM element with same class, thus reducing the width to `50%`.

## Resolution
* Removal of condition and `<div>` object as they do not serve any meaningful purpose.