### PR TITLE
fix(DTFS2-6036): shouldCoverStartOnSubmission validation

### DIFF
--- a/e2e-tests/gef/cypress.json
+++ b/e2e-tests/gef/cypress.json
@@ -13,7 +13,7 @@
   "testFiles": "**/*.spec.js",
   "pageLoadTimeout": 120000,
   "responseTimeout": 120000,
-  "numTestsKeptInMemory": 100,
+  "numTestsKeptInMemory": 1,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/e2e-tests/gef/cypress.json
+++ b/e2e-tests/gef/cypress.json
@@ -13,7 +13,7 @@
   "testFiles": "**/*.spec.js",
   "pageLoadTimeout": 120000,
   "responseTimeout": 120000,
-  "numTestsKeptInMemory": 1,
+  "numTestsKeptInMemory": 100,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/e2e-tests/gef/cypress/fixtures/dateConstants.js
+++ b/e2e-tests/gef/cypress/fixtures/dateConstants.js
@@ -11,6 +11,7 @@ const fourDaysAgo = sub(today, { days: 4 });
 const fourDaysAgoDay = format(fourDaysAgo, 'dd');
 const fourDaysAgoMonth = format(fourDaysAgo, 'M');
 const fourDaysAgoYear = format(fourDaysAgo, 'yyyy');
+const yesterday = sub(today, { days: 1 });
 const oneMonth = add(today, { months: 1 });
 const oneMonthDay = format(oneMonth, 'dd');
 const oneMonthMonth = format(oneMonth, 'M');
@@ -59,6 +60,7 @@ export default {
   tomorrowDay,
   tomorrowMonth,
   tomorrowYear,
+  yesterday,
   fourDaysAgo,
   fourDaysAgoDay,
   fourDaysAgoMonth,

--- a/e2e-tests/gef/cypress/integration/about-facility.spec.js
+++ b/e2e-tests/gef/cypress/integration/about-facility.spec.js
@@ -1,11 +1,13 @@
 import relative from './relativeURL';
 import aboutFacility from './pages/about-facility';
 import CREDENTIALS from '../fixtures/credentials.json';
+import dateConstants from '../fixtures/dateConstants';
 
 const applications = [];
 let token;
 
 const now = new Date();
+const { yesterday } = dateConstants;
 
 context('About Facility Page', () => {
   before(() => {
@@ -132,7 +134,7 @@ context('About Facility Page', () => {
       aboutFacility.coverEndDateError().contains('The cover end date must be after the cover start date');
     });
 
-    it('should show an error message if coverStartDate and coverEndDate are the same', () => {
+    it('should show an error message if coverStartDate and coverEndDate are the same - shouldCoverStartOnSubmission', () => {
       cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[0].details._id}/about-facility`));
       aboutFacility.facilityName().type('Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
@@ -141,6 +143,17 @@ context('About Facility Page', () => {
       aboutFacility.coverEndDateYear().clear().type(now.getFullYear());
       aboutFacility.continueButton().click();
       aboutFacility.coverEndDateError().contains('The cover end date must be after the cover start date');
+    });
+
+    it('should show an error message if coverEndDate is before the coverStartDate - shouldCoverStartOnSubmission', () => {
+      cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[0].details._id}/about-facility`));
+      aboutFacility.facilityName().type('Name');
+      aboutFacility.shouldCoverStartOnSubmissionYes().click();
+      aboutFacility.coverEndDateDay().clear().type(yesterday.getDate());
+      aboutFacility.coverEndDateMonth().clear().type(yesterday.getMonth() + 1);
+      aboutFacility.coverEndDateYear().clear().type(yesterday.getFullYear());
+      aboutFacility.continueButton().click();
+      aboutFacility.coverEndDateError().contains('Cover end date cannot be before cover start date');
     });
 
     it('redirects the user to `provided facility` page when form has been successfully filled in', () => {

--- a/e2e-tests/gef/cypress/integration/about-facility.spec.js
+++ b/e2e-tests/gef/cypress/integration/about-facility.spec.js
@@ -132,6 +132,17 @@ context('About Facility Page', () => {
       aboutFacility.coverEndDateError().contains('The cover end date must be after the cover start date');
     });
 
+    it('should show an error message if coverStartDate and coverEndDate are the same', () => {
+      cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[0].details._id}/about-facility`));
+      aboutFacility.facilityName().type('Name');
+      aboutFacility.shouldCoverStartOnSubmissionYes().click();
+      aboutFacility.coverEndDateDay().clear().type(now.getDate());
+      aboutFacility.coverEndDateMonth().clear().type(now.getMonth() + 1);
+      aboutFacility.coverEndDateYear().clear().type(now.getFullYear());
+      aboutFacility.continueButton().click();
+      aboutFacility.coverEndDateError().contains('The cover end date must be after the cover start date');
+    });
+
     it('redirects the user to `provided facility` page when form has been successfully filled in', () => {
       cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[0].details._id}/about-facility`));
       aboutFacility.facilityName().type('Name');

--- a/gef-ui/server/controllers/about-facility/index.js
+++ b/gef-ui/server/controllers/about-facility/index.js
@@ -298,6 +298,24 @@ const validateAboutFacility = async (req, res) => {
     }
   }
 
+  // validation if should start on submission - no coverStartDate to check against
+  if (body.shouldCoverStartOnSubmission && coverEndDateIsFullyComplete) {
+    // temporarily set coverStartDate to now
+    const coverStartNow = set(
+      new Date(),
+      {
+        hours: 0, minutes: 0, seconds: 0, milliseconds: 0,
+      },
+    );
+
+    if (isEqual(coverStartNow, coverEndDate) && coverEndDateValid) {
+      aboutFacilityErrors.push({
+        errRef: 'coverEndDate',
+        errMsg: 'The cover end date must be after the cover start date',
+      });
+    }
+  }
+
   // Regex tests to see if value is a number only
   const digitsRegex = /^[0-9]*$/;
   if (body.monthsOfCover) {

--- a/gef-ui/server/controllers/about-facility/index.js
+++ b/gef-ui/server/controllers/about-facility/index.js
@@ -308,6 +308,13 @@ const validateAboutFacility = async (req, res) => {
       },
     );
 
+    if ((coverEndDate < coverStartNow) && coverEndDateValid) {
+      aboutFacilityErrors.push({
+        errRef: 'coverEndDate',
+        errMsg: 'Cover end date cannot be before cover start date',
+      });
+    }
+
     if (isEqual(coverStartNow, coverEndDate) && coverEndDateValid) {
       aboutFacilityErrors.push({
         errRef: 'coverEndDate',

--- a/gef-ui/server/controllers/about-facility/index.test.js
+++ b/gef-ui/server/controllers/about-facility/index.test.js
@@ -582,6 +582,23 @@ describe('controllers/about-facility', () => {
       }));
     });
 
+    it('should show error message if cover starts on submission which is the same as the coverEndDate', async () => {
+      mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
+      mockRequest.body.hasBeenIssued = 'true';
+      mockRequest.body.shouldCoverStartOnSubmission = 'true';
+      mockRequest.body['cover-end-date-day'] = format(now, 'd');
+      mockRequest.body['cover-end-date-month'] = format(now, 'M');
+      mockRequest.body['cover-end-date-year'] = format(now, 'yyyy');
+
+      await validateAboutFacility(mockRequest, mockResponse);
+
+      expect(mockResponse.render).toHaveBeenCalledWith('partials/about-facility.njk', expect.objectContaining({
+        errors: expect.objectContaining({
+          errorSummary: expect.arrayContaining([{ href: '#coverEndDate', text: expect.any(String) }]),
+        }),
+      }));
+    });
+
     it('shows error message if no monthsOfcover has been provided', async () => {
       mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
       mockRequest.body.hasBeenIssued = 'false';

--- a/gef-ui/server/controllers/about-facility/index.test.js
+++ b/gef-ui/server/controllers/about-facility/index.test.js
@@ -594,7 +594,7 @@ describe('controllers/about-facility', () => {
 
       expect(mockResponse.render).toHaveBeenCalledWith('partials/about-facility.njk', expect.objectContaining({
         errors: expect.objectContaining({
-          errorSummary: expect.arrayContaining([{ href: '#coverEndDate', text: expect.any(String) }]),
+          errorSummary: expect.arrayContaining([{ href: '#coverEndDate', text: 'The cover end date must be after the cover start date' }]),
         }),
       }));
     });
@@ -611,7 +611,7 @@ describe('controllers/about-facility', () => {
 
       expect(mockResponse.render).toHaveBeenCalledWith('partials/about-facility.njk', expect.objectContaining({
         errors: expect.objectContaining({
-          errorSummary: expect.arrayContaining([{ href: '#coverEndDate', text: expect.any(String) }]),
+          errorSummary: expect.arrayContaining([{ href: '#coverEndDate', text: 'Cover end date cannot be before cover start date' }]),
         }),
       }));
     });

--- a/gef-ui/server/controllers/about-facility/index.test.js
+++ b/gef-ui/server/controllers/about-facility/index.test.js
@@ -599,6 +599,23 @@ describe('controllers/about-facility', () => {
       }));
     });
 
+    it('should show error message if cover starts on submission which is before the coverEndDate', async () => {
+      mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
+      mockRequest.body.hasBeenIssued = 'true';
+      mockRequest.body.shouldCoverStartOnSubmission = 'true';
+      mockRequest.body['cover-end-date-day'] = format(yesterday, 'd');
+      mockRequest.body['cover-end-date-month'] = format(yesterday, 'M');
+      mockRequest.body['cover-end-date-year'] = format(yesterday, 'yyyy');
+
+      await validateAboutFacility(mockRequest, mockResponse);
+
+      expect(mockResponse.render).toHaveBeenCalledWith('partials/about-facility.njk', expect.objectContaining({
+        errors: expect.objectContaining({
+          errorSummary: expect.arrayContaining([{ href: '#coverEndDate', text: expect.any(String) }]),
+        }),
+      }));
+    });
+
     it('shows error message if no monthsOfcover has been provided', async () => {
       mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
       mockRequest.body.hasBeenIssued = 'false';


### PR DESCRIPTION
# Issue: 
* If select shouldCoverStartOnSubmission and go back to change coverEndDate, could choose coverEndDate on the same day and could proceed if before

# Changes made:
* Added validation if shouldCoverStartOnSubmission  then to temporarily create a coverStartDate and compare to coverEndDate
* Added tests