### PR TITLE
fix: ACBS Exposure period - Null cover start and end date

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/helpers/get-exposure-period.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-exposure-period.js
@@ -80,6 +80,11 @@ const getExposurePeriod = (facility, dealType, fmr = null) => {
     const durationMonths = coverEndDate.diff(coverStartDate, 'months') + 1;
     const monthOffset = moment(coverStartDate).date() === moment(coverEndDate).date() ? -1 : 0;
 
+    // Return `exposure` when `coverStartDate` and `coverEndDate` are null
+    if (!durationMonths && !monthOffset) {
+      return String(exposure);
+    }
+
     exposure = durationMonths + monthOffset;
   }
 


### PR DESCRIPTION
## Introduction
When cover start date and end date is null due to facility not being issued, exposure period helper function returns `NaN` for `BSS/EWCS` deals.

## Resolution
* Returns `exposure` when both month duration and month off set are void.