### PR TITLE
fix(DTFS2-6056): All facilities - fix dealId conversion to string

### DIFF
--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-update-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-update-deal.controller.js
@@ -103,11 +103,8 @@ const updateDealSnapshot = async (deal, snapshotChanges) => {
   if (ObjectId.isValid(deal._id)) {
     try {
       const collection = await db.getCollection('tfm-deals');
-
       const update = {
-        ...deal,
         dealSnapshot: {
-          ...deal.dealSnapshot,
           ...snapshotChanges,
         },
       };

--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-MIN-with-unissued-facilities-and-resubmit-issued-facilities-updates-facilities-in-tfm/submit-MIN-with-unissued-facilities-and-resubmit-issued-facilities-updates-facilities-in-tfm.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-MIN-with-unissued-facilities-and-resubmit-issued-facilities-updates-facilities-in-tfm/submit-MIN-with-unissued-facilities-and-resubmit-issued-facilities-updates-facilities-in-tfm.spec.js
@@ -258,5 +258,9 @@ context('Portal to TFM deal submission', () => {
       // this text is only displayed if a total exists.
       expect(text.trim()).to.contain('Total');
     });
+
+    tfmPages.facilityPage.allFacilitiesLink().click();
+    tfmPages.facilitiesPage.facilityIdLink(dealFacilities.bonds[0]._id).should('exist');
+    tfmPages.facilitiesPage.facilityIdLink(dealFacilities.loans[0]._id).should('exist');
   });
 });

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/facilitiesPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/facilitiesPage.js
@@ -10,6 +10,7 @@ const facilitiesPage = {
   searchFormInput: () => cy.get('[data-cy="search-input"]'),
   searchFormSubmitButton: () => cy.get('[data-cy="submit-button"]'),
   dealsTableRows: () => cy.get('[data-cy="tfm-facilities-table"] tbody tr'),
+  facilityIdLink: (id) => cy.get(`[data-cy="deal-${id}-ukef-facility-id-link-text"]`),
 };
 
 module.exports = facilitiesPage;

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/facilityPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/facilityPage.js
@@ -1,4 +1,5 @@
 const facilityPage = {
+  allFacilitiesLink: () => cy.get('[data-cy="all-facilities-link"]'),
   facilityTabDetails: () => cy.get('[data-cy="facility-details-tab-details"]'),
   facilityTabPremiumSchedule: () => cy.get('[data-cy="facility-details-tab-premium-schedule"]'),
 

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -654,7 +654,7 @@ describe('/v1/deals', () => {
 
         expect(status).toEqual(200);
         expect(body.submissionType).toEqual(CONSTANTS.DEALS.SUBMISSION_TYPE.MIN);
-        expect(typeof body.manualInclusionNoticeSubmissionDate).toEqual('number');
+        expect(typeof body.manualInclusionNoticeSubmissionDate).toEqual('string');
       });
     });
   });

--- a/trade-finance-manager-api/src/v1/controllers/update-portal-deal-from-MIA-to-MIN.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-portal-deal-from-MIA-to-MIN.api-test.js
@@ -1,0 +1,58 @@
+const { updatePortalDealFromMIAtoMIN } = require('./update-portal-deal-from-MIA-to-MIN');
+const api = require('../api');
+
+const CONSTANTS = require('../../constants');
+
+describe('updatePortalDealFromMIAtoMIN()', () => {
+  const checker = {
+    _id: '1234',
+    username: 'checker@checker',
+    roles: ['checker'],
+    bank: {
+      id: '1',
+      name: 'bank',
+    },
+    firstname: 'bob',
+    surname: 'bob',
+  };
+
+  const dealId = '123';
+
+  beforeEach(() => {
+    api.updatePortalGefDeal = jest.fn(() => Promise.resolve({}));
+    api.updatePortalDeal = jest.fn(() => Promise.resolve({}));
+    api.updateGefMINActivity = jest.fn(() => Promise.resolve({}));
+  });
+
+  it('should return the dealUpdate object on gef deal update', async () => {
+    const update = await updatePortalDealFromMIAtoMIN(dealId, CONSTANTS.DEALS.DEAL_TYPE.GEF, checker);
+
+    const dealUpdate = {
+      submissionType: CONSTANTS.DEALS.SUBMISSION_TYPE.MIN,
+      checkerMIN: checker,
+      manualInclusionNoticeSubmissionDate: expect.any(String),
+    };
+
+    expect(update).toEqual(dealUpdate);
+  });
+
+  it('should return the dealUpdate object on BSS deal update', async () => {
+    const update = await updatePortalDealFromMIAtoMIN(dealId, CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS, checker);
+
+    const dealUpdate = {
+      submissionType: CONSTANTS.DEALS.SUBMISSION_TYPE.MIN,
+      details: {
+        checkerMIN: checker,
+        manualInclusionNoticeSubmissionDate: expect.any(String),
+      },
+    };
+
+    expect(update).toEqual(dealUpdate);
+  });
+
+  it('should return undefined if no deal type', async () => {
+    const update = await updatePortalDealFromMIAtoMIN(dealId, '', checker);
+
+    expect(update).toBeUndefined();
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/update-portal-deal-from-MIA-to-MIN.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-portal-deal-from-MIA-to-MIN.js
@@ -4,7 +4,6 @@ const now = require('../../now');
 
 const updatePortalDealFromMIAtoMIN = async (dealId, dealType, checker) => {
   console.info('Updating Portal deal from MIA to MIN');
-  let update;
   let dealUpdate;
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
@@ -14,10 +13,10 @@ const updatePortalDealFromMIAtoMIN = async (dealId, dealType, checker) => {
       manualInclusionNoticeSubmissionDate: now(),
     };
 
-    update = await api.updatePortalGefDeal(dealId, dealUpdate);
+    await api.updatePortalGefDeal(dealId, dealUpdate);
 
     // adds portal activity object for min submission and facilities changed -> issued
-    update = await api.updateGefMINActivity(dealId);
+    await api.updateGefMINActivity(dealId);
   } else if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
     dealUpdate = {
       submissionType: CONSTANTS.DEALS.SUBMISSION_TYPE.MIN,
@@ -27,10 +26,10 @@ const updatePortalDealFromMIAtoMIN = async (dealId, dealType, checker) => {
       },
     };
 
-    update = await api.updatePortalDeal(dealId, dealUpdate);
+    await api.updatePortalDeal(dealId, dealUpdate);
   }
 
-  return update;
+  return dealUpdate;
 };
 
 exports.updatePortalDealFromMIAtoMIN = updatePortalDealFromMIAtoMIN;


### PR DESCRIPTION
# Issue: 
* MIN facilities do not show up on all facilities tab
* MIN tfm-deal dealSnapshot._id converted to string instead of ObjectId

# Changes made:
* returned dealUpdate from `updatePortalDealFromMIAtoMIN` as compared to returning full deal 
* removed full update body from update in `updateDealSnapshot` 
* Added extra tests