### PR TITLE
fix(DTFS2-6065): Null ukefFacilityId fix

### DIFF
--- a/trade-finance-manager-api/graphql-query-tests/query-facilities.api-test.js
+++ b/trade-finance-manager-api/graphql-query-tests/query-facilities.api-test.js
@@ -49,4 +49,13 @@ describe('queryAllFacilities()', () => {
 
     expect(result).toEqual({});
   });
+
+  it('should return ukefFacilityId as `-` if is null', async () => {
+    mockTfmFacilities[0].ukefFacilityId = null;
+    mockTfmFacilities[0].tfmFacilities.ukefFacilityId = null;
+
+    const result = await queryAllFacilities({ params: 'test' });
+
+    expect(result.tfmFacilities[0].ukefFacilityId).toEqual('-');
+  });
 });

--- a/trade-finance-manager-api/src/graphql/resolvers/query-facilities.js
+++ b/trade-finance-manager-api/src/graphql/resolvers/query-facilities.js
@@ -17,6 +17,11 @@ exports.queryAllFacilities = async (queryParams) => {
   for (const item of rawFacilities) {
     const { tfmFacilities: facility } = item;
 
+    // if facilityId is null, replace with '-'
+    if (!facility.ukefFacilityId) {
+      facility.ukefFacilityId = '-';
+    }
+
     // finds latest completed amendment tfm object with mapped values
     const latestCompletedAmendment = findLatestCompletedAmendment(item?.amendments);
 


### PR DESCRIPTION
# Issue:
* If ukefFacilityId is null, tfm-ui crashes as graphql replaces facility with null on all facilities page mapping

# Changes made:
* Replaced null with '-' on query-facilities resolver
* Added test