### PR TITLE
fix(DTFS2-6056): show all MIN facilities - change to _id

### DIFF
--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
@@ -49,7 +49,7 @@ exports.getAllFacilities = async (req, res) => {
       $lookup: {
         from: 'tfm-deals',
         localField: 'facilitySnapshot.dealId',
-        foreignField: 'dealSnapshot._id',
+        foreignField: '_id',
         as: 'tfmDeals'
       }
     },


### PR DESCRIPTION
# Issue:
* Some dealSnapshots on migrated deals still have dealSnapshot._id as a string

# Changes made:
* Changed $lookup to use _id instead of dealSnapshot._id