### PR TITLE
fix: Removed `main-amendments` from GHA

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,7 +29,7 @@ A couple of places this works are:
 At a high-level, the pipeline works by building docker container images (repositories) with various tags associated to it (artifacts)
 which then are saved under specific ACR (Azure container registry) account i.e. `tfsdev`, `tfsstaging` and `tfsprod`.
 
- * Code is pushed to the `main` or `main-amendment` branch.
+ * Code is pushed to the `main` branch.
  * Infrastructure is setup (if any changes) `_infrastructure`, container images are build, pushed and deployed `_deployment` with correct tags (artifacts).
  * Merging to the `infrastructure` branch triggers a refresh of supporting infrastructure (Service Plan, ACR) when a file change is detected in `infrastructure.yml` file.
 

--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -27,7 +27,7 @@ if [ -n "$selection" ]; then
     then
     ############### DEV ###############
     destination=dev
-    branch=main-amendments
+    branch=main
     ############### DEV ###############
     elif [ "$selection" = "2" ]
     then

--- a/.github/workflows/pr_api_tests.yml
+++ b/.github/workflows/pr_api_tests.yml
@@ -2,7 +2,7 @@ name: PR - API tests
 
 on:
   pull_request:
-    branches: [ main, main-amendments ]
+    branches: [ main ]
     paths:
     - 'gef-ui/**'
     - 'portal/**'

--- a/.github/workflows/pr_e2e_tests.yml
+++ b/.github/workflows/pr_e2e_tests.yml
@@ -2,7 +2,7 @@ name: PR - End-To-End tests
 
 on:
   pull_request:
-    branches: [ main, main-amendments ]
+    branches: [ main ]
     paths:
     - 'gef-ui/**'
     - 'portal/**'

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -2,7 +2,7 @@ name: PR - Integration tests
 
 on:
   pull_request:
-    branches: [ main, main-amendments ]
+    branches: [ main ]
     paths:
     - 'portal/**'
     - 'gef-ui/**'

--- a/.github/workflows/pr_no_tests.yml
+++ b/.github/workflows/pr_no_tests.yml
@@ -2,7 +2,7 @@ name: PR tests - Empty tests for github action config
 
 on:
   pull_request:
-    branches: [ main, main-amendments ]
+    branches: [ main ]
     paths:
     - '.github/workflows/**'
     - 'README.md'

--- a/.github/workflows/scan_codeql_analysis.yml
+++ b/.github/workflows/scan_codeql_analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL - Code Quality checkup"
 
 on:
   pull_request:
-    branches: [ main, main-amendments ]
+    branches: [ main ]
 
 jobs:
   analyze:


### PR DESCRIPTION
## Introduction
Since `main-amendment` has been merged into `main`, any reference to same in CICD is now frivolous.

## Resolution
* GHA branches now only refers to `main`.
* Deployment shell script deployment only on `main`
* Updated README.md