### PR TITLE
fix(acbs): GEF facility loan record ML amendment

### DIFF
--- a/azure-functions/acbs-function/acbs-amend-facility/index.js
+++ b/azure-functions/acbs-function/acbs-amend-facility/index.js
@@ -110,8 +110,8 @@ module.exports = df.orchestrator(function* amendACBSFacility(context) {
 
           if (loanId) {
             // 2.3.2 - UKEF Exposure
-            // Loan amount - `Bond` facility types only
-            if (amendment.amount && facilitySnapshot.type === FACILITY.FACILITY_TYPE.BOND) {
+            // Loan amount - All expect `Loan` facility type
+            if (amendment.amount && facilitySnapshot.type !== FACILITY.FACILITY_TYPE.LOAN) {
               const result = yield context.df.callActivityWithRetry('activity-update-facility-loan-amount', retryOptions, {
                 loanId,
                 facilityId,

--- a/azure-functions/acbs-function/acbs-amend-facility/index.js
+++ b/azure-functions/acbs-function/acbs-amend-facility/index.js
@@ -110,7 +110,7 @@ module.exports = df.orchestrator(function* amendACBSFacility(context) {
 
           if (loanId) {
             // 2.3.2 - UKEF Exposure
-            // Loan amount - All expect `Loan` facility type
+            // Loan amount - All except `Loan` facility type
             if (amendment.amount && facilitySnapshot.type !== FACILITY.FACILITY_TYPE.LOAN) {
               const result = yield context.df.callActivityWithRetry('activity-update-facility-loan-amount', retryOptions, {
                 loanId,


### PR DESCRIPTION
#Introduction
Previously only `Bond` facility type were allowed to be amended (FLR).
After a recent `CODA` testing, it has been identified that the `GEF` facility's  ML should be amended alongside  with it's FMR.

`EW` facility specification remains the same.

#Resolution
* `Loan` type facilities are excluded from FLR amendment.
* Documentation update.