### PR TITLE
feat(DTFS2-6098): Show exchange rate in TFM

### DIFF
--- a/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-non-gbp-facilities/submit-deal-with-non-gbp-facilities.spec.js
+++ b/e2e-tests/submit-to-trade-finance-manager/cypress/integration/journeys/portal/submit-deal-with-non-gbp-facilities/submit-deal-with-non-gbp-facilities.spec.js
@@ -80,7 +80,8 @@ context('Portal to TFM deal submission', () => {
     cy.url().should('eq', `${TFM_URL}/case/${dealId}/deal`);
 
     //---------------------------------------------------------------
-    // deal facilities with non-GBP currency display GBP and non-GBP currency values
+    // deal facilities with non-GBP currency display GBP and non-GBP
+    // currency values alongside with an Exchange rate
     //---------------------------------------------------------------
     const facilityWithNonGBPCurrency = dealFacilities.find((facility) => facility.currency.code !== 'GBP');
     const facilityId = facilityWithNonGBPCurrency._id;
@@ -90,12 +91,21 @@ context('Portal to TFM deal submission', () => {
 
     cy.url().should('eq', `${TFM_URL}/case/${dealId}/facility/${facilityId}`);
 
+    // Value (export currency)
     tfmPages.facilityPage
       .facilityValueExportCurrency()
       .invoke('text')
       .then((text) => {
         const facilityCurrency = facilityWithNonGBPCurrency.currency.id;
         expect(text.trim()).to.contain(facilityCurrency);
+      });
+
+    // Exchange rate
+    tfmPages.facilityPage
+      .facilityExchangeRate()
+      .invoke('text')
+      .then((text) => {
+        expect(text.trim()).not.contain('-');
       });
 
     // currency is converted dynamically - tricky/flaky to assert/mock this from e2e test

--- a/e2e-tests/trade-finance-manager/cypress/integration/pages/facilityPage.js
+++ b/e2e-tests/trade-finance-manager/cypress/integration/pages/facilityPage.js
@@ -8,6 +8,7 @@ const facilityPage = {
   facilityStage: () => cy.get('[data-cy="facility-stage"]'),
 
   facilityValueExportCurrency: () => cy.get('[data-cy="facility-value-export-currency"]'),
+  facilityExchangeRate: () => cy.get('[data-cy="facility-exchange-rate"]'),
   facilityValueGbp: () => cy.get('[data-cy="facility-value-gbp"]'),
 
   facilityMaximumUkefExposure: () => cy.get('[data-cy="facility-maximum-ukef-exposure"]'),

--- a/trade-finance-manager-ui/templates/case/facility/_macros/facility_details.component-test.js
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/facility_details.component-test.js
@@ -35,6 +35,7 @@ describe(component, () => {
       },
     },
     facilityTfm: {
+      exchangeRate: '0.89',
       ukefExposure: {
         exposure: 'GBP 123',
         timestamp: '1606900616651',
@@ -111,6 +112,10 @@ describe(component, () => {
   describe('value and exposure section', () => {
     it('should render facilityValueExportCurrency', () => {
       wrapper.expectText('[data-cy="facility-value-export-currency"]').toRead(params.facility.facilityValueExportCurrency);
+    });
+
+    it('Should render exchangeRate (Non-GBP facilities only)', () => {
+      wrapper.expectText('[data-cy="facility-exchange-rate"]').toRead(params.facilityTfm.exchangeRate);
     });
 
     it('should render value', () => {

--- a/trade-finance-manager-ui/templates/case/facility/_macros/facility_details.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/facility_details.njk
@@ -109,7 +109,7 @@
           <h4 class="govuk-heading-s govuk-body-s govuk-!-font-weight-bold">Exchange rate</h4>
         </div>
         <div class="govuk-grid-column-three-quarters">
-          <p class="govuk-body-s">-</p>
+          <p class="govuk-body-s" data-cy="facility-exchange-rate">{{ facilityTfm.exchangeRate | dashIfEmpty}}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Introduction
`Exchange Rate` under `Value and Exposure` in TFM have been hard coded to `-`.
Since `exchangeRate` property is being set with the `midRate` from the Mulesoft API and also being set as part of data-migration, it should be made available in TFM.

After conformation, template have been updated.

## Resolution
* `tfm.exchnageRate` property being read in the NJK template.
* Introduced `facilityExchangeRate` for all the E2E tests.
* Updated E2E tests for `non-GBP` facilities submission.
* Updated component test.