### PR TITLE
fix(DTFS2-6023): Facility amendment decrement

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/facility-loan-amend.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-loan-amend.js
@@ -19,12 +19,12 @@ const facilityLoanAmend = (amendments, facility, facilityMasterRecord) => {
 
       // 1. UKEF Exposure
       if (amount) {
-        // 1.1. Amend amount, if facility type is `Bond`.
-        if (type === CONSTANTS.FACILITY.FACILITY_TYPE.BOND) {
+        // 1.1. Amend amount, if facility type is not `Loan`.
+        if (type !== FACILITY.FACILITY_TYPE.LOAN) {
           record = {
             ...record,
             effectiveDate: now(),
-            amountAmendment: helpers.getLoanAmountDifference(amount, facilityMasterRecord),
+            amountAmendment: helpers.getLoanAmountDifference(amount, type, facilityMasterRecord),
           };
         }
       }

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-loan-amount-difference.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-loan-amount-difference.js
@@ -1,16 +1,32 @@
+const CONSTANTS = require('../../../constants');
+
+const { FACILITY } = CONSTANTS;
+
 /**
  * Calculates amended facility loan amount difference between amended amount
  * and previous amount.
  * Due to Mulesoft API restriction a new amended UKEF exposure amount cannot
  * be send in a payload, instead difference between the amount is expected.
+ *
+ * `GEF` facilities type will return 10% of the difference.
+ * `Bond` facility type will return the full difference.
  * @param {Integer} ukefExposure UKEF Exposure
+ * @param {String} type Facility Type
  * @param {Object} facilityMasterRecord Facility master record object
  * @returns {Integer} Loan amount difference, if null argument then returns `0`
  */
-const getLoanAmountDifference = (ukefExposure, facilityMasterRecord) => {
+const getLoanAmountDifference = (ukefExposure, type, facilityMasterRecord) => {
   if (ukefExposure && facilityMasterRecord) {
     const { maximumLiability } = facilityMasterRecord;
-    return ukefExposure - maximumLiability;
+    const difference = ukefExposure - maximumLiability;
+
+    // GEF Facility - 10% of difference
+    if (type === FACILITY.FACILITY_TYPE.CASH || type === FACILITY.FACILITY_TYPE.CONTINGENT) {
+      return difference * 0.1;
+    }
+
+    // Bond Facility - Full amount
+    return difference;
   }
 
   return 0;


### PR DESCRIPTION
## Introduction
Facility amendment could consists of both value *increment* or value *decrement*.
Value increment works as expected, however decrement require facility records amendment to be swapped.

In a standard value increment records are amended in following sequence:
1. FMR
2. FLR

However, in case of decrement records are amended in reverse:
1. FLR
2. FMR

## Resolution
1. Execution sequence are swapped upon operation type.
2. GEF facility amendment bug resolution with regards to `10%` of the amendment value and condition update for payload construction.

## Miscellaneous
1. Documentation update