### PR TITLE
fix: Void user ID

### DIFF
--- a/portal-api/src/v1/gef/controllers/portal-activities.controller.js
+++ b/portal-api/src/v1/gef/controllers/portal-activities.controller.js
@@ -9,14 +9,17 @@ const CONSTANTS = require('../../../constants');
 // retrieves user information from database
 const getUserInfo = async (userId) => {
   const userCollectionName = 'users';
+  let firstname = '';
+  const surname = '';
 
   const userCollection = await db.getCollection(userCollectionName);
-  const {
-    firstname,
-    surname = '',
-  } = userId
+  const userProfile = userId
     ? await userCollection.findOne({ _id: ObjectId(String(userId)) })
     : {};
+
+  if (userProfile) {
+    firstname = userProfile.firstName;
+  }
 
   // creates user object which can be used
   const user = {
@@ -24,6 +27,7 @@ const getUserInfo = async (userId) => {
     surname,
     _id: userId,
   };
+
   return user;
 };
 


### PR DESCRIPTION
## Introduction
Since migration deals will have user ID which either are invalid, do not exists or are null.
Given the above predicament, portal activities and comments controller should be able to handle a null response from DB `findOne` API call.

## Resolution
* Conditional check on `userProfile`.
* Instantiation  of `firsname` and `lastname` empty string variables.