### PR TITLE
fix(DTFS2-6116): GQL empty facilities mapping

### DIFF
--- a/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapDeals.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapDeals.js
@@ -5,24 +5,29 @@ const mapDeals = (
   mapBssDealFunc,
   mapGefDealFunc,
 ) => {
-  const mappedDeals = deals.map((deal) => {
-    const { dealType } = deal.dealSnapshot;
+  try {
+    const mappedDeals = deals.map((deal) => {
+      const { dealType } = deal.dealSnapshot;
 
-    if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
-      return mapGefDealFunc(deal);
-    }
+      if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
+        return mapGefDealFunc(deal);
+      }
 
-    if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
-      return mapBssDealFunc(deal);
-    }
+      if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
+        return mapBssDealFunc(deal);
+      }
 
-    return deal;
-  });
+      return deal;
+    });
 
-  return {
-    count: mappedDeals.length,
-    deals: mappedDeals,
-  };
+    return {
+      count: mappedDeals.length,
+      deals: mappedDeals,
+    };
+  } catch (e) {
+    console.error('Error mapping deal for GQL reducer: ', { e });
+    return null;
+  }
 };
 
 module.exports = mapDeals;

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.js
@@ -31,13 +31,14 @@ const mapTotals = (facilities) => {
       // If we pass in mapped facilities, value would contain currency code. Therefore:
       // - Bond and Loan facility total is `value`
       // - Cash and Contingent facility total is `value`
-
       return Number(facilitySnapshot.value);
     }
     return null;
   });
 
-  const formattedFacilitiesValue = formattedNumber(facilitiesValue.reduce((a, b) => a + b));
+  const formattedFacilitiesValue = facilitiesValue.length
+    ? formattedNumber(facilitiesValue.reduce((a, b) => a + b))
+    : 0;
 
   totals.facilitiesValueInGBP = `${CURRENCY.GBP} ${formattedFacilitiesValue}`;
 
@@ -59,7 +60,10 @@ const mapTotals = (facilities) => {
   // total ukef exposure for all facilities
   const ukefExposureArray = [...mappedExposureTotal];
 
-  const formattedUkefExposure = formattedNumber(ukefExposureArray.reduce((a, b) => a + b));
+  const formattedUkefExposure = ukefExposureArray.length
+    ? formattedNumber(ukefExposureArray.reduce((a, b) => a + b))
+    : 0;
+
   totals.facilitiesUkefExposure = `${CURRENCY.GBP} ${formattedUkefExposure}`;
 
   return totals;


### PR DESCRIPTION
## Introduction
`/graphql` endpoint responsible for returning all the mapped deals having been failing due to mapping issue.
Certain migrated deals which are `Abandoned` have no facilities there causing the reducer to fail when an empty facilities array is being applied to `reduce` method.

## Resolution
* Ternary operator on empty array.
* Introduction of `try-catch` block for exceptional handling.