### PR TITLE
fix(DTFS2-6116): Void facility validations

### DIFF
--- a/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/deal/mapTotals.js
@@ -6,6 +6,11 @@ const { CURRENCY } = require('../../../../constants/currency.constant');
 const mapTotals = (facilities) => {
   const totals = {};
 
+  // Ensure facilities are not null
+  if (!facilities) {
+    return null;
+  }
+
   // total value of all facilities
   const facilitiesValue = facilities.map((facility) => {
     if (isValidFacility(facility)) {

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilities.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacilities.js
@@ -2,13 +2,18 @@ const mapFacility = require('./mapFacility');
 const mapFacilityTfm = require('./mapFacilityTfm');
 
 const mapFacilities = (facilities, dealDetails, dealTfm) => {
-  const mappedFacility = facilities.map((f) => ({
-    _id: f._id,
-    facilitySnapshot: mapFacility(f.facilitySnapshot, f.tfm, dealDetails, f),
-    tfm: mapFacilityTfm(f.tfm, dealTfm, f),
-  }));
+  // Map facilities if only they exists
+  if (facilities?.length) {
+    const mappedFacility = facilities.map((f) => ({
+      _id: f._id,
+      facilitySnapshot: mapFacility(f.facilitySnapshot, f.tfm, dealDetails, f),
+      tfm: mapFacilityTfm(f.tfm, dealTfm, f),
+    }));
 
-  return mappedFacility;
+    return mappedFacility;
+  }
+
+  return null;
 };
 
 module.exports = mapFacilities;

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacility.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapFacility.js
@@ -14,6 +14,11 @@ const mapUkefExposureValue = require('./mapUkefExposureValue');
 const mapFacilityValueExportCurrency = require('./mapFacilityValueExportCurrency');
 
 const mapFacility = (f, facilityTfm, dealDetails, facilityFull) => {
+  // Ensure facility is valid
+  if (!f) {
+    return null;
+  }
+
   // Deep clone
   const facility = JSON.parse(JSON.stringify(f, null, 4));
 


### PR DESCRIPTION
## Introduction
Deals with empty facilities crash GQL reducers when `map` method is being applied.

## Resolution
* Void facility check