### PR TITLE
fix(DTFS-6128): Users with multiple teams not being able to access tasks

### DIFF
--- a/e2e-tests/e2e-fixtures/tfm-users.fixture.js
+++ b/e2e-tests/e2e-fixtures/tfm-users.fixture.js
@@ -70,7 +70,7 @@ export const UNDERWRITING_SUPPORT_1 = {
 
 export const PIM_USER_1 = {
   username: 'PIM_USER_1',
-  teams: ['PIM'],
+  teams: ['PIM', 'BUSINESS_SUPPORT'],
   firstName: 'Adam',
   lastName: 'Pimson',
   ...defaultUserDetails,

--- a/trade-finance-manager-ui/templates/case/amendments/_macros/tasks-table-amendments.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/_macros/tasks-table-amendments.njk
@@ -39,7 +39,7 @@
                 <tr class="govuk-table__row" data-cy="task-group-{{ taskGroup.id }}-task-{{ task.id }}-row">
 
                   <td class="govuk-table__cell govuk-!-padding-top-4 govuk-!-padding-right-4 govuk-!-padding-bottom-4 govuk-!-padding-left-0 ukef-tasks-table__cell-width-28">
-                    {% if task.canEdit and user.teams in task.team.id %}
+                    {% if task.canEdit and task.team.id in user.teams %}
                       <a class="govuk-link" href="/case/{{ dealId }}/facility/{{facilityId}}/amendment/{{amendmentId}}/task/{{ task.id }}/group/{{ task.groupId }}" data-cy="task-table-row-group-{{ task.groupId }}-task-{{ task.id }}-link">{{ task.title }}</a>
                       {% else %}
                         <span data-cy="task-table-row-group-{{task.groupId}}-task-{{ task.id }}-title">{{ task.title }}</span>

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.njk
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.njk
@@ -31,7 +31,7 @@
 
                 <td class="govuk-table__cell govuk-!-padding-top-4 govuk-!-padding-right-4 govuk-!-padding-bottom-4 govuk-!-padding-left-0 ukef-tasks-table__cell-width-28">
                   {# checks if can edit and if user is in tasks team id group #}
-                  {% if task.canEdit and user.teams in task.team.id %}
+                  {% if task.canEdit and task.team.id in user.teams %}
                     <a class="govuk-link" href="/case/{{ caseId }}/tasks/{{ task.groupId }}/{{ task.id }}" data-cy="task-table-row-group-{{ task.groupId }}-task-{{ task.id }}-link">{{ task.title }}</a>
 
                     {% else %}


### PR DESCRIPTION
# Issue: 
* PIM were not able to access task as were in multiple groups

# Changes made:
* fixed the order in nunjucks for checking if in group
* User group is array and task.team.id is a string
* Added team to mock user PIM group