### PR TITLE
fix(DTFS2-6139): Property name correction whilst de-constructing

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -74,12 +74,12 @@ const updateIssuedFacilityAcbs = ({ facilityId, issuedFacilityMaster }) =>
 const updateAmendedFacilityAcbs = (taskResult) => {
   if (taskResult.instanceId && taskResult.output) {
     const { instanceId } = taskResult;
-    const { facilityMasterRecordAmendments, facilityLoanRecordAmendments } = taskResult.output;
+    const { facilityMasterRecord, facilityLoanRecord } = taskResult.output;
     const { _id } = taskResult.input.amendment.facility;
     const acbsUpdate = {
       [instanceId]: {
-        facilityMasterRecordAmendments,
-        facilityLoanRecordAmendments,
+        facilityMasterRecord,
+        facilityLoanRecord,
       },
     };
 


### PR DESCRIPTION
## Introduction
Upon making an ACBS request output is stored in `durable-functions-log` collection which then is handled by `acbs.controller` to be saved in `tfm-*` collection.

When an amendment request is submitted to ACBS, final output from DOF is returned and saved in `durable-functions-log` which is further then fetched and amended to `tfm-facilities` (tfm.acbs.[amendment_id]). 

Above property was being created, however with an empty object due to `undefined` property de-construction.

## Resolution
* Property names correction.