### PR TITLE
fix(DTFS2-6143): Payload construction

### DIFF
--- a/portal/server/helpers/constructPayload.js
+++ b/portal/server/helpers/constructPayload.js
@@ -1,0 +1,40 @@
+/**
+ * Construct expected properties payload to general consumption.
+ * Method ensures only expected properties are added and any frivolous
+ * properties are filtered out.
+ * @param {Object} body Request body (req.body)
+ * @param {Array} properties Interested properties to be added into payload
+ * @param {Boolean} csrf Include CSRF token, defaulted to `true`
+ * @returns {Object} Payload
+ */
+const constructPayload = (body, properties, csrf = true) => {
+  let payload = {};
+
+  // Return empty payload upon void mandatory arguments
+  if (!body || !properties) {
+    return payload;
+  }
+
+  // Ascertain CSRF inclusion
+  if (csrf && body._csrf) {
+    payload = {
+      _csrf: body._csrf,
+    };
+  }
+
+  // Property insertion
+  properties
+    .filter((property) => property in body)
+    .map((property) => {
+      payload = {
+        ...payload,
+        [property]: body[[property]],
+      };
+
+      return null;
+    });
+
+  return payload;
+};
+
+module.exports = constructPayload;

--- a/portal/server/helpers/constructPayload.test.js
+++ b/portal/server/helpers/constructPayload.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit test cases for `constructPayload` method
+ */
+import constructPayload from './constructPayload';
+
+const mockBody = {
+  _csrf: '3YyRfYmT',
+  currentPassword: 'AbC!2345',
+  password: 'AbC!23456',
+  passwordConfirm: 'AbC!23456',
+};
+
+const mockExtraBody = {
+  roles: ['maker/checker', 'checker', 'maker', 'ukef_operations', 'EFM'],
+  _csrf: '3YyRfYmT',
+  currentPassword: 'AbC!2345',
+  password: 'AbC!23456',
+  passwordConfirm: 'AbC!23456',
+};
+
+const payloadProperties = [
+  'currentPassword',
+  'password',
+  'passwordConfirm',
+];
+
+describe('Unit test cases for constructPayload method', () => {
+  it('Should return an empty payload, when both `body` and `properties` argument are null', () => {
+    const expected = {};
+    const returned = constructPayload(null, null);
+
+    expect(expected).toEqual(returned);
+  });
+
+  it('Should return an empty payload, when `body` argument is null', () => {
+    const expected = {};
+    const returned = constructPayload(null, payloadProperties);
+
+    expect(expected).toEqual(returned);
+  });
+
+  it('Should return an empty payload, when `properties` argument is null', () => {
+    const expected = {};
+    const returned = constructPayload(mockBody, null);
+
+    expect(expected).toEqual(returned);
+  });
+
+  it('Should return expected payload as per `properties` and CSRF argument with extra data in body', () => {
+    const expected = {
+      _csrf: '3YyRfYmT',
+      currentPassword: 'AbC!2345',
+      password: 'AbC!23456',
+      passwordConfirm: 'AbC!23456',
+    };
+    const returned = constructPayload(mockExtraBody, payloadProperties);
+
+    expect(expected).toEqual(returned);
+  });
+
+  it('Should return expected payload as per `properties` and without CSRF argument with extra data in body', () => {
+    const expected = {
+      currentPassword: 'AbC!2345',
+      password: 'AbC!23456',
+      passwordConfirm: 'AbC!23456',
+    };
+    const returned = constructPayload(mockExtraBody, payloadProperties, false);
+
+    expect(expected).toEqual(returned);
+  });
+
+  it('Should return expected payload as per `properties` and CSRF argument with data in standard body', () => {
+    const expected = {
+      _csrf: '3YyRfYmT',
+      currentPassword: 'AbC!2345',
+      password: 'AbC!23456',
+      passwordConfirm: 'AbC!23456',
+    };
+    const returned = constructPayload(mockBody, payloadProperties);
+
+    expect(expected).toEqual(returned);
+  });
+
+  it('Should return expected payload as per `properties` and without CSRF argument with data in standard body', () => {
+    const expected = {
+      currentPassword: 'AbC!2345',
+      password: 'AbC!23456',
+      passwordConfirm: 'AbC!23456',
+    };
+    const returned = constructPayload(mockBody, payloadProperties, false);
+
+    expect(expected).toEqual(returned);
+  });
+});

--- a/portal/server/helpers/index.js
+++ b/portal/server/helpers/index.js
@@ -17,6 +17,7 @@ const postToApi = require('./postToApi');
 const requestParams = require('./requestParams');
 const sanitizeCurrency = require('./sanitizeCurrency');
 const validationErrorHandler = require('./validationErrorHandler');
+const constructPayload = require('./constructPayload');
 
 module.exports = {
   dealFormsCompleted,
@@ -39,4 +40,5 @@ module.exports = {
   requestParams,
   sanitizeCurrency,
   validationErrorHandler,
+  constructPayload,
 };

--- a/portal/server/routes/user/profile.js
+++ b/portal/server/routes/user/profile.js
@@ -5,7 +5,7 @@ const {
   getApiData,
   requestParams,
   errorHref,
-  generateErrorSummary
+  generateErrorSummary,
 } = require('../../helpers');
 
 const router = express.Router();

--- a/portal/server/routes/user/profile.js
+++ b/portal/server/routes/user/profile.js
@@ -1,6 +1,12 @@
 const express = require('express');
 const api = require('../../api');
-const { getApiData, requestParams, errorHref, generateErrorSummary } = require('../../helpers');
+const {
+  constructPayload,
+  getApiData,
+  requestParams,
+  errorHref,
+  generateErrorSummary
+} = require('../../helpers');
 
 const router = express.Router();
 
@@ -33,9 +39,14 @@ router.post('/:_id/change-password', async (req, res) => {
   // Ensure that the user is logged in
   if (req?.session?.user) {
     let formattedValidationErrors;
-
+    const payloadProperties = [
+      'currentPassword',
+      'password',
+      'passwordConfirm',
+    ];
+    const payload = constructPayload(req.body, payloadProperties);
     const { _id } = requestParams(req);
-    const { currentPassword, password, passwordConfirm } = req.body;
+    const { currentPassword, password, passwordConfirm } = payload;
 
     if (!currentPassword || !password || !passwordConfirm) {
       const error = {


### PR DESCRIPTION
## Introduction
A vulnerability has been raised, where a non-privileged or a lower privileged user can amend the `<form>` DOM element on the change password by inserting the `role` attributes DOM elements.

Upon submission whole `req.body` is submitted to the controller thus amending non-targeted the user profile attributes.

## Resolution
* Introduction of `constructPayload` method, which is responsible for creating payload with indented properties only with an optional `CSRF` property inclusion.
* Accompanied with an unit test.