### PR TITLE
fix(DTFS2-6143): payload being passed instead of req.body

### DIFF
--- a/portal/server/routes/admin/users.js
+++ b/portal/server/routes/admin/users.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const api = require('../../api');
 const {
-  getApiData, requestParams, errorHref, generateErrorSummary,
+  getApiData,
+  requestParams,
+  errorHref,
+  generateErrorSummary,
+  constructPayload,
 } = require('../../helpers');
 
 const router = express.Router();
@@ -110,11 +114,18 @@ router.get('/users/edit/:_id', async (req, res) => {
 
 // Admin - user edit
 router.post('/users/edit/:_id', async (req, res) => {
+  const payloadProperties = [
+    'firstname',
+    'surname',
+    'user-status',
+    'roles',
+  ];
+  const payload = constructPayload(req.body, payloadProperties);
   const { _id, userToken } = requestParams(req);
 
   const update = {
-    ...req.body,
-    roles: handleRoles(req.body.roles),
+    ...payload,
+    roles: handleRoles(payload.roles),
   };
 
   await api.updateUser(_id, update, userToken);
@@ -157,17 +168,19 @@ router.get('/users/change-password/:_id', async (req, res) => {
 
 // Admin - Change user password
 router.post('/users/change-password/:_id', async (req, res) => {
+  const payloadProperties = [
+    'password',
+    'passwordConfirm',
+  ];
+  const payload = constructPayload(req.body, payloadProperties);
   const { _id, userToken } = requestParams(req);
-  const update = {
-    ...req.body,
-  };
 
   // Get user information
   const user = await getApiData(api.user(_id, userToken), res);
   // Update user password
-  const { status, data } = await api.updateUser(_id, update, userToken);
+  const { status, data } = await api.updateUser(_id, payload, userToken);
 
-  // Successfull
+  // Successful
   if (status === 200) {
     return res.redirect(`/admin/users/edit/${_id}`);
   }

--- a/portal/server/routes/user/profile.js
+++ b/portal/server/routes/user/profile.js
@@ -80,7 +80,7 @@ router.post('/:_id/change-password', async (req, res) => {
 
       formattedValidationErrors = generateErrorSummary(error, errorHref);
     } else {
-      const { status, data } = await api.updateUser(_id, req.body, req.session.userToken);
+      const { status, data } = await api.updateUser(_id, payload, req.session.userToken);
 
       if (status === 200) {
         return res.redirect(`/user/${_id}`);


### PR DESCRIPTION
## Introduction
* As pointed out `red.body` was still being passed instead of `payload`, thus not patching the vulnerability.
* Other admin endpoints were still passing the whole `req.body` to the update endpoint.

## Resolution
* `payload` being passed to the API endpoint.
* Admin user edit POST endpoint now calls `constructPayload` before user update endpoint invocation.
* Admin user password change POST endpoint calls `constructPayload` before user update endpoint invocation.

## To-do (Post-deployment)
* Add vulnerability E2E tests.
* Add a test confirming `constructPayload` method has been called.

## Miscellaneous
* Typo fix