### PR TITLE
fix(DTFS2-6161): Added unique reference to all outgoing email addresses

### DIFF
--- a/reference-data-proxy/src/v1/controllers/email.controller.ts
+++ b/reference-data-proxy/src/v1/controllers/email.controller.ts
@@ -12,6 +12,8 @@ const notifyClient = new NotifyClient(notifyKey);
 export const emailNotification = async (req: Request, res: Response) => {
   try {
     const { templateId, sendToEmailAddress, emailVariables } = req.body;
+    // Add a unique reference to an email
+    const reference = `${templateId}-${new Date().valueOf()}`;
 
     console.info('Calling Notify API. templateId: ', templateId);
 
@@ -20,7 +22,7 @@ export const emailNotification = async (req: Request, res: Response) => {
     const notifyResponse = await notifyClient
       .sendEmail(templateId, sendToEmailAddress, {
         personalisation,
-        reference: null,
+        reference,
       })
       .then((response: any) => response);
 


### PR DESCRIPTION
## Introduction
All outgoing emails send via `Gov Notify` did not have any `reference` as it was set to default `null`.
An unique reference number always aides in an effective debugging.

## Resolution
* Created unique reference number based on `templateId` and now `EPOCH`.