### PR TITLE
feat(DTFS2-6236): Return tenor across products for all facilities

### DIFF
--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.api-test.js
@@ -16,18 +16,29 @@ describe('mapTenor()', () => {
     'requestedCoverStartDate-day': '1',
   };
 
-  const mockFacility = {
+  const mockGefFacility = {
     facilitySnapshot: {
       _id: '1',
-      facilityStage: '',
+      hasBeenIssued: true,
       monthsOfCover: 12,
+      ukefFacilityType: FACILITY_TYPE.CASH,
+    },
+    tfm: {
+      exposurePeriodInMonths: 12,
+    },
+  };
+
+  const mockBssEwcsFacility = {
+    facilitySnapshot: {
+      _id: '1',
+      hasBeenIssued: false,
+      ukefGuaranteeInMonths: 12,
       requestedCoverStartDate: '2021-12-08T00:00:00.000Z',
       ...mockCoverEndDate,
       ...mockCoverStartDate,
       ukefFacilityType: FACILITY_TYPE.BOND,
     },
     tfm: {
-      exposurePeriodInMonths: 12,
     },
   };
 
@@ -35,32 +46,55 @@ describe('mapTenor()', () => {
     amendmentExposurePeriodInMonths: 2,
   };
 
-  it('should return tenor from facility when no amendment exists', () => {
-    const result = mapTenor(mockFacility.facilitySnapshot, mockFacility.tfm, mockFacility);
+  it('Should return tenor from un-issued BSS/EWCS facility, when no amendment exists', () => {
+    const result = mapTenor(mockBssEwcsFacility.facilitySnapshot, mockBssEwcsFacility.tfm, mockBssEwcsFacility);
 
-    const expected = `${mockFacility.tfm.exposurePeriodInMonths} months`;
+    const expected = `${mockBssEwcsFacility.facilitySnapshot.ukefGuaranteeInMonths} months`;
 
     expect(result).toEqual(expected);
   });
 
-  it('should return tenor from facility when no completed amendment exists', () => {
-    mockFacility.amendments = [{
+  it('Should return tenor from issued BSS/EWCS facility, when no amendment exists', () => {
+    const mockBssEwcsFacilityIssued = {
+      ...mockBssEwcsFacility,
+      tfm: {
+        exposurePeriodInMonths: 21,
+      },
+    };
+
+    const result = mapTenor(mockBssEwcsFacilityIssued.facilitySnapshot, mockBssEwcsFacilityIssued.tfm, mockBssEwcsFacilityIssued);
+
+    const expected = `${mockBssEwcsFacilityIssued.tfm.exposurePeriodInMonths} months`;
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return tenor from GEF facility when no amendment exists', () => {
+    const result = mapTenor(mockGefFacility.facilitySnapshot, mockGefFacility.tfm, mockGefFacility);
+
+    const expected = `${mockGefFacility.tfm.exposurePeriodInMonths} months`;
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return tenor from GEF facility when no completed amendment exists', () => {
+    mockGefFacility.amendments = [{
       coverEndDate: coverEndDateUnix,
     }];
-    const result = mapTenor(mockFacility.facilitySnapshot, mockFacility.tfm, mockFacility);
+    const result = mapTenor(mockGefFacility.facilitySnapshot, mockGefFacility.tfm, mockGefFacility);
 
-    const expected = `${mockFacility.tfm.exposurePeriodInMonths} months`;
+    const expected = `${mockGefFacility.tfm.exposurePeriodInMonths} months`;
 
     expect(result).toEqual(expected);
   });
 
-  it('should return tenor from amendment when completed amendment exists', () => {
-    mockFacility.amendments[0] = {
+  it('should return tenor from GEF amendment when completed amendment exists', () => {
+    mockGefFacility.amendments[0] = {
       tfm: {
         ...mockAmendmentDateResponse,
       },
     };
-    const result = mapTenor(mockFacility.facilitySnapshot, mockFacility.tfm, mockFacility);
+    const result = mapTenor(mockGefFacility.facilitySnapshot, mockGefFacility.tfm, mockGefFacility);
 
     const expected = '2 months';
 

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenor.js
@@ -3,11 +3,17 @@ const { findLatestCompletedAmendment } = require('../../../helpers/amendment.hel
 
 // maps tenor from new amendment coverEndDate or from original facility
 const mapTenor = (facilitySnapshot, facilityTfm, facility) => {
-  const { facilityStage, ukefGuaranteeInMonths: monthsOfCover } = facilitySnapshot;
+  // Facility stage
+  const { hasBeenIssued } = facilitySnapshot;
+  /**
+   * `monthsOfCover`: GEF
+   * `ukefGuaranteeInMonths`: BSS/EWCS
+   */
+  const months = facilitySnapshot.ukefGuaranteeInMonths ?? facilitySnapshot.monthsOfCover;
+  // If issued
   const { exposurePeriodInMonths } = facilityTfm;
+  let exposurePeriod = exposurePeriodInMonths;
 
-  // sets original exposure period from facility
-  let updatedExposurePeriodInMonths = exposurePeriodInMonths;
   // if amendments
   if (facility?.amendments?.length) {
     const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
@@ -15,11 +21,11 @@ const mapTenor = (facilitySnapshot, facilityTfm, facility) => {
     // checks if exposure period in months in latest completed amendment
     if (latestAmendmentTFM?.amendmentExposurePeriodInMonths) {
       // sets updatedExposurePeriodInMonths as amendment exposure period
-      updatedExposurePeriodInMonths = latestAmendmentTFM.amendmentExposurePeriodInMonths;
+      exposurePeriod = latestAmendmentTFM.amendmentExposurePeriodInMonths;
     }
   }
 
-  return mapTenorDate(facilityStage, monthsOfCover, updatedExposurePeriodInMonths);
+  return mapTenorDate(hasBeenIssued, months, exposurePeriod);
 };
 
 module.exports = mapTenor;

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenorDate.api-test.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenorDate.api-test.js
@@ -1,147 +1,97 @@
 const mapTenorDate = require('./mapTenorDate');
 
-describe('mapTenorDate', () => {
-  describe('when facilityStage is `Commitment`', () => {
-    it('should return facility.ukefGuaranteeInMonths', () => {
-      const mockFacility = {
-        facilityStage: 'Commitment',
-        ukefGuaranteeInMonths: '11',
-      };
-
-      const result = mapTenorDate(
-        mockFacility.facilityStage,
-        mockFacility.ukefGuaranteeInMonths,
-      );
-
-      const expected = `${mockFacility.ukefGuaranteeInMonths} months`;
-
-      expect(result).toEqual(expected);
-    });
-
-    describe('when ukefGuaranteeInMonths is exactly 1', () => {
-      it('should return `month` instead and not `months`', () => {
-        const mockFacility = {
-          facilityStage: 'Commitment',
-          ukefGuaranteeInMonths: '1',
-        };
-
-        const result = mapTenorDate(
-          mockFacility.facilityStage,
-          mockFacility.ukefGuaranteeInMonths,
-        );
-
-        const expected = `${mockFacility.ukefGuaranteeInMonths} month`;
-
-        expect(result).toEqual(expected);
-      });
-    });
-  });
-
-  describe('when facilityStage is `Issued`', () => {
-    it('should return facility.ukefGuaranteeInMonths', () => {
-      const mockFacility = {
-        facilityStage: 'Issued',
-        hasBeenIssued: true,
-        ukefGuaranteeInMonths: '11',
-      };
-
-      const result = mapTenorDate(
-        mockFacility.facilityStage,
-        mockFacility.ukefGuaranteeInMonths,
-      );
-
-      const expected = `${mockFacility.ukefGuaranteeInMonths} months`;
-
-      expect(result).toEqual(expected);
-    });
-
-    describe('when ukefGuaranteeInMonths is exactly 1', () => {
-      it('should return `month` instead and not `months`', () => {
-        const mockFacility = {
-          facilityStage: 'Issued',
-          hasBeenIssued: true,
-          ukefGuaranteeInMonths: '1',
-        };
-
-        const result = mapTenorDate(
-          mockFacility.facilityStage,
-          mockFacility.ukefGuaranteeInMonths,
-        );
-
-        const expected = `${mockFacility.ukefGuaranteeInMonths} month`;
-
-        expect(result).toEqual(expected);
-      });
-    });
-  });
-
-  describe('when facilityTfm has exposurePeriodInMonths', () => {
-    const mockFacility = {
-      facilityStage: 'Issued',
+describe('Mapping tenor dates across products', () => {
+  const mockGefFacility = {
+    facilitySnapshot: {
       hasBeenIssued: true,
-    };
+      monthsOfCover: 12,
+    },
+    tfm: {
+      exposurePeriodInMonths: 12,
+    },
+  };
 
-    it('should return exposurePeriodInMonths', () => {
-      const mockFacilityTfm = {
-        exposurePeriodInMonths: 3,
-      };
+  const mockBssEwcsFacility = {
+    facilitySnapshot: {
+      hasBeenIssued: true,
+      ukefGuaranteeInMonths: 12,
+    },
+    tfm: {
+      exposurePeriodInMonths: 12,
+    },
+  };
 
-      const result = mapTenorDate(
-        mockFacility.facilityStage,
-        mockFacility.ukefGuaranteeInMonths,
-        mockFacilityTfm.exposurePeriodInMonths,
-      );
+  const mockGefFacilityUnissued = {
+    facilitySnapshot: {
+      hasBeenIssued: false,
+      monthsOfCover: 21,
+    },
+    tfm: {
+    },
+  };
 
-      const expected = `${mockFacilityTfm.exposurePeriodInMonths} months`;
+  const mockBssEwcsFacilityUnissued = {
+    facilitySnapshot: {
+      hasBeenIssued: false,
+      ukefGuaranteeInMonths: 21,
+    },
+    tfm: {
+    },
+  };
+
+  describe('Should return `exposurePeriod` if the facility is issued', () => {
+    it('GEF', () => {
+      const { facilitySnapshot, tfm } = mockGefFacility;
+      const result = mapTenorDate(facilitySnapshot.hasBeenIssued, facilitySnapshot.monthsOfCover, tfm.exposurePeriodInMonths);
+      const expected = `${tfm.exposurePeriodInMonths} months`;
 
       expect(result).toEqual(expected);
     });
+    it('BSS/EWCS', () => {
+      const { facilitySnapshot, tfm } = mockBssEwcsFacility;
+      const result = mapTenorDate(facilitySnapshot.hasBeenIssued, facilitySnapshot.ukefGuaranteeInMonths, tfm.exposurePeriodInMonths);
+      const expected = `${tfm.exposurePeriodInMonths} months`;
 
-    describe('when exposurePeriodInMonths is exactly 1', () => {
-      it('should return `month` instead and not `months`', () => {
-        const mockFacilityTfm = {
-          exposurePeriodInMonths: 1,
-        };
-
-        const result = mapTenorDate(
-          mockFacility.facilityStage,
-          mockFacility.ukefGuaranteeInMonths,
-          mockFacilityTfm.exposurePeriodInMonths,
-        );
-
-        const expected = `${mockFacilityTfm.exposurePeriodInMonths} month`;
-
-        expect(result).toEqual(expected);
-      });
+      expect(result).toEqual(expected);
     });
   });
 
-  it('should return null when there is no ukefGuaranteeInMonths', () => {
-    const mockFacility = {
-      facilityStage: 'Issued',
-      hasBeenIssued: true,
-      ukefGuaranteeInMonths: '',
-    };
+  describe('Should return cover months if the facility is un-issued', () => {
+    it('GEF', () => {
+      const { facilitySnapshot, tfm } = mockGefFacilityUnissued;
+      const result = mapTenorDate(facilitySnapshot.hasBeenIssued, facilitySnapshot.monthsOfCover, tfm.exposurePeriodInMonths);
+      const expected = `${facilitySnapshot.monthsOfCover} months`;
 
-    const result = mapTenorDate(
-      mockFacility.facilityStage,
-      mockFacility.ukefGuaranteeInMonths,
-    );
+      expect(result).toEqual(expected);
+    });
+    it('BSS/EWCS', () => {
+      const { facilitySnapshot, tfm } = mockBssEwcsFacilityUnissued;
+      const result = mapTenorDate(facilitySnapshot.hasBeenIssued, facilitySnapshot.ukefGuaranteeInMonths, tfm.exposurePeriodInMonths);
+      const expected = `${facilitySnapshot.ukefGuaranteeInMonths} months`;
 
-    expect(result).toEqual(null);
+      expect(result).toEqual(expected);
+    });
   });
 
-  it('should return null when there is no facilityStage', () => {
-    const mockFacility = {
-      facilityStage: '',
-      ukefGuaranteeInMonths: '1',
-    };
+  describe('Should return `null`', () => {
+    it('When months are null', () => {
+      const { facilitySnapshot, tfm } = mockGefFacilityUnissued;
+      const result = mapTenorDate(facilitySnapshot.hasBeenIssued, null, tfm.exposurePeriodInMonths);
 
-    const result = mapTenorDate(
-      mockFacility.facilityStage,
-      mockFacility.ukefGuaranteeInMonths,
-    );
+      expect(result).toEqual(null);
+    });
 
-    expect(result).toEqual(null);
+    it('Upon void argument sets', () => {
+      const { tfm } = mockGefFacilityUnissued;
+      const result = mapTenorDate(null, null, tfm.exposurePeriodInMonths);
+
+      expect(result).toEqual(null);
+    });
+
+    it('Upon void argument sets', () => {
+      const result = mapTenorDate(null, null, null);
+
+      expect(result).toEqual(null);
+    });
   });
 });

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenorDate.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenorDate.js
@@ -11,17 +11,17 @@ const monthString = (period) => (Number(period) === 1 ? 'month' : 'months');
  * or plural `months` text.
  * @param {Boolean} hasBeenIssued Facility issuance stage
  * @param {Integer} months Number of cover months
- * @param {Integer} exposurePeriod Exposure in months
+ * @param {Integer} exposurePeriodMonths Exposure period in months
  * @returns {String} Tenor dates with `month(s)` appended, otherwise null
  */
 const mapTenorDate = (
   hasBeenIssued,
   months,
-  exposurePeriod,
+  exposurePeriodMonths,
 ) => {
   // If issued
-  if (exposurePeriod) {
-    return `${exposurePeriod} ${monthString(exposurePeriod)}`;
+  if (exposurePeriodMonths) {
+    return `${exposurePeriodMonths} ${monthString(exposurePeriodMonths)}`;
   }
 
   if (!months) {

--- a/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenorDate.js
+++ b/trade-finance-manager-api/src/graphql/reducers/mappings/facilities/mapTenorDate.js
@@ -1,39 +1,41 @@
-const CONSTANTS = require('../../../../constants');
+/**
+ * Evaluates whether to return `month` or `months` based
+ * on number of months provided.
+ * @param {Integer} period Number of months
+ * @returns {String} Singular or plural `month` string
+ */
+const monthString = (period) => (Number(period) === 1 ? 'month' : 'months');
 
-const monthString = (period) => {
-  if (Number(period) === 1) {
-    return 'month';
-  }
-
-  return 'months';
-};
-
+/**
+ * Maps tenor dates and return as string with singular
+ * or plural `months` text.
+ * @param {Boolean} hasBeenIssued Facility issuance stage
+ * @param {Integer} months Number of cover months
+ * @param {Integer} exposurePeriod Exposure in months
+ * @returns {String} Tenor dates with `month(s)` appended, otherwise null
+ */
 const mapTenorDate = (
-  facilityStage,
-  ukefGuaranteeInMonths,
-  exposurePeriodInMonths,
+  hasBeenIssued,
+  months,
+  exposurePeriod,
 ) => {
-  let period;
-
-  if (exposurePeriodInMonths) {
-    period = exposurePeriodInMonths;
-
-    return `${period} ${monthString(period)}`;
+  // If issued
+  if (exposurePeriod) {
+    return `${exposurePeriod} ${monthString(exposurePeriod)}`;
   }
 
-  if (!ukefGuaranteeInMonths) {
+  if (!months) {
     return null;
   }
 
-  if (facilityStage === CONSTANTS.FACILITIES.FACILITY_STAGE.COMMITMENT) {
-    period = ukefGuaranteeInMonths;
-    return `${period} ${monthString(period)}`;
+  // Un-issued facility
+  if (!hasBeenIssued) {
+    return `${months} ${monthString(months)}`;
   }
 
-  if (facilityStage === CONSTANTS.FACILITIES.FACILITY_STAGE.ISSUED) {
-    period = ukefGuaranteeInMonths;
-
-    return `${period} ${monthString(period)}`;
+  // Issued facility
+  if (hasBeenIssued) {
+    return `${months} ${monthString(months)}`;
   }
 
   return null;


### PR DESCRIPTION
## Introduction
TFM UI seems to have been missing `tenor` for GEF deals, since this is being resolved by a GQL resolver methods transitively calling helper functions. Both `mapTenor` and `mapTenorDate` methods were not cross-product compliant thus returning `-` for GEF.

## Resolution
* Updated mapping function to accommodate both `un-issued` and `issued` facilities across all the products.
* Updated unit test cases.
* Improved documentation.