### PR TITLE
fix(DTFS2-6239): Facility level default currency

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/facility-master.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-master.js
@@ -49,6 +49,7 @@ const facilityMaster = (deal, facility, acbsData, acbsReference) => {
 
   const issueDate = helpers.getIssueDate(facility, getDealSubmissionDate(deal));
   const facilityStageCode = helpers.getFacilityStageCode(facility.facilitySnapshot, deal.dealSnapshot.dealType);
+  const currency = facility.facilitySnapshot.currency.id ?? CONSTANTS.DEAL.CURRENCY.DEFAULT;
 
   return {
     _id: deal._id,
@@ -60,7 +61,7 @@ const facilityMaster = (deal, facility, acbsData, acbsReference) => {
     productTypeId: helpers.getProductTypeId(facility, true),
     capitalConversionFactorCode: helpers.getCapitalConversionFactorCode(facility),
     productTypeName: deal.dealSnapshot.dealType,
-    currency: facility.facilitySnapshot.currency.id,
+    currency,
     guaranteeCommencementDate,
     guaranteeExpiryDate,
     nextQuarterEndDate: helpers.getNextQuarterDate(issueDate),


### PR DESCRIPTION
## Introduction
Due to a know tech-debt issue, on certain occasion `facility.currency.id` does not exists, due to which perils are high when creating records in ACBS especially during facility level records.

## Resolution
* If the `currency.id` is absent then currency will be defaulted to `GBP`.