### PR TITLE
2e2 Tenor check fix. One date was static, while other dynamic

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress/fixtures/deal-AIN.js
+++ b/e2e-tests/trade-finance-manager/cypress/fixtures/deal-AIN.js
@@ -29,7 +29,7 @@ const MOCK_DEAL = {
       firstname: 'Emilio',
       surname: 'Largo',
     },
-    submissionDate: '1606900616651',
+    submissionDate: `${dateConstants.twoYearsAgoUnix}000`,
     submissionCount: 1,
   },
   submissionDetails: {
@@ -194,7 +194,7 @@ const MOCK_DEAL = {
       'coverEndDate-month': dateConstants.oneMonthMonth,
       'coverEndDate-year': dateConstants.oneMonthYear,
       issuedDate: `${dateConstants.twoYearsAgoUnix}000`,
-      requestedCoverStartDate: '1606900616652',
+      requestedCoverStartDate: `${dateConstants.twoYearsAgoUnix}000`,
       name: 'Test-123',
       updatedAt: Date.now(),
     },


### PR DESCRIPTION
Month ago Abhi changed Tenor check from 25 months to 26 - https://github.com/UK-Export-Finance/dtfs2/pull/1245 
After a month issue appeared again, this change should/might be permanent fix.