### PR TITLE
chore(nginx): Dockerfile image upgrade to 1.23

### DIFF
--- a/reverse-proxy/Dockerfile
+++ b/reverse-proxy/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx
+FROM nginx:1.23
 COPY default.conf.template /etc/nginx/templates/


### PR DESCRIPTION
## Introduction
`nginx` Dockerimage has a new upgrade with lesser known vulnerabilities.

## Resolution
* Upgraded `reverse-proxy` nginx image to `nginx:1.23`.