### PR TITLE
fix(no-currency): Default to `GBP` on void currency

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/facility-covenant.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-covenant.js
@@ -15,13 +15,14 @@ const CONSTANTS = require('../../constants');
 
 const facilityCovenant = (deal, facility, covenantType) => {
   const { guaranteeCommencementDate, guaranteeExpiryDate, effectiveDate } = facility.tfm.facilityGuaranteeDates;
+  const currency = facility.facilitySnapshot.currency.id || CONSTANTS.DEAL.CURRENCY.DEFAULT;
 
   return {
     facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
     covenantType,
     maximumLiability: helpers.getMaximumLiability(facility, true),
-    currency: facility.facilitySnapshot.currency.id,
+    currency,
     guaranteeCommencementDate,
     guaranteeExpiryDate,
     effectiveDate,

--- a/azure-functions/acbs-function/mappings/facility/facility-fee.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-fee.js
@@ -26,6 +26,7 @@ const constructFeeRecord = (deal, facility, premiumScheduleIndex = 0) => {
       nextDueDate,
       nextAccrueToDate,
     } = helpers.getFeeDates(facility, deal.dealSnapshot.dealType, premiumScheduleIndex);
+    const currency = facility.facilitySnapshot.currency.id || CONSTANTS.DEAL.CURRENCY.DEFAULT;
 
     return {
       facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
@@ -35,7 +36,7 @@ const constructFeeRecord = (deal, facility, premiumScheduleIndex = 0) => {
       nextDueDate,
       nextAccrueToDate,
       period: helpers.getFeeRecordPeriod(facility, deal.dealSnapshot.dealType, premiumScheduleIndex),
-      currency: facility.facilitySnapshot.currency.id,
+      currency,
       lenderTypeCode: CONSTANTS.FACILITY.LENDER_TYPE.TYPE1,
       incomeClassCode: helpers.getIncomeClassCode(facility),
       spreadToInvestorsIndicator: true,

--- a/azure-functions/acbs-function/mappings/facility/facility-investor.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-investor.js
@@ -12,12 +12,13 @@ const CONSTANTS = require('../../constants');
 
 const facilityInvestor = (deal, facility) => {
   const { guaranteeCommencementDate, guaranteeExpiryDate, effectiveDate } = facility.tfm.facilityGuaranteeDates;
+  const currency = facility.facilitySnapshot.currency.id || CONSTANTS.DEAL.CURRENCY.DEFAULT;
 
   return {
     facilityIdentifier: facility.facilitySnapshot.ukefFacilityId.padStart(10, 0),
     portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
     maximumLiability: helpers.getMaximumLiability(facility),
-    currency: facility.facilitySnapshot.currency.id,
+    currency,
     guaranteeCommencementDate,
     guaranteeExpiryDate,
     effectiveDate,

--- a/azure-functions/acbs-function/mappings/facility/facility-loan.js
+++ b/azure-functions/acbs-function/mappings/facility/facility-loan.js
@@ -31,6 +31,7 @@ const facilityLoan = (deal, facility, acbsData) => {
     const issueDate = helpers.getIssueDate(facility, getDealSubmissionDate(deal));
     const { guaranteeExpiryDate } = facility.tfm.facilityGuaranteeDates;
     const ukefExposure = helpers.getMaximumLiability(facility);
+    const currency = facility.facilitySnapshot.currency.id || CONSTANTS.DEAL.CURRENCY.DEFAULT;
 
     let loanRecord = {
       portfolioIdentifier: CONSTANTS.FACILITY.PORTFOLIO.E1,
@@ -39,7 +40,7 @@ const facilityLoan = (deal, facility, acbsData) => {
       borrowerPartyIdentifier: acbsData.parties.exporter.partyIdentifier,
       productTypeId: helpers.getProductTypeId(facility),
       productTypeGroup: helpers.getProductTypeGroup(facility, deal.dealSnapshot.dealType),
-      currency: facility.facilitySnapshot.currency.id,
+      currency,
       amount: helpers.getLoanMaximumLiability(ukefExposure, facility, deal.dealSnapshot.dealType),
       issueDate,
       expiryDate: guaranteeExpiryDate,


### PR DESCRIPTION
## Introduction
A known bug produces empty `currency` object, due to which no currency is present and thus causes ACBS payload to fail.

## Resolution
* If object `currency.id` does not exist, then default to `GBP`.