### PR TITLE
fix(dockerfile): Node v10 incompatible with npm 9.5.1

### DIFF
--- a/azure-functions/acbs-function/Dockerfile
+++ b/azure-functions/acbs-function/Dockerfile
@@ -8,8 +8,4 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 COPY . /home/site/wwwroot
 
 WORKDIR /home/site/wwwroot
-
-# NPM
-RUN npm i -g npm@latest
-
 RUN npm install --legacy-peer-deps

--- a/azure-functions/number-generator-function/Dockerfile
+++ b/azure-functions/number-generator-function/Dockerfile
@@ -10,10 +10,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 WORKDIR /home/site/wwwroot
 
 COPY package.json .
-
-# NPM
-RUN npm i -g npm@latest
-
 RUN npm install --legacy-peer-deps
 
 COPY . /home/site/wwwroot


### PR DESCRIPTION
## Introduction
Durable functions which runs node version 10 is not compatible with npm `9.5.0`.

## Resolution
* NPM latest version is not installed on durable functions `acbs` and `number-generator`.