### PR TITLE
fix(portal-api): azure webapp healthcheck

### DIFF
--- a/portal-api/src/createApp.js
+++ b/portal-api/src/createApp.js
@@ -38,6 +38,9 @@ const rootRouter = express.Router();
 rootRouter.get('/', async (req, res) => {
   res.status(200).send();
 });
+rootRouter.get('/robots933456.txt', async (req, res) => {
+  res.status(200).send();
+});
 
 app.use('/', rootRouter);
 


### PR DESCRIPTION
## Introduction
Health check missing for portal-api, since GQL no longer handles wildcard paths.

## Resolution
* Added route for Azure health check before container swap.