### PR TITLE
Avoid race condition in start up with MongoDb for local dev

### DIFF
--- a/reference-data-proxy/src/cronJobs/eStoreCronJobManager.ts
+++ b/reference-data-proxy/src/cronJobs/eStoreCronJobManager.ts
@@ -2,6 +2,11 @@ import CronJobManager from 'cron-job-manager';
 import { getCollection } from '../database';
 
 const cronJobTimer = new Date();
+if (process.env.NODE_ENV === 'dev') {
+  // Artificial 30 second delay to allow for race condition on slow machines in local development
+  cronJobTimer.setSeconds(cronJobTimer.getSeconds() + 30)
+}
+
 export const eStoreCronJobManager = new CronJobManager(
   'eStoreCronJobManager',
   cronJobTimer, // run task as soon as the server is ready


### PR DESCRIPTION
On the dev VMs which run slow there was a race condition that when the mongoDb instance said it was ready another service would start up and query it instantly. Unfortunately this would error as it was not read to accept connections. I've added in a 30 second delay to mongoDb query on startup of the reference data proxy to fix this when running locally.

Long term best fix would be to implement a better healthcheck on the mongoDb container so that the other services do not come up until the mongoDb passes said healthcheck.