### PR TITLE
feat: destructure feedback form on TFM API

### DIFF
--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -434,10 +434,11 @@ exports.getAmendmentsByFacilityId = async (req, res) => {
   if (ObjectId.isValid(facilityId)) {
     let amendment;
     switch (amendmentIdOrStatus) {
-      case CONSTANTS.AMENDMENT.AMENDMENT_QUERY_STATUSES.IN_PROGRESS:
+      case CONSTANTS.AMENDMENT.AMENDMENT_QUERY_STATUSES.IN_PROGRESS: {
         const amendmentsInProgress = (await findAmendmentByStatusAndFacilityId(facilityId, CONSTANTS.AMENDMENT.AMENDMENT_STATUS.IN_PROGRESS)) ?? [];
         amendment = amendmentsInProgress[0] ?? {};
         break;
+      }
       case CONSTANTS.AMENDMENT.AMENDMENT_QUERY_STATUSES.COMPLETED:
         if (type === CONSTANTS.AMENDMENT.AMENDMENT_QUERIES.LATEST_VALUE) {
           amendment = (await findLatestCompletedValueAmendmentByFacilityId(facilityId)) ?? {};

--- a/trade-finance-manager-api/src/v1/controllers/feedback-controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/feedback-controller.js
@@ -18,17 +18,6 @@ exports.create = async (req, res) => {
     });
   }
 
-  const modifiedFeedback = {
-    ...req.body,
-    created: getUnixTime(new Date()),
-  };
-
-  const collection = await db.getCollection('tfm-feedback');
-  const createdFeedback = await collection.insertOne(modifiedFeedback);
-
-  // get formatted date from created timestamp, to display in email
-  const formattedCreated = format(fromUnixTime(modifiedFeedback.created), 'dd/MM/yyyy HH:mm');
-
   const {
     role,
     team,
@@ -38,7 +27,25 @@ exports.create = async (req, res) => {
     howCanWeImprove,
     emailAddress,
     submittedBy,
-  } = modifiedFeedback;
+  } = req.body;
+
+  const modifiedFeedback = {
+    role,
+    team,
+    whyUsingService,
+    easyToUse,
+    satisfied,
+    howCanWeImprove,
+    emailAddress,
+    submittedBy,
+    created: getUnixTime(new Date())
+  };
+
+  const collection = await db.getCollection('tfm-feedback');
+  const createdFeedback = await collection.insertOne(modifiedFeedback);
+
+  // get formatted date from created timestamp, to display in email
+  const formattedCreated = format(fromUnixTime(modifiedFeedback.created), 'dd/MM/yyyy HH:mm');
 
   if (!submittedBy.username) {
     submittedBy.username = 'N/A';


### PR DESCRIPTION
The feedback controller on the TFM amendments API was the only endpoint that was vulnerable of saving unwanted form fields from the forms in the frontend so I've moved the object destructuring that already existed to before the DB save call so that unwanted fields are filtering out from the request body.