### PR TITLE
feat(fn-417): storage

### DIFF
--- a/infrastructure/arm_templates/storage-private-endpoint/parameters.json
+++ b/infrastructure/arm_templates/storage-private-endpoint/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "privateEndpoints_tfsdevstorage_name": {
+            "value": null
+        },
+        "storageAccounts_tfsdevstorage_externalid": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/storage-private-endpoint/template.json
+++ b/infrastructure/arm_templates/storage-private-endpoint/template.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "privateEndpoints_tfsdevstorage_name": {
+            "defaultValue": "tfsdevstorage",
+            "type": "String"
+        },
+        "storageAccounts_tfsdevstorage_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Storage/storageAccounts/tfsdevstorage",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-11-01",
+            "name": "[parameters('privateEndpoints_tfsdevstorage_name')]",
+            "location": "uksouth",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "[parameters('privateEndpoints_tfsdevstorage_name')]",
+                        "id": "[concat(resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpoints_tfsdevstorage_name')), concat('/privateLinkServiceConnections/', parameters('privateEndpoints_tfsdevstorage_name')))]",
+                        "properties": {
+                            "privateLinkServiceId": "[parameters('storageAccounts_tfsdevstorage_externalid')]",
+                            "groupIds": [
+                                "file"
+                            ],
+                            "privateLinkServiceConnectionState": {
+                                "status": "Approved",
+                                "description": "Auto-Approved",
+                                "actionsRequired": "None"
+                            }
+                        }
+                    }
+                ],
+                "manualPrivateLinkServiceConnections": [],
+                "subnet": {
+                    "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-private-endpoints')]"
+                },
+                "ipConfigurations": [],
+                "customDnsConfigs": [
+                    {
+                        "fqdn": "[concat(parameters('privateEndpoints_tfsdevstorage_name'), '.file.core.windows.net')]",
+                        "ipAddresses": [
+                            "172.16.40.4"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/storage/parameters.json
+++ b/infrastructure/arm_templates/storage/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccounts_tfsdevstorage_name": {
+            "value": null
+        },
+        "virtualNetworks_vnet_ukef_uks_prod_externalid": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/storage/template.json
+++ b/infrastructure/arm_templates/storage/template.json
@@ -1,0 +1,569 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccounts_tfsdevstorage_name": {
+            "defaultValue": "tfsdevstorage",
+            "type": "String"
+        },
+        "virtualNetworks_vnet_ukef_uks_prod_externalid": {
+            "defaultValue": "/subscriptions/08887298-3821-49f0-8303-f88859c12b9b/resourceGroups/rg-ukef-uks-network/providers/Microsoft.Network/virtualNetworks/vnet-ukef-uks-prod",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2022-09-01",
+            "name": "[parameters('storageAccounts_tfsdevstorage_name')]",
+            "location": "uksouth",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "sku": {
+                "name": "Standard_ZRS",
+                "tier": "Standard"
+            },
+            "kind": "StorageV2",
+            "properties": {
+                "defaultToOAuthAuthentication": false,
+                "publicNetworkAccess": "Enabled",
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": false,
+                "allowSharedKeyAccess": true,
+                "networkAcls": {
+                    "resourceAccessRules": [],
+                    "bypass": "AzureServices",
+                    "virtualNetworkRules": [
+                        {
+                            "id": "[concat(parameters('virtualNetworks_vnet_ukef_uks_prod_externalid'), '/subnets/snet-wvd')]",
+                            "action": "Allow",
+                            "state": "Succeeded"
+                        },
+                        {
+                            "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/Digital-Dev-vm')]",
+                            "action": "Allow",
+                            "state": "Succeeded"
+                        },
+                        {
+                            "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-app-service-plan-egress')]",
+                            "action": "Allow",
+                            "state": "Succeeded"
+                        },
+                        {
+                            "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-gateway')]",
+                            "action": "Allow",
+                            "state": "Succeeded"
+                        },
+                        {
+                            "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-private-endpoints')]",
+                            "action": "Allow",
+                            "state": "Succeeded"
+                        }
+                    ],
+                    "ipRules": [
+                        {
+                            "value": "213.86.43.20",
+                            "action": "Allow"
+                        },
+                        {
+                            "value": "213.86.43.22",
+                            "action": "Allow"
+                        },
+                        {
+                            "value": "51.140.76.208",
+                            "action": "Allow"
+                        }
+                    ],
+                    "defaultAction": "Allow"
+                },
+                "supportsHttpsTrafficOnly": true,
+                "encryption": {
+                    "services": {
+                        "file": {
+                            "keyType": "Account",
+                            "enabled": true
+                        },
+                        "blob": {
+                            "keyType": "Account",
+                            "enabled": true
+                        }
+                    },
+                    "keySource": "Microsoft.Storage"
+                },
+                "accessTier": "Hot"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "sku": {
+                "name": "Standard_ZRS",
+                "tier": "Standard"
+            },
+            "properties": {
+                "containerDeleteRetentionPolicy": {
+                    "enabled": true,
+                    "days": 3
+                },
+                "cors": {
+                    "corsRules": []
+                },
+                "deleteRetentionPolicy": {
+                    "allowPermanentDelete": false,
+                    "enabled": true,
+                    "days": 3
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/fileServices",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "sku": {
+                "name": "Standard_ZRS",
+                "tier": "Standard"
+            },
+            "properties": {
+                "protocolSettings": {
+                    "smb": {}
+                },
+                "cors": {
+                    "corsRules": []
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/privateEndpointConnections",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/', parameters('storageAccounts_tfsdevstorage_name'), '.e2571c56-66d6-4962-80b4-69cae9adbdf1')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "provisioningState": "Succeeded",
+                "privateEndpoint": {},
+                "privateLinkServiceConnectionState": {
+                    "status": "Approved",
+                    "description": "Auto-Approved",
+                    "actionRequired": "None"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "cors": {
+                    "corsRules": []
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "cors": {
+                    "corsRules": []
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-largemessages')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "immutableStorageWithVersioning": {
+                    "enabled": false
+                },
+                "defaultEncryptionScope": "$account-encryption-key",
+                "denyEncryptionScopeOverride": false,
+                "publicAccess": "None"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-leases')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "immutableStorageWithVersioning": {
+                    "enabled": false
+                },
+                "defaultEncryptionScope": "$account-encryption-key",
+                "denyEncryptionScopeOverride": false,
+                "publicAccess": "None"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/azure-webjobs-hosts')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "immutableStorageWithVersioning": {
+                    "enabled": false
+                },
+                "defaultEncryptionScope": "$account-encryption-key",
+                "denyEncryptionScopeOverride": false,
+                "publicAccess": "None"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/azure-webjobs-secrets')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "immutableStorageWithVersioning": {
+                    "enabled": false
+                },
+                "defaultEncryptionScope": "$account-encryption-key",
+                "denyEncryptionScopeOverride": false,
+                "publicAccess": "None"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergenerator-leases')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "immutableStorageWithVersioning": {
+                    "enabled": false
+                },
+                "defaultEncryptionScope": "$account-encryption-key",
+                "denyEncryptionScopeOverride": false,
+                "publicAccess": "None"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/files')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/fileServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "accessTier": "TransactionOptimized",
+                "shareQuota": 5120,
+                "enabledProtocols": "SMB"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/portal')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/fileServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "accessTier": "TransactionOptimized",
+                "shareQuota": 5120,
+                "enabledProtocols": "SMB"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/workflow')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/fileServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "accessTier": "TransactionOptimized",
+                "shareQuota": 5120,
+                "enabledProtocols": "SMB"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-control-00')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-control-01')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-control-02')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-control-03')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbs-workitems')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/durablefunctionshub-control-00')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/durablefunctionshub-control-01')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/durablefunctionshub-control-02')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/durablefunctionshub-control-03')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/durablefunctionshub-workitems')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergenerator-control-00')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergenerator-control-01')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergenerator-control-02')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergenerator-control-03')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergenerator-workitems')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/queueServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {
+                "metadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbsHistory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/acbsInstances')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/AzureFunctionsDiagnosticEvents202304')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/DurableFunctionsHubHistory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/DurableFunctionsHubInstances')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergeneratorHistory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/tableServices/tables",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('storageAccounts_tfsdevstorage_name'), '/default/numbergeneratorInstances')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/tableServices', parameters('storageAccounts_tfsdevstorage_name'), 'default')]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_tfsdevstorage_name'))]"
+            ],
+            "properties": {}
+        }
+    ]
+}

--- a/infrastructure/arm_templates/storage/template.json
+++ b/infrastructure/arm_templates/storage/template.json
@@ -67,18 +67,6 @@
                         }
                     ],
                     "ipRules": [
-                        {
-                            "value": "213.86.43.20",
-                            "action": "Allow"
-                        },
-                        {
-                            "value": "213.86.43.22",
-                            "action": "Allow"
-                        },
-                        {
-                            "value": "51.140.76.208",
-                            "action": "Allow"
-                        }
                     ],
                     "defaultAction": "Allow"
                 },

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -44,6 +44,19 @@ param peeringAddressSpace string = '10.50.0.0/16'
 param frontDoorAccess string = 'Allow'
 param apiPortalAccessPort string = '44232' // not set in staging / prod
 
+param onPremiseNetworkIps array = [
+  //'COLT Technology Services Group Limited'
+  '213.86.43.20'
+  //'COLT Technology Services Group Limited'
+  '213.86.43.22'
+  // UKEF Office
+  '51.140.76.208'
+]
+
+@allowed(['Allow', 'Deny'])
+param storageNetworkAccessDefaultAction string= 'Allow'
+// Staging has the default as Deny, corresponding to "Enabled from selected virtual networks and IP addresses".
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName
   location: location
@@ -135,5 +148,18 @@ module redisCacheDns 'modules/privatelink-redis-cache-windows-net.bicep' = {
   name: 'redisCacheDns'
   params: {
     vnetId: vnet.outputs.vnetId
+  }
+}
+
+module storage 'modules/storage.bicep' = {
+  name: 'storage'
+  params: {
+    location: location
+    environment: environment
+    appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
+    gatewaySubnetId: vnet.outputs.gatewaySubnetId
+    privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
+    allowedIps: onPremiseNetworkIps
+    networkAccessDefaultAction: storageNetworkAccessDefaultAction
   }
 }

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -53,9 +53,13 @@ param onPremiseNetworkIps array = [
   '51.140.76.208'
 ]
 
-@allowed(['Allow', 'Deny'])
-param storageNetworkAccessDefaultAction string= 'Allow'
+// For public access to storage, Dev has the default as 'Allow' but we may want to update this to Deny.
 // Staging has the default as Deny, corresponding to "Enabled from selected virtual networks and IP addresses".
+@allowed(['Allow', 'Deny'])
+param storageNetworkAccessDefaultAction string = 'Allow'
+
+@description('Enable 7-day soft deletes on file shares')
+param shareDeleteRetentionEnabled bool = false
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName
@@ -161,5 +165,6 @@ module storage 'modules/storage.bicep' = {
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     allowedIps: onPremiseNetworkIps
     networkAccessDefaultAction: storageNetworkAccessDefaultAction
+    shareDeleteRetentionEnabled: shareDeleteRetentionEnabled
   }
 }

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -55,8 +55,6 @@ param storageNetworkAccessDefaultAction string = 'Allow'
 @description('Enable 7-day soft deletes on file shares')
 param shareDeleteRetentionEnabled bool = false
 
-param onPremiseNetworkIps array = json(onPremiseNetworkIpsString)
-
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName
   location: location
@@ -159,7 +157,7 @@ module storage 'modules/storage.bicep' = {
     appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
     gatewaySubnetId: vnet.outputs.gatewaySubnetId
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
-    allowedIps: onPremiseNetworkIps
+    allowedIpsString: onPremiseNetworkIpsString
     networkAccessDefaultAction: storageNetworkAccessDefaultAction
     shareDeleteRetentionEnabled: shareDeleteRetentionEnabled
   }

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -44,14 +44,8 @@ param peeringAddressSpace string = '10.50.0.0/16'
 param frontDoorAccess string = 'Allow'
 param apiPortalAccessPort string = '44232' // not set in staging / prod
 
-param onPremiseNetworkIps array = [
-  //'COLT Technology Services Group Limited'
-  '213.86.43.20'
-  //'COLT Technology Services Group Limited'
-  '213.86.43.22'
-  // UKEF Office
-  '51.140.76.208'
-]
+@secure()
+param onPremiseNetworkIpsString string
 
 // For public access to storage, Dev has the default as 'Allow' but we may want to update this to Deny.
 // Staging has the default as Deny, corresponding to "Enabled from selected virtual networks and IP addresses".
@@ -60,6 +54,8 @@ param storageNetworkAccessDefaultAction string = 'Allow'
 
 @description('Enable 7-day soft deletes on file shares')
 param shareDeleteRetentionEnabled bool = false
+
+param onPremiseNetworkIps array = json(onPremiseNetworkIpsString)
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName

--- a/infrastructure/resource_group_level/modules/storage.bicep
+++ b/infrastructure/resource_group_level/modules/storage.bicep
@@ -21,6 +21,43 @@ var ipRules = [for ip in allowedIps: {
   action: 'Allow'
 }]
 
+var queueNames = [
+  'acbs-control-00'
+  'acbs-control-01'
+  'acbs-control-02'
+  'acbs-control-03'
+  'acbs-workitems'
+  'durablefunctionshub-control-00'
+  'durablefunctionshub-control-01'
+  'durablefunctionshub-control-02'
+  'durablefunctionshub-control-03'
+  'durablefunctionshub-workitems'
+  'numbergenerator-control-00'
+  'numbergenerator-control-01'
+  'numbergenerator-control-02'
+  'numbergenerator-control-03'
+  'numbergenerator-workitems'
+]
+
+var tableNames = [
+  'acbsHistory'
+  'acbsInstances'
+  // TODO:FN-417 Is this needed? It seems rather transitory.
+  'AzureFunctionsDiagnosticEvents202304'
+  'DurableFunctionsHubHistory'
+  'DurableFunctionsHubInstances'
+  'numbergeneratorHistory'
+  'numbergeneratorInstances'
+]
+
+var blobContainerNames = [
+  'acbs-largemessages'
+  'acbs-leases'
+  'azure-webjobs-hosts'
+  'azure-webjobs-secrets'
+  'numbergenerator-leases'
+]
+
 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   name: storageAccountName
   location: location
@@ -88,9 +125,6 @@ resource defaultBlobService 'Microsoft.Storage/storageAccounts/blobServices@2022
       enabled: true
       days: 3
     }
-    cors: {
-      corsRules: []
-    }
     deleteRetentionPolicy: {
       allowPermanentDelete: false
       enabled: true
@@ -102,36 +136,21 @@ resource defaultBlobService 'Microsoft.Storage/storageAccounts/blobServices@2022
 resource defaultFileService 'Microsoft.Storage/storageAccounts/fileServices@2022-09-01' = {
   parent: storageAccount
   name: 'default'
-  properties: {
-    cors: {
-      corsRules: []
-    }
-  }
 }
 
 resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2022-09-01' = {
   parent: storageAccount
   name: 'default'
-  properties: {
-    cors: {
-      corsRules: []
-    }
-  }
 }
 
 resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2022-09-01' = {
   parent: storageAccount
   name: 'default'
-  properties: {
-    cors: {
-      corsRules: []
-    }
-  }
 }
 
-resource largeMessageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+resource blobContainers 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = [for blobContainerName in blobContainerNames: {
   parent: defaultBlobService
-  name: 'acbs-largemessages'
+  name: blobContainerName
   properties: {
     immutableStorageWithVersioning: {
       enabled: false
@@ -140,59 +159,7 @@ resource largeMessageContainer 'Microsoft.Storage/storageAccounts/blobServices/c
     denyEncryptionScopeOverride: false
     publicAccess: 'None'
   }
-}
-
-resource acbsLeasesContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
-  parent: defaultBlobService
-  name: 'acbs-leases'
-  properties: {
-    immutableStorageWithVersioning: {
-      enabled: false
-    }
-    defaultEncryptionScope: '$account-encryption-key'
-    denyEncryptionScopeOverride: false
-    publicAccess: 'None'
-  }
-}
-
-resource webjobsHostsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
-  parent: defaultBlobService
-  name: 'azure-webjobs-hosts'
-  properties: {
-    immutableStorageWithVersioning: {
-      enabled: false
-    }
-    defaultEncryptionScope: '$account-encryption-key'
-    denyEncryptionScopeOverride: false
-    publicAccess: 'None'
-  }
-}
-
-resource webjobsSecretsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
-  parent: defaultBlobService
-  name: 'azure-webjobs-secrets'
-  properties: {
-    immutableStorageWithVersioning: {
-      enabled: false
-    }
-    defaultEncryptionScope: '$account-encryption-key'
-    denyEncryptionScopeOverride: false
-    publicAccess: 'None'
-  }
-}
-
-resource numberGeneratoreLeasesContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
-  parent: defaultBlobService
-  name: 'numbergenerator-leases'
-  properties: {
-    immutableStorageWithVersioning: {
-      enabled: false
-    }
-    defaultEncryptionScope: '$account-encryption-key'
-    denyEncryptionScopeOverride: false
-    publicAccess: 'None'
-  }
-}
+}]
 
 resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
   parent: defaultFileService
@@ -214,178 +181,16 @@ resource portalFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@
   }
 }
 
-resource workflowFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
-  parent: defaultFileService
-  name: 'workflow'
-  properties: {
-    accessTier: 'TransactionOptimized'
-    shareQuota: 5120
-    enabledProtocols: 'SMB'
-  }
-}
-
-resource acbsControlQueue0 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+resource queues 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = [for queueName in queueNames: {
   parent: queueService
-  name: 'acbs-control-00'
-  properties: {
-    metadata: {}
-  }
-}
+  name: queueName
+}]
 
-resource acbsControlQueue1 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'acbs-control-01'
-  properties: {
-    metadata: {}
-  }
-}
 
-resource acbsControlQueue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'acbs-control-02'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource acbsControlQueue3 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'acbs-control-03'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource acbsWorkItemsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'acbs-workitems'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultDurableFunctionsHubControlQueue0 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'durablefunctionshub-control-00'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultDurableFunctionsHubControlQueue1 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'durablefunctionshub-control-01'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultDurableFunctionsHubControlQueue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'durablefunctionshub-control-02'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultDurableFunctionsHubControlQueue3 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'durablefunctionshub-control-03'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultDurableFunctionsHubWorkItemsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'durablefunctionshub-workitems'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultNumberGeneratorControlQueue0 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'numbergenerator-control-00'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultNumberGeneratorControlQueue1 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'numbergenerator-control-01'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultNumberGeneratorControlQueue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'numbergenerator-control-02'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultNumberGeneratorControlQueue3 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'numbergenerator-control-03'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource defaultNumberGeneratorWorkItemsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
-  parent: queueService
-  name: 'numbergenerator-workitems'
-  properties: {
-    metadata: {}
-  }
-}
-
-resource acbsHistoryTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+resource tables 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = [for tableName in tableNames: {
   parent: tableService
-  name: 'acbsHistory'
-  properties: {}
-}
-
-resource defaultAcbsInstancesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
-  parent: tableService
-  name: 'acbsInstances'
-  properties: {}
-}
-
-// TODO:FN-417 Is this the right name?
-resource azureFunctionsDiagnosticEventsTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
-  parent: tableService
-  name: 'AzureFunctionsDiagnosticEvents202304'
-  properties: {}
-}
-
-resource defaultDurableFunctionsHubHistoryTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
-  parent: tableService
-  name: 'DurableFunctionsHubHistory'
-  properties: {}
-}
-
-resource durableFunctionsHubInstancesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
-  parent: tableService
-  name: 'DurableFunctionsHubInstances'
-  properties: {}
-}
-
-resource defaultNumbergeneratorHistoryTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
-  parent: tableService
-  name: 'numbergeneratorHistory'
-  properties: {}
-}
-
-resource defaultNumbergeneratorInstancesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
-  parent: tableService
-  name: 'numbergeneratorInstances'
-  properties: {}
-}
+  name: tableName
+}]
 
 // This resource definition is taken from the storage-private-endpoint export 
 resource storagePrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {

--- a/infrastructure/resource_group_level/modules/storage.bicep
+++ b/infrastructure/resource_group_level/modules/storage.bicep
@@ -135,7 +135,6 @@ resource defaultBlobService 'Microsoft.Storage/storageAccounts/blobServices@2022
   }
 }
 
-
 resource defaultFileService 'Microsoft.Storage/storageAccounts/fileServices@2022-09-01' = {
   parent: storageAccount
   name: 'default'

--- a/infrastructure/resource_group_level/modules/storage.bicep
+++ b/infrastructure/resource_group_level/modules/storage.bicep
@@ -1,0 +1,421 @@
+param environment string
+param location string
+
+// TODO:FN-417 why is there a production subnet? Remove if appropriate
+// param virtualNetworks_vnet_ukef_uks_prod_externalid string = '/subscriptions/08887298-3821-49f0-8303-f88859c12b9b/resourceGroups/rg-ukef-uks-network/providers/Microsoft.Network/virtualNetworks/vnet-ukef-uks-prod'
+
+param appServicePlanEgressSubnetId string
+param gatewaySubnetId string
+param privateEndpointsSubnetId string
+
+@description('IPs or CIDRs still allowed to access the storage if the default action is Deny')
+param allowedIps array
+
+@description('Is public access to the storage account allowed or denied for evertone')
+@allowed(['Allow', 'Deny'])
+param networkAccessDefaultAction string
+
+var storageAccountName = 'tfs${environment}storage'
+var ipRules = [for ip in allowedIps: {
+  value: ip
+  action: 'Allow'
+}]
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: storageAccountName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  sku: {
+    name: 'Standard_ZRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    defaultToOAuthAuthentication: false
+    publicNetworkAccess: 'Enabled'
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: true
+    networkAcls: {
+      resourceAccessRules: []
+      bypass: 'AzureServices'
+      virtualNetworkRules: [
+      // TODO:FN-417 why is there a production subnet here? Only include if proved necessary
+        // {
+        //   id: '${virtualNetworks_vnet_ukef_uks_prod_externalid}/subnets/snet-wvd'
+        //   action: 'Allow'
+        // }
+        {
+          id: appServicePlanEgressSubnetId
+          action: 'Allow'
+        }
+        {
+          id: gatewaySubnetId
+          action: 'Allow'
+        }
+        {
+          id: privateEndpointsSubnetId
+          action: 'Allow'
+        }
+      ]
+      ipRules: ipRules
+      defaultAction: networkAccessDefaultAction
+    }
+    supportsHttpsTrafficOnly: true
+    encryption: {
+      services: {
+        file: {
+          keyType: 'Account'
+          enabled: true
+        }
+        blob: {
+          keyType: 'Account'
+          enabled: true
+        }
+      }
+      keySource: 'Microsoft.Storage'
+    }
+    accessTier: 'Hot'
+  }
+}
+
+resource defaultBlobService 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    containerDeleteRetentionPolicy: {
+      enabled: true
+      days: 3
+    }
+    cors: {
+      corsRules: []
+    }
+    deleteRetentionPolicy: {
+      allowPermanentDelete: false
+      enabled: true
+      days: 3
+    }
+  }
+}
+
+resource defaultFileService 'Microsoft.Storage/storageAccounts/fileServices@2022-09-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    cors: {
+      corsRules: []
+    }
+  }
+}
+
+resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2022-09-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    cors: {
+      corsRules: []
+    }
+  }
+}
+
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2022-09-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    cors: {
+      corsRules: []
+    }
+  }
+}
+
+resource largeMessageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  parent: defaultBlobService
+  name: 'acbs-largemessages'
+  properties: {
+    immutableStorageWithVersioning: {
+      enabled: false
+    }
+    defaultEncryptionScope: '$account-encryption-key'
+    denyEncryptionScopeOverride: false
+    publicAccess: 'None'
+  }
+}
+
+resource acbsLeasesContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  parent: defaultBlobService
+  name: 'acbs-leases'
+  properties: {
+    immutableStorageWithVersioning: {
+      enabled: false
+    }
+    defaultEncryptionScope: '$account-encryption-key'
+    denyEncryptionScopeOverride: false
+    publicAccess: 'None'
+  }
+}
+
+resource webjobsHostsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  parent: defaultBlobService
+  name: 'azure-webjobs-hosts'
+  properties: {
+    immutableStorageWithVersioning: {
+      enabled: false
+    }
+    defaultEncryptionScope: '$account-encryption-key'
+    denyEncryptionScopeOverride: false
+    publicAccess: 'None'
+  }
+}
+
+resource webjobsSecretsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  parent: defaultBlobService
+  name: 'azure-webjobs-secrets'
+  properties: {
+    immutableStorageWithVersioning: {
+      enabled: false
+    }
+    defaultEncryptionScope: '$account-encryption-key'
+    denyEncryptionScopeOverride: false
+    publicAccess: 'None'
+  }
+}
+
+resource numberGeneratoreLeasesContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  parent: defaultBlobService
+  name: 'numbergenerator-leases'
+  properties: {
+    immutableStorageWithVersioning: {
+      enabled: false
+    }
+    defaultEncryptionScope: '$account-encryption-key'
+    denyEncryptionScopeOverride: false
+    publicAccess: 'None'
+  }
+}
+
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
+  parent: defaultFileService
+  name: 'files'
+  properties: {
+    accessTier: 'TransactionOptimized'
+    shareQuota: 5120
+    enabledProtocols: 'SMB'
+  }
+}
+
+resource portalFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
+  parent: defaultFileService
+  name: 'portal'
+  properties: {
+    accessTier: 'TransactionOptimized'
+    shareQuota: 5120
+    enabledProtocols: 'SMB'
+  }
+}
+
+resource workflowFileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2022-09-01' = {
+  parent: defaultFileService
+  name: 'workflow'
+  properties: {
+    accessTier: 'TransactionOptimized'
+    shareQuota: 5120
+    enabledProtocols: 'SMB'
+  }
+}
+
+resource acbsControlQueue0 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'acbs-control-00'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource acbsControlQueue1 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'acbs-control-01'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource acbsControlQueue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'acbs-control-02'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource acbsControlQueue3 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'acbs-control-03'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource acbsWorkItemsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'acbs-workitems'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultDurableFunctionsHubControlQueue0 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'durablefunctionshub-control-00'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultDurableFunctionsHubControlQueue1 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'durablefunctionshub-control-01'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultDurableFunctionsHubControlQueue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'durablefunctionshub-control-02'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultDurableFunctionsHubControlQueue3 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'durablefunctionshub-control-03'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultDurableFunctionsHubWorkItemsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'durablefunctionshub-workitems'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultNumberGeneratorControlQueue0 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'numbergenerator-control-00'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultNumberGeneratorControlQueue1 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'numbergenerator-control-01'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultNumberGeneratorControlQueue2 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'numbergenerator-control-02'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultNumberGeneratorControlQueue3 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'numbergenerator-control-03'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource defaultNumberGeneratorWorkItemsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2022-09-01' = {
+  parent: queueService
+  name: 'numbergenerator-workitems'
+  properties: {
+    metadata: {}
+  }
+}
+
+resource acbsHistoryTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'acbsHistory'
+  properties: {}
+}
+
+resource defaultAcbsInstancesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'acbsInstances'
+  properties: {}
+}
+
+// TODO:FN-417 Is this the right name?
+resource azureFunctionsDiagnosticEventsTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'AzureFunctionsDiagnosticEvents202304'
+  properties: {}
+}
+
+resource defaultDurableFunctionsHubHistoryTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'DurableFunctionsHubHistory'
+  properties: {}
+}
+
+resource durableFunctionsHubInstancesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'DurableFunctionsHubInstances'
+  properties: {}
+}
+
+resource defaultNumbergeneratorHistoryTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'numbergeneratorHistory'
+  properties: {}
+}
+
+resource defaultNumbergeneratorInstancesTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2022-09-01' = {
+  parent: tableService
+  name: 'numbergeneratorInstances'
+  properties: {}
+}
+
+// This resource definition is taken from the storage-private-endpoint export 
+resource storagePrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {
+  name: storageAccountName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: storageAccountName
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'file'
+          ]
+          privateLinkServiceConnectionState: {
+            status: 'Approved'
+            description: 'Auto-Approved'
+            actionsRequired: 'None'
+          }
+        }
+      }
+    ]
+    manualPrivateLinkServiceConnections: []
+    subnet: {
+      id: privateEndpointsSubnetId
+    }
+    ipConfigurations: []
+    // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}

--- a/infrastructure/resource_group_level/modules/storage.bicep
+++ b/infrastructure/resource_group_level/modules/storage.bicep
@@ -9,7 +9,8 @@ param gatewaySubnetId string
 param privateEndpointsSubnetId string
 
 @description('IPs or CIDRs still allowed to access the storage if the default action is Deny')
-param allowedIps array
+@secure()
+param allowedIpsString string
 
 @description('Is public access to the storage account allowed or denied for evertone')
 @allowed(['Allow', 'Deny'])
@@ -18,6 +19,9 @@ param networkAccessDefaultAction string
 param shareDeleteRetentionEnabled bool
 
 var storageAccountName = 'tfs${environment}storage'
+
+var allowedIps = json(allowedIpsString)
+
 var ipRules = [for ip in allowedIps: {
   value: ip
   action: 'Allow'

--- a/infrastructure/resource_group_level/modules/storage.bicep
+++ b/infrastructure/resource_group_level/modules/storage.bicep
@@ -15,6 +15,8 @@ param allowedIps array
 @allowed(['Allow', 'Deny'])
 param networkAccessDefaultAction string
 
+param shareDeleteRetentionEnabled bool
+
 var storageAccountName = 'tfs${environment}storage'
 var ipRules = [for ip in allowedIps: {
   value: ip
@@ -133,9 +135,18 @@ resource defaultBlobService 'Microsoft.Storage/storageAccounts/blobServices@2022
   }
 }
 
+
 resource defaultFileService 'Microsoft.Storage/storageAccounts/fileServices@2022-09-01' = {
   parent: storageAccount
   name: 'default'
+  // TODO:DTFS-6422 Note that the extant envrionments don't have
+  // 7 day soft deletes enabled. We may want to enable this functionality.
+  properties: {
+    shareDeleteRetentionPolicy: {
+      enabled: shareDeleteRetentionEnabled
+      days: 7
+    }
+  }
 }
 
 resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2022-09-01' = {

--- a/infrastructure/resource_group_level/modules/vnet.bicep
+++ b/infrastructure/resource_group_level/modules/vnet.bicep
@@ -208,4 +208,22 @@ resource vnet 'Microsoft.Network/virtualNetworks@2022-11-01' = {
   }
 }
 
+resource appServicePlanEgressSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-11-01' existing = {
+  parent: vnet
+  name: appServicePlanEgressSubnetName
+}
+
+resource gatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2022-11-01' existing = {
+  parent: vnet
+  name: gatewaySubnetName
+}
+
+resource privateEndpointsSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-11-01' existing = {
+  parent: vnet
+  name: privateEndpointsSubnetName
+}
+
+output appServicePlanEgressSubnetId string = appServicePlanEgressSubnet.id
+output gatewaySubnetId string = gatewaySubnet.id
+output privateEndpointsSubnetId string = privateEndpointsSubnet.id
 output vnetId string = vnet.id


### PR DESCRIPTION
## Introduction
We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:
* produce a complete new deployment environment (`feature`) mirroring the current ones.
* be in a position to take over the extant environments.
Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.
Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers wiring up the storage only. Note that there will be some tidying / refactoring when all the components are in place, (e.g. commonise tags, consider parameter sets), but the code should be of reasonable quality and clear.

## Resolution

This code wires up the storage account and its components.