### PR TITLE
feat(fn-416): cosmosdb

### DIFF
--- a/infrastructure/arm_templates/cosmosdb/errors.json
+++ b/infrastructure/arm_templates/cosmosdb/errors.json
@@ -1,0 +1,31 @@
+{
+    "code": "ExportTemplateCompletedWithErrors",
+    "message": "Export template operation completed with errors. Some resources were not exported. Please see details for more information.",
+    "details": [
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.DocumentDB/databaseAccounts/graphs",
+            "message": "Could not get resources of the type 'Microsoft.DocumentDB/databaseAccounts/graphs'. Resources of this type will not be exported."
+        },
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+            "message": "Could not get resources of the type 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments'. Resources of this type will not be exported."
+        },
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions",
+            "message": "Could not get resources of the type 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions'. Resources of this type will not be exported."
+        },
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions",
+            "message": "Could not get resources of the type 'Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions'. Resources of this type will not be exported."
+        },
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions",
+            "message": "Could not get resources of the type 'Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions'. Resources of this type will not be exported."
+        }
+    ]
+}

--- a/infrastructure/arm_templates/cosmosdb/parameters.json
+++ b/infrastructure/arm_templates/cosmosdb/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "databaseAccounts_tfs_dev_mongo_name": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        },
+        "privateEndpoints_tfs_dev_mongo_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/cosmosdb/private-endpoint/parameters.json
+++ b/infrastructure/arm_templates/cosmosdb/private-endpoint/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "privateEndpoints_tfs_dev_mongo_name": {
+            "value": null
+        },
+        "databaseAccounts_tfs_dev_mongo_externalid": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/cosmosdb/private-endpoint/template.json
+++ b/infrastructure/arm_templates/cosmosdb/private-endpoint/template.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "privateEndpoints_tfs_dev_mongo_name": {
+            "defaultValue": "tfs-dev-mongo",
+            "type": "String"
+        },
+        "databaseAccounts_tfs_dev_mongo_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.DocumentDB/databaseAccounts/tfs-dev-mongo",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-11-01",
+            "name": "[parameters('privateEndpoints_tfs_dev_mongo_name')]",
+            "location": "uksouth",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "[parameters('privateEndpoints_tfs_dev_mongo_name')]",
+                        "id": "[concat(resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpoints_tfs_dev_mongo_name')), concat('/privateLinkServiceConnections/', parameters('privateEndpoints_tfs_dev_mongo_name')))]",
+                        "properties": {
+                            "privateLinkServiceId": "[parameters('databaseAccounts_tfs_dev_mongo_externalid')]",
+                            "groupIds": [
+                                "MongoDB"
+                            ],
+                            "privateLinkServiceConnectionState": {
+                                "status": "Approved",
+                                "actionsRequired": "None"
+                            }
+                        }
+                    }
+                ],
+                "manualPrivateLinkServiceConnections": [],
+                "subnet": {
+                    "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-private-endpoints')]"
+                },
+                "ipConfigurations": [],
+                "customDnsConfigs": [
+                    {
+                        "fqdn": "[concat(parameters('privateEndpoints_tfs_dev_mongo_name'), '.mongo.cosmos.azure.com')]",
+                        "ipAddresses": [
+                            "172.16.40.6"
+                        ]
+                    },
+                    {
+                        "fqdn": "[concat(parameters('privateEndpoints_tfs_dev_mongo_name'), '-uksouth.mongo.cosmos.azure.com')]",
+                        "ipAddresses": [
+                            "172.16.40.7"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/cosmosdb/serverless_example/parameters.json
+++ b/infrastructure/arm_templates/cosmosdb/serverless_example/parameters.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "databaseAccounts_gremos_feature_check_mongo_db_name": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/cosmosdb/serverless_example/template.json
+++ b/infrastructure/arm_templates/cosmosdb/serverless_example/template.json
@@ -85,9 +85,6 @@
                     },
                     {
                         "ipAddressOrRange": "52.187.184.26"
-                    },
-                    {
-                        "ipAddressOrRange": "51.140.76.208"
                     }
                 ],
                 "backupPolicy": {

--- a/infrastructure/arm_templates/cosmosdb/serverless_example/template.json
+++ b/infrastructure/arm_templates/cosmosdb/serverless_example/template.json
@@ -1,0 +1,107 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "databaseAccounts_gremos_feature_check_mongo_db_name": {
+            "defaultValue": "gremos-feature-check-mongo-db",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts",
+            "apiVersion": "2023-04-15",
+            "name": "[parameters('databaseAccounts_gremos_feature_check_mongo_db_name')]",
+            "location": "UK South",
+            "tags": {
+                "defaultExperience": "Azure Cosmos DB for MongoDB API",
+                "hidden-cosmos-mmspecial": "",
+                "Environment": "Preproduction"
+            },
+            "kind": "MongoDB",
+            "identity": {
+                "type": "None"
+            },
+            "properties": {
+                "publicNetworkAccess": "Enabled",
+                "enableAutomaticFailover": false,
+                "enableMultipleWriteLocations": false,
+                "isVirtualNetworkFilterEnabled": false,
+                "virtualNetworkRules": [],
+                "disableKeyBasedMetadataWriteAccess": false,
+                "enableFreeTier": false,
+                "enableAnalyticalStorage": false,
+                "analyticalStorageConfiguration": {
+                    "schemaType": "FullFidelity"
+                },
+                "createMode": "Default",
+                "databaseAccountOfferType": "Standard",
+                "defaultIdentity": "FirstPartyIdentity",
+                "networkAclBypass": "None",
+                "disableLocalAuth": false,
+                "enablePartitionMerge": false,
+                "minimalTlsVersion": "Tls12",
+                "consistencyPolicy": {
+                    "defaultConsistencyLevel": "Session",
+                    "maxIntervalInSeconds": 5,
+                    "maxStalenessPrefix": 100
+                },
+                "apiProperties": {
+                    "serverVersion": "4.2"
+                },
+                "locations": [
+                    {
+                        "locationName": "UK South",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0,
+                        "isZoneRedundant": false
+                    }
+                ],
+                "cors": [],
+                "capabilities": [
+                    {
+                        "name": "EnableMongo"
+                    },
+                    {
+                        "name": "DisableRateLimitingResponses"
+                    },
+                    {
+                        "name": "EnableServerless"
+                    }
+                ],
+                "ipRules": [
+                    {
+                        "ipAddressOrRange": "104.42.195.92"
+                    },
+                    {
+                        "ipAddressOrRange": "40.76.54.131"
+                    },
+                    {
+                        "ipAddressOrRange": "52.176.6.30"
+                    },
+                    {
+                        "ipAddressOrRange": "52.169.50.45"
+                    },
+                    {
+                        "ipAddressOrRange": "52.187.184.26"
+                    },
+                    {
+                        "ipAddressOrRange": "51.140.76.208"
+                    }
+                ],
+                "backupPolicy": {
+                    "type": "Continuous",
+                    "continuousModeProperties": {
+                        "tier": "Continuous7Days"
+                    }
+                },
+                "networkAclBypassResourceIds": [],
+                "capacity": {
+                    "totalThroughputLimit": 4000
+                },
+                "keysMetadata": {}
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/cosmosdb/template.json
+++ b/infrastructure/arm_templates/cosmosdb/template.json
@@ -1,0 +1,633 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "databaseAccounts_tfs_dev_mongo_name": {
+            "defaultValue": "tfs-dev-mongo",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/digital-dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        },
+        "privateEndpoints_tfs_dev_mongo_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/privateEndpoints/tfs-dev-mongo",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts",
+            "apiVersion": "2023-04-15",
+            "name": "[parameters('databaseAccounts_tfs_dev_mongo_name')]",
+            "location": "UK South",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "kind": "MongoDB",
+            "identity": {
+                "type": "None"
+            },
+            "properties": {
+                "publicNetworkAccess": "Enabled",
+                "enableAutomaticFailover": false,
+                "enableMultipleWriteLocations": false,
+                "isVirtualNetworkFilterEnabled": true,
+                "virtualNetworkRules": [
+                    {
+                        "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-app-service-plan-egress')]",
+                        "ignoreMissingVNetServiceEndpoint": false
+                    },
+                    {
+                        "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/digital-dev-vm')]",
+                        "ignoreMissingVNetServiceEndpoint": false
+                    }
+                ],
+                "disableKeyBasedMetadataWriteAccess": false,
+                "enableFreeTier": false,
+                "enableAnalyticalStorage": false,
+                "analyticalStorageConfiguration": {},
+                "createMode": "Default",
+                "databaseAccountOfferType": "Standard",
+                "defaultIdentity": "FirstPartyIdentity",
+                "networkAclBypass": "None",
+                "disableLocalAuth": false,
+                "enablePartitionMerge": false,
+                "minimalTlsVersion": "Tls12",
+                "consistencyPolicy": {
+                    "defaultConsistencyLevel": "Session",
+                    "maxIntervalInSeconds": 5,
+                    "maxStalenessPrefix": 100
+                },
+                "apiProperties": {
+                    "serverVersion": "4.2"
+                },
+                "locations": [
+                    {
+                        "locationName": "UK South",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0,
+                        "isZoneRedundant": false
+                    }
+                ],
+                "cors": [],
+                "capabilities": [
+                    {
+                        "name": "EnableMongo"
+                    }
+                ],
+                "ipRules": [
+                    {
+                        "ipAddressOrRange": "51.140.76.208"
+                    },
+                    {
+                        "ipAddressOrRange": "213.86.43.20"
+                    },
+                    {
+                        "ipAddressOrRange": "213.86.43.22"
+                    },
+                    {
+                        "ipAddressOrRange": "86.130.182.52"
+                    },
+                    {
+                        "ipAddressOrRange": "81.154.165.161"
+                    },
+                    {
+                        "ipAddressOrRange": "86.139.72.145"
+                    },
+                    {
+                        "ipAddressOrRange": "104.42.195.92"
+                    },
+                    {
+                        "ipAddressOrRange": "40.76.54.131"
+                    },
+                    {
+                        "ipAddressOrRange": "52.176.6.30"
+                    },
+                    {
+                        "ipAddressOrRange": "52.169.50.45"
+                    },
+                    {
+                        "ipAddressOrRange": "52.187.184.26"
+                    },
+                    {
+                        "ipAddressOrRange": "0.0.0.0"
+                    }
+                ],
+                "backupPolicy": {
+                    "type": "Continuous",
+                    "continuousModeProperties": {
+                        "tier": "Continuous30Days"
+                    }
+                },
+                "networkAclBypassResourceIds": [],
+                "capacity": {
+                    "totalThroughputLimit": 4000
+                },
+                "keysMetadata": {}
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "dtfs-submissions"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/', parameters('databaseAccounts_tfs_dev_mongo_name'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "provisioningState": "Succeeded",
+                "groupId": "MongoDB",
+                "privateEndpoint": {
+                    "id": "[parameters('privateEndpoints_tfs_dev_mongo_externalid')]"
+                },
+                "privateLinkServiceConnectionState": {
+                    "status": "Approved"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/banks')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "banks",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/cron-job-logs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "cron-job-logs",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/deals')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "deals",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/durable-functions-log')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "durable-functions-log",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        },
+                        {
+                            "key": {
+                                "keys": [
+                                    "status"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/eligibilityCriteria')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "eligibilityCriteria",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        },
+                        {
+                            "key": {
+                                "keys": [
+                                    "version"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/facilities')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "facilities",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/feedback')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "feedback",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/files')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "files",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/gef-eligibilityCriteria')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "gef-eligibilityCriteria",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        },
+                        {
+                            "key": {
+                                "keys": [
+                                    "version"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/gef-mandatoryCriteriaVersioned')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "gef-mandatoryCriteriaVersioned",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        },
+                        {
+                            "key": {
+                                "keys": [
+                                    "version"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/mandatoryCriteria')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "mandatoryCriteria",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        },
+                        {
+                            "key": {
+                                "keys": [
+                                    "version"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/tfm-deals')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "tfm-deals",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/tfm-facilities')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "tfm-facilities",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/tfm-feedback')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "tfm-feedback",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/tfm-teams')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "tfm-teams",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/tfm-users')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "tfm-users",
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/users')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "id": "users",
+                    "shardKey": {
+                        "_id": "Hash"
+                    },
+                    "indexes": [
+                        {
+                            "key": {
+                                "keys": [
+                                    "_id"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings",
+            "apiVersion": "2023-04-15",
+            "name": "[concat(parameters('databaseAccounts_tfs_dev_mongo_name'), '/dtfs-submissions/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('databaseAccounts_tfs_dev_mongo_name'), 'dtfs-submissions')]",
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('databaseAccounts_tfs_dev_mongo_name'))]"
+            ],
+            "properties": {
+                "resource": {
+                    "throughput": 400,
+                    "autoscaleSettings": {
+                        "maxThroughput": 4000
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/cosmosdb/template.json
+++ b/infrastructure/arm_templates/cosmosdb/template.json
@@ -79,24 +79,6 @@
                 ],
                 "ipRules": [
                     {
-                        "ipAddressOrRange": "51.140.76.208"
-                    },
-                    {
-                        "ipAddressOrRange": "213.86.43.20"
-                    },
-                    {
-                        "ipAddressOrRange": "213.86.43.22"
-                    },
-                    {
-                        "ipAddressOrRange": "86.130.182.52"
-                    },
-                    {
-                        "ipAddressOrRange": "81.154.165.161"
-                    },
-                    {
-                        "ipAddressOrRange": "86.139.72.145"
-                    },
-                    {
                         "ipAddressOrRange": "104.42.195.92"
                     },
                     {

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -173,7 +173,7 @@ module cosmosDb 'modules/cosmosdb.bicep' = {
     environment: environment
     appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
-    onPremiseNetworkIps: onPremiseNetworkIps
+    allowedIpsString: onPremiseNetworkIpsString
     capacityMode: cosmosDbCapacityMode
   }
 }

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -55,6 +55,9 @@ param storageNetworkAccessDefaultAction string = 'Allow'
 @description('Enable 7-day soft deletes on file shares')
 param shareDeleteRetentionEnabled bool = false
 
+@allowed(['Provisioned Throughput', 'Serverless'])
+param cosmosDbCapacityMode string = 'Serverless' // All current environments use 'Provisioned Throughput'
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName
   location: location
@@ -160,5 +163,17 @@ module storage 'modules/storage.bicep' = {
     allowedIpsString: onPremiseNetworkIpsString
     networkAccessDefaultAction: storageNetworkAccessDefaultAction
     shareDeleteRetentionEnabled: shareDeleteRetentionEnabled
+  }
+}
+
+module cosmosDb 'modules/cosmosdb.bicep' = {
+  name: 'mongoDb'
+  params: {
+    location: location
+    environment: environment
+    appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
+    privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
+    onPremiseNetworkIps: onPremiseNetworkIps
+    capacityMode: cosmosDbCapacityMode
   }
 }

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -55,8 +55,10 @@ param storageNetworkAccessDefaultAction string = 'Allow'
 @description('Enable 7-day soft deletes on file shares')
 param shareDeleteRetentionEnabled bool = false
 
+// All current environments use 'Provisioned Throughput'
+// TODO:DTFS-6422 Ensure we use 'Provisioned Throughput' for extant environments, but consider changing.
 @allowed(['Provisioned Throughput', 'Serverless'])
-param cosmosDbCapacityMode string = 'Serverless' // All current environments use 'Provisioned Throughput'
+param cosmosDbCapacityMode string = 'Serverless'
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -60,6 +60,11 @@ param shareDeleteRetentionEnabled bool = false
 @allowed(['Provisioned Throughput', 'Serverless'])
 param cosmosDbCapacityMode string = 'Serverless'
 
+// TODO:DTFS-6422 Note that all extant environments currently use Continuous30Days.
+// Consider changing non-prod environments to Continuous7Days.
+@allowed(['Continuous7Days', 'Continuous30Days'])
+param cosmosDbBackupPolicyTier string = 'Continuous7Days'
+
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: appServicePlanName
   location: location
@@ -177,5 +182,6 @@ module cosmosDb 'modules/cosmosdb.bicep' = {
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     allowedIpsString: onPremiseNetworkIpsString
     capacityMode: cosmosDbCapacityMode
+    backupPolicyTier: cosmosDbBackupPolicyTier
   }
 }

--- a/infrastructure/resource_group_level/modules/cosmosdb.bicep
+++ b/infrastructure/resource_group_level/modules/cosmosdb.bicep
@@ -1,0 +1,564 @@
+param location string
+param environment string
+param appServicePlanEgressSubnetId string
+param privateEndpointsSubnetId string
+
+param onPremiseNetworkIps array
+
+// See https://learn.microsoft.com/en-gb/azure/cosmos-db/throughput-serverless
+@allowed(['Provisioned Throughput', 'Serverless'])
+param capacityMode string
+
+var cosmosDbName = 'tfs-${environment}-mongo'
+var privateEndpointName = 'tfs-${environment}-mongo'
+
+
+// TODO:FN-416 Work out what these misc. IPs with access are.
+// Misc IPs
+var miscIps =  [
+  '86.130.182.52'
+  '81.154.165.161'
+  '86.139.72.145'
+] 
+
+// On activating "Allow access from Azure Portal":
+// https://github.com/Azure/azure-cli/issues/7495 ->
+// https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-configure-firewall#allow-requests-from-the-azure-portal
+// As mentioned above, adding the following is equivalent to checking "Allow access from Azure Portal" "Accept connections from within public Azure datacenters" in the portal.
+var azurePortalIps = [
+  '104.42.195.92'
+  '40.76.54.131'
+  '52.176.6.30'
+  '52.169.50.45'
+  '52.187.184.26'
+]
+
+// As mentioned above, adding the following is equivalent to checking "Accept connections from within public Azure datacenters" in the portal.
+// We need this for Azure functions.
+var acceptPublicAzureDatacentersIp = ['0.0.0.0']
+
+var allowedIps = concat(onPremiseNetworkIps, miscIps, azurePortalIps, acceptPublicAzureDatacentersIp)
+
+var capabilities = capacityMode == 'Provisioned Throughput' ? [
+  {
+    name: 'EnableMongo'
+  }
+] : [
+  {
+    name: 'EnableMongo'
+  }
+  {
+    name: 'DisableRateLimitingResponses'
+  }
+  {
+    name: 'EnableServerless'
+  }  
+]
+
+
+resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
+  name: cosmosDbName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  kind: 'MongoDB'
+  identity: {
+    type: 'None'
+  }
+  properties: {
+    publicNetworkAccess: 'Enabled'
+    enableAutomaticFailover: false
+    enableMultipleWriteLocations: false
+    isVirtualNetworkFilterEnabled: true
+    virtualNetworkRules: [
+      {
+        id: appServicePlanEgressSubnetId
+        ignoreMissingVNetServiceEndpoint: false
+      }
+    ]
+    disableKeyBasedMetadataWriteAccess: false
+    enableFreeTier: false
+    enableAnalyticalStorage: false
+    analyticalStorageConfiguration: {}
+    createMode: 'Default'
+    databaseAccountOfferType: 'Standard'
+    defaultIdentity: 'FirstPartyIdentity'
+    networkAclBypass: 'None'
+    disableLocalAuth: false
+    enablePartitionMerge: false
+    minimalTlsVersion: 'Tls12'
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+      maxIntervalInSeconds: 5
+      maxStalenessPrefix: 100
+    }
+    apiProperties: {
+      serverVersion: '4.2'
+    }
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    cors: []
+    capabilities: capabilities
+    ipRules: [for ip in allowedIps: {
+      ipAddressOrRange: ip
+    }]
+    backupPolicy: {
+      type: 'Continuous'
+      continuousModeProperties: {
+        tier: 'Continuous30Days'
+      }
+    }
+    networkAclBypassResourceIds: []
+    capacity: {
+      totalThroughputLimit: 4000
+    }
+  }
+}
+
+
+resource submissionsDb 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2023-04-15' = {
+  parent: cosmosDb
+  name: 'dtfs-submissions'
+  properties: {
+    resource: {
+      id: 'dtfs-submissions'
+    }
+  }
+}
+
+resource banksCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'banks'
+  properties: {
+    resource: {
+      id: 'banks'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource cronJobsLogsCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'cron-job-logs'
+  properties: {
+    resource: {
+      id: 'cron-job-logs'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource dealsCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'deals'
+  properties: {
+    resource: {
+      id: 'deals'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource durableFunctionsLogCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'durable-functions-log'
+  properties: {
+    resource: {
+      id: 'durable-functions-log'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+        {
+          key: {
+            keys: [
+              'status'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource eligibilityCriteriaCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'eligibilityCriteria'
+  properties: {
+    resource: {
+      id: 'eligibilityCriteria'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+        {
+          key: {
+            keys: [
+              'version'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource facilitiesCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'facilities'
+  properties: {
+    resource: {
+      id: 'facilities'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource feedbackCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'feedback'
+  properties: {
+    resource: {
+      id: 'feedback'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource filesCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'files'
+  properties: {
+    resource: {
+      id: 'files'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource gefEligibilityCriteriaCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'gef-eligibilityCriteria'
+  properties: {
+    resource: {
+      id: 'gef-eligibilityCriteria'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+        {
+          key: {
+            keys: [
+              'version'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource gefMandatoryCriteriaVersionedCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'gef-mandatoryCriteriaVersioned'
+  properties: {
+    resource: {
+      id: 'gef-mandatoryCriteriaVersioned'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+        {
+          key: {
+            keys: [
+              'version'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource mandatoryCriteriaCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'mandatoryCriteria'
+  properties: {
+    resource: {
+      id: 'mandatoryCriteria'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+        {
+          key: {
+            keys: [
+              'version'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource tfmDealsCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'tfm-deals'
+  properties: {
+    resource: {
+      id: 'tfm-deals'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource tfmFacilitiesCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'tfm-facilities'
+  properties: {
+    resource: {
+      id: 'tfm-facilities'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource tfmFeedbackCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'tfm-feedback'
+  properties: {
+    resource: {
+      id: 'tfm-feedback'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource tfmTeamsCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'tfm-teams'
+  properties: {
+    resource: {
+      id: 'tfm-teams'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource tfmUsersCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'tfm-users'
+  properties: {
+    resource: {
+      id: 'tfm-users'
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource usersCollection 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections@2023-04-15' = {
+  parent: submissionsDb
+  name: 'users'
+  properties: {
+    resource: {
+      id: 'users'
+      shardKey: {
+        _id: 'Hash'
+      }
+      indexes: [
+        {
+          key: {
+            keys: [
+              '_id'
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+
+// Setting the throughput only makes sense for 'Provisioned Throughput' mode
+resource defaultThroughputSettings 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings@2023-04-15' = if (capacityMode == 'Provisioned Throughput') {
+  parent: submissionsDb
+  name: 'default'
+  properties: {
+    resource: {
+      throughput: 400
+      autoscaleSettings: {
+        maxThroughput: 4000
+      }
+    }
+  }
+}
+
+// The private endpoint is taken from the cosmosdb/private-endpoint export
+resource mongoDbPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {
+  name: privateEndpointName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: cosmosDb.id
+          groupIds: [
+            'MongoDB'
+          ]
+          privateLinkServiceConnectionState: {
+            status: 'Approved'
+            actionsRequired: 'None'
+          }
+        }
+      }
+    ]
+    manualPrivateLinkServiceConnections: []
+    subnet: {
+      id: privateEndpointsSubnetId
+    }
+    ipConfigurations: []
+    // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}

--- a/infrastructure/resource_group_level/modules/cosmosdb.bicep
+++ b/infrastructure/resource_group_level/modules/cosmosdb.bicep
@@ -12,6 +12,9 @@ param allowedIpsString string
 @allowed(['Provisioned Throughput', 'Serverless'])
 param capacityMode string
 
+@allowed(['Continuous7Days', 'Continuous30Days'])
+param backupPolicyTier string
+
 var cosmosDbName = 'tfs-${environment}-mongo'
 var privateEndpointName = 'tfs-${environment}-mongo'
 
@@ -107,7 +110,7 @@ resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
     backupPolicy: {
       type: 'Continuous'
       continuousModeProperties: {
-        tier: 'Continuous30Days'
+        tier: backupPolicyTier
       }
     }
     networkAclBypassResourceIds: []

--- a/infrastructure/resource_group_level/modules/privatelink-mongo-cosmos-azure-com.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-mongo-cosmos-azure-com.bicep
@@ -1,8 +1,8 @@
-param privateDnsZones_privatelink_mongo_cosmos_azure_com_name string = 'privatelink.mongo.cosmos.azure.com'
+param privateDnsZoneName string = 'privatelink.mongo.cosmos.azure.com'
 param vnetId string
 
 resource mongoDbDnsZone 'Microsoft.Network/privateDnsZones@2018-09-01' = {
-  name: privateDnsZones_privatelink_mongo_cosmos_azure_com_name
+  name: privateDnsZoneName
   location: 'global'
   tags: {
     Environment: 'Preproduction'


### PR DESCRIPTION
## Introduction
We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.

Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.
Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers wiring up cosmosdb (MongoDB) only. Note that there will be some tidying / refactoring when all the components are in place, (e.g. commonise tags, consider parameter sets), but the code should be of reasonable quality and clear.
### Resolution

This code wires up cosmosdb and its private link.