### PR TITLE
feat(fn-418): redis

### DIFF
--- a/infrastructure/arm_templates/redis/parameters.json
+++ b/infrastructure/arm_templates/redis/parameters.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "Redis_tfs_dev_redis_name": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/redis/template.json
+++ b/infrastructure/arm_templates/redis/template.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "Redis_tfs_dev_redis_name": {
+            "defaultValue": "tfs-dev-redis",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Cache/Redis",
+            "apiVersion": "2023-05-01-preview",
+            "name": "[parameters('Redis_tfs_dev_redis_name')]",
+            "location": "UK South",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "redisVersion": "6.0",
+                "sku": {
+                    "name": "Basic",
+                    "family": "C",
+                    "capacity": 0
+                },
+                "enableNonSslPort": false,
+                "minimumTlsVersion": "1.2",
+                "publicNetworkAccess": "Enabled",
+                "tenantSettings": {},
+                "redisConfiguration": {
+                    "maxmemory-reserved": "0",
+                    "maxfragmentationmemory-reserved": "0",
+                    "maxmemory-policy": "volatile-lru",
+                    "maxmemory-delta": "0"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Cache/Redis/accessPolicies",
+            "apiVersion": "2023-05-01-preview",
+            "name": "[concat(parameters('Redis_tfs_dev_redis_name'), '/Contributor')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Cache/Redis', parameters('Redis_tfs_dev_redis_name'))]"
+            ],
+            "properties": {
+                "permissions": "+@all -@dangerous allkeys"
+            }
+        },
+        {
+            "type": "Microsoft.Cache/Redis/accessPolicies",
+            "apiVersion": "2023-05-01-preview",
+            "name": "[concat(parameters('Redis_tfs_dev_redis_name'), '/Owner')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Cache/Redis', parameters('Redis_tfs_dev_redis_name'))]"
+            ],
+            "properties": {
+                "permissions": "+@all allkeys"
+            }
+        },
+        {
+            "type": "Microsoft.Cache/Redis/accessPolicies",
+            "apiVersion": "2023-05-01-preview",
+            "name": "[concat(parameters('Redis_tfs_dev_redis_name'), '/Reader')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Cache/Redis', parameters('Redis_tfs_dev_redis_name'))]"
+            ],
+            "properties": {
+                "permissions": "+@read allkeys"
+            }
+        }
+    ]
+}

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -185,3 +185,11 @@ module cosmosDb 'modules/cosmosdb.bicep' = {
     backupPolicyTier: cosmosDbBackupPolicyTier
   }
 }
+
+module redis 'modules/redis.bicep' = {
+  name: 'redis'
+  params: {
+    location: location
+    environment: environment
+  }
+}

--- a/infrastructure/resource_group_level/modules/redis.bicep
+++ b/infrastructure/resource_group_level/modules/redis.bicep
@@ -1,6 +1,15 @@
 param location string
 param environment string
 
+// TODO:FN-504 decide what sku to use.
+// Note that it isn't recommended to use Basic or C0 in production
+// See https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-best-practices-development
+param sku object = {
+  name: 'Basic'
+  family: 'C'
+  capacity: 0
+}
+
 var redisName = 'tfs-${environment}-redis'
 
 // See https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-redis-cache-bicep-provision?tabs=CLI
@@ -9,15 +18,6 @@ var redisName = 'tfs-${environment}-redis'
 // TODO:FN-504 Configure private link.
 // See line 718 in developmentinfrastructure.yml
 // and https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link
-
-// TODO:FN-504 decide what sku to use.
-// Note that it isn't recommended to use Basic or C0 in production
-// See https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-best-practices-development
-var sku = {
-  name: 'Basic'
-  family: 'C'
-  capacity: 0
-}
 
 resource redis 'Microsoft.Cache/redis@2022-06-01' = {
   name: redisName

--- a/infrastructure/resource_group_level/modules/redis.bicep
+++ b/infrastructure/resource_group_level/modules/redis.bicep
@@ -1,0 +1,42 @@
+param location string
+param environment string
+
+var redisName = 'tfs-${environment}-redis'
+
+// See https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-redis-cache-bicep-provision?tabs=CLI
+// for an example Bicep file
+
+// TODO:FN-504 Configure private link.
+// See line 718 in developmentinfrastructure.yml
+// and https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link
+
+// TODO:FN-504 decide what sku to use.
+// Note that it isn't recommended to use Basic or C0 in production
+// See https://learn.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-best-practices-development
+var sku = {
+  name: 'Basic'
+  family: 'C'
+  capacity: 0
+}
+
+resource redis 'Microsoft.Cache/redis@2022-06-01' = {
+  name: redisName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  properties: {
+    redisVersion: '6.0'
+    sku: sku
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+    tenantSettings: {}
+    redisConfiguration: {
+      'maxmemory-reserved': '0'
+      'maxfragmentationmemory-reserved': '0'
+      'maxmemory-policy': 'volatile-lru'
+      'maxmemory-delta': '0'
+    }
+  }
+}


### PR DESCRIPTION
## Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

*   produce a complete new deployment environment (feature) mirroring the current ones.
*   be in a position to take over the extant environments.

Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.
Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers wiring up Redis only. Note that there will be some tidying / refactoring when all the components are in place, (e.g. commonise tags, consider parameter sets), but the code should be of reasonable quality and clear.

Note also that this replicates the current setup. Enhancements, including adding a private link are covered in FN-504 

## Resolution

This code wires up Redis
