### PR TITLE
Fix(DTFS2): Add interface to premium Schedule

### DIFF
--- a/external-api/src/interfaces/index.ts
+++ b/external-api/src/interfaces/index.ts
@@ -3,3 +3,4 @@ export * from './currency.interface';
 export * from './industry-sector.interface';
 export * from './eStore.interface';
 export * from './amendment.interface';
+export * from './premiumSchedule.interface';

--- a/external-api/src/interfaces/premiumSchedule.interface.ts
+++ b/external-api/src/interfaces/premiumSchedule.interface.ts
@@ -1,14 +1,14 @@
 export interface PremiumSchedule {
-  premiumTypeId: string;
-  premiumFrequencyId: string;
+  premiumTypeId: number;
+  premiumFrequencyId: number;
   productGroup: string;
-  facilityURN: string;
+  facilityURN: number;
   guaranteeCommencementDate: string;
   guaranteeExpiryDate: string;
-  guaranteeFeePercentage: string;
-  guaranteePercentage: string;
+  guaranteeFeePercentage: number;
+  guaranteePercentage: number;
   dayBasis: string;
-  exposurePeriod: string;
+  exposurePeriod: number;
   maximumLiability: number;
   cumulativeAmount: number;
 }

--- a/external-api/src/interfaces/premiumSchedule.interface.ts
+++ b/external-api/src/interfaces/premiumSchedule.interface.ts
@@ -1,0 +1,14 @@
+export interface PremiumSchedule {
+  premiumTypeId: string;
+  premiumFrequencyId: string;
+  productGroup: string;
+  facilityURN: string;
+  guaranteeCommencementDate: string;
+  guaranteeExpiryDate: string;
+  guaranteeFeePercentage: string;
+  guaranteePercentage: string;
+  dayBasis: string;
+  exposurePeriod: string;
+  maximumLiability: number;
+  cumulativeAmount: number;
+}

--- a/external-api/src/v1/controllers/premium-schedule.controller.ts
+++ b/external-api/src/v1/controllers/premium-schedule.controller.ts
@@ -79,6 +79,12 @@ const getScheduleData = async (facilityId: any) => {
   return new Error(`Error getting Premium schedule segments. Facility:${facilityId}`);
 };
 
+/**
+ * Get premium schedule segments from facility URN
+ * @param {Express.Request} req Facility ID
+ * @param {Express.Response} res Facility ID
+ * @returns {Object} Premium schedule data
+ */
 export const getPremiumSchedule = async (req: Request, res: Response) => {
   const premiumScheduleParameters: PremiumSchedule = req.body;
 

--- a/external-api/src/v1/controllers/premium-schedule.controller.ts
+++ b/external-api/src/v1/controllers/premium-schedule.controller.ts
@@ -8,6 +8,7 @@ import axios from 'axios';
 import * as dotenv from 'dotenv';
 import { Request, Response } from 'express';
 import { objectIsEmpty } from '../../utils';
+import { PremiumSchedule } from '../../interfaces';
 dotenv.config();
 
 const mdm: any = process.env.APIM_MDM_URL;
@@ -79,7 +80,7 @@ const getScheduleData = async (facilityId: any) => {
 };
 
 export const getPremiumSchedule = async (req: Request, res: Response) => {
-  const premiumScheduleParameters = req.body;
+  const premiumScheduleParameters: PremiumSchedule = req.body;
 
   const postPremiumScheduleResponse = await postPremiumSchedule(premiumScheduleParameters);
 


### PR DESCRIPTION
## Introduction
The get premium schedule endpoint posted the request body without any sanitization meaning it was vulnerable to having extra fields than what it should accept in request body and sending all of those on.

## Resolution
Introduce new interface to cast the request body to so that extra fields aren't passed through.