### PR TITLE
feat(FN-573): Configure automatic A Record generation

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -170,6 +170,7 @@ module storage 'modules/storage.bicep' = {
     allowedIpsString: onPremiseNetworkIpsString
     networkAccessDefaultAction: storageNetworkAccessDefaultAction
     shareDeleteRetentionEnabled: shareDeleteRetentionEnabled
+    filesDnsZoneId: filesDns.outputs.filesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/modules/privatelink-file-core-windows-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-file-core-windows-net.bicep
@@ -41,20 +41,4 @@ resource filesVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@20
   }
 }
 
-// TODO:DTFS-6422 Wire up A record IPs correctly, getting appropriate values.
-
-// // Dev A records
-
-// // TODO:DTFS-6422 update ip values
-// resource devStorage 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: filesDnsZone
-//   name: 'tfsdevstorage'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.4'
-//       }
-//     ]
-//   }
-// }
+output filesDnsZoneId string = filesDnsZone.id


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers wiring up the A Record generation in the private DNS for the storage private link.
If all is ok, we can apply this to all the private links.

### Resolution

This code adds a private dns zone config, which triggers the CNAME generation and management.
See the resources here:
https://stackoverflow.com/questions/69810938/what-is-azure-private-dns-zone-group
https://learn.microsoft.com/en-us/azure/private-link/create-private-endpoint-bicep?tabs=CLI
https://bhabalajinkya.medium.com/azure-bicep-private-communication-between-azure-resources-f4a17c171cfb