### PR TITLE
feat(FN-422): Add dtfs-central-api webapp

### DIFF
--- a/infrastructure/arm_templates/app-service-plan/parameters.json
+++ b/infrastructure/arm_templates/app-service-plan/parameters.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serverfarms_dev_name": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/app-service-plan/template.json
+++ b/infrastructure/arm_templates/app-service-plan/template.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serverfarms_dev_name": {
+            "defaultValue": "dev",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2022-09-01",
+            "name": "[parameters('serverfarms_dev_name')]",
+            "location": "UK South",
+            "tags": {
+                "hidden-related:diagnostics/changeAnalysisScanEnabled": "true",
+                "Environment": "Preproduction",
+                "Product": "exip, dtfs"
+            },
+            "sku": {
+                "name": "P2v2",
+                "tier": "PremiumV2",
+                "size": "P2v2",
+                "family": "Pv2",
+                "capacity": 1
+            },
+            "kind": "linux",
+            "properties": {
+                "perSiteScaling": false,
+                "elasticScaleEnabled": false,
+                "maximumElasticWorkerCount": 1,
+                "isSpot": false,
+                "reserved": true,
+                "isXenon": false,
+                "hyperV": false,
+                "targetWorkerCount": 0,
+                "targetWorkerSizeId": 0,
+                "zoneRedundant": false
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/dtfs-central-api/application-insights/parameters.json
+++ b/infrastructure/arm_templates/dtfs-central-api/application-insights/parameters.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "components_tfs_dev_dtfs_central_api_name": {
+            "value": null
+        },
+        "workspaces_digital_dev_logs_workspace_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/dtfs-central-api/application-insights/template.json
+++ b/infrastructure/arm_templates/dtfs-central-api/application-insights/template.json
@@ -1,0 +1,349 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "components_tfs_dev_dtfs_central_api_name": {
+            "defaultValue": "tfs-dev-dtfs-central-api",
+            "type": "String"
+        },
+        "workspaces_digital_dev_logs_workspace_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/digital-dev/providers/microsoft.operationalinsights/workspaces/digital-dev-logs-workspace",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "microsoft.insights/components",
+            "apiVersion": "2020-02-02",
+            "name": "[parameters('components_tfs_dev_dtfs_central_api_name')]",
+            "location": "uksouth",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "kind": "web",
+            "properties": {
+                "Application_Type": "web",
+                "Flow_Type": "Redfield",
+                "Request_Source": "IbizaAIExtensionEnablementBlade",
+                "RetentionInDays": 90,
+                "WorkspaceResourceId": "[parameters('workspaces_digital_dev_logs_workspace_externalid')]",
+                "IngestionMode": "LogAnalytics",
+                "publicNetworkAccessForIngestion": "Enabled",
+                "publicNetworkAccessForQuery": "Enabled"
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/degradationindependencyduration')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "degradationindependencyduration",
+                    "DisplayName": "Degradation in dependency duration",
+                    "Description": "Smart Detection rules notify you of performance anomaly issues.",
+                    "HelpUrl": "https://docs.microsoft.com/en-us/azure/application-insights/app-insights-proactive-performance-diagnostics",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": false,
+                    "SupportsEmailNotifications": true
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/degradationinserverresponsetime')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "degradationinserverresponsetime",
+                    "DisplayName": "Degradation in server response time",
+                    "Description": "Smart Detection rules notify you of performance anomaly issues.",
+                    "HelpUrl": "https://docs.microsoft.com/en-us/azure/application-insights/app-insights-proactive-performance-diagnostics",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": false,
+                    "SupportsEmailNotifications": true
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/digestMailConfiguration')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "digestMailConfiguration",
+                    "DisplayName": "Digest Mail Configuration",
+                    "Description": "This rule describes the digest mail preferences",
+                    "HelpUrl": "www.homail.com",
+                    "IsHidden": true,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": false,
+                    "SupportsEmailNotifications": true
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/extension_billingdatavolumedailyspikeextension')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "extension_billingdatavolumedailyspikeextension",
+                    "DisplayName": "Abnormal rise in daily data volume (preview)",
+                    "Description": "This detection rule automatically analyzes the billing data generated by your application, and can warn you about an unusual increase in your application's billing costs",
+                    "HelpUrl": "https://github.com/Microsoft/ApplicationInsights-Home/tree/master/SmartDetection/billing-data-volume-daily-spike.md",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/extension_canaryextension')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "extension_canaryextension",
+                    "DisplayName": "Canary extension",
+                    "Description": "Canary extension",
+                    "HelpUrl": "https://github.com/Microsoft/ApplicationInsights-Home/blob/master/SmartDetection/",
+                    "IsHidden": true,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/extension_exceptionchangeextension')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "extension_exceptionchangeextension",
+                    "DisplayName": "Abnormal rise in exception volume (preview)",
+                    "Description": "This detection rule automatically analyzes the exceptions thrown in your application, and can warn you about unusual patterns in your exception telemetry.",
+                    "HelpUrl": "https://github.com/Microsoft/ApplicationInsights-Home/blob/master/SmartDetection/abnormal-rise-in-exception-volume.md",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/extension_memoryleakextension')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "extension_memoryleakextension",
+                    "DisplayName": "Potential memory leak detected (preview)",
+                    "Description": "This detection rule automatically analyzes the memory consumption of each process in your application, and can warn you about potential memory leaks or increased memory consumption.",
+                    "HelpUrl": "https://github.com/Microsoft/ApplicationInsights-Home/tree/master/SmartDetection/memory-leak.md",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/extension_securityextensionspackage')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "extension_securityextensionspackage",
+                    "DisplayName": "Potential security issue detected (preview)",
+                    "Description": "This detection rule automatically analyzes the telemetry generated by your application and detects potential security issues.",
+                    "HelpUrl": "https://github.com/Microsoft/ApplicationInsights-Home/blob/master/SmartDetection/application-security-detection-pack.md",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/extension_traceseveritydetector')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "extension_traceseveritydetector",
+                    "DisplayName": "Degradation in trace severity ratio (preview)",
+                    "Description": "This detection rule automatically analyzes the trace logs emitted from your application, and can warn you about unusual patterns in the severity of your trace telemetry.",
+                    "HelpUrl": "https://github.com/Microsoft/ApplicationInsights-Home/blob/master/SmartDetection/degradation-in-trace-severity-ratio.md",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/longdependencyduration')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "longdependencyduration",
+                    "DisplayName": "Long dependency duration",
+                    "Description": "Smart Detection rules notify you of performance anomaly issues.",
+                    "HelpUrl": "https://docs.microsoft.com/en-us/azure/application-insights/app-insights-proactive-performance-diagnostics",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": false,
+                    "SupportsEmailNotifications": true
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/migrationToAlertRulesCompleted')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "migrationToAlertRulesCompleted",
+                    "DisplayName": "Migration To Alert Rules Completed",
+                    "Description": "A configuration that controls the migration state of Smart Detection to Smart Alerts",
+                    "HelpUrl": "https://docs.microsoft.com/en-us/azure/application-insights/app-insights-proactive-performance-diagnostics",
+                    "IsHidden": true,
+                    "IsEnabledByDefault": false,
+                    "IsInPreview": true,
+                    "SupportsEmailNotifications": false
+                },
+                "enabled": false,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/slowpageloadtime')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "slowpageloadtime",
+                    "DisplayName": "Slow page load time",
+                    "Description": "Smart Detection rules notify you of performance anomaly issues.",
+                    "HelpUrl": "https://docs.microsoft.com/en-us/azure/application-insights/app-insights-proactive-performance-diagnostics",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": false,
+                    "SupportsEmailNotifications": true
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        },
+        {
+            "type": "microsoft.insights/components/ProactiveDetectionConfigs",
+            "apiVersion": "2018-05-01-preview",
+            "name": "[concat(parameters('components_tfs_dev_dtfs_central_api_name'), '/slowserverresponsetime')]",
+            "location": "uksouth",
+            "dependsOn": [
+                "[resourceId('microsoft.insights/components', parameters('components_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "ruleDefinitions": {
+                    "Name": "slowserverresponsetime",
+                    "DisplayName": "Slow server response time",
+                    "Description": "Smart Detection rules notify you of performance anomaly issues.",
+                    "HelpUrl": "https://docs.microsoft.com/en-us/azure/application-insights/app-insights-proactive-performance-diagnostics",
+                    "IsHidden": false,
+                    "IsEnabledByDefault": true,
+                    "IsInPreview": false,
+                    "SupportsEmailNotifications": true
+                },
+                "enabled": true,
+                "sendEmailsToSubscriptionOwners": true,
+                "customEmails": []
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/dtfs-central-api/errors.json
+++ b/infrastructure/arm_templates/dtfs-central-api/errors.json
@@ -1,0 +1,21 @@
+{
+    "code": "ExportTemplateCompletedWithErrors",
+    "message": "Export template operation completed with errors. Some resources were not exported. Please see details for more information.",
+    "details": [
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.Web/sites/extensions",
+            "message": "Could not get resources of the type 'Microsoft.Web/sites/extensions'. Resources of this type will not be exported."
+        },
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.Web/sites/siteextensions",
+            "message": "Could not get resources of the type 'Microsoft.Web/sites/siteextensions'. Resources of this type will not be exported."
+        },
+        {
+            "code": "ExportTemplateProviderError",
+            "target": "Microsoft.Web/sites/hybridconnection",
+            "message": "Could not get resources of the type 'Microsoft.Web/sites/hybridconnection'. Resources of this type will not be exported."
+        }
+    ]
+}

--- a/infrastructure/arm_templates/dtfs-central-api/parameters.json
+++ b/infrastructure/arm_templates/dtfs-central-api/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "sites_tfs_dev_dtfs_central_api_name": {
+            "value": null
+        },
+        "serverfarms_dev_externalid": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/dtfs-central-api/private-endpoint/parameters.json
+++ b/infrastructure/arm_templates/dtfs-central-api/private-endpoint/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "privateEndpoints_tfs_dev_dtfs_central_api_name": {
+            "value": null
+        },
+        "sites_tfs_dev_dtfs_central_api_externalid": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/dtfs-central-api/private-endpoint/template.json
+++ b/infrastructure/arm_templates/dtfs-central-api/private-endpoint/template.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "privateEndpoints_tfs_dev_dtfs_central_api_name": {
+            "defaultValue": "tfs-dev-dtfs-central-api",
+            "type": "String"
+        },
+        "sites_tfs_dev_dtfs_central_api_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Web/sites/tfs-dev-dtfs-central-api",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-11-01",
+            "name": "[parameters('privateEndpoints_tfs_dev_dtfs_central_api_name')]",
+            "location": "uksouth",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "[parameters('privateEndpoints_tfs_dev_dtfs_central_api_name')]",
+                        "id": "[concat(resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpoints_tfs_dev_dtfs_central_api_name')), concat('/privateLinkServiceConnections/', parameters('privateEndpoints_tfs_dev_dtfs_central_api_name')))]",
+                        "properties": {
+                            "privateLinkServiceId": "[parameters('sites_tfs_dev_dtfs_central_api_externalid')]",
+                            "groupIds": [
+                                "sites"
+                            ],
+                            "privateLinkServiceConnectionState": {
+                                "status": "Approved",
+                                "actionsRequired": "None"
+                            }
+                        }
+                    }
+                ],
+                "manualPrivateLinkServiceConnections": [],
+                "subnet": {
+                    "id": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-private-endpoints')]"
+                },
+                "ipConfigurations": [],
+                "customDnsConfigs": [
+                    {
+                        "fqdn": "[concat(parameters('privateEndpoints_tfs_dev_dtfs_central_api_name'), '.azurewebsites.net')]",
+                        "ipAddresses": [
+                            "172.16.40.8"
+                        ]
+                    },
+                    {
+                        "fqdn": "[concat(parameters('privateEndpoints_tfs_dev_dtfs_central_api_name'), '.scm.azurewebsites.net')]",
+                        "ipAddresses": [
+                            "172.16.40.8"
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/dtfs-central-api/template.json
+++ b/infrastructure/arm_templates/dtfs-central-api/template.json
@@ -1,0 +1,1879 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "sites_tfs_dev_dtfs_central_api_name": {
+            "defaultValue": "tfs-dev-dtfs-central-api",
+            "type": "String"
+        },
+        "serverfarms_dev_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Web/serverfarms/dev",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2022-09-01",
+            "name": "[parameters('sites_tfs_dev_dtfs_central_api_name')]",
+            "location": "UK South",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "kind": "app,linux,container",
+            "properties": {
+                "enabled": true,
+                "hostNameSslStates": [
+                    {
+                        "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '.azurewebsites.net')]",
+                        "sslState": "Disabled",
+                        "hostType": "Standard"
+                    },
+                    {
+                        "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '.scm.azurewebsites.net')]",
+                        "sslState": "Disabled",
+                        "hostType": "Repository"
+                    }
+                ],
+                "serverFarmId": "[parameters('serverfarms_dev_externalid')]",
+                "reserved": true,
+                "isXenon": false,
+                "hyperV": false,
+                "vnetRouteAllEnabled": true,
+                "vnetImagePullEnabled": false,
+                "vnetContentShareEnabled": false,
+                "siteConfig": {
+                    "numberOfWorkers": 1,
+                    "linuxFxVersion": "DOCKER|tfsdev.azurecr.io/dtfs-central-api:dev",
+                    "acrUseManagedIdentityCreds": false,
+                    "alwaysOn": true,
+                    "http20Enabled": true,
+                    "functionAppScaleLimit": 0,
+                    "minimumElasticInstanceCount": 0
+                },
+                "scmSiteAlsoStopped": false,
+                "clientAffinityEnabled": true,
+                "clientCertEnabled": false,
+                "clientCertMode": "Required",
+                "hostNamesDisabled": false,
+                "customDomainVerificationId": "799591A29BF706E656906E134F41DABB87DFAD60A3D5E73B22B7E45E5A356B5C",
+                "containerSize": 0,
+                "dailyMemoryTimeQuota": 0,
+                "httpsOnly": false,
+                "redundancyMode": "None",
+                "storageAccountRequired": false,
+                "virtualNetworkSubnetId": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-app-service-plan-egress')]",
+                "keyVaultReferenceIdentity": "SystemAssigned"
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/ftp')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "allow": true
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/scm')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "allow": true
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/config",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/web')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "numberOfWorkers": 1,
+                "defaultDocuments": [
+                    "Default.htm",
+                    "Default.html",
+                    "Default.asp",
+                    "index.htm",
+                    "index.html",
+                    "iisstart.htm",
+                    "default.aspx",
+                    "index.php",
+                    "hostingstart.html"
+                ],
+                "netFrameworkVersion": "v4.0",
+                "linuxFxVersion": "DOCKER|tfsdev.azurecr.io/dtfs-central-api:dev",
+                "requestTracingEnabled": false,
+                "remoteDebuggingEnabled": false,
+                "remoteDebuggingVersion": "VS2019",
+                "httpLoggingEnabled": true,
+                "acrUseManagedIdentityCreds": false,
+                "logsDirectorySizeLimit": 100,
+                "detailedErrorLoggingEnabled": false,
+                "publishingUsername": "$tfs-dev-dtfs-central-api",
+                "scmType": "None",
+                "use32BitWorkerProcess": true,
+                "webSocketsEnabled": false,
+                "alwaysOn": true,
+                "managedPipelineMode": "Integrated",
+                "virtualApplications": [
+                    {
+                        "virtualPath": "/",
+                        "physicalPath": "site\\wwwroot",
+                        "preloadEnabled": true
+                    }
+                ],
+                "loadBalancing": "LeastRequests",
+                "experiments": {
+                    "rampUpRules": []
+                },
+                "autoHealEnabled": false,
+                "vnetName": "5c50c79a-d80a-4a69-9acb-6f1a859658a9_dev-app-service-plan-egress",
+                "vnetRouteAllEnabled": true,
+                "vnetPrivatePortsCount": 0,
+                "localMySqlEnabled": false,
+                "ipSecurityRestrictions": [
+                    {
+                        "ipAddress": "Any",
+                        "action": "Allow",
+                        "priority": 2147483647,
+                        "name": "Allow all",
+                        "description": "Allow all access"
+                    }
+                ],
+                "scmIpSecurityRestrictions": [
+                    {
+                        "ipAddress": "Any",
+                        "action": "Allow",
+                        "priority": 2147483647,
+                        "name": "Allow all",
+                        "description": "Allow all access"
+                    }
+                ],
+                "scmIpSecurityRestrictionsUseMain": false,
+                "http20Enabled": true,
+                "minTlsVersion": "1.2",
+                "scmMinTlsVersion": "1.0",
+                "ftpsState": "Disabled",
+                "preWarmedInstanceCount": 0,
+                "elasticWebAppScaleLimit": 0,
+                "functionsRuntimeScaleMonitoringEnabled": false,
+                "minimumElasticInstanceCount": 0,
+                "azureStorageAccounts": {}
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/hostNameBindings",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/', parameters('sites_tfs_dev_dtfs_central_api_name'), '.azurewebsites.net')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "siteName": "tfs-dev-dtfs-central-api",
+                "hostNameType": "Verified"
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/privateEndpointConnections",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/', parameters('sites_tfs_dev_dtfs_central_api_name'), '-e0c5a7d2-d4f7-4244-a379-0d406a301909')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "privateLinkServiceConnectionState": {
+                    "status": "Approved",
+                    "actionsRequired": "None"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-29T12_44_48_6111692')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-29T18_44_48_7343127')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-30T03_44_48_9533224')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-30T12_44_49_1682756')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-30T18_44_49_3007591')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-31T03_44_49_4786513')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-31T12_44_49_7094830')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-05-31T18_44_49_8437779')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-01T03_44_50_0445824')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-01T12_44_50_2726358')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-01T18_44_50_4057340')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-02T03_44_50_5866566')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-02T12_44_50_8542914')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-02T18_44_50_9569992')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-03T03_44_51_1767458')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-03T12_44_51_4503678')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-03T18_44_51_5340014')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-04T03_44_51_7773959')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-04T12_44_52_1742356')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-04T18_44_52_2877726')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-05T03_44_52_5145656')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-05T12_44_52_7584300')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-05T18_44_52_8870140')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-06T03_44_53_1350220')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-06T12_44_53_3748627')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-06T18_44_53_4843741')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-07T03_44_53_7746385')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-07T12_44_54_1450966')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-07T18_44_54_0576762')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-08T03_44_54_2520142')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-08T12_44_54_6204170')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-08T18_44_54_7482157')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-09T03_44_54_9163407')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-09T12_44_55_1373481')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-09T18_44_55_2792895')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-10T03_44_55_4804266')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-10T12_44_55_7016727')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-10T18_44_56_3968982')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-11T03_44_56_6248026')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-11T12_44_56_8401777')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-11T18_44_56_9604007')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-12T03_44_57_1480943')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-12T12_44_57_3733426')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-12T18_44_57_4931845')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-13T03_44_57_7213535')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-13T12_44_57_9217309')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-13T18_44_58_0468652')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-14T03_44_58_2706377')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-14T12_44_58_4927173')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-14T15_44_58_5961353')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-14T18_44_58_6079869')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-14T21_44_58_6366097')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-15T00_44_58_7146212')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-15T03_44_58_7539083')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-15T12_44_58_9928466')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-15T15_44_59_0509615')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-15T18_44_59_1975370')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-15T21_44_59_2529206')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-16T00_44_59_3090448')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-16T03_45_00_1974429')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-16T12_45_00_4578894')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-16T15_45_00_6503275')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-16T18_45_00_8023388')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-16T21_45_00_7861797')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-17T00_45_00_6227671')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-17T03_45_00_7746998')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-17T12_45_00_9107935')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-17T15_45_00_9883547')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-17T18_45_01_1045841')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-17T21_45_01_1433280')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-18T00_45_01_2230335')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-18T03_45_01_2679022')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-18T12_45_01_5400044')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-18T15_45_01_5763479')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-18T18_45_01_6442916')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-18T21_45_01_6965571')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-19T00_45_01_7749648')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-19T03_45_01_8679860')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-19T12_45_02_0965434')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-19T15_45_02_1525737')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-19T18_45_02_2609350')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-19T21_45_02_3055811')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-20T00_45_02_3551048')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-20T03_45_02_4675831')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-20T12_45_03_1820692')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-20T15_45_03_2655081')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-20T18_45_03_3480604')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-20T21_45_03_3710878')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-21T00_45_03_4407910')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-21T03_45_03_5335381')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-21T12_45_04_0806411')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-21T15_45_03_8285649')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-21T18_45_03_8548785')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-21T21_45_03_9483671')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-22T00_45_04_0315740')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-22T03_45_04_1991228')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-22T12_45_04_3236438')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-22T15_45_04_5385699')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-22T18_45_04_4647622')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-22T21_45_04_5533744')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-23T00_45_04_6195136')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-23T03_45_04_6757763')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-23T12_45_04_8831274')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-23T15_45_04_9472590')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-23T18_45_05_0132738')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-23T21_45_05_0785617')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T00_45_05_7174309')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T03_45_05_8023528')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T10_45_05_9637331')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T11_45_05_9971212')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T12_45_06_0188785')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T13_45_05_9864719')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T14_45_06_0334974')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T15_45_06_0356227')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T16_45_06_0521506')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T17_45_06_1058420')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T18_45_06_1223846')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T19_45_06_1489568')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T20_45_06_1745237')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T21_45_06_1899529')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T22_45_06_2405439')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-24T23_45_06_2530191')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T00_45_06_2726884')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T01_45_06_3160729')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T02_45_06_3407991')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T03_45_06_3389392')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T04_45_06_3838923')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T05_45_06_4257926')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T06_45_06_4198654')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T07_45_06_4706268')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T08_45_06_4667972')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T09_45_06_4776284')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T10_45_06_5218421')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T11_45_06_5656134')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T12_45_06_5568137')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T13_45_06_5786276')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T14_45_06_6179229')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T15_45_06_6406331')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T16_45_06_6600490')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T17_45_06_6721884')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T18_45_06_7039439')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T19_45_06_7186142')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T20_45_06_7563653')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T21_45_06_7915477')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T22_45_06_8186745')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-25T23_45_06_8491995')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T00_45_06_8622858')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T01_45_06_9396549')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T02_45_06_9220278')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T03_45_06_9277556')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T04_45_06_9565204')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T05_45_06_9809747')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T06_45_07_0054523')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T07_45_07_0397384')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T08_45_07_0724570')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T09_45_07_0606836')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T10_45_07_1017870')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T11_45_07_1724066')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T12_45_07_1467223')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T13_45_07_1802861')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T14_45_07_1913675')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T15_45_07_2359353')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T16_45_07_2466492')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T17_45_07_2593716')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T18_45_07_2888284')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T19_45_07_3630702')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T20_45_07_3273222')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T21_45_07_3493049')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T22_45_07_3734948')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-26T23_45_07_4027716')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T00_45_07_4299819')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T01_45_07_4422408')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T02_45_07_4835857')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T03_45_07_4829442')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T04_45_07_5282186')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T05_45_07_5436934')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T06_45_07_6000990')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T07_45_07_5842674')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T08_45_08_3252443')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T09_45_07_6457417')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T10_45_07_6909684')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T11_45_07_7188336')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T12_45_07_7669567')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T13_45_07_7398053')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T14_45_07_7561542')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T15_45_07_7917040')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T16_45_08_1037523')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T17_45_07_8272404')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T18_45_07_8656200')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T19_45_08_5447369')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T20_45_07_8983174')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T21_45_07_9896003')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T22_45_07_9758920')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-27T23_45_07_9951759')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T00_45_08_0264384')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T01_45_08_0332390')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T02_45_08_0708691')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T03_45_08_1606037')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T04_45_08_1223449')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T05_45_08_9146071')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T06_45_08_3962804')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T07_45_08_2129791')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T08_45_08_2191785')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T09_45_08_2353634')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T10_45_08_2776594')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/2023-06-28T11_45_09_0404717')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/virtualNetworkConnections",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_dtfs_central_api_name'), '/5c50c79a-d80a-4a69-9acb-6f1a859658a9_dev-app-service-plan-egress')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_dtfs_central_api_name'))]"
+            ],
+            "properties": {
+                "vnetResourceId": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-app-service-plan-egress')]",
+                "isSwift": true
+            }
+        }
+    ]
+}

--- a/infrastructure/arm_templates/log-analytics-workspace/parameters.json
+++ b/infrastructure/arm_templates/log-analytics-workspace/parameters.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "workspaces_digital_dev_logs_workspace_name": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/log-analytics-workspace/template.json
+++ b/infrastructure/arm_templates/log-analytics-workspace/template.json
@@ -1,0 +1,8380 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "workspaces_digital_dev_logs_workspace_name": {
+            "defaultValue": "digital-dev-logs-workspace",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "microsoft.operationalinsights/workspaces",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[parameters('workspaces_digital_dev_logs_workspace_name')]",
+            "location": "uksouth",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "sku": {
+                    "name": "pergb2018"
+                },
+                "retentionInDays": 30,
+                "features": {
+                    "enableLogAccessUsingOnlyResourcePermissions": true
+                },
+                "workspaceCapping": {
+                    "dailyQuotaGb": -1
+                },
+                "publicNetworkAccessForIngestion": "Enabled",
+                "publicNetworkAccessForQuery": "Enabled"
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_General|AlphabeticallySortedComputers')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Computers with their most recent data",
+                "category": "General Exploration",
+                "query": "search not(ObjectName == \"Advisor Metrics\" or ObjectName == \"ManagedSpace\") | summarize AggregatedValue = max(TimeGenerated) by Computer | limit 500000 | sort by Computer asc\r\n// Oql: NOT(ObjectName=\"Advisor Metrics\" OR ObjectName=ManagedSpace) | measure max(TimeGenerated) by Computer | top 500000 | Sort Computer // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_General|dataPointsPerManagementGroup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Which Management Group is generating the most data points?",
+                "category": "General Exploration",
+                "query": "search * | summarize AggregatedValue = count() by ManagementGroupName\r\n// Oql: * | Measure count() by ManagementGroupName // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_General|dataTypeDistribution')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Distribution of data Types",
+                "category": "General Exploration",
+                "query": "search * | extend Type = $table | summarize AggregatedValue = count() by Type\r\n// Oql: * | Measure count() by Type // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_General|StaleComputers')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Stale Computers (data older than 24 hours)",
+                "category": "General Exploration",
+                "query": "search not(ObjectName == \"Advisor Metrics\" or ObjectName == \"ManagedSpace\") | summarize lastdata = max(TimeGenerated) by Computer | limit 500000 | where lastdata < ago(24h)\r\n// Oql: NOT(ObjectName=\"Advisor Metrics\" OR ObjectName=ManagedSpace) | measure max(TimeGenerated) as lastdata by Computer | top 500000 | where lastdata < NOW-24HOURS // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AllEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Events",
+                "category": "Log Management",
+                "query": "Event | sort by TimeGenerated desc\r\n// Oql: Type=Event // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AllSyslog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Syslogs",
+                "category": "Log Management",
+                "query": "Syslog | sort by TimeGenerated desc\r\n// Oql: Type=Syslog // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AllSyslogByFacility')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Syslog Records grouped by Facility",
+                "category": "Log Management",
+                "query": "Syslog | summarize AggregatedValue = count() by Facility\r\n// Oql: Type=Syslog | Measure count() by Facility // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AllSyslogByProcessName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Syslog Records grouped by ProcessName",
+                "category": "Log Management",
+                "query": "Syslog | summarize AggregatedValue = count() by ProcessName\r\n// Oql: Type=Syslog | Measure count() by ProcessName // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AllSyslogsWithErrors')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Syslog Records with Errors",
+                "category": "Log Management",
+                "query": "Syslog | where SeverityLevel == \"error\" | sort by TimeGenerated desc\r\n// Oql: Type=Syslog SeverityLevel=error // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AverageHTTPRequestTimeByClientIPAddress')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Average HTTP Request time by Client IP Address",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = avg(TimeTaken) by cIP\r\n// Oql: Type=W3CIISLog | Measure Avg(TimeTaken) by cIP // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|AverageHTTPRequestTimeHTTPMethod')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Average HTTP Request time by HTTP Method",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = avg(TimeTaken) by csMethod\r\n// Oql: Type=W3CIISLog | Measure Avg(TimeTaken) by csMethod // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountIISLogEntriesClientIPAddress')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of IIS Log Entries by Client IP Address",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by cIP\r\n// Oql: Type=W3CIISLog | Measure count() by cIP // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountIISLogEntriesHTTPRequestMethod')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of IIS Log Entries by HTTP Request Method",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by csMethod\r\n// Oql: Type=W3CIISLog | Measure count() by csMethod // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountIISLogEntriesHTTPUserAgent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of IIS Log Entries by HTTP User Agent",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by csUserAgent\r\n// Oql: Type=W3CIISLog | Measure count() by csUserAgent // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountOfIISLogEntriesByHostRequestedByClient')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of IIS Log Entries by Host requested by client",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by csHost\r\n// Oql: Type=W3CIISLog | Measure count() by csHost // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountOfIISLogEntriesByURLForHost')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of IIS Log Entries by URL for the host \"www.contoso.com\" (replace with your own)",
+                "category": "Log Management",
+                "query": "search csHost == \"www.contoso.com\" | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by csUriStem\r\n// Oql: Type=W3CIISLog csHost=\"www.contoso.com\" | Measure count() by csUriStem // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountOfIISLogEntriesByURLRequestedByClient')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of IIS Log Entries by URL requested by client (without query strings)",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by csUriStem\r\n// Oql: Type=W3CIISLog | Measure count() by csUriStem // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|CountOfWarningEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of Events with level \"Warning\" grouped by Event ID",
+                "category": "Log Management",
+                "query": "Event | where EventLevelName == \"warning\" | summarize AggregatedValue = count() by EventID\r\n// Oql: Type=Event EventLevelName=warning | Measure count() by EventID // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|DisplayBreakdownRespondCodes')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Shows breakdown of response codes",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by scStatus\r\n// Oql: Type=W3CIISLog | Measure count() by scStatus // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|EventsByEventLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of Events grouped by Event Log",
+                "category": "Log Management",
+                "query": "Event | summarize AggregatedValue = count() by EventLog\r\n// Oql: Type=Event | Measure count() by EventLog // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|EventsByEventsID')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of Events grouped by Event ID",
+                "category": "Log Management",
+                "query": "Event | summarize AggregatedValue = count() by EventID\r\n// Oql: Type=Event | Measure count() by EventID // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|EventsByEventSource')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of Events grouped by Event Source",
+                "category": "Log Management",
+                "query": "Event | summarize AggregatedValue = count() by Source\r\n// Oql: Type=Event | Measure count() by Source // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|EventsInOMBetween2000to3000')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Events in the Operations Manager Event Log whose Event ID is in the range between 2000 and 3000",
+                "category": "Log Management",
+                "query": "Event | where EventLog == \"Operations Manager\" and EventID >= 2000 and EventID <= 3000 | sort by TimeGenerated desc\r\n// Oql: Type=Event EventLog=\"Operations Manager\" EventID:[2000..3000] // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|EventsWithStartedinEventID')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Count of Events containing the word \"started\" grouped by EventID",
+                "category": "Log Management",
+                "query": "search in (Event) \"started\" | summarize AggregatedValue = count() by EventID\r\n// Oql: Type=Event \"started\" | Measure count() by EventID // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|FindMaximumTimeTakenForEachPage')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Find the maximum time taken for each page",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = max(TimeTaken) by csUriStem\r\n// Oql: Type=W3CIISLog | Measure Max(TimeTaken) by csUriStem // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|IISLogEntriesForClientIP')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "IIS Log Entries for a specific client IP Address (replace with your own)",
+                "category": "Log Management",
+                "query": "search cIP == \"192.168.0.1\" | extend Type = $table | where Type == W3CIISLog | sort by TimeGenerated desc | project csUriStem, scBytes, csBytes, TimeTaken, scStatus\r\n// Oql: Type=W3CIISLog cIP=\"192.168.0.1\" | Select csUriStem,scBytes,csBytes,TimeTaken,scStatus // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|ListAllIISLogEntries')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All IIS Log Entries",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | sort by TimeGenerated desc\r\n// Oql: Type=W3CIISLog // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|NoOfConnectionsToOMSDKService')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "How many connections to Operations Manager's SDK service by day",
+                "category": "Log Management",
+                "query": "Event | where EventID == 26328 and EventLog == \"Operations Manager\" | summarize AggregatedValue = count() by bin(TimeGenerated, 1d) | sort by TimeGenerated desc\r\n// Oql: Type=Event EventID=26328 EventLog=\"Operations Manager\" | Measure count() interval 1DAY // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|ServerRestartTime')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "When did my servers initiate restart?",
+                "category": "Log Management",
+                "query": "search in (Event) \"shutdown\" and EventLog == \"System\" and Source == \"User32\" and EventID == 1074 | sort by TimeGenerated desc | project TimeGenerated, Computer\r\n// Oql: shutdown Type=Event EventLog=System Source=User32 EventID=1074 | Select TimeGenerated,Computer // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|Show404PagesList')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Shows which pages people are getting a 404 for",
+                "category": "Log Management",
+                "query": "search scStatus == 404 | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by csUriStem\r\n// Oql: Type=W3CIISLog scStatus=404 | Measure count() by csUriStem // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|ShowServersThrowingInternalServerError')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Shows servers that are throwing internal server error",
+                "category": "Log Management",
+                "query": "search scStatus == 500 | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = count() by sComputerName\r\n// Oql: Type=W3CIISLog scStatus=500 | Measure count() by sComputerName // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|TotalBytesReceivedByEachAzureRoleInstance')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Total Bytes received by each Azure Role Instance",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = sum(csBytes) by RoleInstance\r\n// Oql: Type=W3CIISLog | Measure Sum(csBytes) by RoleInstance // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|TotalBytesReceivedByEachIISComputer')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Total Bytes received by each IIS Computer",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = sum(csBytes) by Computer | limit 500000\r\n// Oql: Type=W3CIISLog | Measure Sum(csBytes) by Computer | top 500000 // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|TotalBytesRespondedToClientsByClientIPAddress')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Total Bytes responded back to clients by Client IP Address",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = sum(scBytes) by cIP\r\n// Oql: Type=W3CIISLog | Measure Sum(scBytes) by cIP // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|TotalBytesRespondedToClientsByEachIISServerIPAddress')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Total Bytes responded back to clients by each IIS ServerIP Address",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = sum(scBytes) by sIP\r\n// Oql: Type=W3CIISLog | Measure Sum(scBytes) by sIP // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|TotalBytesSentByClientIPAddress')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Total Bytes sent by Client IP Address",
+                "category": "Log Management",
+                "query": "search * | extend Type = $table | where Type == W3CIISLog | summarize AggregatedValue = sum(csBytes) by cIP\r\n// Oql: Type=W3CIISLog | Measure Sum(csBytes) by cIP // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PEF: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|WarningEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "All Events with level \"Warning\"",
+                "category": "Log Management",
+                "query": "Event | where EventLevelName == \"warning\" | sort by TimeGenerated desc\r\n// Oql: Type=Event EventLevelName=warning // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|WindowsFireawallPolicySettingsChanged')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "Windows Firewall Policy settings have changed",
+                "category": "Log Management",
+                "query": "Event | where EventLog == \"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall\" and EventID == 2008 | sort by TimeGenerated desc\r\n// Oql: Type=Event EventLog=\"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall\" EventID=2008 // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/savedSearches",
+            "apiVersion": "2020-08-01",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogManagement(', parameters('workspaces_digital_dev_logs_workspace_name'), ')_LogManagement|WindowsFireawallPolicySettingsChangedByMachines')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "displayName": "On which machines and how many times have Windows Firewall Policy settings changed",
+                "category": "Log Management",
+                "query": "Event | where EventLog == \"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall\" and EventID == 2008 | summarize AggregatedValue = count() by Computer | limit 500000\r\n// Oql: Type=Event EventLog=\"Microsoft-Windows-Windows Firewall With Advanced Security/Firewall\" EventID=2008 | measure count() by Computer | top 500000 // Args: {OQ: True; WorkspaceId: 00000000-0000-0000-0000-000000000000} // Settings: {PTT: True; SortI: True; SortF: True} // Version: 0.1.122",
+                "version": 2
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AACAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AACAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AACHttpRequest')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AACHttpRequest"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADB2CRequestLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADB2CRequestLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesAccountLogon')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesAccountLogon"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesAccountManagement')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesAccountManagement"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesDirectoryServiceAccess')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesDirectoryServiceAccess"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesDNSAuditsDynamicUpdates')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesDNSAuditsDynamicUpdates"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesDNSAuditsGeneral')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesDNSAuditsGeneral"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesLogonLogoff')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesLogonLogoff"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesPolicyChange')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesPolicyChange"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesPrivilegeUse')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesPrivilegeUse"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADDomainServicesSystemSecurity')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADDomainServicesSystemSecurity"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADManagedIdentitySignInLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADManagedIdentitySignInLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADNonInteractiveUserSignInLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADNonInteractiveUserSignInLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADProvisioningLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADProvisioningLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADRiskyServicePrincipals')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADRiskyServicePrincipals"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADRiskyUsers')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADRiskyUsers"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADServicePrincipalRiskEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADServicePrincipalRiskEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADServicePrincipalSignInLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADServicePrincipalSignInLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AADUserRiskEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AADUserRiskEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ABSBotRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ABSBotRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ABSChannelToBotRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ABSChannelToBotRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ABSDependenciesRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ABSDependenciesRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACICollaborationAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACICollaborationAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACRConnectedClientList')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACRConnectedClientList"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSAuthIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSAuthIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSBillingUsage')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSBillingUsage"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallAutomationIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallAutomationIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallAutomationMediaSummary')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallAutomationMediaSummary"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallDiagnostics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallDiagnostics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallRecordingIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallRecordingIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallRecordingSummary')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallRecordingSummary"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallSummary')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallSummary"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSCallSurvey')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSCallSurvey"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSChatIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSChatIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSEmailSendMailOperational')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSEmailSendMailOperational"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSEmailStatusUpdateOperational')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSEmailStatusUpdateOperational"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSEmailUserEngagementOperational')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSEmailUserEngagementOperational"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSNetworkTraversalDiagnostics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSNetworkTraversalDiagnostics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSNetworkTraversalIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSNetworkTraversalIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSRoomsIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSRoomsIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ACSSMSIncomingOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ACSSMSIncomingOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AddonAzureBackupAlerts')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AddonAzureBackupAlerts"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AddonAzureBackupJobs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AddonAzureBackupJobs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AddonAzureBackupPolicy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AddonAzureBackupPolicy"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AddonAzureBackupProtectedInstance')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AddonAzureBackupProtectedInstance"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AddonAzureBackupStorage')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AddonAzureBackupStorage"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFActivityRun')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFActivityRun"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFAirflowSchedulerLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFAirflowSchedulerLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFAirflowTaskLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFAirflowTaskLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFAirflowWebLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFAirflowWebLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFAirflowWorkerLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFAirflowWorkerLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFPipelineRun')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFPipelineRun"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSandboxActivityRun')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSandboxActivityRun"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSandboxPipelineRun')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSandboxPipelineRun"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSignInLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSignInLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSISIntegrationRuntimeLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSISIntegrationRuntimeLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSISPackageEventMessageContext')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSISPackageEventMessageContext"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSISPackageEventMessages')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSISPackageEventMessages"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSISPackageExecutableStatistics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSISPackageExecutableStatistics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSISPackageExecutionComponentPhases')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSISPackageExecutionComponentPhases"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFSSISPackageExecutionDataStatistics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFSSISPackageExecutionDataStatistics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADFTriggerRun')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADFTriggerRun"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADPAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADPAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADPDiagnostics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADPDiagnostics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADPRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADPRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADSecurityAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADSecurityAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADTDataHistoryOperation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADTDataHistoryOperation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADTDigitalTwinsOperation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADTDigitalTwinsOperation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADTEventRoutesOperation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADTEventRoutesOperation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADTModelsOperation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADTModelsOperation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADTQueryOperation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADTQueryOperation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADXCommand')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADXCommand"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADXIngestionBatching')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADXIngestionBatching"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADXJournal')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADXJournal"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADXQuery')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADXQuery"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADXTableDetails')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADXTableDetails"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ADXTableUsageStatistics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ADXTableUsageStatistics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AegDataPlaneRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AegDataPlaneRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AegDeliveryFailureLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AegDeliveryFailureLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AegPublishFailureLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AegPublishFailureLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AEWAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AEWAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AEWComputePipelinesLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AEWComputePipelinesLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodApplicationAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodApplicationAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodFarmManagementLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodFarmManagementLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodFarmOperationLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodFarmOperationLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodInsightLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodInsightLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodJobProcessedLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodJobProcessedLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodModelInferenceLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodModelInferenceLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodProviderAuthLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodProviderAuthLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodSatelliteLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodSatelliteLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodSensorManagementLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodSensorManagementLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AgriFoodWeatherLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AgriFoodWeatherLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AGSGrafanaLoginEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AGSGrafanaLoginEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AHDSDicomAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AHDSDicomAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AHDSDicomDiagnosticLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AHDSDicomDiagnosticLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AHDSMedTechDiagnosticLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AHDSMedTechDiagnosticLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AirflowDagProcessingLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AirflowDagProcessingLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AKSAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AKSAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AKSAuditAdmin')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AKSAuditAdmin"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AKSControlPlane')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AKSControlPlane"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Alert')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Alert"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlComputeClusterEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlComputeClusterEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlComputeClusterNodeEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlComputeClusterNodeEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlComputeCpuGpuUtilization')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlComputeCpuGpuUtilization"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlComputeInstanceEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlComputeInstanceEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlComputeJobEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlComputeJobEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlDataLabelEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlDataLabelEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlDataSetEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlDataSetEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlDataStoreEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlDataStoreEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlDeploymentEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlDeploymentEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlEnvironmentEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlEnvironmentEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlInferencingEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlInferencingEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlModelsEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlModelsEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlOnlineEndpointConsoleLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlOnlineEndpointConsoleLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlOnlineEndpointEventLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlOnlineEndpointEventLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlOnlineEndpointTrafficLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlOnlineEndpointTrafficLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlPipelineEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlPipelineEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlRegistryReadEventsLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlRegistryReadEventsLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlRegistryWriteEventsLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlRegistryWriteEventsLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlRunEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlRunEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AmlRunStatusChangedEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AmlRunStatusChangedEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AMSKeyDeliveryRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AMSKeyDeliveryRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AMSLiveEventOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AMSLiveEventOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AMSMediaAccountHealth')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AMSMediaAccountHealth"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AMSStreamingEndpointRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AMSStreamingEndpointRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ANFFileAccess')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ANFFileAccess"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ApiManagementGatewayLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ApiManagementGatewayLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ApiManagementWebSocketConnectionLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ApiManagementWebSocketConnectionLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppAvailabilityResults')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppAvailabilityResults"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppBrowserTimings')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppBrowserTimings"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppCenterError')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppCenterError"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppDependencies')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppDependencies"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppEnvSpringAppConsoleLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppEnvSpringAppConsoleLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppEvents"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppExceptions')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppExceptions"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppMetrics"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPageViews')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPageViews"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPerformanceCounters')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPerformanceCounters"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPlatformBuildLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPlatformBuildLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPlatformContainerEventLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPlatformContainerEventLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPlatformIngressLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPlatformIngressLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPlatformLogsforSpring')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPlatformLogsforSpring"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppPlatformSystemLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppPlatformSystemLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppRequests"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceAntivirusScanAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceAntivirusScanAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceAppLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceAppLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceConsoleLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceConsoleLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceEnvironmentPlatformLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceEnvironmentPlatformLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceFileAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceFileAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceHTTPLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceHTTPLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceIPSecAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceIPSecAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServicePlatformLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServicePlatformLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppServiceServerlessSecurityPluginData')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppServiceServerlessSecurityPluginData"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppSystemEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppSystemEvents"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AppTraces')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AppTraces"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASCAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASCAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASCDeviceEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASCDeviceEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASimAuditEventLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASimAuditEventLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASimAuthenticationEventLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASimAuthenticationEventLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASimProcessEventLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASimProcessEventLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASRJobs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASRJobs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ASRReplicatedItems')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ASRReplicatedItems"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ATCExpressRouteCircuitIpfix')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ATCExpressRouteCircuitIpfix"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AUIEventsAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AUIEventsAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AUIEventsOperational')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AUIEventsOperational"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AutoscaleEvaluationsLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AutoscaleEvaluationsLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AutoscaleScaleActionsLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AutoscaleScaleActionsLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AVNMNetworkGroupMembershipChange')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AVNMNetworkGroupMembershipChange"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AVSSyslog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AVSSyslog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWApplicationRule')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWApplicationRule"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWApplicationRuleAggregation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWApplicationRuleAggregation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWDnsQuery')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWDnsQuery"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWFatFlow')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWFatFlow"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWFlowTrace')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWFlowTrace"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWIdpsSignature')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWIdpsSignature"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWInternalFqdnResolutionFailure')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWInternalFqdnResolutionFailure"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWNatRule')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWNatRule"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWNatRuleAggregation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWNatRuleAggregation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWNetworkRule')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWNetworkRule"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWNetworkRuleAggregation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWNetworkRuleAggregation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZFWThreatIntel')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZFWThreatIntel"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZKVAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZKVAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZKVPolicyEvaluationDetailsLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZKVPolicyEvaluationDetailsLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSApplicationMetricLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSApplicationMetricLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSArchiveLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSArchiveLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSAutoscaleLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSAutoscaleLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSCustomerManagedKeyUserLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSCustomerManagedKeyUserLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSHybridConnectionsEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSHybridConnectionsEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSKafkaCoordinatorLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSKafkaCoordinatorLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSKafkaUserErrorLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSKafkaUserErrorLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSOperationalLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSOperationalLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSRunTimeAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSRunTimeAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AZMSVnetConnectionEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AZMSVnetConnectionEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureActivity')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureActivity"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureActivityV2')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureActivityV2"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureAttestationDiagnostics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureAttestationDiagnostics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureCloudHsmAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureCloudHsmAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureDevOpsAuditing')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureDevOpsAuditing"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureDiagnostics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureDiagnostics",
+                    "columns": [
+                        {
+                            "name": "CacheFileName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "CacheTransactionId_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "errorInfo_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ruleSetType_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ruleSetVersion_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ruleId_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ruleGroup_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Message",
+                            "type": "string"
+                        },
+                        {
+                            "name": "details_message_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "details_file_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "details_line_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "hostname_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "policyId_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "policyScope_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "policyScopeName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "engine_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "WAFEvaluationTime_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "WAFMode_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "details_msg_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "details_data_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "timeStamp_t",
+                            "type": "datetime"
+                        },
+                        {
+                            "name": "listenerName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "backendPoolName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "backendSettingName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "instanceId_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "clientPort_d",
+                            "type": "real"
+                        },
+                        {
+                            "name": "originalRequestUriWithArgs_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "requestQuery_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "httpStatus_d",
+                            "type": "real"
+                        },
+                        {
+                            "name": "receivedBytes_d",
+                            "type": "real"
+                        },
+                        {
+                            "name": "sentBytes_d",
+                            "type": "real"
+                        },
+                        {
+                            "name": "clientResponseTime_d",
+                            "type": "real"
+                        },
+                        {
+                            "name": "timeTaken_d",
+                            "type": "real"
+                        },
+                        {
+                            "name": "transactionId_g",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "sslEnabled_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sslCipher_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sslProtocol_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sslClientVerify_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sslClientCertificateFingerprint_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sslClientCertificateIssuerName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "serverRouted_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "serverStatus_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "serverResponseLatency_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "upstreamSourcePort_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "originalHost_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "httpMethod_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "httpVersion_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "requestBytes_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "responseBytes_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "userAgent_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "clientIp_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "socketIp_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "timeToFirstByte_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "timeTaken_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "requestProtocol_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "securityProtocol_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "routingRuleName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "rulesEngineMatchNames_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "backendHostname_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "isReceivedFromClient_b",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "httpStatusCode_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "httpStatusDetails_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "pop_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "cacheStatus_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ErrorInfo_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Category",
+                            "type": "string"
+                        },
+                        {
+                            "name": "OperationName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "clientIP_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "clientPort_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "socketIP_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "requestUri_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ruleName_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "policy_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "action_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "host_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "trackingReference_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "policyMode_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "details_matches_s",
+                            "type": "string"
+                        },
+                        {
+                            "name": "SubscriptionId",
+                            "type": "guid"
+                        },
+                        {
+                            "name": "ResourceGroup",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceProvider",
+                            "type": "string"
+                        },
+                        {
+                            "name": "Resource",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ResourceType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "_CustomFieldsCollection",
+                            "type": "dynamic"
+                        }
+                    ]
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureLoadTestingOperation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureLoadTestingOperation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/AzureMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "AzureMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/BaiClusterEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "BaiClusterEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/BaiClusterNodeEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "BaiClusterNodeEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/BaiJobEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "BaiJobEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CassandraAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CassandraAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CassandraLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CassandraLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CCFApplicationLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CCFApplicationLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBCassandraRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBCassandraRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBControlPlaneRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBControlPlaneRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBDataPlaneRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBDataPlaneRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBGremlinRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBGremlinRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBMongoRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBMongoRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBPartitionKeyRUConsumption')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBPartitionKeyRUConsumption"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBPartitionKeyStatistics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBPartitionKeyStatistics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CDBQueryRuntimeStatistics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CDBQueryRuntimeStatistics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ChaosStudioExperimentEventLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ChaosStudioExperimentEventLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CHSMManagementAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CHSMManagementAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CIEventsAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CIEventsAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CIEventsOperational')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CIEventsOperational"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ComputerGroup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ComputerGroup"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerAppConsoleLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerAppConsoleLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerAppSystemLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerAppSystemLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerImageInventory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerImageInventory"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerInventory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerInventory"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerLogV2')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerLogV2"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerNodeInventory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerNodeInventory"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerRegistryLoginEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerRegistryLoginEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerRegistryRepositoryEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerRegistryRepositoryEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ContainerServiceLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ContainerServiceLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/CoreAzureBackup')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "CoreAzureBackup"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksAccounts')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksAccounts"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksCapsule8Dataplane')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksCapsule8Dataplane"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksClamAVScan')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksClamAVScan"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksClusterLibraries')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksClusterLibraries"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksClusters')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksClusters"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksDatabricksSQL')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksDatabricksSQL"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksDBFS')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksDBFS"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksDeltaPipelines')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksDeltaPipelines"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksFeatureStore')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksFeatureStore"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksGenie')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksGenie"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksGitCredentials')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksGitCredentials"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksGlobalInitScripts')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksGlobalInitScripts"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksIAMRole')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksIAMRole"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksInstancePools')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksInstancePools"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksJobs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksJobs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksMLflowAcledArtifact')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksMLflowAcledArtifact"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksMLflowExperiment')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksMLflowExperiment"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksModelRegistry')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksModelRegistry"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksNotebook')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksNotebook"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksPartnerHub')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksPartnerHub"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksRemoteHistoryService')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksRemoteHistoryService"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksRepos')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksRepos"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksSecrets')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksSecrets"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksServerlessRealTimeInference')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksServerlessRealTimeInference"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksSQL')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksSQL"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksSQLPermissions')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksSQLPermissions"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksSSH')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksSSH"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksTables')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksTables"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksUnityCatalog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksUnityCatalog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksWebTerminal')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksWebTerminal"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DatabricksWorkspace')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DatabricksWorkspace"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DataTransferOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DataTransferOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DevCenterDiagnosticLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DevCenterDiagnosticLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DSMAzureBlobStorageLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DSMAzureBlobStorageLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DSMDataClassificationLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DSMDataClassificationLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/DSMDataLabelingLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "DSMDataLabelingLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/EnrichedMicrosoft365AuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "EnrichedMicrosoft365AuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ETWEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ETWEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Event')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Event"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ExchangeAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ExchangeAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ExchangeOnlineAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ExchangeOnlineAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/FailedIngestion')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "FailedIngestion"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/FunctionAppLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "FunctionAppLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightAmbariClusterAlerts')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightAmbariClusterAlerts"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightAmbariSystemMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightAmbariSystemMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightGatewayAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightGatewayAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHadoopAndYarnLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHadoopAndYarnLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHadoopAndYarnMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHadoopAndYarnMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHBaseLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHBaseLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHBaseMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHBaseMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHiveAndLLAPLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHiveAndLLAPLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHiveAndLLAPMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHiveAndLLAPMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHiveQueryAppStats')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHiveQueryAppStats"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightHiveTezAppStats')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightHiveTezAppStats"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightJupyterNotebookEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightJupyterNotebookEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightKafkaLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightKafkaLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightKafkaMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightKafkaMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightKafkaServerLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightKafkaServerLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightOozieLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightOozieLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightRangerAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightRangerAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSecurityLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSecurityLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkApplicationEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkApplicationEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkBlockManagerEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkBlockManagerEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkEnvironmentEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkEnvironmentEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkExecutorEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkExecutorEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkExtraEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkExtraEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkJobEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkJobEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkSQLExecutionEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkSQLExecutionEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkStageEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkStageEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkStageTaskAccumulables')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkStageTaskAccumulables"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightSparkTaskEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightSparkTaskEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightStormLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightStormLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightStormMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightStormMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/HDInsightStormTopologyMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "HDInsightStormTopologyMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Heartbeat')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Heartbeat"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/InsightsMetrics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "InsightsMetrics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/IntuneAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "IntuneAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/IntuneDeviceComplianceOrg')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "IntuneDeviceComplianceOrg"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/IntuneDevices')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "IntuneDevices"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/IntuneOperationalLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "IntuneOperationalLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubeEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubeEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubeHealth')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubeHealth"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubeMonAgentEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubeMonAgentEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubeNodeInventory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubeNodeInventory"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubePodInventory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubePodInventory"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubePVInventory')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubePVInventory"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/KubeServices')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "KubeServices"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LAQueryLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "LAQueryLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/LogicAppWorkflowRuntime')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "LogicAppWorkflowRuntime"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MCCEventLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MCCEventLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MCVPAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MCVPAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MCVPOperationLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MCVPOperationLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftAzureBastionAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftAzureBastionAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftDataShareReceivedSnapshotLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftDataShareReceivedSnapshotLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftDataShareSentSnapshotLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftDataShareSentSnapshotLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftDynamicsTelemetryPerformanceLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftDynamicsTelemetryPerformanceLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftDynamicsTelemetrySystemMetricsLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftDynamicsTelemetrySystemMetricsLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftGraphActivityLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftGraphActivityLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/MicrosoftHealthcareApisAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "MicrosoftHealthcareApisAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NetworkAccessTraffic')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NetworkAccessTraffic"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NSPAccessLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NSPAccessLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NTAIpDetails')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NTAIpDetails"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NTANetAnalytics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NTANetAnalytics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NTATopologyDetails')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NTATopologyDetails"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NWConnectionMonitorDestinationListenerResult')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NWConnectionMonitorDestinationListenerResult"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NWConnectionMonitorDNSResult')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NWConnectionMonitorDNSResult"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NWConnectionMonitorPathResult')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NWConnectionMonitorPathResult"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/NWConnectionMonitorTestResult')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "NWConnectionMonitorTestResult"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OEPAirFlowTask')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OEPAirFlowTask"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OEPAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OEPAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OEPDataplaneLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OEPDataplaneLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OEPElasticOperator')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OEPElasticOperator"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OEPElasticsearch')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OEPElasticsearch"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OLPSupplyChainEntityOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OLPSupplyChainEntityOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/OLPSupplyChainEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "OLPSupplyChainEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Operation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Operation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Perf')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Perf"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PFTitleAuditLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PFTitleAuditLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIAuditTenant')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIAuditTenant"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIDatasetsTenant')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIDatasetsTenant"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIDatasetsTenantPreview')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIDatasetsTenantPreview"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIDatasetsWorkspace')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIDatasetsWorkspace"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIDatasetsWorkspacePreview')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIDatasetsWorkspacePreview"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIReportUsageTenant')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIReportUsageTenant"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PowerBIReportUsageWorkspace')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PowerBIReportUsageWorkspace"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ProtectionStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ProtectionStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PurviewDataSensitivityLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PurviewDataSensitivityLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PurviewScanStatusLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PurviewScanStatusLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/PurviewSecurityLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "PurviewSecurityLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/REDConnectionEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "REDConnectionEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ResourceManagementPublicAccessLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ResourceManagementPublicAccessLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SCCMAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SCCMAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SCOMAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SCOMAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecureScoreControls')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecureScoreControls"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecureScores')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecureScores"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecurityAlert')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecurityAlert"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecurityBaseline')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecurityBaseline"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecurityBaselineSummary')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecurityBaselineSummary"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecurityNestedRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecurityNestedRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecurityRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecurityRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SecurityRegulatoryCompliance')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SecurityRegulatoryCompliance"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ServiceFabricOperationalEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ServiceFabricOperationalEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ServiceFabricReliableActorEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ServiceFabricReliableActorEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/ServiceFabricReliableServiceEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "ServiceFabricReliableServiceEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SfBAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SfBAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SfBOnlineAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SfBOnlineAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SharePointOnlineAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SharePointOnlineAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SignalRServiceDiagnosticLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SignalRServiceDiagnosticLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SigninLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SigninLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SPAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SPAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SQLAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SQLAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SQLSecurityAuditEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SQLSecurityAuditEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageAntimalwareScanResults')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageAntimalwareScanResults"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageBlobLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageBlobLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageCacheOperationEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageCacheOperationEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageCacheUpgradeEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageCacheUpgradeEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageCacheWarningEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageCacheWarningEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageFileLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageFileLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageMalwareScanningResults')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageMalwareScanningResults"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageMoverCopyLogsFailed')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageMoverCopyLogsFailed"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageMoverCopyLogsTransferred')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageMoverCopyLogsTransferred"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageMoverJobRunLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageMoverJobRunLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageQueueLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageQueueLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/StorageTableLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "StorageTableLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SucceededIngestion')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SucceededIngestion"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseBigDataPoolApplicationsEnded')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseBigDataPoolApplicationsEnded"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseBuiltinSqlPoolRequestsEnded')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseBuiltinSqlPoolRequestsEnded"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXCommand')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXCommand"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXFailedIngestion')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXFailedIngestion"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXIngestionBatching')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXIngestionBatching"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXQuery')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXQuery"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXSucceededIngestion')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXSucceededIngestion"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXTableDetails')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXTableDetails"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseDXTableUsageStatistics')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseDXTableUsageStatistics"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseGatewayApiRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseGatewayApiRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseGatewayEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseGatewayEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseIntegrationActivityRuns')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseIntegrationActivityRuns"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseIntegrationActivityRunsEnded')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseIntegrationActivityRunsEnded"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseIntegrationPipelineRuns')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseIntegrationPipelineRuns"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseIntegrationPipelineRunsEnded')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseIntegrationPipelineRunsEnded"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseIntegrationTriggerRuns')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseIntegrationTriggerRuns"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseIntegrationTriggerRunsEnded')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseIntegrationTriggerRunsEnded"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseLinkEvent')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseLinkEvent"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseRBACEvents')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseRBACEvents"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseRbacOperations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseRbacOperations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseScopePoolScopeJobsEnded')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseScopePoolScopeJobsEnded"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseScopePoolScopeJobsStateChange')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseScopePoolScopeJobsStateChange"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseSqlPoolDmsWorkers')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseSqlPoolDmsWorkers"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseSqlPoolExecRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseSqlPoolExecRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseSqlPoolRequestSteps')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseSqlPoolRequestSteps"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseSqlPoolSqlRequests')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseSqlPoolSqlRequests"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/SynapseSqlPoolWaits')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "SynapseSqlPoolWaits"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Syslog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Syslog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/TSIIngress')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "TSIIngress"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCClient')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCClient"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCClientReadinessStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCClientReadinessStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCClientUpdateStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCClientUpdateStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCDeviceAlert')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCDeviceAlert"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCDOAggregatedStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCDOAggregatedStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCDOStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCDOStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCServiceUpdateStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCServiceUpdateStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UCUpdateAlert')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UCUpdateAlert"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Update')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Update"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/UpdateSummary')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "UpdateSummary"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/Usage')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 90,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "Usage"
+                },
+                "retentionInDays": 90
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/VIAudit')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "VIAudit"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/VIIndexing')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "VIIndexing"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/VMBoundPort')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "VMBoundPort"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/VMComputer')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "VMComputer"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/VMConnection')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "VMConnection"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/VMProcess')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "VMProcess"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/W3CIISLog')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "W3CIISLog"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WebPubSubConnectivity')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WebPubSubConnectivity"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WebPubSubHttpRequest')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WebPubSubHttpRequest"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WebPubSubMessaging')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WebPubSubMessaging"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WindowsClientAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WindowsClientAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WindowsServerAssessmentRecommendation')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WindowsServerAssessmentRecommendation"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WorkloadDiagnosticLogs')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WorkloadDiagnosticLogs"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDAgentHealthStatus')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDAgentHealthStatus"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDAutoscaleEvaluationPooled')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDAutoscaleEvaluationPooled"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDCheckpoints')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDCheckpoints"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDConnectionGraphicsDataPreview')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDConnectionGraphicsDataPreview"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDConnectionNetworkData')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDConnectionNetworkData"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDConnections')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDConnections"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDErrors')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDErrors"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDFeeds')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDFeeds"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDHostRegistrations')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDHostRegistrations"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDManagement')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDManagement"
+                },
+                "retentionInDays": 30
+            }
+        },
+        {
+            "type": "Microsoft.OperationalInsights/workspaces/tables",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[concat(parameters('workspaces_digital_dev_logs_workspace_name'), '/WVDSessionHostManagement')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaces_digital_dev_logs_workspace_name'))]"
+            ],
+            "properties": {
+                "totalRetentionInDays": 30,
+                "plan": "Analytics",
+                "schema": {
+                    "name": "WVDSessionHostManagement"
+                },
+                "retentionInDays": 30
+            }
+        }
+    ]
+}

--- a/infrastructure/resource_group_level/modules/dtfs-central-api.bicep
+++ b/infrastructure/resource_group_level/modules/dtfs-central-api.bicep
@@ -1,0 +1,173 @@
+param location string
+param environment string
+param containerRegistryName string
+param appServicePlanEgressSubnetId string
+param appServicePlanId string
+param privateEndpointsSubnetId string
+param cosmosDbAccountName string
+param cosmosDbDatabaseName string
+param logAnalyticsWorkspaceId string
+
+var dockerImageName = '${containerRegistryName}.azurecr.io/dtfs-central-api:${environment}'
+var dockerRegistryServerUsername = 'tfs${environment}'
+
+@secure()
+param secureSettings object = {
+
+}
+
+// These values are taken from an export of Configuration on Dev (& validating with staging).
+@secure()
+param additionalSecureSettings object = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+}
+
+// https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+var azureDnsServerIp = '168.63.129.16'
+
+// These values are hardcoded in the CLI scripts
+var settings = {
+  WEBSITE_DNS_SERVER: azureDnsServerIp
+  WEBSITE_VNET_ROUTE_ALL: '1'
+  PORT: '5000'
+  WEBSITES_PORT: '5000'
+}
+
+// These values are taken from an export of Configuration on Dev (& validating with staging).
+var additionalSettings = {
+  APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
+  // Note that the config has APPINSIGHTS_INSTRUMENTATIONKEY as a slot setting, though the advice
+  // is not to use at the same time as its replacement - APPLICATIONINSIGHTS_CONNECTION_STRING
+  // APPINSIGHTS_INSTRUMENTATIONKEY: applicationInsights.properties.InstrumentationKey
+  DOCKER_ENABLE_CI: 'true'
+  DOCKER_REGISTRY_SERVER_URL: '${containerRegistryName}.azurecr.io'
+  DOCKER_REGISTRY_SERVER_USERNAME: dockerRegistryServerUsername
+  LOG4J_FORMAT_MSG_NO_LOOKUPS: 'true'
+  TZ: 'Europe/London'
+  WEBSITE_HTTPLOGGING_RETENTION_DAYS: '3'
+  WEBSITES_ENABLE_APP_SERVICE_STORAGE: 'false'
+}
+
+var nodeEnv = environment == 'dev' ? { NODE_ENV: 'development' } : {}
+
+var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+
+var dtfsCentralApiName = 'tfs-${environment}-dtfs-central-api'
+var privateEndpointName = 'tfs-${environment}-dtfs-central-api'
+var applicationInsightsName = 'tfs-${environment}-dtfs-central-api'
+
+
+// These have come from the CLI scripts
+var mongoDbConnectionString = replace(cosmosDbAccount.listConnectionStrings().connectionStrings[0].connectionString, '&replicaSet=globaldb', '')
+var connectionStrings = {
+  EXTERNAL_API_URL: {
+    type: 'Custom'
+    // TODO:FN-421 get external-api (reference-data-proxy) default hostname.
+    value: 'https://tfs-feature-external-api.azurewebsites.net/'
+  }
+  MONGO_INITDB_DATABASE: {
+    type: 'Custom'
+    value: cosmosDbDatabaseName
+  }
+  MONGODB_URI: {
+    type: 'Custom'
+    value: mongoDbConnectionString
+  }
+}
+
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
+  name: cosmosDbAccountName
+}
+
+resource dtfsCentralApi 'Microsoft.Web/sites@2022-09-01' = {
+  name: dtfsCentralApiName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  kind: 'app,linux,container'
+  properties: {
+    httpsOnly: false
+    serverFarmId: appServicePlanId
+    siteConfig: {
+      numberOfWorkers: 1
+      linuxFxVersion: 'DOCKER|${dockerImageName}'
+      acrUseManagedIdentityCreds: false
+      alwaysOn: true
+      http20Enabled: true
+      functionAppScaleLimit: 0
+      // non-default parameter
+      logsDirectorySizeLimit: 100 // default is 35
+      // The following Fields have been added after comparing with dev
+      vnetRouteAllEnabled: true
+      ftpsState: 'Disabled'
+      scmMinTlsVersion: '1.0'
+      remoteDebuggingVersion: 'VS2019'
+      httpLoggingEnabled: true // false in staging, true in prod
+    }
+    virtualNetworkSubnetId: appServicePlanEgressSubnetId
+  }
+}
+
+resource dtfsCentralApiSettings 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: dtfsCentralApi
+  name: 'appsettings'
+  properties: appSettings
+}
+
+resource dtfsCentralApiConnectionStrings 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: dtfsCentralApi
+  name: 'connectionstrings'
+  properties: connectionStrings
+}
+
+// The private endpoint is taken from the cosmosdb/private-endpoint export
+resource dtfsCentralApiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {
+  name: privateEndpointName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: dtfsCentralApi.id
+          groupIds: [
+            'sites'
+          ]
+          privateLinkServiceConnectionState: {
+            status: 'Approved'
+            actionsRequired: 'None'
+          }
+        }
+      }
+    ]
+    manualPrivateLinkServiceConnections: []
+    subnet: {
+      id: privateEndpointsSubnetId
+    }
+    ipConfigurations: []
+    // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: applicationInsightsName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    Flow_Type: 'Redfield'
+    Request_Source: 'IbizaAIExtensionEnablementBlade'
+    RetentionInDays: 90
+    WorkspaceResourceId: logAnalyticsWorkspaceId
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers 
- adding the backing infrastructure of the dtfs-central-api webapp
### Resolution
The code
- links with application insights
- wires up with dummy environment variables
- creates a private link
- DOES NOT wire up A Records. I'll do those in a batch.
- DOES NOT send in the environment variables from `main.bicep`. It doesn't seem helpful until we do the GitHub Actions stuff

### Notes
Note that it is very likely that we will commonised the code to work with the other webapps. This will happen in the next card.
We need to make sure the Github secrets are correctly wired up. If FN-419 is ok, I'll go ahead and do so presumptively.