### PR TITLE
feat(FN-686): remove Mulesoft config

### DIFF
--- a/infrastructure/resource_group_level/modules/function-acbs.bicep
+++ b/infrastructure/resource_group_level/modules/function-acbs.bicep
@@ -7,27 +7,22 @@ param privateEndpointsSubnetId string
 param storageAccountName string
 
 
-// These values are taken from GitHub secrets
-// TODO:FN-686 Replace Mulesoft values, verify in GH Secrets.
+// These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object = {
-  MULESOFT_API_KEY: 'test-value'
-  MULESOFT_API_SECRET: 'test-value'
-  MULESOFT_API_UKEF_TF_EA_URL: 'test-value'
+  APIM_TFS_KEY: 'test-value'
+  APIM_TFS_VALUE: 'test-value'
+  APIM_TFS_URL: 'test-value'
   APIM_MDM_KEY: 'test-value'
   APIM_MDM_URL: 'test-value'
   APIM_MDM_VALUE: 'test-value' // different in staging and dev
 }
 
 // These values are taken from an export of Configuration on Dev
-// TODO:FN-686 Replace Mulesoft values, verify in GH Secrets.
 @secure()
 param additionalSecureSettings object = {
   DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'  // different in staging and dev
   MACHINEKEY_DecryptionKey: 'test-value' // different in staging and dev
-  MULESOFT_API_UKEF_MDM_EA_KEY: 'test-value'
-  MULESOFT_API_UKEF_MDM_EA_SECRET: 'test-value'
-  MULESOFT_API_UKEF_MDM_EA_URL: 'test-value' // different in staging and dev
 }
 
 


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

Note that the Infrastructure is not totally static while this work is underway. We need to cope with changes to it, such as this one which is the reirement of the Mulesoft API.

This card covers:
- removing Mulesoft API secrets / environment variables
- replacing them with APIM secrets
according to:
```
MULESOFT_API_UKEF_MDM_EA_URL=${{ secrets.MULESOFT_API_UKEF_MDM_EA_URL }}       ----> APIM_MDM_URL=${{ secrets.APIM_MDM_URL }}
MULESOFT_API_UKEF_MDM_EA_KEY=${{ secrets.MULESOFT_API_UKEF_MDM_EA_KEY }}       ----> APIM_MDM_KEY=${{ secrets.APIM_MDM_KEY }}
MULESOFT_API_UKEF_MDM_EA_SECRET=${{ secrets.MULESOFT_API_UKEF_MDM_EA_SECRET }} ----> APIM_MDM_VALUE=${{ secrets.APIM_MDM_VALUE }}
			  
MULESOFT_API_KEY=${{ secrets.MULESOFT_API_KEY }}                       ---->  APIM_TFS_KEY=${{ secrets.APIM_TFS_KEY }}
MULESOFT_API_SECRET=${{ secrets.MULESOFT_API_SECRET }}                 ---->  APIM_TFS_VALUE=${{ secrets.APIM_TFS_VALUE }}
MULESOFT_API_UKEF_TF_EA_URL=${{ secrets.MULESOFT_API_UKEF_TF_EA_URL }} ---->  APIM_TFS_URL=${{ secrets.APIM_TFS_URL }}

MULESOFT_API_ACBS_DEAL_URL: ${{ secrets.MULESOFT_API_ACBS_DEAL_URL }}             ---> <none>
MULESOFT_API_ACBS_FACILITY_URL="${{ secrets.MULESOFT_API_ACBS_FACILITY_URL }}"    ---> <none>
MULESOFT_API_EXPOSURE_PERIOD_URL: ${{ secrets.MULESOFT_API_EXPOSURE_PERIOD_URL }} ---> <none>
MULESOFT_API_NUMBER_GENERATOR_URL: ${{ secrets.MULESOFT_API_NUMBER_GENERATOR_URL }} -> <none>
````
### Resolution

All secrets in the above list have been replaced with their equivalents.