### PR TITLE
feat(FN-423): portal api to Bicep

### DIFF
--- a/infrastructure/arm_templates/portal-api/parameters.json
+++ b/infrastructure/arm_templates/portal-api/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "sites_tfs_dev_portal_api_name": {
+            "value": null
+        },
+        "serverfarms_dev_externalid": {
+            "value": null
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "value": null
+        }
+    }
+}

--- a/infrastructure/arm_templates/portal-api/template.json
+++ b/infrastructure/arm_templates/portal-api/template.json
@@ -1,0 +1,1898 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "sites_tfs_dev_portal_api_name": {
+            "defaultValue": "tfs-dev-portal-api",
+            "type": "String"
+        },
+        "serverfarms_dev_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Web/serverfarms/dev",
+            "type": "String"
+        },
+        "virtualNetworks_tfs_dev_vnet_externalid": {
+            "defaultValue": "/subscriptions/8beaa40a-2fb6-49d1-b080-ff1871b6276f/resourceGroups/Digital-Dev/providers/Microsoft.Network/virtualNetworks/tfs-dev-vnet",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2022-09-01",
+            "name": "[parameters('sites_tfs_dev_portal_api_name')]",
+            "location": "UK South",
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "kind": "app,linux,container",
+            "properties": {
+                "enabled": true,
+                "hostNameSslStates": [
+                    {
+                        "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '.azurewebsites.net')]",
+                        "sslState": "Disabled",
+                        "hostType": "Standard"
+                    },
+                    {
+                        "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '.scm.azurewebsites.net')]",
+                        "sslState": "Disabled",
+                        "hostType": "Repository"
+                    }
+                ],
+                "serverFarmId": "[parameters('serverfarms_dev_externalid')]",
+                "reserved": true,
+                "isXenon": false,
+                "hyperV": false,
+                "vnetRouteAllEnabled": true,
+                "vnetImagePullEnabled": false,
+                "vnetContentShareEnabled": false,
+                "siteConfig": {
+                    "numberOfWorkers": 1,
+                    "linuxFxVersion": "DOCKER|tfsdev.azurecr.io/portal-api:dev",
+                    "acrUseManagedIdentityCreds": false,
+                    "alwaysOn": true,
+                    "http20Enabled": true,
+                    "functionAppScaleLimit": 0,
+                    "minimumElasticInstanceCount": 0
+                },
+                "scmSiteAlsoStopped": false,
+                "clientAffinityEnabled": true,
+                "clientCertEnabled": false,
+                "clientCertMode": "Required",
+                "hostNamesDisabled": false,
+                "customDomainVerificationId": "799591A29BF706E656906E134F41DABB87DFAD60A3D5E73B22B7E45E5A356B5C",
+                "containerSize": 0,
+                "dailyMemoryTimeQuota": 0,
+                "httpsOnly": false,
+                "redundancyMode": "None",
+                "publicNetworkAccess": "Disabled",
+                "storageAccountRequired": false,
+                "virtualNetworkSubnetId": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-app-service-plan-egress')]",
+                "keyVaultReferenceIdentity": "SystemAssigned"
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/ftp')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ],
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "allow": true
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/scm')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ],
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "allow": true
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/config",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/web')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ],
+            "tags": {
+                "Environment": "Preproduction"
+            },
+            "properties": {
+                "numberOfWorkers": 1,
+                "defaultDocuments": [
+                    "Default.htm",
+                    "Default.html",
+                    "Default.asp",
+                    "index.htm",
+                    "index.html",
+                    "iisstart.htm",
+                    "default.aspx",
+                    "index.php",
+                    "hostingstart.html"
+                ],
+                "netFrameworkVersion": "v4.0",
+                "linuxFxVersion": "DOCKER|tfsdev.azurecr.io/portal-api:dev",
+                "requestTracingEnabled": false,
+                "remoteDebuggingEnabled": false,
+                "remoteDebuggingVersion": "VS2019",
+                "httpLoggingEnabled": true,
+                "acrUseManagedIdentityCreds": false,
+                "logsDirectorySizeLimit": 100,
+                "detailedErrorLoggingEnabled": false,
+                "publishingUsername": "$tfs-dev-portal-api",
+                "scmType": "None",
+                "use32BitWorkerProcess": true,
+                "webSocketsEnabled": false,
+                "alwaysOn": true,
+                "managedPipelineMode": "Integrated",
+                "virtualApplications": [
+                    {
+                        "virtualPath": "/",
+                        "physicalPath": "site\\wwwroot",
+                        "preloadEnabled": true
+                    }
+                ],
+                "loadBalancing": "LeastRequests",
+                "experiments": {
+                    "rampUpRules": []
+                },
+                "autoHealEnabled": false,
+                "vnetName": "5c50c79a-d80a-4a69-9acb-6f1a859658a9_dev-app-service-plan-egress",
+                "vnetRouteAllEnabled": true,
+                "vnetPrivatePortsCount": 0,
+                "publicNetworkAccess": "Disabled",
+                "localMySqlEnabled": false,
+                "ipSecurityRestrictions": [
+                    {
+                        "ipAddress": "51.140.76.208/32",
+                        "action": "Deny",
+                        "tag": "Default",
+                        "priority": 100,
+                        "name": "VPM_DENY"
+                    },
+                    {
+                        "ipAddress": "Any",
+                        "action": "Deny",
+                        "priority": 2147483647,
+                        "name": "Deny all",
+                        "description": "Deny all access"
+                    }
+                ],
+                "ipSecurityRestrictionsDefaultAction": "Deny",
+                "scmIpSecurityRestrictions": [
+                    {
+                        "ipAddress": "Any",
+                        "action": "Deny",
+                        "priority": 2147483647,
+                        "name": "Deny all",
+                        "description": "Deny all access"
+                    }
+                ],
+                "scmIpSecurityRestrictionsDefaultAction": "Deny",
+                "scmIpSecurityRestrictionsUseMain": false,
+                "http20Enabled": true,
+                "minTlsVersion": "1.2",
+                "scmMinTlsVersion": "1.0",
+                "ftpsState": "Disabled",
+                "preWarmedInstanceCount": 0,
+                "elasticWebAppScaleLimit": 0,
+                "functionsRuntimeScaleMonitoringEnabled": false,
+                "minimumElasticInstanceCount": 0,
+                "azureStorageAccounts": {}
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/hostNameBindings",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/', parameters('sites_tfs_dev_portal_api_name'), '.azurewebsites.net')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ],
+            "properties": {
+                "siteName": "tfs-dev-portal-api",
+                "hostNameType": "Verified"
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/privateEndpointConnections",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/', parameters('sites_tfs_dev_portal_api_name'), '-b3297a0a-e83d-4425-a155-490a7adacb99')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ],
+            "properties": {
+                "privateLinkServiceConnectionState": {
+                    "status": "Approved",
+                    "actionsRequired": "None"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-29T18_44_48_7343127')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-30T03_44_48_9533224')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-30T12_44_49_1682756')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-30T18_44_49_3007591')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-31T03_44_49_4786513')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-31T12_44_49_7094830')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-05-31T18_44_49_8437779')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-01T03_44_50_0445824')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-01T12_44_50_2726358')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-01T18_44_50_4057340')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-02T03_44_50_5866566')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-02T12_44_50_8542914')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-02T18_44_50_9569992')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-03T03_44_51_1767458')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-03T12_44_51_4503678')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-03T18_44_51_5340014')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-04T03_44_51_7773959')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-04T12_44_52_1742356')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-04T18_44_52_2877726')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-05T03_44_52_5145656')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-05T12_44_52_7584300')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-05T18_44_52_8870140')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-06T03_44_53_1350220')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-06T12_44_53_3748627')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-06T18_44_53_4843741')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-07T03_44_53_7746385')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-07T12_44_54_1450966')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-07T18_44_54_0576762')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-08T03_44_54_2520142')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-08T12_44_54_6204170')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-08T18_44_54_7482157')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-09T03_44_54_9163407')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-09T12_44_55_1373481')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-09T18_44_55_2792895')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-10T03_44_55_4804266')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-10T12_44_55_7016727')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-10T18_44_56_3968982')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-11T03_44_56_6248026')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-11T12_44_56_8401777')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-11T18_44_56_9604007')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-12T03_44_57_1480943')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-12T12_44_57_3733426')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-12T18_44_57_4931845')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-13T03_44_57_7213535')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-13T12_44_57_9217309')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-13T18_44_58_0468652')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-14T03_44_58_2706377')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-14T12_44_58_4927173')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-14T15_44_58_5961353')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-14T18_44_58_6079869')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-14T21_44_58_6366097')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-15T00_44_58_7146212')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-15T03_44_58_7539083')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-15T12_44_58_9928466')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-15T15_44_59_0509615')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-15T18_44_59_1975370')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-15T21_44_59_2529206')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-16T00_44_59_3090448')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-16T03_45_00_1974429')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-16T12_45_00_4578894')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-16T15_45_00_6503275')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-16T18_45_00_8023388')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-16T21_45_00_7861797')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-17T00_45_00_6227671')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-17T03_45_00_7746998')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-17T12_45_00_9107935')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-17T15_45_00_9883547')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-17T18_45_01_1045841')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-17T21_45_01_1433280')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-18T00_45_01_2230335')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-18T03_45_01_2679022')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-18T12_45_01_5400044')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-18T15_45_01_5763479')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-18T18_45_01_6442916')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-18T21_45_01_6965571')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-19T00_45_01_7749648')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-19T03_45_01_8679860')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-19T12_45_02_0965434')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-19T15_45_02_1525737')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-19T18_45_02_2609350')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-19T21_45_02_3055811')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-20T00_45_02_3551048')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-20T03_45_02_4675831')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-20T12_45_03_1820692')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-20T15_45_03_2655081')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-20T18_45_03_3480604')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-20T21_45_03_3710878')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-21T00_45_03_4407910')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-21T03_45_03_5335381')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-21T12_45_04_0806411')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-21T15_45_03_8285649')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-21T18_45_03_8548785')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-21T21_45_03_9483671')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-22T00_45_04_0315740')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-22T03_45_04_1991228')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-22T12_45_04_3236438')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-22T15_45_04_5385699')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-22T18_45_04_4647622')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-22T21_45_04_5533744')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-23T00_45_04_6195136')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-23T03_45_04_6757763')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-23T12_45_04_8831274')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-23T15_45_04_9472590')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-23T18_45_05_0132738')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-23T21_45_05_0785617')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T00_45_05_7174309')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T03_45_05_8023528')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T10_45_05_9637331')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T11_45_05_9971212')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T12_45_06_0188785')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T13_45_05_9864719')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T14_45_06_0334974')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T15_45_06_0356227')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T16_45_06_0521506')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T17_45_06_1058420')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T18_45_06_1223846')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T19_45_06_1489568')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T20_45_06_1745237')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T21_45_06_1899529')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T22_45_06_2405439')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-24T23_45_06_2530191')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T00_45_06_2726884')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T01_45_06_3160729')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T02_45_06_3407991')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T03_45_06_3389392')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T04_45_06_3838923')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T05_45_06_4257926')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T06_45_06_4198654')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T07_45_06_4706268')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T08_45_06_4667972')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T09_45_06_4776284')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T10_45_06_5218421')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T11_45_06_5656134')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T12_45_06_5568137')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T13_45_06_5786276')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T14_45_06_6179229')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T15_45_06_6406331')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T16_45_06_6600490')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T17_45_06_6721884')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T18_45_06_7039439')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T19_45_06_7186142')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T20_45_06_7563653')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T21_45_06_7915477')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T22_45_06_8186745')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-25T23_45_06_8491995')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T00_45_06_8622858')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T01_45_06_9396549')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T02_45_06_9220278')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T03_45_06_9277556')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T04_45_06_9565204')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T05_45_06_9809747')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T06_45_07_0054523')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T07_45_07_0397384')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T08_45_07_0724570')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T09_45_07_0606836')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T10_45_07_1017870')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T11_45_07_1724066')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T12_45_07_1467223')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T13_45_07_1802861')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T14_45_07_1913675')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T15_45_07_2359353')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T16_45_07_2466492')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T17_45_07_2593716')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T18_45_07_2888284')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T19_45_07_3630702')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T20_45_07_3273222')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T21_45_07_3493049')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T22_45_07_3734948')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-26T23_45_07_4027716')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T00_45_07_4299819')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T01_45_07_4422408')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T02_45_07_4835857')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T03_45_07_4829442')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T04_45_07_5282186')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T05_45_07_5436934')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T06_45_07_6000990')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T07_45_07_5842674')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T08_45_08_3252443')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T09_45_07_6457417')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T10_45_07_6909684')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T11_45_07_7188336')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T12_45_07_7669567')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T13_45_07_7398053')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T14_45_07_7561542')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T15_45_07_7917040')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T16_45_08_1037523')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T17_45_07_8272404')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T18_45_07_8656200')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T19_45_08_5447369')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T20_45_07_8983174')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T21_45_07_9896003')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T22_45_07_9758920')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-27T23_45_07_9951759')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T00_45_08_0264384')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T01_45_08_0332390')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T02_45_08_0708691')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T03_45_08_1606037')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T04_45_08_1223449')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T05_45_08_9146071')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T06_45_08_3962804')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T07_45_08_2129791')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T08_45_08_2191785')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T09_45_08_2353634')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T10_45_08_2776594')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T11_45_09_0404717')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T12_45_08_3599887')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/snapshots",
+            "apiVersion": "2015-08-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/2023-06-28T13_45_08_3608458')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Web/sites/virtualNetworkConnections",
+            "apiVersion": "2022-09-01",
+            "name": "[concat(parameters('sites_tfs_dev_portal_api_name'), '/5c50c79a-d80a-4a69-9acb-6f1a859658a9_dev-app-service-plan-egress')]",
+            "location": "UK South",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('sites_tfs_dev_portal_api_name'))]"
+            ],
+            "properties": {
+                "vnetResourceId": "[concat(parameters('virtualNetworks_tfs_dev_vnet_externalid'), '/subnets/dev-app-service-plan-egress')]",
+                "isSwift": true
+            }
+        }
+    ]
+}

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -274,3 +274,21 @@ module dtfsCentralApi 'modules/dtfs-central-api.bicep' = {
     externalApiHostname: externalApi.outputs.defaultHostName
   }
 }
+
+module portalApi 'modules/portal-api.bicep' = {
+  name: 'portalApi'
+  params: {
+    appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
+    appServicePlanId: appServicePlan.id
+    containerRegistryName: containerRegistry.name
+    cosmosDbAccountName: cosmosDb.outputs.cosmosDbAccountName
+    cosmosDbDatabaseName: cosmosDbDatabaseName
+    dtfsCentralApiHostname: dtfsCentralApi.outputs.defaultHostName
+    environment: environment
+    externalApiHostname: externalApi.outputs.defaultHostName
+    location: location
+    logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
+    privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
+    storageAccountName: storage.outputs.storageAccountName
+  }
+}

--- a/infrastructure/resource_group_level/modules/dtfs-central-api.bicep
+++ b/infrastructure/resource_group_level/modules/dtfs-central-api.bicep
@@ -174,3 +174,5 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     publicNetworkAccessForQuery: 'Enabled'
   }
 }
+
+output defaultHostName string = dtfsCentralApi.properties.defaultHostName

--- a/infrastructure/resource_group_level/modules/portal-api.bicep
+++ b/infrastructure/resource_group_level/modules/portal-api.bicep
@@ -1,0 +1,246 @@
+param location string
+param environment string
+param containerRegistryName string
+param appServicePlanEgressSubnetId string
+param appServicePlanId string
+param privateEndpointsSubnetId string
+param cosmosDbAccountName string
+param cosmosDbDatabaseName string
+param logAnalyticsWorkspaceId string
+param externalApiHostname string
+param dtfsCentralApiHostname string
+param storageAccountName string
+
+var dockerImageName = '${containerRegistryName}.azurecr.io/portal-api:${environment}'
+var dockerRegistryServerUsername = 'tfs${environment}'
+
+// These values are taken from GitHub secrets injected in the GHA Action
+@secure()
+param secureSettings object = {
+
+}
+
+// These values are taken from an export of Configuration on Dev (& validating with staging).
+@secure()
+param additionalSecureSettings object = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+}
+
+// These values are taken from GitHub secrets injected in the GHA Action
+@secure()
+param secureConnectionStrings object = {
+  // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
+  CORS_ORIGIN: 'test-value'
+  AZURE_PORTAL_EXPORT_FOLDER: 'test-value'
+  AZURE_PORTAL_FILESHARE_NAME: 'test-value'
+  AZURE_WORKFLOW_EXPORT_FOLDER: 'test-value'
+  AZURE_WORKFLOW_FILESHARE_NAME: 'test-value'
+  AZURE_WORKFLOW_IMPORT_FOLDER: 'test-value'
+  AZURE_WORKFLOW_STORAGE_ACCOUNT: 'test-value'
+  AZURE_WORKFLOW_STORAGE_ACCESS_KEY: 'test-value'
+  JWT_SIGNING_KEY: 'test-value'
+  JWT_VALIDATING_KEY: 'test-value'
+  GOV_NOTIFY_API_KEY: 'test-value'
+  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
+  DTFS_PORTAL_SCHEDULER: 'test-value'
+  FETCH_WORKFLOW_TYPE_B_SCHEDULE: 'test-value'
+  COMPANIES_HOUSE_API_URL: 'test-value' // from env
+  COMPANIES_HOUSE_API_KEY: 'test-value' // from env but looks a secret
+}
+
+
+// https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+var azureDnsServerIp = '168.63.129.16'
+
+// These values are hardcoded in the CLI scripts
+var settings = {
+  WEBSITE_DNS_SERVER: azureDnsServerIp
+  WEBSITE_VNET_ROUTE_ALL: '1'
+  PORT: '5000'
+  WEBSITES_PORT: '5000'
+}
+
+// These values are taken from an export of Configuration on Dev (& validating with staging).
+var additionalSettings = {
+  // Note that the dev & staging didn't have AI enabled
+  // If enabling, consider using APPLICATIONINSIGHTS_CONNECTION_STRING instead
+  // APPINSIGHTS_INSTRUMENTATIONKEY: applicationInsights.properties.InstrumentationKey
+  // APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
+  
+  DOCKER_ENABLE_CI: 'true'
+  DOCKER_REGISTRY_SERVER_URL: '${containerRegistryName}.azurecr.io'
+  DOCKER_REGISTRY_SERVER_USERNAME: dockerRegistryServerUsername
+  LOG4J_FORMAT_MSG_NO_LOOKUPS: 'true'
+  TZ: 'Europe/London' // Dev only
+  WEBSITE_DYNAMIC_CACHE: '0'
+  WEBSITE_HTTPLOGGING_RETENTION_DAYS: '3'
+  WEBSITE_LOCAL_CACHE_OPTION: 'Never'
+  WEBSITE_NODE_DEFAULT_VERSION: '16.14.0' // TODO:DTFS2-6422 consider making parameterisable
+  WEBSITES_ENABLE_APP_SERVICE_STORAGE: 'false'
+}
+
+var nodeEnv = environment == 'dev' ? { NODE_ENV: 'development' } : {}
+
+var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+
+var portalApiName = 'tfs-${environment}-portal-api'
+var privateEndpointName = 'tfs-${environment}-portal-api'
+var applicationInsightsName = 'tfs-${environment}-portal-api'
+
+
+var connectionStringsList = [for item in items(secureConnectionStrings): {
+  name: item.key
+  value: item.value
+} ]
+
+var connectionStringsProperties = toObject(connectionStringsList, item => item.name, item => {
+  type: 'Custom'
+  value: item.value
+} )
+
+
+// Then there are the calculated values. 
+var mongoDbConnectionString = replace(cosmosDbAccount.listConnectionStrings().connectionStrings[0].connectionString, '&replicaSet=globaldb', '')
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: storageAccountName
+}
+var storageAccountKey = storageAccount.listKeys().keys[0].value
+
+// Note that in the CLI script, http was used, but the value in the exported config was https.
+var externalApiUrl = 'https://${externalApiHostname}'
+
+var dtfsCentralApiUrl = 'http://${dtfsCentralApiHostname}'
+
+var connectionStringsCalculated = {  
+  AZURE_PORTAL_STORAGE_ACCESS_KEY: {
+    type: 'Custom'
+    value: storageAccountKey
+  }
+  AZURE_PORTAL_STORAGE_ACCOUNT: {
+    type: 'Custom'
+    value: storageAccountName
+  }
+  MONGO_INITDB_DATABASE: {
+    type: 'Custom'
+    value: cosmosDbDatabaseName
+  }
+  MONGODB_URI: {
+    type: 'Custom'
+    value: mongoDbConnectionString
+  }
+  EXTERNAL_API_URL: {
+    type: 'Custom'
+    value: externalApiUrl
+  }
+  DTFS_CENTRAL_API: {
+    type: 'Custom'
+    value: dtfsCentralApiUrl
+  }
+  TFM_API: {
+    type: 'Custom'
+    value: 'TODO:FN-424'
+  }
+} 
+
+
+var connectionStringsCombined = union(connectionStringsProperties, connectionStringsCalculated)
+
+
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
+  name: cosmosDbAccountName
+}
+
+resource portalApi 'Microsoft.Web/sites@2022-09-01' = {
+  name: portalApiName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  kind: 'app,linux,container'
+  properties: {
+    httpsOnly: false
+    serverFarmId: appServicePlanId
+    siteConfig: {
+      numberOfWorkers: 1
+      linuxFxVersion: 'DOCKER|${dockerImageName}'
+      acrUseManagedIdentityCreds: false
+      alwaysOn: true
+      http20Enabled: true
+      functionAppScaleLimit: 0
+      // non-default parameter
+      logsDirectorySizeLimit: 100 // default is 35
+      // The following Fields have been added after comparing with dev
+      vnetRouteAllEnabled: true
+      ftpsState: 'Disabled'
+      scmMinTlsVersion: '1.0'
+      remoteDebuggingVersion: 'VS2019'
+      httpLoggingEnabled: true // false in staging, true in prod
+    }
+    virtualNetworkSubnetId: appServicePlanEgressSubnetId
+  }
+}
+
+resource portalApiSettings 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: portalApi
+  name: 'appsettings'
+  properties: appSettings
+}
+
+resource portalApiConnectionStrings 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: portalApi
+  name: 'connectionstrings'
+  properties: connectionStringsCombined
+}
+
+// The private endpoint is taken from the cosmosdb/private-endpoint export
+resource portalApiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {
+  name: privateEndpointName
+  location: location
+  tags: {
+    Environment: 'Preproduction'
+  }
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: portalApi.id
+          groupIds: [
+            'sites'
+          ]
+          privateLinkServiceConnectionState: {
+            status: 'Approved'
+            actionsRequired: 'None'
+          }
+        }
+      }
+    ]
+    manualPrivateLinkServiceConnections: []
+    subnet: {
+      id: privateEndpointsSubnetId
+    }
+    ipConfigurations: []
+    // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+// Application insights isn't enabled in Dev or staging, but is in prod.
+// resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
+//   name: applicationInsightsName
+//   location: location
+//   tags: {
+//     Environment: 'Preproduction'
+//   }
+//   kind: 'web'
+//   properties: {
+//     Application_Type: 'web'
+//     Flow_Type: 'Redfield'
+//     Request_Source: 'IbizaAIExtensionEnablementBlade'
+//     RetentionInDays: 90
+//     WorkspaceResourceId: logAnalyticsWorkspaceId
+//     IngestionMode: 'LogAnalytics'
+//     publicNetworkAccessForIngestion: 'Enabled'
+//     publicNetworkAccessForQuery: 'Enabled'
+//   }
+// }

--- a/infrastructure/resource_group_level/modules/portal-api.bicep
+++ b/infrastructure/resource_group_level/modules/portal-api.bicep
@@ -33,6 +33,7 @@ param secureConnectionStrings object = {
   CORS_ORIGIN: 'test-value'
   AZURE_PORTAL_EXPORT_FOLDER: 'test-value'
   AZURE_PORTAL_FILESHARE_NAME: 'test-value'
+  // TODO:FN-737 *_WORKFLOW_* variables are not needed and can be removed.
   AZURE_WORKFLOW_EXPORT_FOLDER: 'test-value'
   AZURE_WORKFLOW_FILESHARE_NAME: 'test-value'
   AZURE_WORKFLOW_IMPORT_FOLDER: 'test-value'
@@ -43,6 +44,7 @@ param secureConnectionStrings object = {
   GOV_NOTIFY_API_KEY: 'test-value'
   GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
   DTFS_PORTAL_SCHEDULER: 'test-value'
+  // TODO:FN-737 *_WORKFLOW_* variables are not needed and can be removed.
   FETCH_WORKFLOW_TYPE_B_SCHEDULE: 'test-value'
   COMPANIES_HOUSE_API_URL: 'test-value' // from env
   COMPANIES_HOUSE_API_KEY: 'test-value' // from env but looks a secret


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers:
* Adding the portal-api webapp

### Resolution
* Portal-api webapp is added and wired up in Bicep
NOTE: Numerous settings are sent via connection string.
NOTE: I wire up the vnet & NAT gateway correctly, which is the case in `staging` and `prod` but not test.