### PR TITLE
fix(mock-data-loader): Fix TFM failing on mock-data-loader

### DIFF
--- a/utils/mock-data-loader/re-insert-mocks.js
+++ b/utils/mock-data-loader/re-insert-mocks.js
@@ -1,4 +1,4 @@
-const { createAndLogInAsInitialUser, deleteInitialUser } = require('./user-helper');
+const { createAndLogInAsInitialUser, deleteInitialUser, deleteInitialTFMUser } = require('./user-helper');
 
 const cleanAllTables = require('./clean-all-tables');
 const insertMocks = require('./insert-mocks');
@@ -19,7 +19,6 @@ const init = async () => {
   await insertMocks(portalToken);
   await cleanAllTablesGef(portalToken);
   await insertMocksGef(portalToken);
-  await cleanAllTablesTfm();
 
   const tfmToken = await tokenForTfmUser({
     username: 're-insert-mocks',
@@ -29,8 +28,12 @@ const init = async () => {
     roles: ['data-admin'],
     email: 're-insert-mocks-data-loader-tfm@ukexportfinance.gov.uk',
   });
+
+  await cleanAllTablesTfm(tfmToken);
+
   await insertMocksTfm(tfmToken);
 
+  await deleteInitialTFMUser(tfmToken);
   await deleteInitialUser(portalToken);
 };
 

--- a/utils/mock-data-loader/tfm/clean-all-tables-tfm.js
+++ b/utils/mock-data-loader/tfm/clean-all-tables-tfm.js
@@ -12,7 +12,9 @@ const cleanUsers = async (token) => {
   console.info('cleaning TFM users');
 
   for (const user of await api.listUsers(token)) {
-    await api.deleteUser(user, token);
+    if (user.username !== 're-insert-mocks') {
+      await api.deleteUser(user, token);
+    }
   }
 };
 

--- a/utils/mock-data-loader/user-helper.js
+++ b/utils/mock-data-loader/user-helper.js
@@ -1,4 +1,5 @@
 const api = require('./api');
+const tfmApi = require('./tfm/api');
 
 const mockDataLoaderUser = {
   username: 're-insert-mocks',
@@ -32,4 +33,16 @@ const deleteInitialUser = async (token) => {
   await api.deleteUser(userToDelete, token);
 };
 
-module.exports = { mockDataLoaderUser, createAndLogInAsInitialUser, deleteInitialUser };
+const deleteInitialTFMUser = async (token) => {
+  const allUsers = await tfmApi.listUsers(token);
+  const userToDelete = allUsers.filter((user) => user.username === 're-insert-mocks');
+
+  for (const user of userToDelete) {
+    console.info(`deleting tfm user ${user.username}`);
+    await tfmApi.deleteUser(user);
+  }
+};
+
+module.exports = {
+  mockDataLoaderUser, createAndLogInAsInitialUser, deleteInitialUser, deleteInitialTFMUser
+};


### PR DESCRIPTION
## Introduction
Mock data loader failing for tfm with 401

## Resolution
* re-insert-mocks user not deleted until all tfm mocks inserted
* New function to delete all re-inserted mocks users from tfm