### PR TITLE
fix(SR-12): Stop exposing full error messages and stack traces

### DIFF
--- a/dtfs-central-api/src/v1/controllers/cron-jobs/cron-jobs.controller.js
+++ b/dtfs-central-api/src/v1/controllers/cron-jobs/cron-jobs.controller.js
@@ -8,6 +8,8 @@ exports.deleteAllEstoreLogs = async (req, res) => {
 
     return res.status(200).send();
   } catch (error) {
-    return res.status(500).send(error);
+    return res.status(500).send({
+      error: 'An exception has occured',
+    });
   }
 };

--- a/dtfs-central-api/src/v1/controllers/cron-jobs/cron-jobs.controller.js
+++ b/dtfs-central-api/src/v1/controllers/cron-jobs/cron-jobs.controller.js
@@ -8,6 +8,8 @@ exports.deleteAllEstoreLogs = async (req, res) => {
 
     return res.status(200).send();
   } catch (error) {
+    console.error('CRON job error %O', error);
+
     return res.status(500).send({
       error: 'An exception has occured',
     });

--- a/dtfs-central-api/src/v1/controllers/durable-functions/durable-functions.controller.js
+++ b/dtfs-central-api/src/v1/controllers/durable-functions/durable-functions.controller.js
@@ -8,6 +8,8 @@ exports.deleteAllDurableFunctions = async (req, res) => {
 
     return res.status(200).send();
   } catch (error) {
+    console.error('ACBS DOF error %O', error);
+
     return res.status(500).send({
       error: 'An exception has occured',
     });

--- a/dtfs-central-api/src/v1/controllers/durable-functions/durable-functions.controller.js
+++ b/dtfs-central-api/src/v1/controllers/durable-functions/durable-functions.controller.js
@@ -8,6 +8,8 @@ exports.deleteAllDurableFunctions = async (req, res) => {
 
     return res.status(200).send();
   } catch (error) {
-    return res.status(500).send(error);
+    return res.status(500).send({
+      error: 'An exception has occured',
+    });
   }
 };

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -728,7 +728,7 @@ const getUnissuedFacilitiesReport = async (token) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Unable to return unissued facilities', { error });
+    console.error('Unable to return unissued facilities %O', error);
     return { status: error?.code || 500, data: 'Error getting unissued facilities report.' };
   }
 };
@@ -746,7 +746,7 @@ const getUkefDecisionReport = async (token, payload) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Unable to return Ukef decision report', { error });
+    console.error('Unable to return UKEF decision report %O', error);
     return { status: error?.code || 500, data: 'Error getting Ukef decision report.' };
   }
 };

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -729,7 +729,7 @@ const getUnissuedFacilitiesReport = async (token) => {
     return response.data;
   } catch (error) {
     console.error('Unable to return unissued facilities', { error });
-    return error;
+    return { status: error?.code || 500, data: 'Error getting unissued facilities report.' };
   }
 };
 
@@ -747,7 +747,7 @@ const getUkefDecisionReport = async (token, payload) => {
     return response.data;
   } catch (error) {
     console.error('Unable to return Ukef decision report', { error });
-    return error;
+    return { status: error?.code || 500, data: 'Error getting Ukef decision report.' };
   }
 };
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -237,7 +237,8 @@ const updateDealSnapshot = async (dealId, snapshotUpdate) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('updateDealSnapshot: Failed to update deal snapshot: %s', error);
+    return { status: error?.code || 500, data: 'Failed to update deal snapshot' };
   }
 };
 
@@ -278,8 +279,7 @@ const findOneFacility = async (facilityId) => {
     return response.data;
   } catch (error) {
     console.error('TFM API - error finding BSS facility: %s', facilityId);
-
-    return error;
+    return { status: error?.code || 500, data: 'Error finding BSS facility' };
   }
 };
 
@@ -300,7 +300,8 @@ const findFacilitesByDealId = async (dealId) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('findFacilitiesByDealId: Failed to find facilities by deal id: %s', error);
+    return { status: error?.code || 500, data: 'Failed to find facilities by deal id' };
   }
 };
 
@@ -324,7 +325,8 @@ const updateFacility = async (facilityId, facilityUpdate) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('updateFacility: Failed to update facility: %s', error);
+    return { status: error?.code || 500, data: 'Failed to update facility' };
   }
 };
 
@@ -622,7 +624,7 @@ const updateGefFacility = async (facilityId, facilityUpdate) => {
     return response.data;
   } catch (error) {
     console.error('Unable to update facility %s', error);
-    return error;
+    return { status: error?.code || 500, data: 'Unable to update facility' };
   }
 };
 
@@ -641,7 +643,8 @@ const queryDeals = async ({ queryParams, start = 0, pagesize = 0 }) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('queryDeals: Failed to get deals: %s', error);
+    return { status: error?.code || 500, data: 'Failed to get deals' };
   }
 };
 
@@ -781,7 +784,8 @@ const findOneTeam = async (teamId) => {
 
     return response.data.team;
   } catch (error) {
-    return error;
+    console.error('findOneTeam: Failed to find team: %s', error);
+    return { status: error?.code || 500, data: 'Failed to find team' };
   }
 };
 
@@ -802,7 +806,8 @@ const findTeamMembers = async (teamId) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('findTeamMembers: Failed to find team members: %s', error);
+    return { status: error?.code || 500, data: 'Failed to find team members' };
   }
 };
 
@@ -838,7 +843,7 @@ const getFacilityExposurePeriod = async (startDate, endDate, type) => {
     return response.data;
   } catch (error) {
     console.error('TFM-API - Failed api call to getFacilityExposurePeriod: %s', { error });
-    return error;
+    return { status: error?.code || 500, data: 'Failed to get facility exposure period' };
   }
 };
 
@@ -897,7 +902,7 @@ const updateACBSfacility = async (facility, deal) => {
       return response.data;
     } catch (error) {
       console.error('TFM-API Facility update error: %s', { error });
-      return error;
+      return { status: error?.code || 500, data: 'Failed to update ACBS facility' };
     }
   }
   return {};
@@ -960,7 +965,7 @@ const getFunctionsAPI = async (type = DURABLE_FUNCTIONS.TYPE.ACBS, url = '') => 
     return response.data;
   } catch (error) {
     console.error('Unable to getFunctionsAPI for %s', modifiedUrl, { error });
-    return error;
+    return { status: error?.code || 500, data: 'Failed to get functions API' };
   }
 };
 
@@ -1172,7 +1177,7 @@ const getGefMandatoryCriteriaByVersion = async (version) => {
     return response.data;
   } catch (error) {
     console.error('Unable to get the mandatory criteria by version for GEF deals %s', error);
-    return error;
+    return { status: error?.code || 500, data: 'Failed to get mandatory criteria by version for GEF deals' };
   }
 };
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -214,7 +214,8 @@ const updateDeal = async (dealId, dealUpdate) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('updateDeal: Failed to update deal: %s', error);
+    return { status: error?.code || 500, data: 'Error when updating deal' };
   }
 };
 
@@ -254,7 +255,8 @@ const submitDeal = async (dealType, dealId) => {
 
     return response.data;
   } catch (error) {
-    return error;
+    console.error('submitDeal: Failed to submit deal: %s', error);
+    return { status: error?.code || 500, data: 'Error when submitting deal' };
   }
 };
 


### PR DESCRIPTION
## Introduction
This PR is to fix the [Information exposure through a stack trace](https://github.com/UK-Export-Finance/dtfs2/security/code-scanning?query=is%3Aopen+branch%3Amain+stack+trace++) alerts

## Resolution
Where errors are returned from the api methods, instead of returning them, log them and return an error message instead.