### PR TITLE
test(DTFS-6210): Recover removed test code

### DIFF
--- a/e2e-tests/trade-finance-manager/cypress/e2e/journeys/case/amendments/amendment-tasks-manual.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/e2e/journeys/case/amendments/amendment-tasks-manual.spec.js
@@ -389,10 +389,6 @@ context('Amendments tasks - manual amendment tasks', () => {
     pages.tasksPage.tasks.row(4, 4).status().contains('Cannot start yet');
     pages.tasksPage.tasks.row(4, 5).status().contains('Cannot start yet');
 
-    cy.login(UNDERWRITER_MANAGER_1);
-    cy.visit(relative(`/case/${dealId}/underwriting`));
-    pages.underwritingPage.addAmendmentUnderwriterManagerDecisionButton().should('not.exist');
-
     cy.login(RISK_MANAGER_1);
     cy.visit(relative(`/case/${dealId}/deal`));
     caseSubNavigation.tasksLink().click();
@@ -438,7 +434,6 @@ context('Amendments tasks - manual amendment tasks', () => {
     cy.visit(relative(`/case/${dealId}/underwriting`));
     pages.underwritingPage.addAmendmentUnderwriterManagerDecisionButton().contains('Add decision');
 
-    cy.login(UNDERWRITER_MANAGER_1);
     cy.visit(relative(`/case/${dealId}/deal`));
     caseSubNavigation.tasksLink().click();
     cy.url().should('eq', relative(`/case/${dealId}/tasks`));

--- a/e2e-tests/trade-finance-manager/cypress/e2e/journeys/case/amendments/amendment-tasks-manual.spec.js
+++ b/e2e-tests/trade-finance-manager/cypress/e2e/journeys/case/amendments/amendment-tasks-manual.spec.js
@@ -389,7 +389,9 @@ context('Amendments tasks - manual amendment tasks', () => {
     pages.tasksPage.tasks.row(4, 4).status().contains('Cannot start yet');
     pages.tasksPage.tasks.row(4, 5).status().contains('Cannot start yet');
 
-    // TODO: DTFS2-6210 add when add decision is dependent on tasks, IF THIS IS REQUIRED.
+    cy.login(UNDERWRITER_MANAGER_1);
+    cy.visit(relative(`/case/${dealId}/underwriting`));
+    pages.underwritingPage.addAmendmentUnderwriterManagerDecisionButton().should('not.exist');
 
     cy.login(RISK_MANAGER_1);
     cy.visit(relative(`/case/${dealId}/deal`));
@@ -432,7 +434,15 @@ context('Amendments tasks - manual amendment tasks', () => {
     pages.tasksPage.tasks.row(4, 4).status().contains('In progress');
     pages.tasksPage.tasks.row(4, 5).status().contains('Cannot start yet');
 
-    // TODO: DTFS2-6210 add when add decision is dependent on tasks.
+    cy.login(UNDERWRITER_MANAGER_1);
+    cy.visit(relative(`/case/${dealId}/underwriting`));
+    pages.underwritingPage.addAmendmentUnderwriterManagerDecisionButton().contains('Add decision');
+
+    cy.login(UNDERWRITER_MANAGER_1);
+    cy.visit(relative(`/case/${dealId}/deal`));
+    caseSubNavigation.tasksLink().click();
+    cy.url().should('eq', relative(`/case/${dealId}/tasks`));
+    pages.tasksPage.filterRadioAllTasks().click();
 
     pages.tasksPage.tasks.row(4, 4).link().first().click();
 


### PR DESCRIPTION
### Introduction
There was some commented out test code from `amendment-tasks-manual.spec.js` in the TFM e2e tests, backed up on this ticket, which we need to re-instate.

### Resolution
The tests in this file make an amendment to a deal, and then go through completing each of the tasks on that amendment.

The commented out code had two sections. The first asserted that when the "Approve or decline the amendment" task had the status "Cannot start yet", that the "Add decision" button on the Underwriting tab should not appear.

And the second section asserted that when that task had the status "To do", that the "Add decision" button should appear.


Having looked in the code, the "Add decision" button does not depend on what tasks have and haven't been completed, only on whether an underwriter manager is logged in. So I've not included the first commented out section as it will just make the test incorrectly fail (I have verified that this is what happens)