### PR TITLE
fix(SR-14): file limit size on portal

### DIFF
--- a/portal/server/routes/contract/eligibility/index.js
+++ b/portal/server/routes/contract/eligibility/index.js
@@ -32,7 +32,7 @@ const mergeEligibilityValidationErrors = (criteria, files) => {
   };
 };
 
-const upload = multer({ limits: { fileSize: 10 * 1024 * 1024, files: 20 }, fileFilter: multerFilter }).any();
+const upload = multer({ limits: { fileSize: FILE_UPLOAD.MAX_FILE_SIZE }, fileFilter: multerFilter }).any();
 
 const router = express.Router();
 


### PR DESCRIPTION
## Introduction
File size limit was found to be 10mb in QA instead of 12mb

## Resolution
Change to use file upload constant with 12mb