### PR TITLE
feat(FN-685) A record generation

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -323,6 +323,7 @@ module dtfsCentralApi 'modules/dtfs-central-api.bicep' = {
     cosmosDbDatabaseName: cosmosDbDatabaseName
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     externalApiHostname: externalApi.outputs.defaultHostName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -275,6 +275,7 @@ module functionAcbs 'modules/function-acbs.bicep' = {
     appServicePlanId: appServicePlan.id
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     storageAccountName: storage.outputs.storageAccountName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -362,7 +362,7 @@ module tfmApi 'modules/trade-finance-manager-api.bicep' = {
     location: location
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
-    storageAccountName: storage.outputs.storageAccountName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -306,7 +306,8 @@ module externalApi 'modules/external-api.bicep' = {
     cosmosDbDatabaseName: cosmosDbDatabaseName
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     acbsFunctionDefaultHostName: functionAcbs.outputs.defaultHostName
-    numberGeneratorFunctionDefaultHostName: 'TODO:FN-420'
+    numberGeneratorFunctionDefaultHostName: functionNumberGenerator.outputs.defaultHostName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -397,6 +397,7 @@ module tfmUi 'modules/trade-finance-manager-ui.bicep' = {
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     redisName: redis.outputs.redisName
     tfmApiHostname: tfmApi.outputs.defaultHostName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -411,6 +411,7 @@ module gefUi 'modules/gef-ui.bicep' = {
     portalApiHostname: portalApi.outputs.defaultHostName
     redisName: redis.outputs.redisName
     tfmApiHostname: tfmApi.outputs.defaultHostName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -343,6 +343,7 @@ module portalApi 'modules/portal-api.bicep' = {
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     storageAccountName: storage.outputs.storageAccountName
     tfmApiHostname: tfmApi.outputs.defaultHostName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -289,6 +289,7 @@ module functionNumberGenerator 'modules/function-number-generator.bicep' = {
     appServicePlanId: appServicePlan.id
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     storageAccountName: storage.outputs.storageAccountName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -379,6 +379,7 @@ module portalUi 'modules/portal-ui.bicep' = {
     portalApiHostname: portalApi.outputs.defaultHostName
     redisName: redis.outputs.redisName
     tfmApiHostname: tfmApi.outputs.defaultHostName
+    azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
   }
 }
 

--- a/infrastructure/resource_group_level/modules/dtfs-central-api.bicep
+++ b/infrastructure/resource_group_level/modules/dtfs-central-api.bicep
@@ -8,6 +8,7 @@ param cosmosDbAccountName string
 param cosmosDbDatabaseName string
 param logAnalyticsWorkspaceId string
 param externalApiHostname string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/dtfs-central-api:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -153,6 +154,21 @@ resource dtfsCentralApiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: dtfsCentralApiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/resource_group_level/modules/external-api.bicep
+++ b/infrastructure/resource_group_level/modules/external-api.bicep
@@ -9,6 +9,7 @@ param cosmosDbDatabaseName string
 param logAnalyticsWorkspaceId string
 param acbsFunctionDefaultHostName string
 param numberGeneratorFunctionDefaultHostName string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/external-api:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -155,6 +156,21 @@ resource dtfsCentralApiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: dtfsCentralApiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/resource_group_level/modules/function-acbs.bicep
+++ b/infrastructure/resource_group_level/modules/function-acbs.bicep
@@ -5,7 +5,7 @@ param appServicePlanEgressSubnetId string
 param appServicePlanId string
 param privateEndpointsSubnetId string
 param storageAccountName string
-
+param azureWebsitesDnsZoneId string
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
@@ -155,6 +155,21 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {
   }
 }
 
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: applicationInsightsName
   location: location
@@ -163,8 +178,5 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     Application_Type: 'web'
   }
 }
-
-
-// TODO:FN-685 Add automatic A Record generation.
 
 output defaultHostName string = functionAcbs.properties.defaultHostName

--- a/infrastructure/resource_group_level/modules/function-number-generator.bicep
+++ b/infrastructure/resource_group_level/modules/function-number-generator.bicep
@@ -5,6 +5,7 @@ param appServicePlanEgressSubnetId string
 param appServicePlanId string
 param privateEndpointsSubnetId string
 param storageAccountName string
+param azureWebsitesDnsZoneId string
 
 
 // These values are taken from GitHub secrets injected in the GHA Action
@@ -143,6 +144,21 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = {
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: privateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/resource_group_level/modules/function-number-generator.bicep
+++ b/infrastructure/resource_group_level/modules/function-number-generator.bicep
@@ -171,7 +171,4 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-
-// TODO:FN-685 Add automatic A Record generation.
-
 output defaultHostName string = functionNumberGenerator.properties.defaultHostName

--- a/infrastructure/resource_group_level/modules/gef-ui.bicep
+++ b/infrastructure/resource_group_level/modules/gef-ui.bicep
@@ -9,6 +9,7 @@ param externalApiHostname string
 param tfmApiHostname string
 param portalApiHostname string
 param redisName string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/gef-ui:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -195,6 +196,22 @@ resource gefUiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = 
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
   }
 }
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: gefUiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
+  }
+}
+
 
 // Application insights isn't enabled in Dev or staging, but is in prod.
 // resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {

--- a/infrastructure/resource_group_level/modules/portal-api.bicep
+++ b/infrastructure/resource_group_level/modules/portal-api.bicep
@@ -11,6 +11,7 @@ param externalApiHostname string
 param dtfsCentralApiHostname string
 param tfmApiHostname string
 param storageAccountName string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/portal-api:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -232,6 +233,21 @@ resource portalApiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: portalApiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/resource_group_level/modules/portal-ui.bicep
+++ b/infrastructure/resource_group_level/modules/portal-ui.bicep
@@ -9,6 +9,7 @@ param externalApiHostname string
 param tfmApiHostname string
 param portalApiHostname string
 param redisName string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/portal-ui:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -192,6 +193,21 @@ resource portalUiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01'
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: portalUiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -76,32 +76,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 //   }
 // }
 
-// resource devFunctionAcbs 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-function-acbs'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.14'
-//       }
-//     ]
-//   }
-// }
-
-// resource devFunctionAcbsScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-function-acbs.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.14'
-//       }
-//     ]
-//   }
-// }
-
 // resource devFunctionNumberGenerator 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-function-number-generator'
@@ -283,3 +257,5 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 //     ]
 //   }
 // }
+
+output azureWebsitesDnsZoneId string = azureWebsitesDnsZone.id

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -42,38 +42,8 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 }
 
 // TODO:DTFS-6422 Wire up A record IPs correctly, getting appropriate values.
-// TODO:DTFS-6422 use array of objects and loop over to create all resources.
 // Dev included a set of "Demo" values too in the original export. I have not included them
-// Test seeems to include a set of "Staging" values too.
+// Test seeems to include a set of "Staging" values too. Check this
 
-// // TODO:DTFS-6422 update for "Feature" values
-
-// // Dev A records
-
-// resource devTfmUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-trade-finance-manager-ui'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.10'
-//       }
-//     ]
-//   }
-// }
-
-// resource devTfmUiScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-trade-finance-manager-ui.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.10'
-//       }
-//     ]
-//   }
-// }
 
 output azureWebsitesDnsZoneId string = azureWebsitesDnsZone.id

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -50,32 +50,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 
 // // Dev A records
 
-// resource devPortalApi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-portal-api'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.11'
-//       }
-//     ]
-//   }
-// }
-
-// resource devPortalApiScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-portal-api.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.11'
-//       }
-//     ]
-//   }
-// }
-
 // resource devPortalUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-portal-ui'

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -50,32 +50,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 
 // // Dev A records
 
-// resource devReferenceDataProxy 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-reference-data-proxy'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.5'
-//       }
-//     ]
-//   }
-// }
-
-// resource devReferenceDataProxyScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-reference-data-proxy.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.5'
-//       }
-//     ]
-//   }
-// }
-
 // resource devTfmApi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-trade-finance-manager-api'

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -50,32 +50,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 
 // // Dev A records
 
-// resource devTfmApi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-trade-finance-manager-api'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.9'
-//       }
-//     ]
-//   }
-// }
-
-// resource devTfmApiScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-trade-finance-manager-api.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.9'
-//       }
-//     ]
-//   }
-// }
-
 // resource devTfmUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-trade-finance-manager-ui'

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -76,32 +76,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 //   }
 // }
 
-// resource devFunctionNumberGenerator 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-function-number-generator'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.16'
-//       }
-//     ]
-//   }
-// }
-
-// resource devFunctionNumberGeneratorScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-function-number-generator.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.16'
-//       }
-//     ]
-//   }
-// }
-
 // resource devGefUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-gef-ui'

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -50,32 +50,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 
 // // Dev A records
 
-// resource devCentralApi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-dtfs-central-api'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.8'
-//       }
-//     ]
-//   }
-// }
-
-// resource devCentralApiScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-dtfs-central-api.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.8'
-//       }
-//     ]
-//   }
-// }
-
 // resource devGefUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-gef-ui'

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -50,32 +50,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 
 // // Dev A records
 
-// resource devGefUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-gef-ui'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.12'
-//       }
-//     ]
-//   }
-// }
-
-// resource devGefUiScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-gef-ui.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.12'
-//       }
-//     ]
-//   }
-// }
-
 // resource devPortalApi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-portal-api'

--- a/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-azurewebsites-net.bicep
@@ -50,32 +50,6 @@ resource appServiceVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLin
 
 // // Dev A records
 
-// resource devPortalUi 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-portal-ui'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.13'
-//       }
-//     ]
-//   }
-// }
-
-// resource devPortalUiScm 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
-//   parent: azureWebsitesDnsZone
-//   name: 'tfs-dev-portal-ui.scm'
-//   properties: {
-//     ttl: 3600
-//     aRecords: [
-//       {
-//         ipv4Address: '172.16.40.13'
-//       }
-//     ]
-//   }
-// }
-
 // resource devReferenceDataProxy 'Microsoft.Network/privateDnsZones/A@2018-09-01' = {
 //   parent: azureWebsitesDnsZone
 //   name: 'tfs-dev-reference-data-proxy'

--- a/infrastructure/resource_group_level/modules/trade-finance-manager-api.bicep
+++ b/infrastructure/resource_group_level/modules/trade-finance-manager-api.bicep
@@ -9,7 +9,7 @@ param cosmosDbDatabaseName string
 param logAnalyticsWorkspaceId string
 param externalApiHostname string
 param dtfsCentralApiHostname string
-param storageAccountName string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/trade-finance-manager-api:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -215,6 +215,21 @@ resource tfmApiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' =
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: tfmApiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 

--- a/infrastructure/resource_group_level/modules/trade-finance-manager-ui.bicep
+++ b/infrastructure/resource_group_level/modules/trade-finance-manager-ui.bicep
@@ -8,6 +8,7 @@ param logAnalyticsWorkspaceId string
 param externalApiHostname string
 param tfmApiHostname string
 param redisName string
+param azureWebsitesDnsZoneId string
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/trade-finance-manager-ui:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -186,6 +187,21 @@ resource tfmUiPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' = 
     }
     ipConfigurations: []
     // Note that the customDnsConfigs array gets created automatically and doesn't need setting here.
+  }
+}
+
+resource zoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-11-01' = {
+  parent: tfmUiPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'zoneConfig'
+        properties: {
+          privateDnsZoneId: azureWebsitesDnsZoneId
+        }
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers:
* Wiring up A Records for all private links to enable traffic routing
### Resolution
* Adds privateDNSZoneGroups linked to the resources - this triggers the A Record generation.
NOTE: Dev has `reference-data-proxy` as well as `external-api` and a load of `demo` values. I have not attempted to recreate those.