### PR TITLE
chore: apply cspell check in lint-staged to all packages

### DIFF
--- a/azure-functions/acbs-function/package.json
+++ b/azure-functions/acbs-function/package.json
@@ -10,7 +10,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "axios": "^0.27.2",

--- a/azure-functions/number-generator-function/package.json
+++ b/azure-functions/number-generator-function/package.json
@@ -9,7 +9,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "axios": "^1.4.0",

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -31,7 +31,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "axios": "^1.4.0",

--- a/external-api/package.json
+++ b/external-api/package.json
@@ -29,7 +29,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "@types/compression": "^1.7.2",

--- a/gef-ui/package.json
+++ b/gef-ui/package.json
@@ -33,7 +33,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "@ministryofjustice/frontend": "1.8.0",

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -30,7 +30,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "@azure/storage-file-share": "12.14.0",

--- a/portal/package.json
+++ b/portal/package.json
@@ -33,7 +33,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "@ministryofjustice/frontend": "1.8.0",

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -30,7 +30,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "@graphql-tools/schema": "^9.0.19",

--- a/trade-finance-manager-ui/package.json
+++ b/trade-finance-manager-ui/package.json
@@ -34,7 +34,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",

--- a/utils/data-migration/package.json
+++ b/utils/data-migration/package.json
@@ -11,7 +11,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "axios": "^0.27.2",

--- a/utils/mock-data-loader/package.json
+++ b/utils/mock-data-loader/package.json
@@ -12,7 +12,10 @@
   "lint-staged": {
     "package.json": "sort-package-json",
     "*.js": "eslint --fix",
-    "*.ts": "eslint --fix"
+    "*.ts": "eslint --fix",
+    "*": [
+      "cspell lint --gitignore --no-summary --fail-fast --no-must-find-files --color"
+    ]
   },
   "dependencies": {
     "axios": "^1.4.0",


### PR DESCRIPTION
## Introduction

@AlexBramhill noticed in #1955 that it was possible to commit a change to a file with a spelling mistake in `utils/data-migration/helpers/package.json`, so the `cspell` linting must not have been working properly.

I investigated this and found that `lint-staged` uses the nearest configuration file for each file that it lints (see [here](https://github.com/okonet/lint-staged#how-to-use-lint-staged-in-a-multi-package-monorepo)) so we needed to add our `cspell` linting step to the `lint-staged` section of every `package.json` file.

## Resolution
I have added our `cspell` linting step to the `lint-staged` section of every `package.json` file.