### PR TITLE
fix(sr-8): update error message name

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -22,6 +22,7 @@
         "ORDANANCE",
         "Abhi",
         "acbs",
+        "aChecker",
         "actionsheet",
         "APIM",
         "azurecr",

--- a/gef-ui/server/utils/helpers.js
+++ b/gef-ui/server/utils/helpers.js
@@ -74,7 +74,7 @@ const validationErrorHandler = (errs, href = '') => {
 
   errors.forEach((el) => {
     const errorsForReference = ErrorMessagesMap[el.errRef];
-    const mappedErrorMessage = errorsForReference ? errorsForReference[el.status] : el.errMsg;
+    const mappedErrorMessage = errorsForReference ? errorsForReference[el.errCode] : el.errMsg;
 
     errorSummary.push({
       text: mappedErrorMessage,

--- a/gef-ui/server/utils/helpers.js
+++ b/gef-ui/server/utils/helpers.js
@@ -74,7 +74,7 @@ const validationErrorHandler = (errs, href = '') => {
 
   errors.forEach((el) => {
     const errorsForReference = ErrorMessagesMap[el.errRef];
-    const mappedErrorMessage = errorsForReference ? errorsForReference[el.errCode] : el.errMsg;
+    const mappedErrorMessage = errorsForReference ? errorsForReference[el.status] : el.errMsg;
 
     errorSummary.push({
       text: mappedErrorMessage,

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -257,7 +257,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(removeName).to(baseUrl);
       expect(body).toEqual([{
-        errCode: 'MANDATORY_FIELD',
+        status: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);
@@ -271,7 +271,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(removeName).to(baseUrl);
       expect(body).toEqual([{
-        errCode: 'MANDATORY_FIELD',
+        status: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);
@@ -341,7 +341,7 @@ describe(baseUrl, () => {
       const res = await as(aMaker).put({ status: 'NOT_A_STATUS' }).to(`${baseUrl}/status/${body._id}`);
       expect(res.status).toEqual(422);
       expect(res.body).toEqual([{
-        errCode: 'ENUM_ERROR',
+        status: 'ENUM_ERROR',
         errRef: 'status',
         errMsg: 'Unrecognised enum',
       }]);

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -257,7 +257,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(removeName).to(baseUrl);
       expect(body).toEqual([{
-        status: 'MANDATORY_FIELD',
+        errCode: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);
@@ -271,7 +271,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(removeName).to(baseUrl);
       expect(body).toEqual([{
-        status: 'MANDATORY_FIELD',
+        errCode: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);
@@ -341,7 +341,7 @@ describe(baseUrl, () => {
       const res = await as(aMaker).put({ status: 'NOT_A_STATUS' }).to(`${baseUrl}/status/${body._id}`);
       expect(res.status).toEqual(422);
       expect(res.body).toEqual([{
-        status: 'ENUM_ERROR',
+        errCode: 'ENUM_ERROR',
         errRef: 'status',
         errMsg: 'Unrecognised enum',
       }]);

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -33,13 +33,13 @@ const mockEligibilityCriteriaLatestVersion = mockEligibilityCriteria.find((crite
 
 describe(baseUrl, () => {
   let aMaker;
-  let checker;
+  let aChecker;
   const tfmDealSubmitSpy = jest.fn(() => Promise.resolve());
 
   beforeAll(async () => {
     const testUsers = await testUserCache.initialise(app);
     aMaker = testUsers().withRole('maker').one();
-    checker = testUsers().withRole('checker').one();
+    aChecker = testUsers().withRole('checker').one();
   });
 
   beforeEach(async () => {
@@ -76,7 +76,7 @@ describe(baseUrl, () => {
       await as(aMaker).post(mockApplications[14]).to(baseUrl);
       await as(aMaker).post(mockApplications[15]).to(baseUrl);
 
-      const { body, status } = await as(checker).get(baseUrl);
+      const { body, status } = await as(aChecker).get(baseUrl);
 
       const expected = {
         items: mockApplications.map((item) => ({
@@ -396,7 +396,7 @@ describe(baseUrl, () => {
           expect(body.submissionCount).toEqual(0);
 
           const dealId = body._id;
-          await as(checker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.CHANGES_REQUIRED }).to(`${baseUrl}/status/${dealId}`);
+          await as(aChecker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.CHANGES_REQUIRED }).to(`${baseUrl}/status/${dealId}`);
 
           const firstSendEmailCall = referenceData.sendEmail.mock.calls[0][0];
 
@@ -405,7 +405,7 @@ describe(baseUrl, () => {
             aMaker.bank.emails[0],
             expectedEmailVariables(
               aMaker,
-              checker,
+              aChecker,
               mockApplication,
               CONSTANTS.DEAL.DEAL_STATUS.CHANGES_REQUIRED,
             ),
@@ -420,16 +420,16 @@ describe(baseUrl, () => {
           expect(body.submissionCount).toEqual(0);
 
           const dealId = body._id;
-          await as(checker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF }).to(`${baseUrl}/status/${dealId}`);
+          await as(aChecker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF }).to(`${baseUrl}/status/${dealId}`);
 
           const firstSendEmailCall = referenceData.sendEmail.mock.calls[0][0];
 
           expect(firstSendEmailCall).toEqual(
             CONSTANTS.EMAIL_TEMPLATE_IDS.UPDATE_STATUS,
-            checker.bank.emails[0],
+            aChecker.bank.emails[0],
             expectedEmailVariables(
               aMaker,
-              checker,
+              aChecker,
               mockApplication,
               CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF,
             ),
@@ -615,17 +615,17 @@ describe(baseUrl, () => {
 
         const dealId = body._id;
 
-        await as(checker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF }).to(`${baseUrl}/status/${dealId}`);
+        await as(aChecker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF }).to(`${baseUrl}/status/${dealId}`);
 
         const expectedChecker = {
           _id: expect.any(Object),
-          bank: checker.bank,
-          email: checker.email,
-          username: checker.username,
-          roles: checker.roles,
-          firstname: checker.firstname,
-          surname: checker.surname,
-          timezone: checker.timezone,
+          bank: aChecker.bank,
+          email: aChecker.email,
+          username: aChecker.username,
+          roles: aChecker.roles,
+          firstname: aChecker.firstname,
+          surname: aChecker.surname,
+          timezone: aChecker.timezone,
           lastLogin: expect.any(String),
           'user-status': 'active',
         };
@@ -646,8 +646,8 @@ describe(baseUrl, () => {
       const dealId = body._id;
 
       // adds required fields to the gef deal
-      await as(checker).put({ checkerId: checker._id, submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIA }).to(`${baseUrl}/${dealId}`);
-      const putResponse = await as(checker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF }).to(`${baseUrl}/status/${dealId}`);
+      await as(aChecker).put({ checkerId: aChecker._id, submissionType: CONSTANTS.DEAL.SUBMISSION_TYPE.MIA }).to(`${baseUrl}/${dealId}`);
+      const putResponse = await as(aChecker).put({ status: CONSTANTS.DEAL.DEAL_STATUS.SUBMITTED_TO_UKEF }).to(`${baseUrl}/status/${dealId}`);
 
       const result = putResponse.body.portalActivities[0];
       expect(result.type).toEqual('NOTICE');
@@ -660,11 +660,11 @@ describe(baseUrl, () => {
       expect(result.text).toEqual('');
       expect(result.label).toEqual('Manual inclusion application submitted to UKEF');
 
-      // get author object from checker
+      // get author object from achecker
       const author = {
-        firstName: checker.firstname,
-        lastName: checker.surname,
-        _id: checker._id,
+        firstName: aChecker.firstname,
+        lastName: aChecker.surname,
+        _id: aChecker._id,
       };
       expect(result.author).toEqual(author);
     });

--- a/portal-api/api-tests/v1/gef/clone-gef-deal.api-test.js
+++ b/portal-api/api-tests/v1/gef/clone-gef-deal.api-test.js
@@ -168,6 +168,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(payload).to(`${baseUrl}/clone`);
       expect(body).toEqual([{
+        status: 422,
         errCode: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
@@ -182,6 +183,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(payload).to(`${baseUrl}/clone`);
       expect(body).toEqual([{
+        status: 422,
         errCode: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',

--- a/portal-api/api-tests/v1/gef/clone-gef-deal.api-test.js
+++ b/portal-api/api-tests/v1/gef/clone-gef-deal.api-test.js
@@ -168,7 +168,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(payload).to(`${baseUrl}/clone`);
       expect(body).toEqual([{
-        status: 'MANDATORY_FIELD',
+        errCode: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);
@@ -182,7 +182,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(payload).to(`${baseUrl}/clone`);
       expect(body).toEqual([{
-        status: 'MANDATORY_FIELD',
+        errCode: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);

--- a/portal-api/api-tests/v1/gef/clone-gef-deal.api-test.js
+++ b/portal-api/api-tests/v1/gef/clone-gef-deal.api-test.js
@@ -168,7 +168,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(payload).to(`${baseUrl}/clone`);
       expect(body).toEqual([{
-        errCode: 'MANDATORY_FIELD',
+        status: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);
@@ -182,7 +182,7 @@ describe(baseUrl, () => {
       };
       const { body, status } = await as(aMaker).post(payload).to(`${baseUrl}/clone`);
       expect(body).toEqual([{
-        errCode: 'MANDATORY_FIELD',
+        status: 'MANDATORY_FIELD',
         errRef: 'bankInternalRefName',
         errMsg: 'bankInternalRefName is Mandatory',
       }]);

--- a/portal-api/api-tests/v1/gef/external-api.api-test.js
+++ b/portal-api/api-tests/v1/gef/external-api.api-test.js
@@ -43,7 +43,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).get(`${baseUrl}/company/1111111`);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        errCode: 'company-profile-not-found',
+        status: 'company-profile-not-found',
         errRef: 'regNumber',
         errMsg: 'Invalid Companies House registration number',
       }]);
@@ -74,7 +74,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).get(`${baseUrl}/address/AA11AA`);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        errCode: 'ERROR',
+        status: 'ERROR',
         errRef: 'postcode',
       }]);
     });

--- a/portal-api/api-tests/v1/gef/external-api.api-test.js
+++ b/portal-api/api-tests/v1/gef/external-api.api-test.js
@@ -43,7 +43,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).get(`${baseUrl}/company/1111111`);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        status: 'company-profile-not-found',
+        errCode: 'company-profile-not-found',
         errRef: 'regNumber',
         errMsg: 'Invalid Companies House registration number',
       }]);
@@ -74,7 +74,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).get(`${baseUrl}/address/AA11AA`);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        status: 'ERROR',
+        errCode: 'ERROR',
         errRef: 'postcode',
       }]);
     });

--- a/portal-api/api-tests/v1/gef/external-api.api-test.js
+++ b/portal-api/api-tests/v1/gef/external-api.api-test.js
@@ -43,6 +43,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).get(`${baseUrl}/company/1111111`);
       expect(status).toEqual(422);
       expect(body).toEqual([{
+        status: 422,
         errCode: 'company-profile-not-found',
         errRef: 'regNumber',
         errMsg: 'Invalid Companies House registration number',
@@ -74,6 +75,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).get(`${baseUrl}/address/AA11AA`);
       expect(status).toEqual(422);
       expect(body).toEqual([{
+        status: 422,
         errCode: 'ERROR',
         errRef: 'postcode',
       }]);

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -553,6 +553,7 @@ describe(baseUrl, () => {
         const { status, body } = await as(aMaker).post({ dealId: mockApplication.body._id, type: 'TEST' }).to(baseUrl);
         expect(status).toEqual(422);
         expect(body).toEqual([{
+          status: 422,
           errCode: ERROR.ENUM_ERROR,
           errMsg: 'Unrecognised enum',
           errRef: 'type',
@@ -565,6 +566,7 @@ describe(baseUrl, () => {
         const res = await as(aMaker).put({ type: 'TEST' }).to(`${baseUrl}/${body.details._id}`);
         expect(res.status).toEqual(422);
         expect(res.body).toEqual([{
+          status: 422,
           errCode: ERROR.ENUM_ERROR,
           errMsg: 'Unrecognised enum',
           errRef: 'type',
@@ -578,6 +580,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).post({ type: 'TEST' }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
+        status: 422,
         errCode: ERROR.MANDATORY_FIELD,
         errMsg: 'No Application ID and/or facility type sent with request',
       }]);
@@ -586,6 +589,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).post({ dealId: mockApplication.body._id }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
+        status: 422,
         errCode: ERROR.MANDATORY_FIELD,
         errMsg: 'No Application ID and/or facility type sent with request',
       }]);

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -553,7 +553,7 @@ describe(baseUrl, () => {
         const { status, body } = await as(aMaker).post({ dealId: mockApplication.body._id, type: 'TEST' }).to(baseUrl);
         expect(status).toEqual(422);
         expect(body).toEqual([{
-          status: ERROR.ENUM_ERROR,
+          errCode: ERROR.ENUM_ERROR,
           errMsg: 'Unrecognised enum',
           errRef: 'type',
         }]);
@@ -565,7 +565,7 @@ describe(baseUrl, () => {
         const res = await as(aMaker).put({ type: 'TEST' }).to(`${baseUrl}/${body.details._id}`);
         expect(res.status).toEqual(422);
         expect(res.body).toEqual([{
-          status: ERROR.ENUM_ERROR,
+          errCode: ERROR.ENUM_ERROR,
           errMsg: 'Unrecognised enum',
           errRef: 'type',
         }]);
@@ -578,7 +578,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).post({ type: 'TEST' }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        status: ERROR.MANDATORY_FIELD,
+        errCode: ERROR.MANDATORY_FIELD,
         errMsg: 'No Application ID and/or facility type sent with request',
       }]);
     });
@@ -586,7 +586,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).post({ dealId: mockApplication.body._id }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        status: ERROR.MANDATORY_FIELD,
+        errCode: ERROR.MANDATORY_FIELD,
         errMsg: 'No Application ID and/or facility type sent with request',
       }]);
     });

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -553,7 +553,7 @@ describe(baseUrl, () => {
         const { status, body } = await as(aMaker).post({ dealId: mockApplication.body._id, type: 'TEST' }).to(baseUrl);
         expect(status).toEqual(422);
         expect(body).toEqual([{
-          errCode: ERROR.ENUM_ERROR,
+          status: ERROR.ENUM_ERROR,
           errMsg: 'Unrecognised enum',
           errRef: 'type',
         }]);
@@ -565,7 +565,7 @@ describe(baseUrl, () => {
         const res = await as(aMaker).put({ type: 'TEST' }).to(`${baseUrl}/${body.details._id}`);
         expect(res.status).toEqual(422);
         expect(res.body).toEqual([{
-          errCode: ERROR.ENUM_ERROR,
+          status: ERROR.ENUM_ERROR,
           errMsg: 'Unrecognised enum',
           errRef: 'type',
         }]);
@@ -578,7 +578,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).post({ type: 'TEST' }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        errCode: ERROR.MANDATORY_FIELD,
+        status: ERROR.MANDATORY_FIELD,
         errMsg: 'No Application ID and/or facility type sent with request',
       }]);
     });
@@ -586,7 +586,7 @@ describe(baseUrl, () => {
       const { status, body } = await as(aMaker).post({ dealId: mockApplication.body._id }).to(baseUrl);
       expect(status).toEqual(422);
       expect(body).toEqual([{
-        errCode: ERROR.MANDATORY_FIELD,
+        status: ERROR.MANDATORY_FIELD,
         errMsg: 'No Application ID and/or facility type sent with request',
       }]);
     });

--- a/portal-api/src/v1/gef/controllers/externalApi.controller.js
+++ b/portal-api/src/v1/gef/controllers/externalApi.controller.js
@@ -44,6 +44,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (!companyNumber || companyNumber === '') {
       return res.status(422).send([
         {
+          status: 422,
           errCode: ERROR.MANDATORY_FIELD,
           errRef: 'regNumber',
           errMsg: 'Enter a Companies House registration number.',
@@ -54,11 +55,14 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (!isValidCompaniesHouseNumber(companyNumber)) {
       console.error('Get company house information API failed for companyNumber %s', companyNumber);
       // returns invalid companies house registration number error
-      return res.status(400).send([{
-        errCode: 'company-profile-not-found',
-        errRef: 'regNumber',
-        errMsg: 'Invalid Companies House registration number',
-      }]);
+      return res.status(400).send([
+        {
+          status: 400,
+          errCode: 'company-profile-not-found',
+          errRef: 'regNumber',
+          errMsg: 'Invalid Companies House registration number',
+        },
+      ]);
     }
 
     const response = await axios({
@@ -70,6 +74,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (response.data.type === 'oversea-company') {
       return res.status(422).send([
         {
+          status: 422,
           errCode: ERROR.OVERSEAS_COMPANY,
           errRef: 'regNumber',
           errMsg: 'UKEF can only process applications from companies based in the UK.',
@@ -85,11 +90,7 @@ exports.getByRegistrationNumber = async (req, res) => {
   } catch (error) {
     console.error('getByRegistrationNumber Error %O', error?.response?.data);
     const response = companiesHouseError(error);
-    let { status } = error.response;
-    if (response[0].errCode === 'company-profile-not-found') {
-      status = 422;
-    }
-    return res.status(status).send(response);
+    return res.status(response.status).send(response);
   }
 };
 
@@ -99,11 +100,14 @@ exports.getAddressesByPostcode = async (req, res) => {
 
     if (!isValidRegex(UK_POSTCODE, postcode)) {
       console.error('Get addresses by postcode failed for postcode %s', postcode);
-      return res.status(400).send([{
-        errCode: 'ERROR',
-        errRef: 'postcode',
-        errMsg: 'Invalid postcode',
-      }]);
+      return res.status(400).send([
+        {
+          status: 400,
+          errCode: 'ERROR',
+          errRef: 'postcode',
+          errMsg: 'Invalid postcode',
+        },
+      ]);
     }
 
     const response = await axios({
@@ -114,44 +118,43 @@ exports.getAddressesByPostcode = async (req, res) => {
 
     const addresses = [];
 
-    if (response?.data?.results) {
-      response.data.results.forEach((item) => {
-        if (item.DPA.LANGUAGE === (req.query.language ? req.query.language : 'EN')) {
+    if (!response?.data?.results) {
+      return res.status(422).send({
+        status: 422,
+        errCode: 'ERROR',
+        errRef: 'postcode',
+      });
+    }
+    response.data.results.forEach((item) => {
+      if (item.DPA.LANGUAGE === (req.query.language ? req.query.language : 'EN')) {
         // Ordnance survey sends duplicated results with the welsh version too via 'CY'
 
-          addresses.push({
-            organisationName: item.DPA.ORGANISATION_NAME || null,
-            addressLine1: `${item.DPA.BUILDING_NAME || ''} ${item.DPA.BUILDING_NUMBER || ''} ${item.DPA.THOROUGHFARE_NAME || ''}`.trim(),
-            addressLine2: item.DPA.DEPENDENT_LOCALITY || null,
-            addressLine3: null, // keys to match registered Address as requested, but not available in OS Places
-            locality: item.DPA.POST_TOWN || null,
-            postalCode: item.DPA.POSTCODE || null,
-            country: null, // keys to match registered Address as requested, but not available in OS Places
-          });
-        }
-      });
+        addresses.push({
+          organisationName: item.DPA.ORGANISATION_NAME || null,
+          addressLine1: `${item.DPA.BUILDING_NAME || ''} ${item.DPA.BUILDING_NUMBER || ''} ${item.DPA.THOROUGHFARE_NAME || ''}`.trim(),
+          addressLine2: item.DPA.DEPENDENT_LOCALITY || null,
+          addressLine3: null, // keys to match registered Address as requested, but not available in OS Places
+          locality: item.DPA.POST_TOWN || null,
+          postalCode: item.DPA.POSTCODE || null,
+          country: null, // keys to match registered Address as requested, but not available in OS Places
+        });
+      }
+    });
 
-      return res.status(200).send(addresses);
-    }
-
-    const notFoundResponse = [{
-      errCode: 'ERROR',
-      errRef: 'postcode',
-    }];
-
-    return res.status(422).send(notFoundResponse);
+    return res.status(200).send(addresses);
   } catch (error) {
+    let { status } = error.response;
+    if (status >= 400 && status < 500) {
+      status = 422;
+    }
     const response = [
       {
+        status,
         errCode: 'ERROR',
         errRef: 'postcode',
         errMsg: error?.response?.data?.error?.message || {},
       },
     ];
-    let { status } = error.response;
-    if (status >= 400 && status < 500) {
-      status = 422;
-    }
     return res.status(status).send(response);
   }
 };

--- a/portal-api/src/v1/gef/controllers/externalApi.controller.js
+++ b/portal-api/src/v1/gef/controllers/externalApi.controller.js
@@ -44,7 +44,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (!companyNumber || companyNumber === '') {
       return res.status(422).send([
         {
-          status: ERROR.MANDATORY_FIELD,
+          errCode: ERROR.MANDATORY_FIELD,
           errRef: 'regNumber',
           errMsg: 'Enter a Companies House registration number.',
         },
@@ -55,7 +55,7 @@ exports.getByRegistrationNumber = async (req, res) => {
       console.error('Get company house information API failed for companyNumber %s', companyNumber);
       // returns invalid companies house registration number error
       return res.status(400).send([{
-        status: 'company-profile-not-found',
+        errCode: 'company-profile-not-found',
         errRef: 'regNumber',
         errMsg: 'Invalid Companies House registration number',
       }]);
@@ -70,7 +70,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (response.data.type === 'oversea-company') {
       return res.status(422).send([
         {
-          status: ERROR.OVERSEAS_COMPANY,
+          errCode: ERROR.OVERSEAS_COMPANY,
           errRef: 'regNumber',
           errMsg: 'UKEF can only process applications from companies based in the UK.',
         },
@@ -86,7 +86,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     console.error('getByRegistrationNumber Error %O', error?.response?.data);
     const response = companiesHouseError(error);
     let { status } = error.response;
-    if (response[0].status === 'company-profile-not-found') {
+    if (response[0].errCode === 'company-profile-not-found') {
       status = 422;
     }
     return res.status(status).send(response);
@@ -100,7 +100,7 @@ exports.getAddressesByPostcode = async (req, res) => {
     if (!isValidRegex(UK_POSTCODE, postcode)) {
       console.error('Get addresses by postcode failed for postcode %s', postcode);
       return res.status(400).send([{
-        status: 'ERROR',
+        errCode: 'ERROR',
         errRef: 'postcode',
         errMsg: 'Invalid postcode',
       }]);
@@ -135,7 +135,7 @@ exports.getAddressesByPostcode = async (req, res) => {
     }
 
     const notFoundResponse = [{
-      status: 'ERROR',
+      errCode: 'ERROR',
       errRef: 'postcode',
     }];
 
@@ -143,7 +143,7 @@ exports.getAddressesByPostcode = async (req, res) => {
   } catch (error) {
     const response = [
       {
-        status: 'ERROR',
+        errCode: 'ERROR',
         errRef: 'postcode',
         errMsg: error?.response?.data?.error?.message || {},
       },

--- a/portal-api/src/v1/gef/controllers/externalApi.controller.js
+++ b/portal-api/src/v1/gef/controllers/externalApi.controller.js
@@ -89,8 +89,8 @@ exports.getByRegistrationNumber = async (req, res) => {
     return res.status(200).send(mappedData);
   } catch (error) {
     console.error('getByRegistrationNumber Error %O', error?.response?.data);
-    const response = companiesHouseError(error);
-    return res.status(response[0].status).send(response);
+    const {status, response} = companiesHouseError(error);
+    return res.status(status).send(response);
   }
 };
 
@@ -123,6 +123,7 @@ exports.getAddressesByPostcode = async (req, res) => {
         {
           status: 422,
           errCode: 'ERROR',
+
           errRef: 'postcode',
         },
       ]);

--- a/portal-api/src/v1/gef/controllers/externalApi.controller.js
+++ b/portal-api/src/v1/gef/controllers/externalApi.controller.js
@@ -44,7 +44,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (!companyNumber || companyNumber === '') {
       return res.status(422).send([
         {
-          errCode: ERROR.MANDATORY_FIELD,
+          status: ERROR.MANDATORY_FIELD,
           errRef: 'regNumber',
           errMsg: 'Enter a Companies House registration number.',
         },
@@ -55,7 +55,7 @@ exports.getByRegistrationNumber = async (req, res) => {
       console.error('Get company house information API failed for companyNumber %s', companyNumber);
       // returns invalid companies house registration number error
       return res.status(400).send([{
-        errCode: 'company-profile-not-found',
+        status: 'company-profile-not-found',
         errRef: 'regNumber',
         errMsg: 'Invalid Companies House registration number',
       }]);
@@ -70,7 +70,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     if (response.data.type === 'oversea-company') {
       return res.status(422).send([
         {
-          errCode: ERROR.OVERSEAS_COMPANY,
+          status: ERROR.OVERSEAS_COMPANY,
           errRef: 'regNumber',
           errMsg: 'UKEF can only process applications from companies based in the UK.',
         },
@@ -86,7 +86,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     console.error('getByRegistrationNumber Error %O', error?.response?.data);
     const response = companiesHouseError(error);
     let { status } = error.response;
-    if (response[0].errCode === 'company-profile-not-found') {
+    if (response[0].status === 'company-profile-not-found') {
       status = 422;
     }
     return res.status(status).send(response);
@@ -100,7 +100,7 @@ exports.getAddressesByPostcode = async (req, res) => {
     if (!isValidRegex(UK_POSTCODE, postcode)) {
       console.error('Get addresses by postcode failed for postcode %s', postcode);
       return res.status(400).send([{
-        errCode: 'ERROR',
+        status: 'ERROR',
         errRef: 'postcode',
         errMsg: 'Invalid postcode',
       }]);
@@ -135,7 +135,7 @@ exports.getAddressesByPostcode = async (req, res) => {
     }
 
     const notFoundResponse = [{
-      errCode: 'ERROR',
+      status: 'ERROR',
       errRef: 'postcode',
     }];
 
@@ -143,7 +143,7 @@ exports.getAddressesByPostcode = async (req, res) => {
   } catch (error) {
     const response = [
       {
-        errCode: 'ERROR',
+        status: 'ERROR',
         errRef: 'postcode',
         errMsg: error?.response?.data?.error?.message || {},
       },

--- a/portal-api/src/v1/gef/controllers/externalApi.controller.js
+++ b/portal-api/src/v1/gef/controllers/externalApi.controller.js
@@ -90,7 +90,7 @@ exports.getByRegistrationNumber = async (req, res) => {
   } catch (error) {
     console.error('getByRegistrationNumber Error %O', error?.response?.data);
     const response = companiesHouseError(error);
-    return res.status(response.status).send(response);
+    return res.status(response[0].status).send(response);
   }
 };
 
@@ -119,11 +119,13 @@ exports.getAddressesByPostcode = async (req, res) => {
     const addresses = [];
 
     if (!response?.data?.results) {
-      return res.status(422).send({
-        status: 422,
-        errCode: 'ERROR',
-        errRef: 'postcode',
-      });
+      return res.status(422).send([
+        {
+          status: 422,
+          errCode: 'ERROR',
+          errRef: 'postcode',
+        },
+      ]);
     }
     response.data.results.forEach((item) => {
       if (item.DPA.LANGUAGE === (req.query.language ? req.query.language : 'EN')) {

--- a/portal-api/src/v1/gef/controllers/externalApi.controller.js
+++ b/portal-api/src/v1/gef/controllers/externalApi.controller.js
@@ -89,7 +89,7 @@ exports.getByRegistrationNumber = async (req, res) => {
     return res.status(200).send(mappedData);
   } catch (error) {
     console.error('getByRegistrationNumber Error %O', error?.response?.data);
-    const {status, response} = companiesHouseError(error);
+    const { status, response } = companiesHouseError(error);
     return res.status(status).send(response);
   }
 };

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -15,6 +15,7 @@ exports.create = async (req, res) => {
   if (!req.body.type || !req.body.dealId) {
     return res.status(422).send([{ status: 422, errCode: 'MANDATORY_FIELD', errMsg: 'No Application ID and/or facility type sent with request' }]);
   }
+
   if (enumValidationErr) {
     return res.status(422).send(enumValidationErr);
   }

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -12,7 +12,7 @@ const dealsCollectionName = 'deals';
 
 exports.create = async (req, res) => {
   const enumValidationErr = facilitiesCheckEnums(req.body);
-  if (!req.body.type && !req.body.dealId) {
+  if (!req.body.type || !req.body.dealId) {
     return res.status(422).send([{ status: 422, errCode: 'MANDATORY_FIELD', errMsg: 'No Application ID and/or facility type sent with request' }]);
   }
   if (enumValidationErr) {

--- a/portal-api/src/v1/gef/controllers/validation/application.js
+++ b/portal-api/src/v1/gef/controllers/validation/application.js
@@ -6,7 +6,7 @@ const validateMandatoryField = (fieldName, fieldValue) => {
   const value = fieldValue ?? '';
   if (value.length <= 0) {
     return {
-      status: ERROR.MANDATORY_FIELD,
+      errCode: ERROR.MANDATORY_FIELD,
       errRef: fieldName,
       errMsg: `${fieldName} is Mandatory`,
     };
@@ -19,7 +19,7 @@ const validateNameFieldValue = (fieldName, fieldValue) => {
   const value = fieldValue ?? '';
   if (value.length > 30) {
     return {
-      status: ERROR.FIELD_TOO_LONG,
+      errCode: ERROR.FIELD_TOO_LONG,
       errRef: fieldName,
       errMsg: `${fieldName} can only be up to 30 characters in length`,
     };
@@ -27,7 +27,7 @@ const validateNameFieldValue = (fieldName, fieldValue) => {
 
   if (/[^A-Za-z0-9 .,:;'-]/.test(fieldValue)) {
     return {
-      status: ERROR.FIELD_INVALID_CHARACTERS,
+      errCode: ERROR.FIELD_INVALID_CHARACTERS,
       errRef: fieldName,
       errMsg: `${fieldName} can only contain letters, numbers and punctuation`,
     };
@@ -68,7 +68,7 @@ const validatorStatusCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({ status: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
+      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
       break;
   }
   return enumErrors.length === 0 ? null : enumErrors;

--- a/portal-api/src/v1/gef/controllers/validation/application.js
+++ b/portal-api/src/v1/gef/controllers/validation/application.js
@@ -6,7 +6,7 @@ const validateMandatoryField = (fieldName, fieldValue) => {
   const value = fieldValue ?? '';
   if (value.length <= 0) {
     return {
-      errCode: ERROR.MANDATORY_FIELD,
+      status: ERROR.MANDATORY_FIELD,
       errRef: fieldName,
       errMsg: `${fieldName} is Mandatory`,
     };
@@ -19,7 +19,7 @@ const validateNameFieldValue = (fieldName, fieldValue) => {
   const value = fieldValue ?? '';
   if (value.length > 30) {
     return {
-      errCode: ERROR.FIELD_TOO_LONG,
+      status: ERROR.FIELD_TOO_LONG,
       errRef: fieldName,
       errMsg: `${fieldName} can only be up to 30 characters in length`,
     };
@@ -27,7 +27,7 @@ const validateNameFieldValue = (fieldName, fieldValue) => {
 
   if (/[^A-Za-z0-9 .,:;'-]/.test(fieldValue)) {
     return {
-      errCode: ERROR.FIELD_INVALID_CHARACTERS,
+      status: ERROR.FIELD_INVALID_CHARACTERS,
       errRef: fieldName,
       errMsg: `${fieldName} can only contain letters, numbers and punctuation`,
     };
@@ -68,7 +68,7 @@ const validatorStatusCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
+      enumErrors.push({ status: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
       break;
   }
   return enumErrors.length === 0 ? null : enumErrors;

--- a/portal-api/src/v1/gef/controllers/validation/application.js
+++ b/portal-api/src/v1/gef/controllers/validation/application.js
@@ -6,6 +6,7 @@ const validateMandatoryField = (fieldName, fieldValue) => {
   const value = fieldValue ?? '';
   if (value.length <= 0) {
     return {
+      status: 422,
       errCode: ERROR.MANDATORY_FIELD,
       errRef: fieldName,
       errMsg: `${fieldName} is Mandatory`,
@@ -19,6 +20,7 @@ const validateNameFieldValue = (fieldName, fieldValue) => {
   const value = fieldValue ?? '';
   if (value.length > 30) {
     return {
+      status: 422,
       errCode: ERROR.FIELD_TOO_LONG,
       errRef: fieldName,
       errMsg: `${fieldName} can only be up to 30 characters in length`,
@@ -27,6 +29,7 @@ const validateNameFieldValue = (fieldName, fieldValue) => {
 
   if (/[^A-Za-z0-9 .,:;'-]/.test(fieldValue)) {
     return {
+      status: 422,
       errCode: ERROR.FIELD_INVALID_CHARACTERS,
       errRef: fieldName,
       errMsg: `${fieldName} can only contain letters, numbers and punctuation`,
@@ -68,7 +71,7 @@ const validatorStatusCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
+      enumErrors.push({status: 422, errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
       break;
   }
   return enumErrors.length === 0 ? null : enumErrors;

--- a/portal-api/src/v1/gef/controllers/validation/application.js
+++ b/portal-api/src/v1/gef/controllers/validation/application.js
@@ -71,7 +71,7 @@ const validatorStatusCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({status: 422, errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
+      enumErrors.push({ status: 422, errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'status' });
       break;
   }
   return enumErrors.length === 0 ? null : enumErrors;

--- a/portal-api/src/v1/gef/controllers/validation/external.js
+++ b/portal-api/src/v1/gef/controllers/validation/external.js
@@ -1,6 +1,6 @@
 const companiesHouseError = (error) => {
   let errMsg;
-  let errCode;
+  let status;
 
   if (error.response?.data?.data === 'Invalid company registration number') {
     errMsg = 'Invalid Companies House registration number';
@@ -8,18 +8,18 @@ const companiesHouseError = (error) => {
     switch (error.response?.data?.errors?.length > 0 && error.response?.data?.errors[0]?.error) {
       case 'company-profile-not-found':
         errMsg = 'Invalid Companies House registration number';
-        errCode = error.response?.data?.errors[0]?.error;
+        status = error.response?.data?.errors[0]?.error;
         break;
       default:
         errMsg = 'There was a problem getting the Companies House registration number';
-        errCode = error.response?.data?.errors[0]?.error;
+        status = error.response?.data?.errors[0]?.error;
         break;
     }
   }
 
   return [
     {
-      errCode,
+      status,
       errRef: 'regNumber',
       errMsg,
     },

--- a/portal-api/src/v1/gef/controllers/validation/external.js
+++ b/portal-api/src/v1/gef/controllers/validation/external.js
@@ -1,6 +1,6 @@
 const companiesHouseError = (error) => {
   let errMsg;
-  let status;
+  let errCode;
 
   if (error.response?.data?.data === 'Invalid company registration number') {
     errMsg = 'Invalid Companies House registration number';
@@ -8,18 +8,18 @@ const companiesHouseError = (error) => {
     switch (error.response?.data?.errors?.length > 0 && error.response?.data?.errors[0]?.error) {
       case 'company-profile-not-found':
         errMsg = 'Invalid Companies House registration number';
-        status = error.response?.data?.errors[0]?.error;
+        errCode = error.response?.data?.errors[0]?.error;
         break;
       default:
         errMsg = 'There was a problem getting the Companies House registration number';
-        status = error.response?.data?.errors[0]?.error;
+        errCode = error.response?.data?.errors[0]?.error;
         break;
     }
   }
 
   return [
     {
-      status,
+      errCode,
       errRef: 'regNumber',
       errMsg,
     },

--- a/portal-api/src/v1/gef/controllers/validation/external.js
+++ b/portal-api/src/v1/gef/controllers/validation/external.js
@@ -2,16 +2,19 @@ const companiesHouseError = (error) => {
   let errMsg;
   let errCode;
 
+  let { status } = error.response;
+
   if (error.response?.data?.data === 'Invalid company registration number') {
     errMsg = 'Invalid Companies House registration number';
   } else {
     switch (error.response?.data?.errors?.length > 0 && error.response?.data?.errors[0]?.error) {
       case 'company-profile-not-found':
+        status = 422;
         errMsg = 'Invalid Companies House registration number';
         errCode = error.response?.data?.errors[0]?.error;
         break;
       default:
-        errMsg = 'There was a problem getting the Companies House registration number';
+        (errMsg = 'There was a problem getting the Companies House registration number');
         errCode = error.response?.data?.errors[0]?.error;
         break;
     }
@@ -19,6 +22,7 @@ const companiesHouseError = (error) => {
 
   return [
     {
+      status,
       errCode,
       errRef: 'regNumber',
       errMsg,

--- a/portal-api/src/v1/gef/controllers/validation/external.js
+++ b/portal-api/src/v1/gef/controllers/validation/external.js
@@ -14,20 +14,23 @@ const companiesHouseError = (error) => {
         errCode = error.response?.data?.errors[0]?.error;
         break;
       default:
-        (errMsg = 'There was a problem getting the Companies House registration number');
+        errMsg = 'There was a problem getting the Companies House registration number';
         errCode = error.response?.data?.errors[0]?.error;
         break;
     }
   }
 
-  return [
-    {
-      status,
-      errCode,
-      errRef: 'regNumber',
-      errMsg,
-    },
-  ];
+  return {
+    status,
+    response: [
+      {
+        status,
+        errCode,
+        errRef: 'regNumber',
+        errMsg,
+      },
+    ],
+  };
 };
 
 module.exports = {

--- a/portal-api/src/v1/gef/controllers/validation/facilities.js
+++ b/portal-api/src/v1/gef/controllers/validation/facilities.js
@@ -102,7 +102,7 @@ const facilitiesCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'type' });
+      enumErrors.push({ status: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'type' });
       break;
   }
 

--- a/portal-api/src/v1/gef/controllers/validation/facilities.js
+++ b/portal-api/src/v1/gef/controllers/validation/facilities.js
@@ -102,7 +102,7 @@ const facilitiesCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({ status: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'type' });
+      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'type' });
       break;
   }
 

--- a/portal-api/src/v1/gef/controllers/validation/facilities.js
+++ b/portal-api/src/v1/gef/controllers/validation/facilities.js
@@ -102,7 +102,7 @@ const facilitiesCheckEnums = (doc) => {
     case undefined:
       break;
     default:
-      enumErrors.push({ errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'type' });
+      enumErrors.push({ status: 422, errCode: 'ENUM_ERROR', errMsg: 'Unrecognised enum', errRef: 'type' });
       break;
   }
 


### PR DESCRIPTION
## Introduction
@abhi-markan suggested renaming `errCode` to `status` in some error messages in https://github.com/UK-Export-Finance/dtfs2/pull/1955#discussion_r1293534151

## Resolution
As per the conversation below: We've kept `errCode` but added a `status` field following existing patterns