### PR TITLE
feat(FN-930): configure vnet peering

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -40,6 +40,10 @@ param vnetAddressPrefixes array = [
 ]
 
 param privateEndpointsCidr string = '172.16.20.0/24'
+
+param peeringRemoteVnetSubscriptionId string = '08887298-3821-49f0-8303-f88859c12b9b'
+param peeringRemoteVnetResourceGroupName string = 'UKEF-Firewall-Appliance-UKS'
+param peeringRemoteVnetName string = 'VNET_UKEF_UKS'
 param peeringAddressSpace string = '10.50.0.0/16'
 
 @allowed(['Allow', 'Deny'])
@@ -192,9 +196,13 @@ module vnet 'modules/vnet.bicep' = {
     appServicePlanEgressPrefixCidr: appServicePlanEgressPrefixCidr
     applicationGatewayCidr: applicationGatewayCidr
     storageLocations: storageLocations
+    peeringRemoteVnetSubscriptionId: peeringRemoteVnetSubscriptionId
+    peeringRemoteVnetResourceGroupName: peeringRemoteVnetResourceGroupName
+    peeringRemoteVnetName: peeringRemoteVnetName
     peeringAddressSpace: peeringAddressSpace
     routeTableId: routeTable.outputs.routeTableId
     networkSecurityGroupId: networkSecurityGroup.outputs.networkSecurityGroupId
+
   }
 }
 


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers 
* wiring up vnet peering with the `VNET_UKEF_UKS` vnet on another subscription.
### Resolution
* OUR Side only - adds vnet link
* NOTE: Someone also needs to configure the `VNET_UKEF_UKS` at least for `feature`.

NOTE: I haven't tested this as I can't deploy until Risual increase the number of available static IPs in Azure.
