### PR TITLE
feat(FN-939):use parameter sets

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -276,7 +276,7 @@ module vnet 'modules/vnet.bicep' = {
     environment: environment
     location: location
     appServicePlanName: appServicePlan.name
-    addressPrefixes: parametersMap[environment].vnet.vnetAddressPrefixes
+    addressPrefixes: parametersMap[environment].vnet.addressPrefixes
     privateEndpointsCidr: parametersMap[environment].vnet.privateEndpointsCidr
     appServicePlanEgressPrefixCidr: parametersMap[environment].vnet.appServicePlanEgressPrefixCidr
     applicationGatewayCidr: parametersMap[environment].vnet.applicationGatewayCidr

--- a/infrastructure/resource_group_level/modules/cosmosdb.bicep
+++ b/infrastructure/resource_group_level/modules/cosmosdb.bicep
@@ -538,3 +538,4 @@ resource mongoDbPrivateEndpoint 'Microsoft.Network/privateEndpoints@2022-11-01' 
 }
 
 output cosmosDbAccountName string = cosmosDbAccount.name
+output cosmosDbDatabaseName string = submissionsDb.name


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* Using parameter sets based on the environment to configure some settings
### Resolution
* a parameter set was created, while checking the values against the actual deployments