### PR TITLE
feat(FN-742): Set values from GitHub

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -23,134 +23,199 @@ param peeringAddressSpace string = '10.50.0.0/16'
 param onPremiseNetworkIpsString string
 
 // Secrets sent in from GHA
+@secure()
+param APIM_TFS_KEY string
+@secure()
+param APIM_TFS_VALUE string
+@secure()
+param APIM_TFS_URL string
+@secure()
+param APIM_MDM_KEY string
+@secure()
+param APIM_MDM_URL string
+@secure()
+param APIM_MDM_VALUE string // different in staging and dev
+@secure()
+param DOCKER_REGISTRY_SERVER_PASSWORD string  // different in staging and dev
+@secure()
+param MACHINEKEY_DecryptionKey string // different in staging and dev
+@secure()
+param CORS_ORIGIN string
+@secure()
+param APIM_ESTORE_URL string
+@secure()
+param APIM_ESTORE_KEY string
+@secure()
+param APIM_ESTORE_VALUE string
+@secure()
+param COMPANIES_HOUSE_API_KEY string // Actually set from an env variable but that's from a secret.
+@secure()
+param ORDNANCE_SURVEY_API_KEY string
+@secure()
+param GOV_NOTIFY_API_KEY string
+@secure()
+param GOV_NOTIFY_EMAIL_RECIPIENT string
+@secure()
+param COMPANIES_HOUSE_API_URL string // from env
+@secure()
+param AZURE_PORTAL_EXPORT_FOLDER string
+@secure()
+param AZURE_PORTAL_FILESHARE_NAME string
+@secure()
+param JWT_SIGNING_KEY string
+@secure()
+param JWT_VALIDATING_KEY string
+@secure()
+param UKEF_INTERNAL_NOTIFICATION string
+@secure()
+param DTFS_CENTRAL_API_KEY string
+@secure()
+param EXTERNAL_API_KEY string
+@secure()
+param PORTAL_API_KEY string
+@secure()
+param TFM_API_KEY string
+@secure()
+param UKEF_TFM_API_SYSTEM_KEY string
+@secure()
+param UKEF_TFM_API_REPORTS_KEY string
+@secure()
+param TFM_UI_URL string
+@secure()
+param AZURE_NUMBER_GENERATOR_FUNCTION_SCHEDULE string
+@secure()
+param SESSION_SECRET string
+@secure()
+param ESTORE_URL string
+
 
 // These values are taken from GitHub secrets injected in the GHA Action
 // The values for both functions are identical
 var functionSecureSettings = {
-  APIM_TFS_KEY: 'test-value'
-  APIM_TFS_VALUE: 'test-value'
-  APIM_TFS_URL: 'test-value'
-  APIM_MDM_KEY: 'test-value'
-  APIM_MDM_URL: 'test-value'
-  APIM_MDM_VALUE: 'test-value' // different in staging and dev
+  APIM_TFS_KEY: APIM_TFS_KEY
+  APIM_TFS_VALUE: APIM_TFS_VALUE
+  APIM_TFS_URL: APIM_TFS_URL
+  APIM_MDM_KEY: APIM_MDM_KEY
+  APIM_MDM_URL: APIM_MDM_URL
+  APIM_MDM_VALUE: APIM_MDM_VALUE // different in staging and dev
 }
 // These values are taken from an export of Configuration on Dev
 var functionAdditionalSecureSettings = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'  // different in staging and dev
-  MACHINEKEY_DecryptionKey: 'test-value' // different in staging and dev
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD  // different in staging and dev
+  MACHINEKEY_DecryptionKey: MACHINEKEY_DecryptionKey // different in staging and dev
 }
 
 var externalApiSecureSettings = {
-  CORS_ORIGIN: 'test-value'
-  APIM_TFS_URL: 'test-value'
-  APIM_TFS_KEY: 'test-value'
-  APIM_TFS_VALUE: 'test-value'
-  APIM_MDM_URL: 'test-value'
-  APIM_MDM_KEY: 'test-value'
-  APIM_MDM_VALUE: 'test-value'
-  APIM_ESTORE_URL: 'test-value'
-  APIM_ESTORE_KEY: 'test-value'
-  APIM_ESTORE_VALUE: 'test-value'
-  COMPANIES_HOUSE_API_KEY: 'test-value' // Actually set from an env variable but that's from a secret.
-  ORDNANCE_SURVEY_API_KEY: 'test-value'
-  GOV_NOTIFY_API_KEY: 'test-value'
-  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
+  CORS_ORIGIN: CORS_ORIGIN
+  APIM_TFS_URL: APIM_TFS_URL
+  APIM_TFS_KEY: APIM_TFS_KEY
+  APIM_TFS_VALUE: APIM_TFS_VALUE
+  APIM_MDM_URL: APIM_MDM_URL
+  APIM_MDM_KEY: APIM_MDM_KEY
+  APIM_MDM_VALUE: APIM_MDM_VALUE
+  APIM_ESTORE_URL: APIM_ESTORE_URL
+  APIM_ESTORE_KEY: APIM_ESTORE_KEY
+  APIM_ESTORE_VALUE: APIM_ESTORE_VALUE
+  COMPANIES_HOUSE_API_KEY: COMPANIES_HOUSE_API_KEY // Actually set from an env variable but that's from a secret.
+  ORDNANCE_SURVEY_API_KEY: ORDNANCE_SURVEY_API_KEY
+  GOV_NOTIFY_API_KEY: GOV_NOTIFY_API_KEY
+  GOV_NOTIFY_EMAIL_RECIPIENT: GOV_NOTIFY_EMAIL_RECIPIENT
 }
 var externalApiAdditionalSecureSettings = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
 }
 
 var dtfsCentralApiSecureSettings = {}
 var dtfsCentralApiAdditionalSecureSetting = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
 }
 
 var portalApiSecureSettings = {}
 var portalApiAdditionalSecureSetting = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
 }
 var portalApiConnectionStrings = {
-  COMPANIES_HOUSE_API_URL: 'test-value' // from env
+  COMPANIES_HOUSE_API_URL: COMPANIES_HOUSE_API_URL // from env
 }
 var portalApiSecureConnectionStrings = {
   // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
-  CORS_ORIGIN: 'test-value'
-  AZURE_PORTAL_EXPORT_FOLDER: 'test-value'
-  AZURE_PORTAL_FILESHARE_NAME: 'test-value'
-  JWT_SIGNING_KEY: 'test-value'
-  JWT_VALIDATING_KEY: 'test-value'
-  GOV_NOTIFY_API_KEY: 'test-value'
-  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
-  COMPANIES_HOUSE_API_KEY: 'test-value' // from env but looks a secret
+  CORS_ORIGIN: CORS_ORIGIN
+  AZURE_PORTAL_EXPORT_FOLDER: AZURE_PORTAL_EXPORT_FOLDER
+  AZURE_PORTAL_FILESHARE_NAME: AZURE_PORTAL_FILESHARE_NAME
+  JWT_SIGNING_KEY: JWT_SIGNING_KEY
+  JWT_VALIDATING_KEY: JWT_VALIDATING_KEY
+  GOV_NOTIFY_API_KEY: GOV_NOTIFY_API_KEY
+  GOV_NOTIFY_EMAIL_RECIPIENT: GOV_NOTIFY_EMAIL_RECIPIENT
+  COMPANIES_HOUSE_API_KEY: COMPANIES_HOUSE_API_KEY // from env but looks a secret
 }
 
 var tfmApiSecureSettings = {}
 var tfmApiAdditionalSecureSettings = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  UKEF_INTERNAL_NOTIFICATION: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  JWT_VALIDATING_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
+  UKEF_INTERNAL_NOTIFICATION: UKEF_INTERNAL_NOTIFICATION
+  DTFS_CENTRAL_API_KEY: DTFS_CENTRAL_API_KEY
+  EXTERNAL_API_KEY: EXTERNAL_API_KEY
+  JWT_VALIDATING_KEY: JWT_VALIDATING_KEY
+  PORTAL_API_KEY: PORTAL_API_KEY
+  TFM_API_KEY: TFM_API_KEY
 }
 var tfmApiSecureConnectionStrings = {
   // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
-  CORS_ORIGIN: 'test-value'
-  UKEF_TFM_API_SYSTEM_KEY: 'test-value'
-  UKEF_TFM_API_REPORTS_KEY: 'test-value'
+  CORS_ORIGIN: CORS_ORIGIN
+  UKEF_TFM_API_SYSTEM_KEY: UKEF_TFM_API_SYSTEM_KEY
+  UKEF_TFM_API_REPORTS_KEY: UKEF_TFM_API_REPORTS_KEY
   // TODO:FN-429 Note that TFM_UI_URL (renamed from TFM_URI) has a value like https://tfs-dev-tfm-fd.azurefd.net
   // while in the CLI it is injected as a secret, we can probably calculate it from the Front Door component.
-  TFM_UI_URL: 'test-value'
-  AZURE_NUMBER_GENERATOR_FUNCTION_SCHEDULE: 'test-value'
-  JWT_SIGNING_KEY: 'test-value' // NOTE - in the export this appears to be a slot setting. However, we don't need to replicate that.
+  TFM_UI_URL: TFM_UI_URL
+  AZURE_NUMBER_GENERATOR_FUNCTION_SCHEDULE: AZURE_NUMBER_GENERATOR_FUNCTION_SCHEDULE
+  JWT_SIGNING_KEY: JWT_SIGNING_KEY // NOTE - in the export this appears to be a slot setting. However, we don't need to replicate that.
 }
 var tfmApiAdditionalSecureConnectionStrings = {
-  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
+  GOV_NOTIFY_EMAIL_RECIPIENT: GOV_NOTIFY_EMAIL_RECIPIENT
 }
 
 var portalUiSecureSettings = {}
 var portalUiAdditionalSecureSettings = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
+  DTFS_CENTRAL_API_KEY: DTFS_CENTRAL_API_KEY
+  EXTERNAL_API_KEY: EXTERNAL_API_KEY
+  PORTAL_API_KEY: PORTAL_API_KEY
+  TFM_API_KEY: TFM_API_KEY
 }
 var portalUiSecureConnectionStrings = {
-  COMPANIES_HOUSE_API_KEY : 'test-value'
-  SESSION_SECRET: 'test-value'
+  COMPANIES_HOUSE_API_KEY: COMPANIES_HOUSE_API_KEY
+  SESSION_SECRET: SESSION_SECRET
 }
 var portalUiAdditionalSecureConnectionStrings = {}
 
 var tfmUiSecureSettings = {
-  UKEF_TFM_API_SYSTEM_KEY: 'test-value'
-  ESTORE_URL: 'test-value'
+  UKEF_TFM_API_SYSTEM_KEY: UKEF_TFM_API_SYSTEM_KEY
+  ESTORE_URL: ESTORE_URL
 }
 var tfmUiAdditionalSecureSettings = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
+  DTFS_CENTRAL_API_KEY: DTFS_CENTRAL_API_KEY
+  EXTERNAL_API_KEY: EXTERNAL_API_KEY
+  PORTAL_API_KEY: PORTAL_API_KEY
+  TFM_API_KEY: TFM_API_KEY
 }
 var tfmUiSecureConnectionStrings = {
-  SESSION_SECRET: 'test-value'
+  SESSION_SECRET: SESSION_SECRET
 }
 var tfmUiAdditionalSecureConnectionStrings = {}
 
 var gefUiSecureSettings = {}
 var gefUiAdditionalSecureSettings = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
+  DOCKER_REGISTRY_SERVER_PASSWORD: DOCKER_REGISTRY_SERVER_PASSWORD
+  DTFS_CENTRAL_API_KEY: DTFS_CENTRAL_API_KEY
+  EXTERNAL_API_KEY: EXTERNAL_API_KEY
+  PORTAL_API_KEY: PORTAL_API_KEY
+  TFM_API_KEY: TFM_API_KEY
 }
 var gefUiSecureConnectionStrings = {
   // TODO:FN-820 Remove COMPANIES_HOUSE_API_KEY as it is not referenced directly in gef-ui
-  COMPANIES_HOUSE_API_KEY : 'test-value'
-  SESSION_SECRET: 'test-value'
+  COMPANIES_HOUSE_API_KEY: COMPANIES_HOUSE_API_KEY
+  SESSION_SECRET: SESSION_SECRET
 }
 var gefUiAdditionalSecureConnectionStrings = {}
 

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -22,6 +22,137 @@ param peeringAddressSpace string = '10.50.0.0/16'
 @secure()
 param onPremiseNetworkIpsString string
 
+// Secrets sent in from GHA
+
+// These values are taken from GitHub secrets injected in the GHA Action
+// The values for both functions are identical
+var functionSecureSettings = {
+  APIM_TFS_KEY: 'test-value'
+  APIM_TFS_VALUE: 'test-value'
+  APIM_TFS_URL: 'test-value'
+  APIM_MDM_KEY: 'test-value'
+  APIM_MDM_URL: 'test-value'
+  APIM_MDM_VALUE: 'test-value' // different in staging and dev
+}
+// These values are taken from an export of Configuration on Dev
+var functionAdditionalSecureSettings = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'  // different in staging and dev
+  MACHINEKEY_DecryptionKey: 'test-value' // different in staging and dev
+}
+
+var externalApiSecureSettings = {
+  CORS_ORIGIN: 'test-value'
+  APIM_TFS_URL: 'test-value'
+  APIM_TFS_KEY: 'test-value'
+  APIM_TFS_VALUE: 'test-value'
+  APIM_MDM_URL: 'test-value'
+  APIM_MDM_KEY: 'test-value'
+  APIM_MDM_VALUE: 'test-value'
+  APIM_ESTORE_URL: 'test-value'
+  APIM_ESTORE_KEY: 'test-value'
+  APIM_ESTORE_VALUE: 'test-value'
+  COMPANIES_HOUSE_API_KEY: 'test-value' // Actually set from an env variable but that's from a secret.
+  ORDNANCE_SURVEY_API_KEY: 'test-value'
+  GOV_NOTIFY_API_KEY: 'test-value'
+  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
+}
+var externalApiAdditionalSecureSettings = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+}
+
+var dtfsCentralApiSecureSettings = {}
+var dtfsCentralApiAdditionalSecureSetting = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+}
+
+var portalApiSecureSettings = {}
+var portalApiAdditionalSecureSetting = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+}
+var portalApiConnectionStrings = {
+  COMPANIES_HOUSE_API_URL: 'test-value' // from env
+}
+var portalApiSecureConnectionStrings = {
+  // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
+  CORS_ORIGIN: 'test-value'
+  AZURE_PORTAL_EXPORT_FOLDER: 'test-value'
+  AZURE_PORTAL_FILESHARE_NAME: 'test-value'
+  JWT_SIGNING_KEY: 'test-value'
+  JWT_VALIDATING_KEY: 'test-value'
+  GOV_NOTIFY_API_KEY: 'test-value'
+  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
+  COMPANIES_HOUSE_API_KEY: 'test-value' // from env but looks a secret
+}
+
+var tfmApiSecureSettings = {}
+var tfmApiAdditionalSecureSettings = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  UKEF_INTERNAL_NOTIFICATION: 'test-value'
+  DTFS_CENTRAL_API_KEY: 'test-value'
+  EXTERNAL_API_KEY: 'test-value'
+  JWT_VALIDATING_KEY: 'test-value'
+  PORTAL_API_KEY: 'test-value'
+  TFM_API_KEY: 'test-value'
+}
+var tfmApiSecureConnectionStrings = {
+  // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
+  CORS_ORIGIN: 'test-value'
+  UKEF_TFM_API_SYSTEM_KEY: 'test-value'
+  UKEF_TFM_API_REPORTS_KEY: 'test-value'
+  // TODO:FN-429 Note that TFM_UI_URL (renamed from TFM_URI) has a value like https://tfs-dev-tfm-fd.azurefd.net
+  // while in the CLI it is injected as a secret, we can probably calculate it from the Front Door component.
+  TFM_UI_URL: 'test-value'
+  AZURE_NUMBER_GENERATOR_FUNCTION_SCHEDULE: 'test-value'
+  JWT_SIGNING_KEY: 'test-value' // NOTE - in the export this appears to be a slot setting. However, we don't need to replicate that.
+}
+var tfmApiAdditionalSecureConnectionStrings = {
+  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
+}
+
+var portalUiSecureSettings = {}
+var portalUiAdditionalSecureSettings = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  DTFS_CENTRAL_API_KEY: 'test-value'
+  EXTERNAL_API_KEY: 'test-value'
+  PORTAL_API_KEY: 'test-value'
+  TFM_API_KEY: 'test-value'
+}
+var portalUiSecureConnectionStrings = {
+  COMPANIES_HOUSE_API_KEY : 'test-value'
+  SESSION_SECRET: 'test-value'
+}
+var portalUiAdditionalSecureConnectionStrings = {}
+
+var tfmUiSecureSettings = {
+  UKEF_TFM_API_SYSTEM_KEY: 'test-value'
+  ESTORE_URL: 'test-value'
+}
+var tfmUiAdditionalSecureSettings = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  DTFS_CENTRAL_API_KEY: 'test-value'
+  EXTERNAL_API_KEY: 'test-value'
+  PORTAL_API_KEY: 'test-value'
+  TFM_API_KEY: 'test-value'
+}
+var tfmUiSecureConnectionStrings = {
+  SESSION_SECRET: 'test-value'
+}
+var tfmUiAdditionalSecureConnectionStrings = {}
+
+var gefUiSecureSettings = {}
+var gefUiAdditionalSecureSettings = {
+  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
+  DTFS_CENTRAL_API_KEY: 'test-value'
+  EXTERNAL_API_KEY: 'test-value'
+  PORTAL_API_KEY: 'test-value'
+  TFM_API_KEY: 'test-value'
+}
+var gefUiSecureConnectionStrings = {
+  // TODO:FN-820 Remove COMPANIES_HOUSE_API_KEY as it is not referenced directly in gef-ui
+  COMPANIES_HOUSE_API_KEY : 'test-value'
+  SESSION_SECRET: 'test-value'
+}
+var gefUiAdditionalSecureConnectionStrings = {}
 
 // The following settings have not been made part of the parameters map
 // as they are the same for all environments and don't look like they will change.
@@ -367,6 +498,8 @@ module functionAcbs 'modules/function-acbs.bicep' = {
     storageAccountName: storage.outputs.storageAccountName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: functionSecureSettings
+    additionalSecureSettings: functionAdditionalSecureSettings
   }
 }
 
@@ -382,6 +515,8 @@ module functionNumberGenerator 'modules/function-number-generator.bicep' = {
     storageAccountName: storage.outputs.storageAccountName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: functionSecureSettings
+    additionalSecureSettings: functionAdditionalSecureSettings
   }
 }
 
@@ -401,6 +536,8 @@ module externalApi 'modules/webapps/external-api.bicep' = {
     numberGeneratorFunctionDefaultHostName: functionNumberGenerator.outputs.defaultHostName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: externalApiSecureSettings
+    additionalSecureSettings: externalApiAdditionalSecureSettings
   }
 }
 
@@ -419,6 +556,8 @@ module dtfsCentralApi 'modules/webapps/dtfs-central-api.bicep' = {
     externalApiHostname: externalApi.outputs.defaultHostName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: dtfsCentralApiSecureSettings
+    additionalSecureSettings: dtfsCentralApiAdditionalSecureSetting
   }
 }
 
@@ -440,6 +579,10 @@ module portalApi 'modules/webapps/portal-api.bicep' = {
     tfmApiHostname: tfmApi.outputs.defaultHostName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: portalApiSecureSettings
+    additionalSecureSettings: portalApiAdditionalSecureSetting
+    connectionStrings: portalApiConnectionStrings
+    secureConnectionStrings: portalApiSecureConnectionStrings
   }
 }
 
@@ -460,6 +603,10 @@ module tfmApi 'modules/webapps/trade-finance-manager-api.bicep' = {
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
     numberGeneratorFunctionDefaultHostName: functionNumberGenerator.outputs.defaultHostName
+    secureSettings: tfmApiSecureSettings
+    additionalSecureSettings: tfmApiAdditionalSecureSettings
+    secureConnectionStrings: tfmApiSecureConnectionStrings
+    additionalSecureConnectionStrings: tfmApiAdditionalSecureConnectionStrings
   }
 }
 
@@ -479,6 +626,10 @@ module portalUi 'modules/webapps/portal-ui.bicep' = {
     tfmApiHostname: tfmApi.outputs.defaultHostName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: portalUiSecureSettings
+    additionalSecureSettings: portalUiAdditionalSecureSettings
+    secureConnectionStrings: portalUiSecureConnectionStrings
+    additionalSecureConnectionStrings: portalUiAdditionalSecureConnectionStrings
   }
 }
 
@@ -497,6 +648,10 @@ module tfmUi 'modules/webapps/trade-finance-manager-ui.bicep' = {
     tfmApiHostname: tfmApi.outputs.defaultHostName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: tfmUiSecureSettings
+    additionalSecureSettings: tfmUiAdditionalSecureSettings
+    secureConnectionStrings: tfmUiSecureConnectionStrings
+    additionalSecureConnectionStrings: tfmUiAdditionalSecureConnectionStrings
   }
 }
 
@@ -516,6 +671,10 @@ module gefUi 'modules/webapps/gef-ui.bicep' = {
     tfmApiHostname: tfmApi.outputs.defaultHostName
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
+    secureSettings: gefUiSecureSettings
+    additionalSecureSettings: gefUiAdditionalSecureSettings
+    secureConnectionStrings: gefUiSecureConnectionStrings
+    additionalSecureConnectionStrings: gefUiAdditionalSecureConnectionStrings
   }
 }
 

--- a/infrastructure/resource_group_level/modules/function-acbs.bicep
+++ b/infrastructure/resource_group_level/modules/function-acbs.bicep
@@ -10,6 +10,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'function-acbs'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -33,10 +35,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing 
 var storageAccountKey = storageAccount.listKeys().keys[0].value
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
+var staticSettings = {
   // hard coded
   FUNCTIONS_WORKER_RUNTIME: 'node'
   WEBSITE_DNS_SERVER: azureDnsServerIp
@@ -62,7 +61,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var functionAcbsName = 'tfs-${environment}-${resourceNameFragment}'
 var privateEndpointName = 'tfs-${environment}-${resourceNameFragment}'

--- a/infrastructure/resource_group_level/modules/function-acbs.bicep
+++ b/infrastructure/resource_group_level/modules/function-acbs.bicep
@@ -12,22 +12,11 @@ param resourceNameFragment string = 'function-acbs'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-  APIM_TFS_KEY: 'test-value'
-  APIM_TFS_VALUE: 'test-value'
-  APIM_TFS_URL: 'test-value'
-  APIM_MDM_KEY: 'test-value'
-  APIM_MDM_URL: 'test-value'
-  APIM_MDM_VALUE: 'test-value' // different in staging and dev
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'  // different in staging and dev
-  MACHINEKEY_DecryptionKey: 'test-value' // different in staging and dev
-}
-
+param additionalSecureSettings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/azure-${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/function-number-generator.bicep
+++ b/infrastructure/resource_group_level/modules/function-number-generator.bicep
@@ -12,22 +12,11 @@ param resourceNameFragment string = 'function-number-generator'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-  APIM_TFS_KEY: 'test-value'
-  APIM_TFS_VALUE: 'test-value'
-  APIM_TFS_URL: 'test-value'
-  APIM_MDM_KEY: 'test-value'
-  APIM_MDM_URL: 'test-value'
-  APIM_MDM_VALUE: 'test-value' // different in staging and dev
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'  // different in staging and dev
-  MACHINEKEY_DecryptionKey: 'test-value' // different in staging and dev
-}
-
+param additionalSecureSettings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/azure-${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/function-number-generator.bicep
+++ b/infrastructure/resource_group_level/modules/function-number-generator.bicep
@@ -10,6 +10,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'function-number-generator'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -33,10 +35,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing 
 var storageAccountKey = storageAccount.listKeys().keys[0].value
 
 // These values are hardcoded in the CLI scripts
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value' // injected from vars
-
+var staticSettings = {
   // hard coded
   FUNCTIONS_WORKER_RUNTIME: 'node'
   WEBSITE_DNS_SERVER: azureDnsServerIp
@@ -62,7 +61,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var functionNumberGeneratorName = 'tfs-${environment}-${resourceNameFragment}'
 var privateEndpointName = 'tfs-${environment}-${resourceNameFragment}'

--- a/infrastructure/resource_group_level/modules/privatelink-file-core-windows-net.bicep
+++ b/infrastructure/resource_group_level/modules/privatelink-file-core-windows-net.bicep
@@ -1,4 +1,4 @@
-param filesDnsZoneName string = 'privatelink.file.core.windows.net'
+param filesDnsZoneName string = 'privatelink.file.${environment().suffixes.storage}'
 param vnetId string
 
 resource filesDnsZone 'Microsoft.Network/privateDnsZones@2018-09-01' = {

--- a/infrastructure/resource_group_level/modules/webapps/dtfs-central-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/dtfs-central-api.bicep
@@ -15,14 +15,10 @@ param resourceNameFragment string = 'dtfs-central-api'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-}
-
+param secureSettings object
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-}
+param additionalSecureSettings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/webapps/dtfs-central-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/dtfs-central-api.bicep
@@ -13,6 +13,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'dtfs-central-api'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -27,10 +29,7 @@ var dockerRegistryServerUsername = 'tfs${environment}'
 var azureDnsServerIp = '168.63.129.16'
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
+var staticSettings = {
   // hard coded
   WEBSITE_DNS_SERVER: azureDnsServerIp
   WEBSITE_VNET_ROUTE_ALL: '1'
@@ -56,7 +55,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 // These have come from the CLI scripts
 var mongoDbConnectionString = replace(cosmosDbAccount.listConnectionStrings().connectionStrings[0].connectionString, '&replicaSet=globaldb', '')

--- a/infrastructure/resource_group_level/modules/webapps/external-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/external-api.bicep
@@ -16,29 +16,12 @@ param resourceNameFragment string = 'external-api'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-  CORS_ORIGIN: 'test-value'
-  APIM_TFS_URL: 'test-value'
-  APIM_TFS_KEY: 'test-value'
-  APIM_TFS_VALUE: 'test-value'
-  APIM_MDM_URL: 'test-value'
-  APIM_MDM_KEY: 'test-value'
-  APIM_MDM_VALUE: 'test-value'
-  APIM_ESTORE_URL: 'test-value'
-  APIM_ESTORE_KEY: 'test-value'
-  APIM_ESTORE_VALUE: 'test-value'
-  COMPANIES_HOUSE_API_KEY: 'test-value' // Actually set from an env variable but that's from a secret.
-  ORDNANCE_SURVEY_API_KEY: 'test-value'
-  GOV_NOTIFY_API_KEY: 'test-value'
-  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev (& validating with staging),
 // that look like they need to be kept secure.
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-}
+param additionalSecureSettings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/webapps/external-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/external-api.bicep
@@ -14,6 +14,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'external-api'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -32,16 +34,9 @@ var azureDnsServerIp = '168.63.129.16'
 var mongoDbConnectionString = replace(cosmosDbAccount.listConnectionStrings().connectionStrings[0].connectionString, '&replicaSet=globaldb', '')
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
-  // from env.
-  COMPANIES_HOUSE_API_URL: 'test-value'
-  ORDNANCE_SURVEY_API_URL: 'test-value'
+var staticSettings = {
+    // derived
   MONGO_INITDB_DATABASE: cosmosDbDatabaseName
-
-  // derived
   MONGODB_URI: mongoDbConnectionString
   AZURE_ACBS_FUNCTION_URL: 'https://${acbsFunctionDefaultHostName}'
   AZURE_NUMBER_GENERATOR_FUNCTION_URL: 'https://${numberGeneratorFunctionDefaultHostName}'
@@ -69,7 +64,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
   name: cosmosDbAccountName

--- a/infrastructure/resource_group_level/modules/webapps/gef-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/gef-ui.bicep
@@ -16,32 +16,18 @@ param resourceNameFragment string = 'gef-ui'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-
-}
-
+param secureSettings object
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
-}
+param additionalSecureSettings object
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureConnectionStrings object = {
-  // TODO:FN-820 Remove COMPANIES_HOUSE_API_KEY as it is not referenced directly in gef-ui
-  COMPANIES_HOUSE_API_KEY : 'test-value'
-  SESSION_SECRET: 'test-value'
-}
+param secureConnectionStrings object
 
 // These values are taken from an export of Connection strings on Dev (& validating with staging).
 @secure()
-param additionalSecureConnectionStrings object = {
-}
+param additionalSecureConnectionStrings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/webapps/gef-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/gef-ui.bicep
@@ -14,6 +14,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'gef-ui'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -45,14 +47,7 @@ var externalApiUrl = 'https://${externalApiHostname}'
 var azureDnsServerIp = '168.63.129.16'
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
-  // from env.
-  // TODO:FN-820 Remove COMPANIES_HOUSE_API_URL as it is not referenced directly in gef-ui
-  COMPANIES_HOUSE_API_URL: 'test-value'
-
+var staticSettings = {
   // derived
   PORTAL_API_URL: portalApiUrl
   REDIS_HOSTNAME: redis.properties.hostName
@@ -86,7 +81,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
   name: item.key

--- a/infrastructure/resource_group_level/modules/webapps/portal-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-api.bicep
@@ -16,6 +16,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'portal-api'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -38,11 +40,7 @@ var dockerRegistryServerUsername = 'tfs${environment}'
 var azureDnsServerIp = '168.63.129.16'
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
-var settings = {
-  // from vars.
-  // TODO:FN-742 set from config.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
+var staticSettings = {
   // hard coded
   WEBSITE_DNS_SERVER: azureDnsServerIp
   WEBSITE_VNET_ROUTE_ALL: '1'
@@ -66,7 +64,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var connectionStringsList = [for item in items(union(connectionStrings, secureConnectionStrings)): {
   name: item.key

--- a/infrastructure/resource_group_level/modules/webapps/portal-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-api.bicep
@@ -18,34 +18,18 @@ param resourceNameFragment string = 'portal-api'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-}
+param additionalSecureSettings object
 
 // These values are inlined in the CLI scripts
-param connectionStrings object = {
-  COMPANIES_HOUSE_API_URL: 'test-value' // from env
-}
+param connectionStrings object
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureConnectionStrings object = {
-  // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
-  CORS_ORIGIN: 'test-value'
-  AZURE_PORTAL_EXPORT_FOLDER: 'test-value'
-  AZURE_PORTAL_FILESHARE_NAME: 'test-value'
-  JWT_SIGNING_KEY: 'test-value'
-  JWT_VALIDATING_KEY: 'test-value'
-  GOV_NOTIFY_API_KEY: 'test-value'
-  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
-  COMPANIES_HOUSE_API_KEY: 'test-value' // from env but looks a secret
-}
+param secureConnectionStrings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'
@@ -56,6 +40,7 @@ var azureDnsServerIp = '168.63.129.16'
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
 var settings = {
   // from vars.
+  // TODO:FN-742 set from config.
   RATE_LIMIT_THRESHOLD: 'test-value'
 
   // hard coded

--- a/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
@@ -16,31 +16,17 @@ param resourceNameFragment string = 'portal-ui'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
-}
-
+param additionalSecureSettings object
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureConnectionStrings object = {
-  COMPANIES_HOUSE_API_KEY : 'test-value'
-  SESSION_SECRET: 'test-value'
-}
-
+param secureConnectionStrings object
 // These values are taken from an export of Connection strings on Dev (& validating with staging).
 @secure()
-param additionalSecureConnectionStrings object = {
-}
+param additionalSecureConnectionStrings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
@@ -14,6 +14,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'portal-ui'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -44,13 +46,7 @@ var externalApiUrl = 'https://${externalApiHostname}'
 var azureDnsServerIp = '168.63.129.16'
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
-  // from env.
-  COMPANIES_HOUSE_API_URL: 'test-value'
-
+var staticSettings = {
   // derived
   PORTAL_API_URL: portalApiUrl
   REDIS_HOSTNAME: redis.properties.hostName
@@ -85,7 +81,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
   name: item.key

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api.bicep
@@ -15,6 +15,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'trade-finance-manager-api'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -37,10 +39,7 @@ var dockerRegistryServerUsername = 'tfs${environment}'
 var azureDnsServerIp = '168.63.129.16'
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
+var staticSettings = {
   // hard coded
   WEBSITE_DNS_SERVER: azureDnsServerIp
   WEBSITE_VNET_ROUTE_ALL: '1'
@@ -71,7 +70,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
   name: item.key

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api.bicep
@@ -17,41 +17,18 @@ param resourceNameFragment string = 'trade-finance-manager-api'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  UKEF_INTERNAL_NOTIFICATION: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  JWT_VALIDATING_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
-}
-
+param additionalSecureSettings object
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureConnectionStrings object = {
-  // NOTE that CORS_ORIGIN is not present in the variables exported from dev or staging
-  CORS_ORIGIN: 'test-value'
-  UKEF_TFM_API_SYSTEM_KEY: 'test-value'
-  UKEF_TFM_API_REPORTS_KEY: 'test-value'
-  // TODO:FN-429 Note that TFM_UI_URL (renamed from TFM_URI) has a value like https://tfs-dev-tfm-fd.azurefd.net 
-  // while in the CLI it is injected as a secret, we can probably calculate it from the Front Door component.
-  TFM_UI_URL: 'test-value'
-  AZURE_NUMBER_GENERATOR_FUNCTION_SCHEDULE: 'test-value'
-  JWT_SIGNING_KEY: 'test-value' // NOTE - in the export this appears to be a slot setting. However, we don't need to replicate that.
-}
+param secureConnectionStrings object
 
 // These values are taken from an export of Connection strings on Dev (& validating with staging).
 @secure()
-param additionalSecureConnectionStrings object = {
-  GOV_NOTIFY_EMAIL_RECIPIENT: 'test-value'
-}
+param additionalSecureConnectionStrings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-ui.bicep
@@ -15,31 +15,19 @@ param resourceNameFragment string = 'trade-finance-manager-ui'
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureSettings object = {
-  UKEF_TFM_API_SYSTEM_KEY: 'test-value'
-  ESTORE_URL: 'test-value'
-}
+param secureSettings object
 
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
-param additionalSecureSettings object = {
-  DOCKER_REGISTRY_SERVER_PASSWORD: 'test-value'
-  DTFS_CENTRAL_API_KEY: 'test-value'
-  EXTERNAL_API_KEY: 'test-value'
-  PORTAL_API_KEY: 'test-value'
-  TFM_API_KEY: 'test-value'
-}
+param additionalSecureSettings object
 
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
-param secureConnectionStrings object = {
-  SESSION_SECRET: 'test-value'
-}
+param secureConnectionStrings object
 
 // These values are taken from an export of Connection strings on Dev (& validating with staging).
 @secure()
-param additionalSecureConnectionStrings object = {
-}
+param additionalSecureConnectionStrings object
 
 var dockerImageName = '${containerRegistryName}.azurecr.io/${resourceNameFragment}:${environment}'
 var dockerRegistryServerUsername = 'tfs${environment}'

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-ui.bicep
@@ -13,6 +13,8 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'trade-finance-manager-ui'
 
+param settings object
+
 // These values are taken from GitHub secrets injected in the GHA Action
 @secure()
 param secureSettings object
@@ -44,12 +46,7 @@ var externalApiUrl = 'https://${externalApiHostname}'
 var azureDnsServerIp = '168.63.129.16'
 
 // These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables
-var settings = {
-  // from vars.
-  RATE_LIMIT_THRESHOLD: 'test-value'
-
-  // from env.
-
+var staticSettings = {
   // derived
   TFM_API_URL: tfmApiUrl
   REDIS_HOSTNAME: redis.properties.hostName
@@ -80,7 +77,7 @@ var additionalSettings = {
 
 var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
-var appSettings = union(settings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
+var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
   name: item.key


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* input of secure parameters, typically from GitHub secrets
* input of other parameter
### Resolution
* multiple params are added, deviating from the normal naming scheme for clarity
* combination of params into the correct inputs for the app services
* NOTE: I have kept the distinction between the different "classes" of parameters.