### PR TITLE
feat(DTFS2-6182): replace get facilities graphql endpoint with REST endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ run-name: Executing test QA on ${{ github.repository }} 🚀
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/DTFS2-6182/replace-graphql-query-facility-in-tfm-with-rest]
     paths:
       - "package*.json"
       - "docker*.yml"

--- a/trade-finance-manager-api/src/constants/regex.js
+++ b/trade-finance-manager-api/src/constants/regex.js
@@ -2,4 +2,5 @@ module.exports = {
   UKEF_ID: /^\d{10}$/,
   PARTY_URN: /^\d{8}$/,
   NUMERIC_ID: /^\d+$/,
+  DATE: /^(\d{2})[ ](Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ ](\d{4})$/, // dd MMM yyyy
 };

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -31,12 +31,14 @@ const getFacilities = async (req, res) => {
   try {
     const queryParams = req.body;
 
+    // TODO DTFS2-6182: This is as current resolver implimentation, but should this be a 400?
     if (!queryParams) {
       return {};
     }
 
     const dbFacilities = await api.getAllFacilities(queryParams);
 
+    // TODO DTFS2-6182: Why is this different from getFacility?
     const facilities = dbFacilities.map((dbFacility) => {
       const { tfmFacilities: facility } = dbFacility;
 
@@ -66,6 +68,7 @@ const getFacilities = async (req, res) => {
 
       if (latestCompletedAmendment?.coverEndDate) {
         const { coverEndDate } = latestCompletedAmendment;
+        // TODO DTFS2-6182: Why is the below * 1000?
         // * 1000 to convert to ms epoch time format so can be correctly formatted by template
         facilityCoverEndDate = format(new Date(coverEndDate * 1000), 'dd MMM yyyy');
         facilityCoverEndDateEpoch = coverEndDate;

--- a/trade-finance-manager-api/src/v1/graphql-mappings/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/src/v1/graphql-mappings/helpers/amendment.helpers.js
@@ -17,7 +17,7 @@ const amendmentChangeValueExportCurrency = (amendment) => {
 const roundValue = (valueInGBP) => {
   const totalDecimals = decimalsCount(valueInGBP);
 
-  // rounds to 2 decimal palces if decimals greater than 2
+  // rounds to 2 decimal places if decimals greater than 2
   const newValue = totalDecimals > 2 ? roundNumber(valueInGBP, 2) : valueInGBP;
 
   return newValue;

--- a/trade-finance-manager-api/src/v1/graphql-mappings/helpers/formatFacilityValue.helper.api-test.js
+++ b/trade-finance-manager-api/src/v1/graphql-mappings/helpers/formatFacilityValue.helper.api-test.js
@@ -1,0 +1,31 @@
+const formatFacilityValue = require('./formatFacilityValue.helper');
+
+describe('facilityValueFormatted()', () => {
+  it('should return BSS value as string unformatted', () => {
+    const value = '30000.00';
+    const result = formatFacilityValue(value);
+
+    expect(result).toEqual(value);
+  });
+
+  it('should return GEF value which already with 2 decimal places', () => {
+    const value = 30000.00;
+    const result = formatFacilityValue(value.toFixed(2));
+
+    expect(result).toEqual(value.toFixed(2));
+  });
+
+  it('should return GEF value with 2 decimal places when original did not have any decimal places', () => {
+    const value = 30000;
+    const result = formatFacilityValue(value.toFixed(2));
+
+    expect(result).toEqual(value.toFixed(2));
+  });
+
+  it('should return unformatted GEF value with 2 decimal places when original has 2 decimal places', () => {
+    const value = 30000.53;
+    const result = formatFacilityValue(value);
+
+    expect(result).toEqual(value);
+  });
+});

--- a/trade-finance-manager-api/src/v1/graphql-mappings/helpers/formatFacilityValue.helper.js
+++ b/trade-finance-manager-api/src/v1/graphql-mappings/helpers/formatFacilityValue.helper.js
@@ -1,0 +1,21 @@
+const { decimalsCount } = require('../../helpers/number');
+
+/**
+ * formats facility value based on type
+ * BSS - string and already formatted with 2 decimal places
+ * GEF - number so needs to have 2 decimal places
+ */
+const formatFacilityValue = (value) => {
+  // BSS is string and formatted so can be returned
+  if (typeof value === 'string') {
+    return value;
+  }
+  // checks number of decimal places
+  const totalDecimals = decimalsCount(value);
+  // if not 2 decimal places, then set 2 decimal places
+  const newValue = totalDecimals !== 2 ? value.toFixed(2) : value;
+
+  return newValue;
+};
+
+module.exports = formatFacilityValue;

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -128,6 +128,9 @@ authRouter
   .put(validation.userIdValidation, handleValidationResult, users.updateTfmUserById)
   .delete(validation.userIdValidation, handleValidationResult, users.removeTfmUserById);
 
+authRouter.route('/facilities/:facilityId').get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility);
+authRouter.route('/facilities').get(facilityController.getFacilities);
+
 authRouter.route('/facilities/:facilityId/amendments').post(validation.facilityIdValidation, handleValidationResult, amendmentController.createFacilityAmendment);
 
 authRouter

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -36,6 +36,7 @@ const getDeal = async (id, tasksFilters, activityFilters) => {
 };
 
 const getFacilities = async (token, queryParams) => {
+  // TODO DTFS-6182: check the returns below
   try {
     const response = await axios({
       method: 'get',
@@ -48,10 +49,10 @@ const getFacilities = async (token, queryParams) => {
         facilities: response.data.tfmFacilities,
       };
     }
-    return response.data;
+    return { facilities: [] };
   } catch (error) {
     console.error(error);
-    return {};
+    return { facilities: [] };  
   }
 };
 

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -2,7 +2,6 @@ const axios = require('axios');
 const apollo = require('./graphql/apollo');
 const dealQuery = require('./graphql/queries/deal-query');
 const dealsLightQuery = require('./graphql/queries/deals-query-light');
-const facilitiesLightQuery = require('./graphql/queries/facilities-query-light');
 const teamMembersQuery = require('./graphql/queries/team-members-query');
 const updatePartiesMutation = require('./graphql/mutations/update-parties');
 const updateTaskMutation = require('./graphql/mutations/update-task');
@@ -36,20 +35,24 @@ const getDeal = async (id, tasksFilters, activityFilters) => {
   return response?.data?.deal;
 };
 
-const getFacilities = async (queryParams) => {
-  const response = await apollo('GET', facilitiesLightQuery, queryParams);
-
-  if (response.errors) {
-    console.error('TFM UI - GraphQL error querying facilities %O', response.errors);
+const getFacilities = async (token, queryParams) => {
+  try {
+    const response = await axios({
+      method: 'get',
+      url: `${TFM_API_URL}/v1/facilities`,
+      headers: generateHeaders(token),
+      data: queryParams,
+    });
+    if (response.data) {
+      return {
+        facilities: response.data.tfmFacilities,
+      };
+    }
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    return {};
   }
-
-  if (response?.data?.facilities?.tfmFacilities) {
-    return {
-      facilities: response.data.facilities.tfmFacilities,
-    };
-  }
-
-  return { facilities: [] };
 };
 
 const getDeals = async (queryParams) => {

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -52,7 +52,7 @@ const getFacilities = async (token, queryParams) => {
     return { facilities: [] };
   } catch (error) {
     console.error(error);
-    return { facilities: [] };  
+    return { facilities: [] };
   }
 };
 

--- a/trade-finance-manager-ui/server/controllers/facilities/index.js
+++ b/trade-finance-manager-ui/server/controllers/facilities/index.js
@@ -3,7 +3,7 @@ const CONSTANTS = require('../../constants');
 
 const getFacilities = async (req, res) => {
   const { userToken } = req.session;
-  // Query parameters have ben implemented in APIs but aren't currently used in frontends
+  // Query parameters have been implemented in APIs but aren't currently used in frontends
   const apiResponse = await api.getFacilities(userToken);
 
   const { data: amendments } = await api.getAllAmendmentsInProgress(userToken);

--- a/trade-finance-manager-ui/server/controllers/facilities/index.js
+++ b/trade-finance-manager-ui/server/controllers/facilities/index.js
@@ -3,7 +3,8 @@ const CONSTANTS = require('../../constants');
 
 const getFacilities = async (req, res) => {
   const { userToken } = req.session;
-  const apiResponse = await api.getFacilities();
+  // Query parameters have ben implemented in APIs but aren't currently used in frontends
+  const apiResponse = await api.getFacilities(userToken);
 
   const { data: amendments } = await api.getAllAmendmentsInProgress(userToken);
 
@@ -42,7 +43,7 @@ const queryFacilities = async (req, res) => {
   const { userToken } = req.session;
 
   const queryParams = { searchString };
-  const apiResponse = await api.getFacilities(queryParams);
+  const apiResponse = await api.getFacilities(userToken, queryParams);
 
   const { data: amendments } = await api.getAllAmendmentsInProgress(userToken);
 

--- a/trade-finance-manager-ui/server/controllers/facilities/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/facilities/index.test.js
@@ -95,7 +95,7 @@ describe('controllers - facilities', () => {
 
         await caseController.queryFacilities(mockReq, res);
 
-        expect(getFacilitiesSpy).toHaveBeenCalledWith({ searchString });
+        expect(getFacilitiesSpy).toHaveBeenCalledWith(undefined, { searchString });
 
         expect(res.render).toHaveBeenCalledWith('facilities/facilities.njk', {
           heading: 'All facilities',
@@ -117,7 +117,7 @@ describe('controllers - facilities', () => {
       it('should call api and render template with data', async () => {
         const mockReq = {
           session: { user: {} },
-          body: { },
+          body: {},
         };
 
         await caseController.queryFacilities(mockReq, res);


### PR DESCRIPTION
## Introduction
We need to standardise the TFM API by moving away from having both gql and REST endpoints. We will move the gql endpoints to REST.

## Resolution
Replace the get facilities graphql endpoint with REST endpoint as part of the gql -> rest migration in TFM API.