### PR TITLE
Feat(DTFS2-6182): replace update facility graphql endpoint with REST endpoint

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -17,6 +17,19 @@ const getFacility = async (req, res) => {
   });
 };
 
+const updateFacility = async (req, res) => {
+  const { _id, facilityUpdate } = req.params;
+  try {
+    const updatedFacility = await api.updateFacility(_id, facilityUpdate);
+    return res.status(200).send({
+      facility: updatedFacility.tfm
+    });
+  } catch (error) {
+    console.error('Unable to update facility: %O', error);
+    return res.status(400).send({ data: 'Unable to update facility ' });
+  }
+};
+
 const findOneFacility = async (_id) => {
   const facility = await api.findOneFacility(_id);
   return facility;
@@ -39,6 +52,7 @@ const updateTfmFacilityRiskProfile = async (facilityId, tfmUpdate) => {
 
 module.exports = {
   getFacility,
+  updateFacility,
   getAllFacilities,
   findOneFacility,
   updateTfmFacility,

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -18,11 +18,12 @@ const getFacility = async (req, res) => {
 };
 
 const updateFacility = async (req, res) => {
-  const { _id, facilityUpdate } = req.params;
+  const { facilityId } = req.params;
+  const facilityUpdate = req.body;
   try {
-    const updatedFacility = await api.updateFacility(_id, facilityUpdate);
+    const updatedFacility = await api.updateFacility(facilityId, facilityUpdate);
     return res.status(200).send({
-      facility: updatedFacility.tfm
+      updateFacility: updatedFacility.tfm
     });
   } catch (error) {
     console.error('Unable to update facility: %O', error);

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -3,18 +3,23 @@ const { findOneTfmDeal } = require('./deal.controller');
 const facilityMapper = require('../graphql-mappings/facility');
 
 const getFacility = async (req, res) => {
-  const { facilityId } = req.params;
-  const facility = await api.findOneFacility(facilityId);
+  try {
+    const { facilityId } = req.params;
+    const facility = await api.findOneFacility(facilityId);
 
-  const { dealId } = facility.facilitySnapshot;
-  const deal = await findOneTfmDeal(dealId);
+    const { dealId } = facility.facilitySnapshot;
+    const deal = await findOneTfmDeal(dealId);
 
-  const { dealSnapshot, tfm: dealTfm } = deal;
-  const tfmFacility = facilityMapper(facility, dealSnapshot, dealTfm);
+    const { dealSnapshot, tfm: dealTfm } = deal;
+    const tfmFacility = facilityMapper(facility, dealSnapshot, dealTfm);
 
-  return res.status(200).json({
-    facility: tfmFacility
-  });
+    return res.status(200).send({
+      facility: tfmFacility
+    });
+  } catch (error) {
+    console.error('Error fetching facility %O', error);
+    return res.status(500).send(error.message);
+  }
 };
 
 const updateFacility = async (req, res) => {

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -12,7 +12,6 @@ const getFacility = async (req, res) => {
   const { dealSnapshot, tfm: dealTfm } = deal;
   const tfmFacility = facilityMapper(facility, dealSnapshot, dealTfm);
 
-  // add error handling
   return res.status(200).json({
     facility: tfmFacility
   });

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -129,8 +129,10 @@ authRouter
 
 authRouter.route('/facilities/:facilityId/amendments').post(validation.facilityIdValidation, handleValidationResult, amendmentController.createFacilityAmendment);
 
-authRouter.route('/facilities/:facilityId').get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility);
-authRouter.route('/facilities/:facilityId').put(validation.facilityIdValidation, handleValidationResult, facilityController.updateFacility);
+authRouter
+  .route('/facilities/:facilityId')
+  .get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility)
+  .put(validation.facilityIdValidation, handleValidationResult, facilityController.updateFacility);
 
 /**
  * @openapi

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -129,6 +129,9 @@ authRouter
 
 authRouter.route('/facilities/:facilityId/amendments').post(validation.facilityIdValidation, handleValidationResult, amendmentController.createFacilityAmendment);
 
+authRouter.route('/facilities/:facilityId').get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility);
+authRouter.route('/facilities/:facilityId').put(validation.facilityIdValidation, handleValidationResult, facilityController.updateFacility);
+
 /**
  * @openapi
  * /facility/:facilityId/amendments:amendmentId:
@@ -157,7 +160,6 @@ authRouter.route('/facilities/:facilityId/amendments/:amendmentIdOrStatus?/:type
 authRouter
   .route('/facilities/:facilityId/amendments/:amendmentId')
   .put(validation.facilityIdAndAmendmentIdValidations, handleValidationResult, amendmentController.updateFacilityAmendment);
-authRouter.route('/facilities/:facilityId').get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility);
 
 authRouter.route('/deals/:dealId/amendments/:status?/:type?').get(validation.dealIdValidation, handleValidationResult, amendmentController.getAmendmentsByDealId);
 authRouter.route('/party/urn/:urn').get(validation.partyUrnValidation, handleValidationResult, party.getCompany);

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -157,7 +157,7 @@ authRouter.route('/facilities/:facilityId/amendments/:amendmentIdOrStatus?/:type
 authRouter
   .route('/facilities/:facilityId/amendments/:amendmentId')
   .put(validation.facilityIdAndAmendmentIdValidations, handleValidationResult, amendmentController.updateFacilityAmendment);
-authRouter.route('/facilities/:facilityId').get(facilityController.getFacility);
+authRouter.route('/facilities/:facilityId').get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility);
 
 authRouter.route('/deals/:dealId/amendments/:status?/:type?').get(validation.dealIdValidation, handleValidationResult, amendmentController.getAmendmentsByDealId);
 authRouter.route('/party/urn/:urn').get(validation.partyUrnValidation, handleValidationResult, party.getCompany);

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -78,13 +78,17 @@ const getDeals = async (queryParams) => {
 };
 
 const getFacility = async (id, token) => {
-  const response = await axios({
-    method: 'get',
-    url: `${TFM_API_URL}/v1/facilities/${id}`,
-    headers: generateHeaders(token),
-  });
-
-  return response.data.facility;
+  try {
+    const response = await axios({
+      method: 'get',
+      url: `${TFM_API_URL}/v1/facilities/${id}`,
+      headers: generateHeaders(token),
+    });
+    return response.data.facility;
+  } catch (error) {
+    console.error(error);
+    return {};
+  }
 };
 
 const getTeamMembers = async (teamId) => {

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -128,7 +128,7 @@ const updateFacility = async (id, facilityUpdate, token) => {
 
     return response.data;
   } catch (error) {
-    console.error('Unable to update facility request %O', error);
+    console.error('Unable to update facility %O', error);
     return { status: error?.response?.status || 500, data: 'Failed to update facility' };
   }
 };
@@ -150,7 +150,7 @@ const updateFacilityRiskProfile = async (id, facilityUpdate, token) => {
     });
     return response.data;
   } catch (error) {
-    console.error('Unable to update facility risk profile request %O', error);
+    console.error('Unable to update facility risk profile %O', error);
     return { status: error?.response?.status || 500, data: 'Failed to update facility risk profile' };
   }
 };

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -122,7 +122,7 @@ const updateFacility = async (id, facilityUpdate, token) => {
 
     return response.data;
   } catch (error) {
-    console.error('Unable to update facility request %s', error);
+    console.error('Unable to update facility request %O', error);
     return { status: error?.response?.status || 500, data: 'Failed to update facility' };
   }
 };

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -112,6 +112,13 @@ const updateParty = async (id, partyUpdate) => {
 
 const updateFacility = async (id, facilityUpdate, token) => {
   try {
+    const isValidFacilityId = isValidMongoId(id);
+
+    if (!isValidFacilityId) {
+      console.error('updateFacility: Invalid facility id provided: %s', id);
+      return { status: 400, data: 'Invalid facility id' };
+    }
+
     const response = await axios({
       method: 'put',
       url: `${TFM_API_URL}/v1/facilities/${id}`,
@@ -128,6 +135,13 @@ const updateFacility = async (id, facilityUpdate, token) => {
 
 const updateFacilityRiskProfile = async (id, facilityUpdate, token) => {
   try {
+    const isValidFacilityId = isValidMongoId(id);
+
+    if (!isValidFacilityId) {
+      console.error('updateFacilityRiskProfile: Invalid facility id provided: %s', id);
+      return { status: 400, data: 'Invalid facility id' };
+    }
+
     const response = await axios({
       method: 'put',
       url: `${TFM_API_URL}/v1/facilities/${id}`,

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -5,7 +5,6 @@ const dealsLightQuery = require('./graphql/queries/deals-query-light');
 const facilitiesLightQuery = require('./graphql/queries/facilities-query-light');
 const teamMembersQuery = require('./graphql/queries/team-members-query');
 const updatePartiesMutation = require('./graphql/mutations/update-parties');
-const updateFacilityMutation = require('./graphql/mutations/update-facilities');
 const updateFacilityRiskProfileMutation = require('./graphql/mutations/update-facility-risk-profile');
 const updateTaskMutation = require('./graphql/mutations/update-task');
 const updateCreditRatingMutation = require('./graphql/mutations/update-credit-rating');
@@ -108,13 +107,20 @@ const updateParty = async (id, partyUpdate) => {
   return response;
 };
 
-const updateFacility = async (id, facilityUpdate) => {
-  const updateVariables = {
-    id,
-    facilityUpdate,
-  };
-  const response = await apollo('PUT', updateFacilityMutation, updateVariables);
-  return response;
+const updateFacility = async (id, facilityUpdate, token) => {
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/facilities/${id}`,
+      headers: generateHeaders(token),
+      data: facilityUpdate,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update facility request %s', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update facility' };
+  }
 };
 
 const updateFacilityRiskProfile = async (id, facilityUpdate) => {

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -5,7 +5,6 @@ const dealsLightQuery = require('./graphql/queries/deals-query-light');
 const facilitiesLightQuery = require('./graphql/queries/facilities-query-light');
 const teamMembersQuery = require('./graphql/queries/team-members-query');
 const updatePartiesMutation = require('./graphql/mutations/update-parties');
-const updateFacilityRiskProfileMutation = require('./graphql/mutations/update-facility-risk-profile');
 const updateTaskMutation = require('./graphql/mutations/update-task');
 const updateCreditRatingMutation = require('./graphql/mutations/update-credit-rating');
 const updateLossGivenDefaultMutation = require('./graphql/mutations/update-loss-given-default');
@@ -127,13 +126,19 @@ const updateFacility = async (id, facilityUpdate, token) => {
   }
 };
 
-const updateFacilityRiskProfile = async (id, facilityUpdate) => {
-  const updateVariables = {
-    id,
-    facilityUpdate,
-  };
-  const response = await apollo('PUT', updateFacilityRiskProfileMutation, updateVariables);
-  return response;
+const updateFacilityRiskProfile = async (id, facilityUpdate, token) => {
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/facilities/${id}`,
+      headers: generateHeaders(token),
+      data: facilityUpdate,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update facility risk profile request %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update facility risk profile' };
+  }
 };
 
 const updateTask = async (dealId, taskUpdate) => {

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -492,6 +492,7 @@ const postTfmFacility = async (req, res) => {
   try {
     delete req.body._csrf;
 
+    const { userToken } = req.session;
     const party = partyType(req.url);
     const bond = bondType(party);
     const { user, urn, facilityId } = req.session;
@@ -525,7 +526,7 @@ const postTfmFacility = async (req, res) => {
         const update = {
           [bond]: urn[index],
         };
-        return api.updateFacility(id, update);
+        return api.updateFacility(id, update, userToken);
       }),
     );
 

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/facility-risk-profile/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/facility-risk-profile/index.js
@@ -57,7 +57,7 @@ const postUnderWritingFacilityRiskProfileEdit = async (req, res) => {
 
   const facilityUpdate = req.body;
 
-  await api.updateFacilityRiskProfile(facilityId, facilityUpdate);
+  await api.updateFacilityRiskProfile(facilityId, facilityUpdate, userToken);
 
   return res.redirect(`/case/${dealId}/underwriting`);
 };


### PR DESCRIPTION
## Introduction
We need to standardise the TFM API by moving away from having both gql and REST endpoints. We will move the gql endpoints to REST.

## Resolution
Replace the updateFacilities and updateFacilityRiskProfile graphql endpoints with an updateFacility REST endpoint as part of the gql -> rest migration in TFM API.