### PR TITLE
feat(DTFS2-6182): replace update party graphql endpoint with REST endpoint 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ run-name: Executing test QA on ${{ github.repository }} 🚀
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/DTFS2-6182/replace-graphql-query-facility-in-tfm-with-rest]
     paths:
       - "package*.json"
       - "docker*.yml"

--- a/trade-finance-manager-api/src/v1/controllers/deal.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.controller.js
@@ -129,7 +129,7 @@ const updateTfmParty = async (dealId, tfmUpdate) => {
   const updatedDeal = await api.updateDeal(dealId, partyUpdate);
 
   if (updatedDeal.dealSnapshot) {
-    if (await canDealBeSubmittedToACBS(updatedDeal.dealSnapshot.submissionType)) {
+    if (canDealBeSubmittedToACBS(updatedDeal.dealSnapshot.submissionType)) {
       await submitACBSIfAllPartiesHaveUrn(dealId);
     }
   }

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -32,7 +32,7 @@ const updateFacility = async (req, res) => {
     });
   } catch (error) {
     console.error('Unable to update facility: %O', error);
-    return res.status(400).send({ data: 'Unable to update facility ' });
+    return res.status(400).send({ data: 'Unable to update facility' });
   }
 };
 

--- a/trade-finance-manager-api/src/v1/controllers/party.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/party.controller.js
@@ -13,7 +13,7 @@ const updateParty = async (req, res) => {
     const updatedDeal = await api.updateDeal(dealId, partyUpdate);
 
     if (updatedDeal.dealSnapshot) {
-      if (await canDealBeSubmittedToACBS(updatedDeal.dealSnapshot.submissionType)) {
+      if (canDealBeSubmittedToACBS(updatedDeal.dealSnapshot.submissionType)) {
         await submitACBSIfAllPartiesHaveUrn(dealId);
       }
     }

--- a/trade-finance-manager-api/src/v1/controllers/party.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/party.controller.js
@@ -1,0 +1,34 @@
+const api = require('../api');
+const { canDealBeSubmittedToACBS, submitACBSIfAllPartiesHaveUrn } = require('./deal.controller');
+
+const updateParty = async (req, res) => {
+  const { dealId } = req.params;
+  const partyUpdate = {
+    tfm: {
+      parties: req.body,
+    },
+  };
+
+  try {
+    const updatedDeal = await api.updateDeal(dealId, partyUpdate);
+
+    if (updatedDeal.dealSnapshot) {
+      if (await canDealBeSubmittedToACBS(updatedDeal.dealSnapshot.submissionType)) {
+        await submitACBSIfAllPartiesHaveUrn(dealId);
+      }
+    }
+
+    return res.status(200).send({
+      updateParty: {
+        parties: updatedDeal.tfm.parties
+      }
+    });
+  } catch (error) {
+    console.error('Unable to update party %O', error);
+    return res.status(500).send(error.message);
+  }
+};
+
+module.exports = {
+  updateParty
+};

--- a/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
@@ -1,17 +1,6 @@
 const activity = require('../helpers/activity');
 const api = require('../api');
 
-const updateTfmParty = (dealId, tfmUpdate) => {
-  const partyUpdate = {
-    tfm: {
-      parties: tfmUpdate,
-    },
-  };
-
-  return api.updateDeal(dealId, partyUpdate);
-};
-exports.updateTfmParty = updateTfmParty;
-
 const updateAcbs = async (taskOutput) => {
   const { ...dealAcbs } = taskOutput;
   // Add various ACBS records to the TFM activities

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -12,6 +12,7 @@ const feedbackController = require('./controllers/feedback-controller');
 const amendmentController = require('./controllers/amendment.controller');
 const dealController = require('./controllers/deal.controller');
 const facilityController = require('./controllers/facility.controller');
+const partyController = require('./controllers/party.controller');
 const users = require('./controllers/user/user.routes');
 const party = require('./controllers/deal.party-db');
 const validation = require('./validation/route-validators/route-validators');
@@ -167,5 +168,6 @@ authRouter
 authRouter.route('/deals/:dealId').put(validation.dealIdValidation, handleValidationResult, dealController.updateDeal);
 authRouter.route('/deals/:dealId/amendments/:status?/:type?').get(validation.dealIdValidation, handleValidationResult, amendmentController.getAmendmentsByDealId);
 authRouter.route('/party/urn/:urn').get(validation.partyUrnValidation, handleValidationResult, party.getCompany);
+authRouter.route('/parties/:dealId').put(validation.dealIdValidation, handleValidationResult, partyController.updateParty);
 
 module.exports = { authRouter, openRouter };

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -4,7 +4,6 @@ const dealQuery = require('./graphql/queries/deal-query');
 const dealsLightQuery = require('./graphql/queries/deals-query-light');
 const facilitiesLightQuery = require('./graphql/queries/facilities-query-light');
 const teamMembersQuery = require('./graphql/queries/team-members-query');
-const updatePartiesMutation = require('./graphql/mutations/update-parties');
 const updateTaskMutation = require('./graphql/mutations/update-task');
 const postUnderwriterManagersDecision = require('./graphql/mutations/update-underwriter-managers-decision');
 const updateLeadUnderwriterMutation = require('./graphql/mutations/update-lead-underwriter');
@@ -103,14 +102,26 @@ const getTeamMembers = async (teamId) => {
   }
 };
 
-const updateParty = async (id, partyUpdate) => {
-  const updateVariables = {
-    id,
-    partyUpdate,
-  };
+const updateParty = async (id, partyUpdate, token) => {
+  try {
+    const isValidDealId = isValidMongoId(id);
 
-  const response = await apollo('PUT', updatePartiesMutation, updateVariables);
-  return response;
+    if (!isValidDealId) {
+      console.error('updateParty: Invalid deal id provided: %s', id);
+      return { status: 400, data: 'Invalid deal id' };
+    }
+
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/parties/${id}`,
+      headers: generateHeaders(token),
+      data: partyUpdate,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update party %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update party' };
+  }
 };
 
 const updateFacility = async (id, facilityUpdate, token) => {

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -534,7 +534,7 @@ const postTfmFacility = async (req, res) => {
      * Trigger's ACBS upon bond `beneficiary`
      * and `issuer` URN criteria match.
      * */
-    await api.updateParty(dealId, deal.parties);
+    await api.updateParty(dealId, deal.parties, userToken);
 
     return res.redirect(`/case/${dealId}/parties`);
   } catch (error) {

--- a/trade-finance-manager-ui/server/controllers/case/parties/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/parties/index.js
@@ -342,7 +342,7 @@ const confirmPartyUrn = async (req, res) => {
  */
 const postPartyDetails = async (req, res) => {
   try {
-    const { user } = req.session;
+    const { user, userToken } = req.session;
 
     delete req.body._csrf;
 
@@ -385,7 +385,7 @@ const postPartyDetails = async (req, res) => {
       delete req.session.commissionRate;
     }
 
-    await api.updateParty(dealId, update);
+    await api.updateParty(dealId, update, userToken);
 
     return res.redirect(`/case/${dealId}/parties`);
   } catch (error) {


### PR DESCRIPTION
## Introduction
We need to standardise the TFM API by moving away from having both gql and REST endpoints. We will move the gql endpoints to REST.

## Resolution
Replace the update party graphql endpoint with a REST endpoint as part of the gql -> rest migration in TFM API.