### PR TITLE
Feat(DTFS2-6182): replace update deal graphql endpoints with REST endpoint

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/deal.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.controller.js
@@ -76,6 +76,21 @@ const findOneGefDeal = async (dealId) => {
 };
 exports.findOneGefDeal = findOneGefDeal;
 
+const updateDeal = async (req, res) => {
+  const { dealId } = req.params;
+  const dealUpdate = req.body;
+  try {
+    const updatedDeal = await api.updateDeal(dealId, dealUpdate);
+    return res.status(200).send({
+      updateDeal: updatedDeal.tfm
+    });
+  } catch (error) {
+    console.error('Unable to update deal: %O', error);
+    return res.status(400).send({ data: 'Unable to update deal ' });
+  }
+};
+exports.updateDeal = updateDeal;
+
 const submitACBSIfAllPartiesHaveUrn = async (dealId) => {
   const deal = await findOneTfmDeal(dealId);
 

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -10,6 +10,7 @@ const { swaggerSpec, swaggerUiOptions } = require('./swagger');
 const dealSubmit = require('./controllers/deal.submit.controller');
 const feedbackController = require('./controllers/feedback-controller');
 const amendmentController = require('./controllers/amendment.controller');
+const dealController = require('./controllers/deal.controller');
 const facilityController = require('./controllers/facility.controller');
 const users = require('./controllers/user/user.routes');
 const party = require('./controllers/deal.party-db');
@@ -159,6 +160,7 @@ authRouter
   .put(validation.facilityIdAndAmendmentIdValidations, handleValidationResult, amendmentController.updateFacilityAmendment);
 authRouter.route('/facilities/:facilityId').get(validation.facilityIdValidation, handleValidationResult, facilityController.getFacility);
 
+authRouter.route('/deals/:dealId').put(validation.dealIdValidation, handleValidationResult, dealController.updateDeal);
 authRouter.route('/deals/:dealId/amendments/:status?/:type?').get(validation.dealIdValidation, handleValidationResult, amendmentController.getAmendmentsByDealId);
 authRouter.route('/party/urn/:urn').get(validation.partyUrnValidation, handleValidationResult, party.getCompany);
 

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -8,12 +8,8 @@ const updatePartiesMutation = require('./graphql/mutations/update-parties');
 const updateFacilityMutation = require('./graphql/mutations/update-facilities');
 const updateFacilityRiskProfileMutation = require('./graphql/mutations/update-facility-risk-profile');
 const updateTaskMutation = require('./graphql/mutations/update-task');
-const updateCreditRatingMutation = require('./graphql/mutations/update-credit-rating');
-const updateLossGivenDefaultMutation = require('./graphql/mutations/update-loss-given-default');
-const updateProbabilityOfDefaultMutation = require('./graphql/mutations/update-probability-of-default');
 const postUnderwriterManagersDecision = require('./graphql/mutations/update-underwriter-managers-decision');
 const updateLeadUnderwriterMutation = require('./graphql/mutations/update-lead-underwriter');
-const createActivityMutation = require('./graphql/mutations/create-activity');
 const { isValidMongoId, isValidPartyUrn } = require('./helpers/validateIds');
 
 require('dotenv').config();
@@ -141,34 +137,70 @@ const updateTask = async (dealId, taskUpdate) => {
   return response;
 };
 
-const updateCreditRating = async (dealId, creditRatingUpdate) => {
-  const updateVariables = {
-    dealId,
-    creditRatingUpdate,
+const updateCreditRating = async (dealId, creditRatingUpdate, token) => {
+  const { exporterCreditRating } = creditRatingUpdate;
+  const dealUpdate = {
+    tfm: {
+      exporterCreditRating,
+    },
   };
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/deals/${dealId}`,
+      headers: generateHeaders(token),
+      data: dealUpdate,
+    });
 
-  const response = await apollo('PUT', updateCreditRatingMutation, updateVariables);
-  return response;
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update credit rating request %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update credit rating' };
+  }
 };
 
-const updateLossGivenDefault = async (dealId, lossGivenDefaultUpdate) => {
-  const updateVariables = {
-    dealId,
-    lossGivenDefaultUpdate,
+const updateLossGivenDefault = async (dealId, lossGivenDefaultUpdate, token) => {
+  const { lossGivenDefault } = lossGivenDefaultUpdate;
+  const dealUpdate = {
+    tfm: {
+      lossGivenDefault,
+    },
   };
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/deals/${dealId}`,
+      headers: generateHeaders(token),
+      data: dealUpdate,
+    });
 
-  const response = await apollo('PUT', updateLossGivenDefaultMutation, updateVariables);
-  return response;
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update loss given default request %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update loss given default' };
+  }
 };
 
-const updateProbabilityOfDefault = async (dealId, probabilityOfDefaultUpdate) => {
-  const updateVariables = {
-    dealId,
-    probabilityOfDefaultUpdate,
+const updateProbabilityOfDefault = async (dealId, probabilityOfDefaultUpdate, token) => {
+  const { probabilityOfDefault } = probabilityOfDefaultUpdate;
+  const dealUpdate = {
+    tfm: {
+      probabilityOfDefault,
+    },
   };
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/deals/${dealId}`,
+      headers: generateHeaders(token),
+      data: dealUpdate,
+    });
 
-  const response = await apollo('PUT', updateProbabilityOfDefaultMutation, updateVariables);
-  return response;
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update probability of default request %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update probability of default' };
+  }
 };
 
 const updateUnderwriterManagersDecision = async (dealId, update) => {
@@ -193,15 +225,25 @@ const updateLeadUnderwriter = async (dealId, leadUnderwriterUpdate) => {
   return response;
 };
 
-const createActivity = async (dealId, activityUpdate) => {
-  const updateVariable = {
-    dealId,
-    activityUpdate,
+const createActivity = async (dealId, activityUpdate, token) => {
+  const dealUpdate = {
+    tfm: {
+      activities: activityUpdate,
+    },
   };
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/deals/${dealId}`,
+      headers: generateHeaders(token),
+      data: dealUpdate,
+    });
 
-  const response = await apollo('PUT', createActivityMutation, updateVariable);
-
-  return response;
+    return response.data;
+  } catch (error) {
+    console.error('Unable to create activity request %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to create activity' };
+  }
 };
 
 const login = async (username, password) => {

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -145,6 +145,13 @@ const updateCreditRating = async (dealId, creditRatingUpdate, token) => {
     },
   };
   try {
+    const isValidDealId = isValidMongoId(dealId);
+
+    if (!isValidDealId) {
+      console.error('updateCreditRating: Invalid deal id provided: %s', dealId);
+      return { status: 400, data: 'Invalid deal id' };
+    }
+
     const response = await axios({
       method: 'put',
       url: `${TFM_API_URL}/v1/deals/${dealId}`,
@@ -167,6 +174,13 @@ const updateLossGivenDefault = async (dealId, lossGivenDefaultUpdate, token) => 
     },
   };
   try {
+    const isValidDealId = isValidMongoId(dealId);
+
+    if (!isValidDealId) {
+      console.error('updateLossGivenDefault: Invalid deal id provided: %s', dealId);
+      return { status: 400, data: 'Invalid deal id' };
+    }
+
     const response = await axios({
       method: 'put',
       url: `${TFM_API_URL}/v1/deals/${dealId}`,
@@ -189,6 +203,13 @@ const updateProbabilityOfDefault = async (dealId, probabilityOfDefaultUpdate, to
     },
   };
   try {
+    const isValidDealId = isValidMongoId(dealId);
+
+    if (!isValidDealId) {
+      console.error('updateProbabilityOfDefault: Invalid deal id provided: %s', dealId);
+      return { status: 400, data: 'Invalid deal id' };
+    }
+
     const response = await axios({
       method: 'put',
       url: `${TFM_API_URL}/v1/deals/${dealId}`,
@@ -232,6 +253,13 @@ const createActivity = async (dealId, activityUpdate, token) => {
     },
   };
   try {
+    const isValidDealId = isValidMongoId(dealId);
+
+    if (!isValidDealId) {
+      console.error('createActivity: Invalid deal id provided: %s', dealId);
+      return { status: 400, data: 'Invalid deal id' };
+    }
+
     const response = await axios({
       method: 'put',
       url: `${TFM_API_URL}/v1/deals/${dealId}`,

--- a/trade-finance-manager-ui/server/controllers/case/activity/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/activity/index.js
@@ -128,7 +128,7 @@ const getCommentBox = async (req, res) => {
 const postComment = async (req, res) => {
   const { params, session, body } = req;
   const dealId = params._id;
-  const { user } = session;
+  const { user, userToken } = session;
   const { comment } = body;
 
   try {
@@ -164,7 +164,7 @@ const postComment = async (req, res) => {
         text: comment,
         label: CONSTANTS.ACTIVITIES.ACTIVITY_LABEL.COMMENT,
       };
-      await api.createActivity(dealId, commentObj);
+      await api.createActivity(dealId, commentObj, userToken);
     }
   } catch (error) {
     console.error('Post comment error %O', error);

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/index.js
@@ -46,7 +46,7 @@ const postUnderWritingPricingAndRisk = async (req, res) => {
   const dealId = req.params._id;
   const deal = await api.getDeal(dealId);
 
-  const { user } = req.session;
+  const { user, userToken } = req.session;
 
   if (!deal || !userCanEditGeneral(user)) {
     return res.redirect('/not-found');
@@ -143,7 +143,7 @@ const postUnderWritingPricingAndRisk = async (req, res) => {
     exporterCreditRating: submittedValue,
   };
 
-  await api.updateCreditRating(dealId, update);
+  await api.updateCreditRating(dealId, update, userToken);
 
   return res.redirect(`/case/${dealId}/underwriting`);
 };

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/loss-given-default/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/loss-given-default/index.js
@@ -29,7 +29,7 @@ const postUnderWritingLossGivenDefault = async (req, res) => {
   const dealId = req.params._id;
   const deal = await api.getDeal(dealId);
 
-  const { user } = req.session;
+  const { user, userToken } = req.session;
   const userCanEdit = userIsInTeam(user, [CONSTANTS.TEAMS.UNDERWRITERS, CONSTANTS.TEAMS.UNDERWRITER_MANAGERS]);
 
   if (!deal || !userCanEdit) {
@@ -85,7 +85,7 @@ const postUnderWritingLossGivenDefault = async (req, res) => {
     lossGivenDefault: Number(lossGivenDefault),
   };
 
-  await api.updateLossGivenDefault(dealId, update);
+  await api.updateLossGivenDefault(dealId, update, userToken);
 
   return res.redirect(`/case/${dealId}/underwriting`);
 };

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/loss-given-default/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/loss-given-default/index.test.js
@@ -116,6 +116,7 @@ describe('POST underwriting - loss given default', () => {
       expect(apiUpdateSpy).toHaveBeenCalledWith(
         mockDeal._id,
         { lossGivenDefault: Number(req.body.lossGivenDefault) },
+        undefined,
       );
 
       expect(res.redirect).toHaveBeenCalledWith(`/case/${mockDeal._id}/underwriting`);

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/probability-of-default/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/probability-of-default/index.js
@@ -30,7 +30,7 @@ const postUnderWritingProbabilityOfDefault = async (req, res) => {
   const dealId = req.params._id;
   const deal = await api.getDeal(dealId);
 
-  const { user } = req.session;
+  const { user, userToken } = req.session;
   const userCanEdit = userIsInTeam(user, [CONSTANTS.TEAMS.UNDERWRITERS, CONSTANTS.TEAMS.UNDERWRITER_MANAGERS]);
 
   if (!deal || !userCanEdit) {
@@ -82,7 +82,7 @@ const postUnderWritingProbabilityOfDefault = async (req, res) => {
     probabilityOfDefault: Number(probabilityOfDefault),
   };
 
-  await api.updateProbabilityOfDefault(dealId, update);
+  await api.updateProbabilityOfDefault(dealId, update, userToken);
 
   return res.redirect(`/case/${dealId}/underwriting`);
 };

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/probability-of-default/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/pricing-and-risk/probability-of-default/index.test.js
@@ -124,6 +124,7 @@ describe('POST underwriting - probability of default', () => {
       expect(apiUpdateSpy).toHaveBeenCalledWith(
         mockDeal._id,
         expectedUpdateObj,
+        undefined,
       );
     });
 
@@ -165,6 +166,7 @@ describe('POST underwriting - probability of default', () => {
       expect(apiUpdateSpy).toHaveBeenCalledWith(
         mockDeal._id,
         expectedUpdateObj,
+        undefined,
       );
     });
 
@@ -206,6 +208,7 @@ describe('POST underwriting - probability of default', () => {
       expect(apiUpdateSpy).toHaveBeenCalledWith(
         mockDeal._id,
         expectedUpdateObj,
+        undefined,
       );
     });
 


### PR DESCRIPTION
## Introduction
We need to standardise the TFM API by moving away from having both gql and REST endpoints. We will move the gql endpoints to REST.

## Resolution
Replace the updateCreditRating, updateLossGivenDefault, updateProbabilityOfDefault, createActivity graphql endpoints with a single `updateDeal` REST endpoint as part of the gql -> rest migration in TFM API.