### PR TITLE
fix(DTFS2-6681): extract reset password payload

### DIFF
--- a/portal-api/package-lock.json
+++ b/portal-api/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.28.1",
         "jest": "^29.6.4",
+        "jest-when": "^3.6.0",
         "prettier": "^2.8.8",
         "supertest": "6.3.3"
       },
@@ -5129,6 +5130,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-when": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.6.0.tgz",
+      "integrity": "sha512-+cZWTy0ekAJo7M9Om0Scdor1jm3wDiYJWmXE8U22UVnkH54YCXAuaqz3P+up/FdtOg8g4wHOxV7Thd7nKhT6Dg==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
       }
     },
     "node_modules/jest-worker": {

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -68,6 +68,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.28.1",
     "jest": "^29.6.4",
+    "jest-when": "^3.6.0",
     "prettier": "^2.8.8",
     "supertest": "6.3.3"
   },

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -302,7 +302,7 @@ module.exports.resetPasswordWithToken = async (req, res, next) => {
   }
 
   // Void token - Token expired
-  const user = await getUserByPasswordToken(resetPwdToken, req.body);
+  const user = await getUserByPasswordToken(resetPwdToken);
   // Stale token - Generated over 24 hours ago
   const hoursSincePasswordResetRequest = user.resetPwdTimestamp
     ? (Date.now() - user.resetPwdTimestamp) / 1000 / 60 / 60
@@ -324,8 +324,8 @@ module.exports.resetPasswordWithToken = async (req, res, next) => {
   }
 
   const errors = applyUpdateRules(user, {
-    resetPwdToken,
-    ...req.body,
+    password,
+    passwordConfirm,
   });
 
   if (errors.length) {
@@ -338,7 +338,8 @@ module.exports.resetPasswordWithToken = async (req, res, next) => {
     });
   }
   const updateData = {
-    ...req.body,
+    password,
+    passwordConfirm,
     resetPwdToken: '',
     resetPwdTimestamp: '',
     currentPassword: '',

--- a/portal-api/src/v1/users/routes.test.js
+++ b/portal-api/src/v1/users/routes.test.js
@@ -1,0 +1,89 @@
+const { ObjectId } = require('mongodb');
+const { when } = require('jest-when');
+const { getUserByPasswordToken } = require('./reset-password.controller');
+const { update } = require('./controller');
+const { resetPasswordWithToken } = require('./routes');
+const utils = require('../../crypto/utils');
+
+jest.mock('./reset-password.controller');
+jest.mock('./controller');
+
+describe('users routes', () => {
+  describe('resetPasswordWithToken', () => {
+    const resetPwdToken = 'token';
+    const oldPassword = 'Old-password1';
+    const newPassword = 'New-password1';
+    const { salt: currentSalt, hash: currentHash } = utils.genPassword(oldPassword);
+
+    const req = {
+      params: { resetPwdToken },
+      body: {
+        password: newPassword,
+        passwordConfirm: newPassword,
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+
+    const reqWithExtraFieldsInBody = {
+      ...req,
+      body: {
+        ...req.body,
+        extraField: 'extraFieldValue',
+      },
+    };
+
+    const user = {
+      _id: new ObjectId(),
+      resetPwdTimestamp: new Date().getTime(),
+      salt: currentSalt,
+      hash: currentHash,
+    };
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+      when(getUserByPasswordToken)
+        .calledWith(resetPwdToken)
+        .mockResolvedValueOnce(user);
+    });
+
+    it('updates the user\'s password and reset password details', async () => {
+      await resetPasswordWithToken(req, res, next);
+
+      expect(update).toHaveBeenCalledWith(
+        user._id,
+        {
+          password: newPassword,
+          passwordConfirm: newPassword,
+          resetPwdToken: '',
+          resetPwdTimestamp: '',
+          currentPassword: '',
+          loginFailureCount: 0,
+          passwordUpdatedAt: expect.any(String),
+        },
+        expect.any(Function)
+      );
+    });
+
+    it('ignores unexpected fields supplied in the request body', async () => {
+      await resetPasswordWithToken(reqWithExtraFieldsInBody, res, next);
+
+      expect(update).toHaveBeenCalledWith(
+        user._id,
+        {
+          password: newPassword,
+          passwordConfirm: newPassword,
+          resetPwdToken: '',
+          resetPwdTimestamp: '',
+          currentPassword: '',
+          loginFailureCount: 0,
+          passwordUpdatedAt: expect.any(String),
+        },
+        expect.any(Function)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Introduction

See DTFS2-6681.
So we can deploy this fix more quickly, I've made minimal changes in this PR and I will raise a separate ticket for more extensive changes that I think we should make.

## Resolution

- installed `jest-when` as a dev dependency in portal-api
- extracted just `password` and `passwordConfirm` from the request body in portal-api's `resetPasswordWithToken` route when updating the user document
- added 2 simple unit tests for `resetPasswordWithToken` in portal-api's user routes to validate the change I've made
