### PR TITLE
feat(FN-712):commonise webapps fix

### DIFF
--- a/infrastructure/resource_group_level/modules/webapps/dtfs-central-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/dtfs-central-api.bicep
@@ -80,8 +80,8 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' exis
   name: cosmosDbAccountName
 }
 
-module dtfsCentralApi 'webapp.bicep' = {
-  name: 'dtfsCentralApi'
+module dtfsCentralApiWebapp 'webapp.bicep' = {
+  name: 'dtfsCentralApiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -100,4 +100,4 @@ module dtfsCentralApi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = dtfsCentralApi.outputs.defaultHostName
+output defaultHostName string = dtfsCentralApiWebapp.outputs.defaultHostName

--- a/infrastructure/resource_group_level/modules/webapps/external-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/external-api.bicep
@@ -71,8 +71,8 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' exis
 }
 
 
-module externalApi 'webapp.bicep' = {
-  name: 'externalApi'
+module externalApiWebapp 'webapp.bicep' = {
+  name: 'externalApiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -91,4 +91,4 @@ module externalApi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = externalApi.outputs.defaultHostName
+output defaultHostName string = externalApiWebapp.outputs.defaultHostName

--- a/infrastructure/resource_group_level/modules/webapps/gef-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/gef-ui.bicep
@@ -100,8 +100,8 @@ var connectionStringsCalculated = { }
 
 var connectionStringsCombined = union(connectionStringsProperties, connectionStringsCalculated)
 
-module gefUi 'webapp.bicep' = {
-  name: 'gefUi'
+module gefUiWebapp 'webapp.bicep' = {
+  name: 'gefUiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -120,4 +120,4 @@ module gefUi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = gefUi.outputs.defaultHostName
+output defaultHostName string = gefUiWebapp.outputs.defaultHostName

--- a/infrastructure/resource_group_level/modules/webapps/portal-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-api.bicep
@@ -130,8 +130,8 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' exis
   name: cosmosDbAccountName
 }
 
-module portalApi 'webapp.bicep' = {
-  name: 'portalApi'
+module portalApiWebapp 'webapp.bicep' = {
+  name: 'portalApiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -150,4 +150,4 @@ module portalApi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = portalApi.outputs.defaultHostName
+output defaultHostName string = portalApiWebapp.outputs.defaultHostName

--- a/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
@@ -98,8 +98,8 @@ var connectionStringsProperties = toObject(connectionStringsList, item => item.n
 var connectionStringsCalculated = { }
 var connectionStringsCombined = union(connectionStringsProperties, connectionStringsCalculated)
 
-module portalUi 'webapp.bicep' = {
-  name: 'portalUi'
+module portalUiWebapp 'webapp.bicep' = {
+  name: 'portalUiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -118,4 +118,4 @@ module portalUi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = portalUi.outputs.defaultHostName
+output defaultHostName string = portalUiWebapp.outputs.defaultHostName

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api.bicep
@@ -115,8 +115,8 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' exis
   name: cosmosDbAccountName
 }
 
-module tfmApi 'webapp.bicep' = {
-  name: 'tfmApi'
+module tfmApiWebapp 'webapp.bicep' = {
+  name: 'tfmApiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -135,4 +135,4 @@ module tfmApi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = tfmApi.outputs.defaultHostName
+output defaultHostName string = tfmApiWebapp.outputs.defaultHostName

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-ui.bicep
@@ -93,8 +93,8 @@ var connectionStringsProperties = toObject(connectionStringsList, item => item.n
 var connectionStringsCalculated = { }
 var connectionStringsCombined = union(connectionStringsProperties, connectionStringsCalculated)
 
-module tfmUi 'webapp.bicep' = {
-  name: 'tfmUi'
+module tfmUiWebapp 'webapp.bicep' = {
+  name: 'tfmUiWebapp'
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
@@ -113,4 +113,4 @@ module tfmUi 'webapp.bicep' = {
   }
 }
 
-output defaultHostName string = tfmUi.outputs.defaultHostName
+output defaultHostName string = tfmUiWebapp.outputs.defaultHostName


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* commonising webapp code and to highlight similarities
* fixing the naming of the webapp references to avoid conflicts
### Resolution
* renamed instances of the child webapp modules.