### PR TITLE
fix(DTFS2-6679): display errors on the edit user page

### DIFF
--- a/portal/server/routes/admin/users.js
+++ b/portal/server/routes/admin/users.js
@@ -23,7 +23,7 @@ const getOptionsForRenderingEditUser = async (req, res) => {
     displayedUser: userToEdit,
     user,
   };
-}
+};
 
 router.get('/users', async (req, res) => {
   const { _id, userToken } = requestParams(req);
@@ -113,10 +113,9 @@ router.post('/users/create', async (req, res) => {
 
 // Admin - user edit
 router.get('/users/edit/:_id', async (req, res) => {
-
   const options = await getOptionsForRenderingEditUser(req, res);
 
-  return res.render('admin/user-edit.njk', options)
+  return res.render('admin/user-edit.njk', options);
 });
 
 // Admin - user edit


### PR DESCRIPTION
### Introduction

Currently the page that admins use to edit a user does not display errors if the update fails. Instead it assumes that the update succeeded and redirects the admin to the list of all users (as it does when the update succeeds).

The update can fail if the admin changes the user to have the `read-only` role AND one or more other roles. This is only possible to achieve via the UI in browsers with JavaScript disabled.

Steps to reproduce bug:

1. Disable JavaScript in the browser
2. Log in to Portal UI as the username ‘ADMIN’
3. Go to the ‘Users’ tab
4. Click on username 'BANK1_MAKER1’, taking you to the edit user page
5. Check the ‘Read-only’ box, so that ‘Maker’ and ‘Read-only’ are both checked
6. Click the save button
7. You are redirected to the ‘Users’ tab, but the update has silently failed - ‘BANK1_MAKER1’ still only has the 'Maker’ role

### Resolution

I've changed the code to check if the update fails and display the edit page with the errors (and keeping the in-progress edit data) if so.

### Misc

- At the moment, it appears that no errors would be shown if the update failed due to a reason other than an invalid selection in the UI (e.g., a 500 Internal Server Error). This should be investigated and it should be decided how we want to deal with this situation, and a ticket should be raised
- I haven't been able to write API tests for this change yet, due to VM issues
- We cannot write E2E tests for this change, as the bug is only present when JS is disabled, which isn't possible in the E2E tests