### PR TITLE
Feat(FN-957): Create payment officer role in portal

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
@@ -1,7 +1,11 @@
 const { header, users, createUser } = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
-const { USER_ROLES: { MAKER, READ_ONLY, CHECKER, PAYMENT_OFFICER } } = require('../../../../fixtures/constants');
+const {
+  USER_ROLES: {
+    MAKER, READ_ONLY, CHECKER, PAYMENT_OFFICER,
+  },
+} = require('../../../../fixtures/constants');
 
 const { ADMIN: AN_ADMIN, USER_WITH_INJECTION } = MOCK_USERS;
 

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
@@ -1,7 +1,7 @@
 const { header, users, createUser } = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
-const { USER_ROLES: { MAKER, READ_ONLY, CHECKER } } = require('../../../../fixtures/constants');
+const { USER_ROLES: { MAKER, READ_ONLY, CHECKER, PAYMENT_OFFICER } } = require('../../../../fixtures/constants');
 
 const { ADMIN: AN_ADMIN, USER_WITH_INJECTION } = MOCK_USERS;
 
@@ -205,13 +205,16 @@ context('Admin user creates a new user', () => {
     it('should unselect other roles if the read-only role is selected', () => {
       createUser.role(MAKER).click();
       createUser.role(CHECKER).click();
+      createUser.role(PAYMENT_OFFICER).click();
       createUser.role(MAKER).should('be.checked');
       createUser.role(CHECKER).should('be.checked');
+      createUser.role(PAYMENT_OFFICER).should('be.checked');
 
       createUser.role(READ_ONLY).click();
       createUser.role(READ_ONLY).should('be.checked');
       createUser.role(MAKER).should('not.be.checked');
       createUser.role(CHECKER).should('not.be.checked');
+      createUser.role(PAYMENT_OFFICER).should('not.be.checked');
     });
 
     it('should unselect the read-only role if another role is selected', () => {

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/restrict-access/restrict-access.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/restrict-access/restrict-access.spec.js
@@ -4,6 +4,7 @@ const {
   BANK1_MAKER1,
   BANK1_CHECKER1,
   BANK1_READ_ONLY1,
+  BANK1_PAYMENT_OFFICER1,
 } = require('../../../../fixtures/users');
 
 context('Only allow authorised users to access admin pages', () => {
@@ -25,6 +26,10 @@ context('Only allow authorised users to access admin pages', () => {
     roleName: 'Read Only users',
     userWithRole: BANK1_READ_ONLY1,
     expectedRedirectLocation: '/dashboard/deals/0',
+  }, {
+    roleName: 'Payment Officers',
+    userWithRole: BANK1_PAYMENT_OFFICER1,
+    expectedRedirectLocation: '/login',
   }];
 
   unauthorisedRoles.forEach(({ roleName, userWithRole, expectedRedirectLocation }) => {

--- a/e2e-tests/portal/cypress/fixtures/constants.js
+++ b/e2e-tests/portal/cypress/fixtures/constants.js
@@ -56,6 +56,7 @@ const USER_ROLES = {
   MAKER: 'maker',
   CHECKER: 'checker',
   READ_ONLY: 'read-only',
+  PAYMENT_OFFICER: 'payment-officer',
 };
 
 module.exports = {

--- a/e2e-tests/portal/cypress/fixtures/users.js
+++ b/e2e-tests/portal/cypress/fixtures/users.js
@@ -14,6 +14,8 @@ const BANK1_CHECKER1 = MOCK_USERS.find((user) => user.roles.includes(USER_ROLES.
 
 const BANK1_READ_ONLY1 = MOCK_USERS.find((user) => user.roles.includes(USER_ROLES.READ_ONLY) && user.username === 'BANK1_READ_ONLY1');
 
+const BANK1_PAYMENT_OFFICER1 = MOCK_USERS.find((user) => user.roles.includes(USER_ROLES.PAYMENT_OFFICER) && user.username === 'BANK1_PAYMENT_OFFICER1');
+
 const ADMIN = MOCK_USERS.find((user) => user.username === 'ADMIN');
 
 // TFM
@@ -36,6 +38,7 @@ module.exports = {
   BANK3_GEF_MAKER1,
   BANK1_CHECKER1,
   BANK1_READ_ONLY1,
+  BANK1_PAYMENT_OFFICER1,
   ADMIN,
   UNDERWRITER_MANAGER,
   USER_WITH_INJECTION,

--- a/portal/component-tests/admin/user-edit.component-test.js
+++ b/portal/component-tests/admin/user-edit.component-test.js
@@ -37,6 +37,10 @@ describe(page, () => {
     roleName: 'Read-only',
     roleDataAttribute: 'read-only',
     roleValue: 'read-only',
+  }, {
+    roleName: 'Payment Officer',
+    roleDataAttribute: 'payment-officer',
+    roleValue: 'payment-officer',
   }];
 
   let wrapper;

--- a/portal/templates/admin/user-edit.njk
+++ b/portal/templates/admin/user-edit.njk
@@ -93,6 +93,13 @@
           attributes: {"data-cy": "role-checker"}
         },
         {
+          value: "payment-officer",
+          text: "Payment Officer",
+          hint: { text: "Report on GEF utilisation and fees" },
+          checked: displayedUser.roles.includes("payment-officer"),
+          attributes: {"data-cy": "role-payment-officer"}
+        },
+        {
           value: "admin",
           text: "Admin",
           hint: { text: "Creates, updates, and removes user accounts" },

--- a/utils/mock-data-loader/portal/roles.js
+++ b/utils/mock-data-loader/portal/roles.js
@@ -3,6 +3,7 @@ const ROLES = {
   CHECKER: 'checker',
   ADMIN: 'admin',
   READ_ONLY: 'read-only',
+  PAYMENT_OFFICER: 'payment-officer',
 };
 
 module.exports = ROLES;

--- a/utils/mock-data-loader/portal/users.js
+++ b/utils/mock-data-loader/portal/users.js
@@ -1,6 +1,6 @@
 const BANKS = require('../banks');
 const {
-  MAKER, CHECKER, ADMIN, READ_ONLY
+  MAKER, CHECKER, ADMIN, READ_ONLY, PAYMENT_OFFICER
 } = require('./roles');
 
 const UKEF_TEST_BANK_1 = BANKS.find((bank) => bank.name === 'UKEF test bank (Delegated)');
@@ -96,6 +96,16 @@ const USERS = [
     email: 'checker3@ukexportfinance.gov.uk',
     timezone: 'Europe/London',
     roles: [MAKER, CHECKER],
+    bank: UKEF_TEST_BANK_1,
+  },
+  {
+    username: 'BANK1_PAYMENT_OFFICER1',
+    password: 'AbC!2345',
+    firstname: 'Payton',
+    surname: 'Archer',
+    email: 'paymentofficer@ukexportfinance.gov.uk',
+    timezone: 'Europe/London',
+    roles: [PAYMENT_OFFICER],
     bank: UKEF_TEST_BANK_1,
   },
   {


### PR DESCRIPTION
## Introduction

Allow admin users to create/edit users to have a new `payment officer` role which will give access to the utilisation reporting service.

## Resolution

- Added payment officer check box to create/edit user form.
- Added a test user in mock data loader.
- Updated component & e2e tests.