### PR TITLE
feat(FN-805):remove deal api url

### DIFF
--- a/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/portal-ui.bicep
@@ -65,8 +65,6 @@ var staticSettings = {
 var tfmApiUrl = 'https://${tfmApiHostname}'
 
 var additionalSettings = {
-  DEAL_API_URL: portalApiUrl // TODO:FN-805 remove DEAL_API_URL
-
   DOCKER_ENABLE_CI: 'true'
   DOCKER_REGISTRY_SERVER_URL: containerRegistryLoginServer
   DOCKER_REGISTRY_SERVER_USERNAME: containerRegistry.listCredentials().username


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* removing `DEAL_API_URL`
### Resolution
* `DEAL_API_URL` was removed after checking it isn't in use
