### PR TITLE
feat(FN-1203): disable function-acbs in non-prod environments

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -286,7 +286,7 @@ var parametersMap = {
       backupPolicyTier: 'Continuous30Days'
     }
     functionAcbs: {
-      enabled: false
+      state: 'Stopped'
     }
     nodeDeveloperMode: true
     nsg: {
@@ -330,7 +330,7 @@ var parametersMap = {
       backupPolicyTier: 'Continuous7Days'
     }
     functionAcbs: {
-      enabled: false
+      state: 'Stopped'
     }
     nodeDeveloperMode: true
     nsg: {
@@ -374,7 +374,7 @@ var parametersMap = {
       backupPolicyTier: 'Continuous30Days'
     }
     functionAcbs: {
-      enabled: false
+      state: 'Stopped'
     }
     nodeDeveloperMode: false
     nsg: {
@@ -418,7 +418,7 @@ var parametersMap = {
       backupPolicyTier: 'Continuous30Days'
     }
     functionAcbs: {
-      enabled: true
+      state: 'Running'
     }
     nodeDeveloperMode: false
     nsg: {
@@ -615,7 +615,7 @@ module functionAcbs 'modules/function-acbs.bicep' = {
   params: {
     environment: environment
     location: location
-    enabled: parametersMap[environment].functionAcbs.enabled
+    state: parametersMap[environment].functionAcbs.state
     containerRegistryName: containerRegistry.name
     appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
     appServicePlanId: appServicePlan.id

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -285,6 +285,9 @@ var parametersMap = {
       capacityMode: 'Provisioned Throughput'
       backupPolicyTier: 'Continuous30Days'
     }
+    functionAcbs: {
+      enabled: false
+    }
     nodeDeveloperMode: true
     nsg: {
       storageNetworkAccessDefaultAction: 'Allow'
@@ -325,6 +328,9 @@ var parametersMap = {
       databaseName: 'dtfs-submissions'
       capacityMode: 'Serverless'
       backupPolicyTier: 'Continuous7Days'
+    }
+    functionAcbs: {
+      enabled: false
     }
     nodeDeveloperMode: true
     nsg: {
@@ -367,6 +373,9 @@ var parametersMap = {
       capacityMode: 'Provisioned Throughput'
       backupPolicyTier: 'Continuous30Days'
     }
+    functionAcbs: {
+      enabled: false
+    }
     nodeDeveloperMode: false
     nsg: {
       // TODO:DTFS2-6422 Note that Staging (and only Staging) has the default as Deny, corresponding to "Enabled from selected virtual networks and IP addresses".
@@ -407,6 +416,9 @@ var parametersMap = {
       databaseName: 'dtfs-submissions'
       capacityMode: 'Provisioned Throughput'
       backupPolicyTier: 'Continuous30Days'
+    }
+    functionAcbs: {
+      enabled: true
     }
     nodeDeveloperMode: false
     nsg: {
@@ -603,6 +615,7 @@ module functionAcbs 'modules/function-acbs.bicep' = {
   params: {
     environment: environment
     location: location
+    enabled: parametersMap[environment].functionAcbs.enabled
     containerRegistryName: containerRegistry.name
     appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
     appServicePlanId: appServicePlan.id

--- a/infrastructure/resource_group_level/modules/function-acbs.bicep
+++ b/infrastructure/resource_group_level/modules/function-acbs.bicep
@@ -1,6 +1,8 @@
 param location string
 param environment string
-param enabled bool
+
+@allowed(['Stopped', 'Running'])
+param state string
 param containerRegistryName string
 param appServicePlanEgressSubnetId string
 param appServicePlanId string
@@ -84,9 +86,9 @@ resource functionAcbs 'Microsoft.Web/sites@2022-09-01' = {
   tags: {}
   kind: 'functionapp,linux,container'
   properties: {
-    enabled: enabled
     httpsOnly: false
     serverFarmId: appServicePlanId
+    state: state
     siteConfig: {
       // These siteConfig values appear inline and in a separate 'web' config object when exported. We just set them inline.
       numberOfWorkers: 1

--- a/infrastructure/resource_group_level/modules/function-acbs.bicep
+++ b/infrastructure/resource_group_level/modules/function-acbs.bicep
@@ -1,5 +1,6 @@
 param location string
 param environment string
+param enabled bool
 param containerRegistryName string
 param appServicePlanEgressSubnetId string
 param appServicePlanId string
@@ -83,6 +84,7 @@ resource functionAcbs 'Microsoft.Web/sites@2022-09-01' = {
   tags: {}
   kind: 'functionapp,linux,container'
   properties: {
+    enabled: enabled
     httpsOnly: false
     serverFarmId: appServicePlanId
     siteConfig: {


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* deploying function-acbs in a disabled state
### Resolution
* adds `enabled` status to `function-acbs` and sets it per-environment
