### PR TITLE
fix(e2e-tests): seed random company names to prevent 3% chance of collision that causes test failure

### DIFF
--- a/e2e-tests/.eslintrc.js
+++ b/e2e-tests/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
     ],
   },
   parserOptions: {
-    ecmaVersion: 12, // es2021
+    ecmaVersion: 14,
   },
   globals: {
     cy: true,

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/dashboard-deals-filter-on-wrong-pagination-page.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/dashboard-deals-filter-on-wrong-pagination-page.spec.js
@@ -1,4 +1,4 @@
-import Chance from 'chance';
+import { RandomValueGenerator } from '../../../../../../support/random-value-generator';
 
 const MOCK_USERS = require('../../../../fixtures/users');
 const { dashboardDeals } = require('../../../pages');
@@ -12,7 +12,7 @@ const { dashboardFilters } = require('../../../partials');
 const filters = dashboardFilters;
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
-const chance = new Chance();
+const randomValueGenerator = new RandomValueGenerator();
 
 context('Dashboard Deals filters - filtering deal on wrong pagination page from deal', () => {
   const exporterNames = [];
@@ -25,7 +25,7 @@ context('Dashboard Deals filters - filtering deal on wrong pagination page from 
     const manyBssDeals = Array.from(Array(15), () => BSS_DEAL_DRAFT);
     manyBssDeals.map((deal) => {
       cy.insertOneDeal(deal, BANK1_MAKER1).then(({ _id }) => {
-        const companyName = chance.company();
+        const companyName = randomValueGenerator.companyName();
         cy.updateDeal(_id, {
           exporter: {
             companyName,
@@ -42,7 +42,7 @@ context('Dashboard Deals filters - filtering deal on wrong pagination page from 
       cy.insertOneGefApplication(deal, BANK1_MAKER1).then(({ _id }) => {
         cy.updateGefApplication(_id, {
           exporter: {
-            companyName: chance.company(),
+            companyName: randomValueGenerator.companyName(),
           },
           // adds company name to array
         }, BANK1_MAKER1).then((insertedDeal) => exporterNames.unshift(insertedDeal.exporter.companyName));

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/dashboard-deals-sort.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/dashboard-deals-sort.spec.js
@@ -25,7 +25,7 @@ context('Dashboard Deals filters - filter by multiple fields with multiple value
         let companyName = '';
         // sets one company to lowercase
         if (index === 3) {
-          companyName = randomValueGenerator.companyName().toLowerCase();
+          companyName = randomValueGenerator.companyName({ lowerCase: true });
         } else {
           companyName = randomValueGenerator.companyName();
         }

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/dashboard-deals-sort.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/dashboard-deals-sort.spec.js
@@ -1,4 +1,4 @@
-import Chance from 'chance';
+import { RandomValueGenerator } from '../../../../../../support/random-value-generator';
 
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
@@ -9,7 +9,7 @@ const {
 } = require('../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
-const chance = new Chance();
+const randomValueGenerator = new RandomValueGenerator();
 
 context('Dashboard Deals filters - filter by multiple fields with multiple values', () => {
   const ALL_DEALS = [];
@@ -25,9 +25,9 @@ context('Dashboard Deals filters - filter by multiple fields with multiple value
         let companyName = '';
         // sets one company to lowercase
         if (index === 3) {
-          companyName = chance.company().toLowerCase();
+          companyName = randomValueGenerator.companyName().toLowerCase();
         } else {
-          companyName = chance.company();
+          companyName = randomValueGenerator.companyName();
         }
         cy.updateDeal(_id, {
           exporter: {
@@ -44,7 +44,7 @@ context('Dashboard Deals filters - filter by multiple fields with multiple value
       cy.insertOneGefApplication(deal, BANK1_MAKER1).then(({ _id }) => {
         cy.updateGefApplication(_id, {
           exporter: {
-            companyName: chance.company(),
+            companyName: randomValueGenerator.companyName(),
           },
           // adds company name to array
         }, BANK1_MAKER1).then((insertedDeal) => ALL_DEALS.unshift(insertedDeal.exporter.companyName));

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-by-exporter-name.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-by-exporter-name.spec.js
@@ -1,4 +1,4 @@
-import Chance from 'chance';
+import { RandomValueGenerator } from '../../../../../../support/random-value-generator';
 
 const MOCK_USERS = require('../../../../fixtures/users');
 const { dashboardFacilities } = require('../../../pages');
@@ -16,7 +16,7 @@ const {
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
-const chance = new Chance();
+const randomValueGenerator = new RandomValueGenerator();
 
 context('Dashboard facilities - sort', () => {
   const ALL_FACILITIES = [];
@@ -29,7 +29,7 @@ context('Dashboard facilities - sort', () => {
     cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then(({ _id }) => {
       cy.updateDeal(_id, {
         exporter: {
-          companyName: chance.company(),
+          companyName: randomValueGenerator.companyName(),
         },
         // adds company name to array
       }, BANK1_MAKER1).then((insertedDeal) => exporterNames.unshift(insertedDeal.exporter.companyName));
@@ -48,7 +48,7 @@ context('Dashboard facilities - sort', () => {
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then(({ _id }) => {
       cy.updateGefApplication(_id, {
         exporter: {
-          companyName: chance.company(),
+          companyName: randomValueGenerator.companyName(),
         },
         // adds company name to array
       }, BANK1_MAKER1).then((insertedDeal) => exporterNames.unshift(insertedDeal.exporter.companyName));

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-on-wrong-pagination-page.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-filter-on-wrong-pagination-page.spec.js
@@ -1,4 +1,4 @@
-import Chance from 'chance';
+import { RandomValueGenerator } from '../../../../../../support/random-value-generator';
 
 const MOCK_USERS = require('../../../../fixtures/users');
 const { dashboardFacilities } = require('../../../pages');
@@ -14,7 +14,7 @@ const filters = dashboardFilters;
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
-const chance = new Chance();
+const randomValueGenerator = new RandomValueGenerator();
 
 context('Dashboard facilities - filtering facility on wrong pagination page from facility', () => {
   const exporterNames = [];
@@ -27,7 +27,7 @@ context('Dashboard facilities - filtering facility on wrong pagination page from
     const manyBssDeals = Array.from(Array(15), () => BSS_DEAL_DRAFT);
     manyBssDeals.map((deal) => {
       cy.insertOneDeal(deal, BANK1_MAKER1).then(({ _id }) => {
-        const companyName = chance.company();
+        const companyName = randomValueGenerator.companyName();
         cy.updateDeal(_id, {
           exporter: {
             companyName,
@@ -50,7 +50,7 @@ context('Dashboard facilities - filtering facility on wrong pagination page from
       cy.insertOneGefApplication(deal, BANK1_MAKER1).then(({ _id }) => {
         cy.updateGefApplication(_id, {
           exporter: {
-            companyName: chance.company(),
+            companyName: randomValueGenerator.companyName(),
           },
           // adds company name to array
         }, BANK1_MAKER1).then((insertedDeal) => exporterNames.unshift(insertedDeal.exporter.companyName));

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-sort.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-sort.spec.js
@@ -1,4 +1,4 @@
-import Chance from 'chance';
+import { RandomValueGenerator } from '../../../../../../support/random-value-generator';
 
 const MOCK_USERS = require('../../../../fixtures/users');
 const { dashboardFacilities } = require('../../../pages');
@@ -11,7 +11,7 @@ const {
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
-const chance = new Chance();
+const randomValueGenerator = new RandomValueGenerator();
 
 context('Dashboard facilities - sort', () => {
   const ALL_FACILITIES = [];
@@ -28,9 +28,9 @@ context('Dashboard facilities - sort', () => {
         let companyName = '';
         // sets one company to lowercase
         if (index === 3) {
-          companyName = chance.company().toLowerCase();
+          companyName = randomValueGenerator.companyName().toLowerCase();
         } else {
-          companyName = chance.company();
+          companyName = randomValueGenerator.companyName();
         }
         cy.updateDeal(_id, {
           exporter: {
@@ -58,7 +58,7 @@ context('Dashboard facilities - sort', () => {
       cy.insertOneGefApplication(deal, BANK1_MAKER1).then(({ _id }) => {
         cy.updateGefApplication(_id, {
           exporter: {
-            companyName: chance.company(),
+            companyName: randomValueGenerator.companyName(),
           },
           // adds company name to array
         }, BANK1_MAKER1).then((insertedDeal) => exporterNames.unshift(insertedDeal.exporter.companyName));

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-sort.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/dashboard-facilities-sort.spec.js
@@ -28,7 +28,7 @@ context('Dashboard facilities - sort', () => {
         let companyName = '';
         // sets one company to lowercase
         if (index === 3) {
-          companyName = randomValueGenerator.companyName().toLowerCase();
+          companyName = randomValueGenerator.companyName({ lowerCase: true });
         } else {
           companyName = randomValueGenerator.companyName();
         }

--- a/e2e-tests/support/random-value-generator.js
+++ b/e2e-tests/support/random-value-generator.js
@@ -1,5 +1,12 @@
 import { Chance } from 'chance';
 
+/**
+ * Class to generate random values for test data.
+ *
+ * RandomValueGenerator uses a fixed seed to make test runs repeatable (although
+ * calling a test on its own or calling changing the test order can change the
+ * random values that will be used).
+ */
 export class RandomValueGenerator {
   static #seed = 0;
 

--- a/e2e-tests/support/random-value-generator.js
+++ b/e2e-tests/support/random-value-generator.js
@@ -1,0 +1,15 @@
+import { Chance } from 'chance';
+
+export class RandomValueGenerator {
+  static #seed = 0;
+
+  #chance;
+
+  constructor() {
+    this.#chance = new Chance(RandomValueGenerator.#seed);
+  }
+
+  companyName() {
+    return this.#chance.company();
+  }
+}

--- a/e2e-tests/support/random-value-generator.js
+++ b/e2e-tests/support/random-value-generator.js
@@ -9,7 +9,8 @@ export class RandomValueGenerator {
     this.#chance = new Chance(RandomValueGenerator.#seed);
   }
 
-  companyName() {
-    return this.#chance.company();
+  companyName({ lowerCase } = {}) {
+    const companyName = this.#chance.company();
+    return lowerCase ? companyName.toLowerCase() : companyName;
   }
 }


### PR DESCRIPTION
## Introduction

@AlexBramhill and I noticed that the `dashboard-deals-filter-on-wrong-pagination-page.spec.js` test in the `portal` e2e tests would randomly fail on PRs that hadn't affected it at all, so we investigated it.

It creates 30 deals with random company names (using `chance.company()` from the `chance` package. It then filters the dashboard by searching by the first company name that was generated, assuming that this should return exactly 1 deal (the first deal).

However, `chance.company()` picks a random company name from a list of roughly 900. That gives ~3% chance that at least one of the other 29 deals have exactly the same company name as the first deal, meaning the test will fail because the dashboard filter will return (at least) 2 deals instead of 1.

## Resolution

I've introduced a new class, `RandomValueGenerator`, for the e2e tests that uses a seeded version of `chance`. This way each test run should be repeatable by using the exact same random company names (assuming the test code and the `chance` code doesn't change). This should eliminate the 3% chance that the test fails, which was a source of flakey e2e test results.

Note there is a chance that in the future we edit the test in such a way that the seeded random value generator will end up generating the same company name for another deal as it does for the first. If this happens, it will happen 100% of the time, so it should be easy to debug. We can then pick a different seed for `chance` to fix the issue.