### PR TITLE
feat(FN-927): wire up tfm-ui url

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -702,14 +702,12 @@ module portalApi 'modules/webapps/portal-api.bicep' = {
   }
 }
 
-module tfmApi 'modules/webapps/trade-finance-manager-api.bicep' = {
+module tfmApi 'modules/webapps/trade-finance-manager-api-no-connection-strings.bicep' = {
   name: 'tfmApi'
   params: {
     appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
     appServicePlanId: appServicePlan.id
     containerRegistryName: containerRegistry.name
-    cosmosDbAccountName: cosmosDb.outputs.cosmosDbAccountName
-    cosmosDbDatabaseName: cosmosDb.outputs.cosmosDbDatabaseName
     dtfsCentralApiHostname: dtfsCentralApi.outputs.defaultHostName
     environment: environment
     externalApiHostname: externalApi.outputs.defaultHostName
@@ -718,12 +716,9 @@ module tfmApi 'modules/webapps/trade-finance-manager-api.bicep' = {
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
-    numberGeneratorFunctionDefaultHostName: functionNumberGenerator.outputs.defaultHostName
     settings: tmfApiSettings
     secureSettings: tfmApiSecureSettings
     additionalSecureSettings: tfmApiAdditionalSecureSettings
-    secureConnectionStrings: tfmApiSecureConnectionStrings
-    additionalSecureConnectionStrings: tfmApiAdditionalSecureConnectionStrings
   }
 }
 
@@ -852,4 +847,20 @@ module frontDoorTfm 'modules/front-door-tfm.bicep' = {
     wafPoliciesId: wafPoliciesPortal.outputs.wafPoliciesId
   }
   dependsOn: [applicationGatewayTfm]
+}
+
+
+var tfmUiUrl = 'https://${frontDoorTfm.outputs.defaultHostName}'
+
+module tfmApiConnectionStrings 'modules/webapps/trade-finance-manager-api-connection-strings.bicep' = {
+  name: 'tfmApiConnectionStrings'
+  params: {
+    cosmosDbAccountName: cosmosDb.outputs.cosmosDbAccountName
+    cosmosDbDatabaseName: cosmosDb.outputs.cosmosDbDatabaseName
+    environment: environment
+    numberGeneratorFunctionDefaultHostName: functionNumberGenerator.outputs.defaultHostName
+    secureConnectionStrings: tfmApiSecureConnectionStrings
+    additionalSecureConnectionStrings: tfmApiAdditionalSecureConnectionStrings
+    tfmUiUrl: tfmUiUrl
+  }
 }

--- a/infrastructure/resource_group_level/modules/front-door-tfm.bicep
+++ b/infrastructure/resource_group_level/modules/front-door-tfm.bicep
@@ -140,3 +140,4 @@ resource frontDoorTfm 'Microsoft.Network/frontdoors@2021-06-01' = {
   }
 }
 
+output defaultHostName string = frontDoorTfm.properties.frontendEndpoints[0].properties.hostName

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-connection-strings.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-connection-strings.bicep
@@ -1,0 +1,67 @@
+// We need to add the connection strings separately beacause the value tfmUri comes from the TFM front-door, which would produce a circulare dependency.
+
+param environment string
+param cosmosDbAccountName string
+param cosmosDbDatabaseName string
+param numberGeneratorFunctionDefaultHostName string
+param tfmUiUrl string
+
+var tfmApiNameFragment = 'trade-finance-manager-api'
+var tfmApiName = 'tfs-${environment}-${tfmApiNameFragment}'
+
+// These values are taken from GitHub secrets injected in the GHA Action
+@secure()
+param secureConnectionStrings object
+
+// These values are taken from an export of Connection strings on Dev (& validating with staging).
+@secure()
+param additionalSecureConnectionStrings object
+
+
+var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
+  name: item.key
+  value: item.value
+} ]
+
+var connectionStringsProperties = toObject(connectionStringsList, item => item.name, item => {
+  type: 'Custom'
+  value: item.value
+} )
+
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
+  name: cosmosDbAccountName
+}
+
+// Then there are the calculated values. 
+var mongoDbConnectionString = replace(cosmosDbAccount.listConnectionStrings().connectionStrings[0].connectionString, '&replicaSet=globaldb', '')
+
+var connectionStringsCalculated = {  
+  MONGO_INITDB_DATABASE: {
+    type: 'Custom'
+    value: cosmosDbDatabaseName
+  }
+  MONGODB_URI: {
+    type: 'Custom'
+    value: mongoDbConnectionString
+  }
+  AZURE_NUMBER_GENERATOR_FUNCTION_URL: {
+    type: 'Custom'
+    value: 'https://${numberGeneratorFunctionDefaultHostName}'
+  }
+  TFM_UI_URL: {
+    type: 'Custom'
+    value: tfmUiUrl
+  }
+} 
+
+var connectionStringsCombined = union(connectionStringsProperties, connectionStringsCalculated)
+
+resource site 'Microsoft.Web/sites@2022-09-01' existing = {
+  name: tfmApiName
+}
+
+resource webappConnectionStrings 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: site
+  name: 'connectionstrings'
+  properties: connectionStringsCombined
+}

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-connection-strings.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-connection-strings.bicep
@@ -1,4 +1,5 @@
-// We need to add the connection strings separately beacause the value tfmUri comes from the TFM front-door, which would produce a circulare dependency.
+// We need to add the connection strings separately beacause the value tfmUri comes from the TFM front-door, which would produce a circular dependency.
+// See the notes in trade-finance-manager-api-no-connection-strings.bicep
 
 param environment string
 param cosmosDbAccountName string

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-connection-strings.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-connection-strings.bicep
@@ -4,12 +4,10 @@ param containerRegistryName string
 param appServicePlanEgressSubnetId string
 param appServicePlanId string
 param privateEndpointsSubnetId string
-param cosmosDbAccountName string
-param cosmosDbDatabaseName string
 param logAnalyticsWorkspaceId string
 param externalApiHostname string
 param dtfsCentralApiHostname string
-param numberGeneratorFunctionDefaultHostName string
+
 param azureWebsitesDnsZoneId string
 param nodeDeveloperMode bool
 
@@ -24,13 +22,6 @@ param secureSettings object
 // These values are taken from an export of Configuration on Dev (& validating with staging).
 @secure()
 param additionalSecureSettings object
-// These values are taken from GitHub secrets injected in the GHA Action
-@secure()
-param secureConnectionStrings object
-
-// These values are taken from an export of Connection strings on Dev (& validating with staging).
-@secure()
-param additionalSecureConnectionStrings object
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
   name: containerRegistryName
@@ -74,40 +65,6 @@ var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
 
 var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
-var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
-  name: item.key
-  value: item.value
-} ]
-
-var connectionStringsProperties = toObject(connectionStringsList, item => item.name, item => {
-  type: 'Custom'
-  value: item.value
-} )
-
-
-// Then there are the calculated values. 
-var mongoDbConnectionString = replace(cosmosDbAccount.listConnectionStrings().connectionStrings[0].connectionString, '&replicaSet=globaldb', '')
-
-var connectionStringsCalculated = {  
-  MONGO_INITDB_DATABASE: {
-    type: 'Custom'
-    value: cosmosDbDatabaseName
-  }
-  MONGODB_URI: {
-    type: 'Custom'
-    value: mongoDbConnectionString
-  }
-  AZURE_NUMBER_GENERATOR_FUNCTION_URL: {
-    type: 'Custom'
-    value: 'https://${numberGeneratorFunctionDefaultHostName}'
-  }
-} 
-
-var connectionStringsCombined = union(connectionStringsProperties, connectionStringsCalculated)
-
-resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' existing = {
-  name: cosmosDbAccountName
-}
 
 module tfmApiWebapp 'webapp.bicep' = {
   name: 'tfmApiWebapp'
@@ -116,7 +73,7 @@ module tfmApiWebapp 'webapp.bicep' = {
     appServicePlanId: appServicePlanId
     appSettings: appSettings
     azureWebsitesDnsZoneId: azureWebsitesDnsZoneId
-    connectionStrings: connectionStringsCombined
+    connectionStrings: {}
     deployApplicationInsights: false // TODO:DTFS2-6422 enable application insights
     dockerImageName: dockerImageName
     environment: environment

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-connection-strings.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-connection-strings.bicep
@@ -1,3 +1,12 @@
+// Note that we don't set the connection strings when creating the tfm-api webapp.
+// This is because we need to include the TFM front door hostname which would set
+// up a circular dependency. We avoid this by setting the connection strings
+// separately later.
+// The alternative is to set them as normal and union the extra setting later.
+// See: https://stackoverflow.com/questions/72940236/is-there-a-workaround-to-keep-app-settings-which-not-defined-in-bicep-template
+// However, I encountered issues with the type of the fetched connection strings
+// then not matching the object type needed to set them.
+
 param location string
 param environment string
 param containerRegistryName string


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* don't use secret to resolve circular dependency on TFM-UI URL connection string
### Resolution
* we now set the connection strings after the TFM-FD is deployed
