### PR TITLE
fix(DTFS2-6678): remove auto-create password for new user as not needed

### DIFF
--- a/e2e-tests/portal/cypress.config.js
+++ b/e2e-tests/portal/cypress.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
 
           return users.findOne({ email: { $eq: email } });
         },
-      })
+      });
     },
   },
   experimentalCspAllowList: ['child-src', 'default-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],

--- a/e2e-tests/portal/cypress.config.js
+++ b/e2e-tests/portal/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('cypress');
+const db = require('./db-client');
 
 module.exports = defineConfig({
   apiProtocol: 'http://',
@@ -12,6 +13,8 @@ module.exports = defineConfig({
   tfmApiPort: '5004',
   // TODO: Read value from environment variable
   apiKey: 'test',
+  dbName: 'dtfs-submissions',
+  dbConnectionString: 'mongodb://root:r00t@localhost:27017/?authMechanism=DEFAULT',
   pageLoadTimeout: 180000,
   numTestsKeptInMemory: 1,
   retries: {
@@ -21,6 +24,18 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost',
     specPattern: 'cypress/e2e/**/*.spec.js',
+    setupNodeEvents(on, config) {
+      const { dbName, dbConnectionString } = config;
+      const connectionOptions = { dbName, dbConnectionString };
+
+      on('task', {
+        async getUserFromDbByEmail(email) {
+          const users = await db.getCollection('users', connectionOptions);
+
+          return users.findOne({ email: { $eq: email } });
+        },
+      })
+    },
   },
   experimentalCspAllowList: ['child-src', 'default-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/activate-deactivate-user/activate-deactivate-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/activate-deactivate-user/activate-deactivate-user.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, editUser, changePassword, resetPassword
+  header, users, createUser, editUser, changePassword, resetPassword,
 } = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/activate-deactivate-user/activate-deactivate-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/activate-deactivate-user/activate-deactivate-user.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, editUser, changePassword, resetPassword,
+  header, users, createUser, editUser,
 } = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
@@ -37,35 +37,29 @@ context('Admin user updates an existing user', () => {
     createUser.bank().select(userToUpdate.bank);
     createUser.createUser().click();
 
-    cy.task('getUserFromDbByEmail', userToUpdate.username).then((user) => {
-      // user sets password
-      resetPassword.visitChangePassword(user.resetPwdToken);
-      changePassword.password().type(userToUpdate.password);
-      changePassword.confirmPassword().type(userToUpdate.password);
-      changePassword.submit().click();
+    cy.userSetPassword(userToUpdate.username, userToUpdate.password);
 
-      // rely on existing 'create user' spec to prove default state
+    // rely on existing 'create user' spec to prove default state
 
-      // edit user +  de-activate
-      users.visit();
-      users.row(userToUpdate).username().click();
-      editUser.Deactivate().click();
-      editUser.save().click();
+    // edit user +  de-activate
+    users.visit();
+    users.row(userToUpdate).username().click();
+    editUser.Deactivate().click();
+    editUser.save().click();
 
-      // prove we can't log in as user
-      cy.login(userToUpdate);
-      cy.url().should('eq', relative('/login'));
+    // prove we can't log in as user
+    cy.login(userToUpdate);
+    cy.url().should('eq', relative('/login'));
 
-      // go back to admin user and re-activate
-      cy.login(ADMIN);
-      header.users().click();
-      users.row(userToUpdate).username().click();
-      editUser.Activate().click();
-      editUser.save().click();
+    // go back to admin user and re-activate
+    cy.login(ADMIN);
+    header.users().click();
+    users.row(userToUpdate).username().click();
+    editUser.Activate().click();
+    editUser.save().click();
 
-      // prove we can log in again
-      cy.login(userToUpdate);
-      cy.url().should('eq', relative('/dashboard/deals/0'));
-    });
+    // prove we can log in again
+    cy.login(userToUpdate);
+    cy.url().should('eq', relative('/dashboard/deals/0'));
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
@@ -1,4 +1,4 @@
-const { header, users, createUser } = require('../../../pages');
+const { header, users, createUser, changePassword, resetPassword } = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
 const { USER_ROLES: { MAKER, READ_ONLY, CHECKER } } = require('../../../../fixtures/constants');
@@ -63,7 +63,7 @@ context('Admin user creates a new user', () => {
     cy.url().should('include', '/admin/users/create');
   });
 
-  it('Admin user adds a new user and confirms the new user works', () => {
+  it('Admin user adds a new user and confirms the new user works once user sets password', () => {
     // Login and go to the dashboard
     cy.login(AN_ADMIN);
 
@@ -76,9 +76,6 @@ context('Admin user creates a new user', () => {
       createUser.role(role).click();
     });
     createUser.username().type(validUser.username);
-    createUser.manualPassword().click();
-    createUser.password().type(validUser.password);
-    createUser.confirmPassword().type(validUser.password);
     createUser.firstname().type(validUser.firstname);
     createUser.surname().type(validUser.surname);
 
@@ -89,21 +86,29 @@ context('Admin user creates a new user', () => {
     cy.url().should('eq', relative('/admin/users/'));
     users.user(validUser).should('exist');
 
-    // login as the new user
-    cy.login(validUser);
-    cy.url().should('eq', relative('/dashboard/deals/0'));
+    cy.task('getUserFromDbByEmail', validUser.username).then((user) => {
+      // user sets password
+      resetPassword.visitChangePassword(user.resetPwdToken);
+      changePassword.password().type(validUser.password);
+      changePassword.confirmPassword().type(validUser.password);
+      changePassword.submit().click();
 
-    // prove the lastLogin timestamp
-    cy.login(AN_ADMIN);
-    cy.url().should('eq', relative('/dashboard/deals/0'));
-    header.users().click();
+      // login as the new user
+      cy.login(validUser);
+      cy.url().should('eq', relative('/dashboard/deals/0'));
 
-    users.row(validUser).lastLogin().invoke('text').then((text) => {
-      expect(text.trim()).to.not.equal('');
+      // prove the lastLogin timestamp
+      cy.login(AN_ADMIN);
+      cy.url().should('eq', relative('/dashboard/deals/0'));
+      header.users().click();
+
+      users.row(validUser).lastLogin().invoke('text').then((text) => {
+        expect(text.trim()).to.not.equal('');
+      });
     });
   });
 
-  it('Admin user adds a new user, triggering validation errors', () => {
+  it('Admin user adds a new user. User tries to set invalid password, triggering validation error', () => {
     // Login and go to the dashboard
     cy.login(AN_ADMIN);
 
@@ -116,23 +121,28 @@ context('Admin user creates a new user', () => {
       createUser.role(role).click();
     });
     createUser.username().type(userWithInvalidPassword.username);
-    createUser.manualPassword().click();
-    createUser.password().type(userWithInvalidPassword.password);
-    createUser.confirmPassword().type(userWithInvalidPassword.password);
     createUser.firstname().type(userWithInvalidPassword.firstname);
     createUser.surname().type(userWithInvalidPassword.surname);
     createUser.bank().select(userWithInvalidPassword.bank);
 
     createUser.createUser().click();
 
-    cy.url().should('eq', relative('/admin/users/create'));
+    cy.task('getUserFromDbByEmail', userWithInvalidPassword.username).then((user) => {
+      // user sets password
+      resetPassword.visitChangePassword(user.resetPwdToken);
+      changePassword.password().type(userWithInvalidPassword.password);
+      changePassword.confirmPassword().type(userWithInvalidPassword.password);
+      changePassword.submit().click();
 
-    createUser.passwordError().invoke('text').then((text) => {
-      expect(text.trim()).to.contain('Your password must be at least 8 characters long and include at least one number, at least one upper-case character, at least one lower-case character and at least one special character. Passwords cannot be re-used.');
+      cy.url().should('eq', relative(`/reset-password/${user.resetPwdToken}`));
+      
+      changePassword.passwordError().invoke('text').then((text) => {
+        expect(text.trim()).to.contain('Your password must be at least 8 characters long and include at least one number, at least one upper-case character, at least one lower-case character and at least one special character. Passwords cannot be re-used.');
+      });
     });
   });
 
-  it('Admin user adds a new user using "{ "$gt": "" }", triggering validation error for email', () => {
+  it('Admin user adds a new user using "{ "$gt": "" }" as the email, triggering validation error', () => {
     // Login and go to the dashboard
     cy.login(AN_ADMIN);
 
@@ -147,9 +157,6 @@ context('Admin user creates a new user', () => {
 
     // as the string has object characters, need to use parseSpecialCharSequences
     createUser.username().type(USER_WITH_INJECTION.username, { parseSpecialCharSequences: false });
-    createUser.manualPassword().click();
-    createUser.password().type(USER_WITH_INJECTION.password);
-    createUser.confirmPassword().type(USER_WITH_INJECTION.password);
     createUser.firstname().type(USER_WITH_INJECTION.firstname);
     createUser.surname().type(USER_WITH_INJECTION.surname);
     createUser.bank().select(USER_WITH_INJECTION.bank);
@@ -186,9 +193,6 @@ context('Admin user creates a new user', () => {
 
     it('should create a read-only user', () => {
       createUser.username().type(validUser.username);
-      createUser.manualPassword().click();
-      createUser.password().type(validUser.password);
-      createUser.confirmPassword().type(validUser.password);
       createUser.firstname().type(validUser.firstname);
       createUser.surname().type(validUser.surname);
       createUser.bank().select(validUser.bank);

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, changePassword, resetPassword,
+  header, users, createUser, changePassword,
 } = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
@@ -88,25 +88,19 @@ context('Admin user creates a new user', () => {
     cy.url().should('eq', relative('/admin/users/'));
     users.user(validUser).should('exist');
 
-    cy.task('getUserFromDbByEmail', validUser.username).then((user) => {
-      // user sets password
-      resetPassword.visitChangePassword(user.resetPwdToken);
-      changePassword.password().type(validUser.password);
-      changePassword.confirmPassword().type(validUser.password);
-      changePassword.submit().click();
+    cy.userSetPassword(validUser.username, validUser.password);
 
-      // login as the new user
-      cy.login(validUser);
-      cy.url().should('eq', relative('/dashboard/deals/0'));
+    // login as the new user
+    cy.login(validUser);
+    cy.url().should('eq', relative('/dashboard/deals/0'));
 
-      // prove the lastLogin timestamp
-      cy.login(AN_ADMIN);
-      cy.url().should('eq', relative('/dashboard/deals/0'));
-      header.users().click();
+    // prove the lastLogin timestamp
+    cy.login(AN_ADMIN);
+    cy.url().should('eq', relative('/dashboard/deals/0'));
+    header.users().click();
 
-      users.row(validUser).lastLogin().invoke('text').then((text) => {
-        expect(text.trim()).to.not.equal('');
-      });
+    users.row(validUser).lastLogin().invoke('text').then((text) => {
+      expect(text.trim()).to.not.equal('');
     });
   });
 
@@ -129,18 +123,10 @@ context('Admin user creates a new user', () => {
 
     createUser.createUser().click();
 
-    cy.task('getUserFromDbByEmail', userWithInvalidPassword.username).then((user) => {
-      // user sets password
-      resetPassword.visitChangePassword(user.resetPwdToken);
-      changePassword.password().type(userWithInvalidPassword.password);
-      changePassword.confirmPassword().type(userWithInvalidPassword.password);
-      changePassword.submit().click();
+    cy.userSetPassword(userWithInvalidPassword.username, userWithInvalidPassword.password);
 
-      cy.url().should('eq', relative(`/reset-password/${user.resetPwdToken}`));
-
-      changePassword.passwordError().invoke('text').then((text) => {
-        expect(text.trim()).to.contain('Your password must be at least 8 characters long and include at least one number, at least one upper-case character, at least one lower-case character and at least one special character. Passwords cannot be re-used.');
-      });
+    changePassword.passwordError().invoke('text').then((text) => {
+      expect(text.trim()).to.contain('Your password must be at least 8 characters long and include at least one number, at least one upper-case character, at least one lower-case character and at least one special character. Passwords cannot be re-used.');
     });
   });
 

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
@@ -1,4 +1,6 @@
-const { header, users, createUser, changePassword, resetPassword } = require('../../../pages');
+const {
+  header, users, createUser, changePassword, resetPassword,
+} = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../fixtures/users');
 const { USER_ROLES: { MAKER, READ_ONLY, CHECKER } } = require('../../../../fixtures/constants');
@@ -135,7 +137,7 @@ context('Admin user creates a new user', () => {
       changePassword.submit().click();
 
       cy.url().should('eq', relative(`/reset-password/${user.resetPwdToken}`));
-      
+
       changePassword.passwordError().invoke('text').then((text) => {
         expect(text.trim()).to.contain('Your password must be at least 8 characters long and include at least one number, at least one upper-case character, at least one lower-case character and at least one special character. Passwords cannot be re-used.');
       });

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/update-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/update-a-user.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, editUser,
+  header, users, createUser, editUser, changePassword, resetPassword
 } = require('../../../pages');
 const { ADMIN: AN_ADMIN } = require('../../../../fixtures/users');
 const { USER_ROLES: { MAKER, CHECKER } } = require('../../../../fixtures/constants');
@@ -35,13 +35,20 @@ context('Admin user updates an existing user', () => {
         createUser.role(role).click();
       });
       createUser.username().type(userToUpdate.username);
-      createUser.manualPassword().click();
-      createUser.password().type(userToUpdate.password);
-      createUser.confirmPassword().type(userToUpdate.password);
       createUser.firstname().type(userToUpdate.firstname);
       createUser.surname().type(userToUpdate.surname);
       createUser.bank().select(userToUpdate.bank);
       createUser.createUser().click();
+
+      cy.task('getUserFromDbByEmail', userToUpdate.username).then((user) => {
+        // user sets password
+        resetPassword.visitChangePassword(user.resetPwdToken);
+        changePassword.password().type(userToUpdate.password);
+        changePassword.confirmPassword().type(userToUpdate.password);
+        changePassword.submit().click();
+      });
+
+      users.visit();
     });
 
     it('changing their roles should display the new roles on the user dashboard', () => {

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/update-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/update-a-user.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, editUser, changePassword, resetPassword,
+  header, users, createUser, editUser,
 } = require('../../../pages');
 const { ADMIN: AN_ADMIN } = require('../../../../fixtures/users');
 const { USER_ROLES: { MAKER, CHECKER } } = require('../../../../fixtures/constants');
@@ -39,16 +39,6 @@ context('Admin user updates an existing user', () => {
       createUser.surname().type(userToUpdate.surname);
       createUser.bank().select(userToUpdate.bank);
       createUser.createUser().click();
-
-      cy.task('getUserFromDbByEmail', userToUpdate.username).then((user) => {
-        // user sets password
-        resetPassword.visitChangePassword(user.resetPwdToken);
-        changePassword.password().type(userToUpdate.password);
-        changePassword.confirmPassword().type(userToUpdate.password);
-        changePassword.submit().click();
-      });
-
-      users.visit();
     });
 
     it('changing their roles should display the new roles on the user dashboard', () => {

--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/update-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/update-a-user.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, editUser, changePassword, resetPassword
+  header, users, createUser, editUser, changePassword, resetPassword,
 } = require('../../../pages');
 const { ADMIN: AN_ADMIN } = require('../../../../fixtures/users');
 const { USER_ROLES: { MAKER, CHECKER } } = require('../../../../fixtures/constants');

--- a/e2e-tests/portal/cypress/e2e/journeys/login/change-password.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/change-password.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, userProfile, changePassword, landingPage,
+  header, users, createUser, userProfile, changePassword, landingPage, resetPassword
 } = require('../../pages');
 const relative = require('../../relativeURL');
 
@@ -7,7 +7,7 @@ const MOCK_USERS = require('../../../fixtures/users');
 
 const { ADMIN } = MOCK_USERS;
 
-context('Admin user creates a new user; the new user updates their password.', () => {
+context('Admin user creates a new user; the new user sets their password and then updates their password.', () => {
   const userToCreate = {
     username: 'email@example.com',
     email: 'email@example.com',
@@ -38,9 +38,6 @@ context('Admin user creates a new user; the new user updates their password.', (
       });
 
       createUser.username().type(userToCreate.username);
-      createUser.manualPassword().click();
-      createUser.password().type(userToCreate.password);
-      createUser.confirmPassword().type(userToCreate.password);
       createUser.firstname().type(userToCreate.firstname);
       createUser.surname().type(userToCreate.surname);
       createUser.bank().select(userToCreate.bank);
@@ -52,6 +49,16 @@ context('Admin user creates a new user; the new user updates their password.', (
   });
 
   describe('User profile page', () => {
+    before(() => {
+      cy.task('getUserFromDbByEmail', userToCreate.username).then((user) => {
+        // user sets password
+        resetPassword.visitChangePassword(user.resetPwdToken);
+        changePassword.password().type(userToCreate.password);
+        changePassword.confirmPassword().type(userToCreate.password);
+        changePassword.submit().click();
+      });
+    });
+
     it('Should go back to the dashboard', () => {
       // Login
       cy.login(userToCreate);

--- a/e2e-tests/portal/cypress/e2e/journeys/login/change-password.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/change-password.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, userProfile, changePassword, landingPage, resetPassword
+  header, users, createUser, userProfile, changePassword, landingPage, resetPassword,
 } = require('../../pages');
 const relative = require('../../relativeURL');
 

--- a/e2e-tests/portal/cypress/e2e/journeys/login/change-password.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/change-password.spec.js
@@ -1,5 +1,5 @@
 const {
-  header, users, createUser, userProfile, changePassword, landingPage, resetPassword,
+  header, users, createUser, userProfile, changePassword, landingPage,
 } = require('../../pages');
 const relative = require('../../relativeURL');
 
@@ -50,13 +50,7 @@ context('Admin user creates a new user; the new user sets their password and the
 
   describe('User profile page', () => {
     before(() => {
-      cy.task('getUserFromDbByEmail', userToCreate.username).then((user) => {
-        // user sets password
-        resetPassword.visitChangePassword(user.resetPwdToken);
-        changePassword.password().type(userToCreate.password);
-        changePassword.confirmPassword().type(userToCreate.password);
-        changePassword.submit().click();
-      });
+      cy.userSetPassword(userToCreate.username, userToCreate.password);
     });
 
     it('Should go back to the dashboard', () => {

--- a/e2e-tests/portal/cypress/e2e/pages/admin/users/createUser.js
+++ b/e2e-tests/portal/cypress/e2e/pages/admin/users/createUser.js
@@ -3,10 +3,6 @@ const page = {
 
   role: (role) => cy.get(`[data-cy="role-${role}"]`),
   username: () => cy.get('[data-cy="username"]'),
-  manualPassword: () => cy.get('[data-cy="autoCreatePassword-false"]'),
-  password: () => cy.get('[data-cy="password"]'),
-  passwordError: () => cy.get('#password-error'),
-  confirmPassword: () => cy.get('[data-cy="confirm-password"]'),
   firstname: () => cy.get('[data-cy="firstname"]'),
   surname: () => cy.get('[data-cy="surname"]'),
   bank: () => cy.get('[data-cy="bank"]'),

--- a/e2e-tests/portal/cypress/e2e/pages/admin/users/editUser.js
+++ b/e2e-tests/portal/cypress/e2e/pages/admin/users/editUser.js
@@ -13,6 +13,7 @@ const page = {
   Activate: () => cy.get('[data-cy="user-status-active"]'),
 
   save: () => cy.get('[data-cy="Save"]'),
+  changePassword: () => cy.get('[data-cy="change-password-button"]'),
 
 };
 

--- a/e2e-tests/portal/cypress/e2e/pages/resetPassword.js
+++ b/e2e-tests/portal/cypress/e2e/pages/resetPassword.js
@@ -2,7 +2,7 @@ const mockToken = 'ABCDEF0123456789';
 
 const resetPassword = {
   visitRequestEmail: () => cy.visit('/reset-password'),
-  visitChangePassword: () => cy.visit(`/reset-password/${mockToken}`),
+  visitChangePassword: (resetPwdToken = mockToken) => cy.visit(`/reset-password/${resetPwdToken}`),
   submit: () => cy.get('[data-cy="reset-password-submit"]'),
   cancel: () => cy.get('[data-cy="reset-password-cancel"]'),
   emailInput: () => cy.get('[data-cy="reset-password-email"]'),

--- a/e2e-tests/portal/cypress/support/commands.js
+++ b/e2e-tests/portal/cypress/support/commands.js
@@ -71,6 +71,7 @@ Cypress.Commands.add('login', require('./portal/logIn'));
 Cypress.Commands.add('loginGoToDealPage', require('./portal/loginGoToDealPage'));
 Cypress.Commands.add('passRedLine', require('./portal/passRedLine'));
 Cypress.Commands.add('renameDeal', require('./portal/renameDeal'));
+Cypress.Commands.add('userSetPassword', require('./portal/userSetPassword'));
 
 // commands that add/edit facilities directly in central API
 Cypress.Commands.add('deleteFacility', require('./central-api/deleteFacility'));

--- a/e2e-tests/portal/cypress/support/portal/userSetPassword.js
+++ b/e2e-tests/portal/cypress/support/portal/userSetPassword.js
@@ -1,0 +1,13 @@
+const {
+    changePassword, resetPassword,
+} = require('../../e2e/pages');
+
+
+module.exports = (email, password) => {
+    cy.task('getUserFromDbByEmail', email).then((user) => {
+        resetPassword.visitChangePassword(user.resetPwdToken);
+        changePassword.password().type(password);
+        changePassword.confirmPassword().type(password);
+        changePassword.submit().click();
+    });
+};

--- a/e2e-tests/portal/cypress/support/portal/userSetPassword.js
+++ b/e2e-tests/portal/cypress/support/portal/userSetPassword.js
@@ -1,13 +1,12 @@
 const {
-    changePassword, resetPassword,
+  changePassword, resetPassword,
 } = require('../../e2e/pages');
 
-
 module.exports = (email, password) => {
-    cy.task('getUserFromDbByEmail', email).then((user) => {
-        resetPassword.visitChangePassword(user.resetPwdToken);
-        changePassword.password().type(password);
-        changePassword.confirmPassword().type(password);
-        changePassword.submit().click();
-    });
+  cy.task('getUserFromDbByEmail', email).then((user) => {
+    resetPassword.visitChangePassword(user.resetPwdToken);
+    changePassword.password().type(password);
+    changePassword.confirmPassword().type(password);
+    changePassword.submit().click();
+  });
 };

--- a/e2e-tests/portal/db-client.js
+++ b/e2e-tests/portal/db-client.js
@@ -1,0 +1,34 @@
+const { MongoClient } = require('mongodb');
+
+let client;
+
+let connection = null;
+
+const dbConnect = async ({ dbConnectionString, dbName }) => {
+  client = await MongoClient.connect(
+    dbConnectionString,
+    {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    },
+  );
+  connection = await client.db(dbName);
+  return connection;
+};
+
+const getConnection = async (connectionOptions) => {
+  if (!connection) {
+    connection = await dbConnect(connectionOptions);
+  }
+
+  return connection;
+};
+
+module.exports.getCollection = async (collectionName, connectionOptions) => {
+  if (!connection) {
+    await getConnection(connectionOptions);
+  }
+  const collection = await connection.collection(collectionName);
+
+  return collection;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "cypress-v10-preserve-cookie": "^1.2.1",
         "date-fns": "^2.30.0",
         "dotenv": "^16.3.1",
-        "moment": "^2.29.4"
+        "moment": "^2.29.4",
+        "mongodb": "^6.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.7.2",
@@ -1106,6 +1107,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1186,8 +1195,7 @@
     "node_modules/@types/node": {
       "version": "20.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
-      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
-      "devOptional": true
+      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.2",
@@ -1210,6 +1218,20 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.4.tgz",
       "integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz",
+      "integrity": "sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.1",
@@ -1253,6 +1275,113 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.4.tgz",
+      "integrity": "sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.7.4",
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/typescript-estree": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
+      "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+      "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
+      "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.4",
+        "@typescript-eslint/visitor-keys": "6.7.4",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
+      "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.7.4",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -5460,6 +5589,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
     "node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -5599,6 +5733,91 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.1.0.tgz",
+      "integrity": "sha512-AvzNY0zMkpothZ5mJAaIo2bGDjlJQqqAbn9fvtVgwIIUPEfdrqGxqNjjbuKyrgQxg2EvCmfWdjq+4uj96c0YPw==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.1.0",
+        "mongodb-connection-string-url": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ms": {
@@ -6639,6 +6858,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "cypress-v10-preserve-cookie": "^1.2.1",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "mongodb": "^6.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.2",

--- a/portal-api/src/v1/users/controller.js
+++ b/portal-api/src/v1/users/controller.js
@@ -209,7 +209,9 @@ exports.update = async (_id, update, callback) => {
       userUpdate.hash = hash;
       // queue the addition of the old salt/hash to our list of blocked passwords that we re-check
       // in 'passwordsCannotBeReUsed' rule
-      userUpdate.blockedPasswordList = oldBlockedPasswordList.concat([{ oldSalt, oldHash }]);
+      if (oldSalt && oldHash) {
+        userUpdate.blockedPasswordList = oldBlockedPasswordList.concat([{ oldSalt, oldHash }]);
+      }
       userUpdate.loginFailureCount = 0;
       userUpdate.passwordUpdatedAt = Date.now();
 

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -92,13 +92,20 @@ module.exports.create = async (req, res, next) => {
         },
       });
     }
+
     const { password } = userToCreate;
-    const saltHash = utils.genPassword(password);
+
+    let salt = '';
+    let hash = '';
+
+    if (password) {
+      const saltHash = utils.genPassword(password);
+      ({ salt, hash } = saltHash);
+    }
 
     userToCreate.password = '';
     userToCreate.passwordConfirm = '';
 
-    const { salt, hash } = saltHash;
     const newUser = {
       ...userToCreate,
       salt,

--- a/portal/templates/admin/user-edit.njk
+++ b/portal/templates/admin/user-edit.njk
@@ -128,7 +128,7 @@
           classes: "govuk-label--s"
         },
         hint: {
-          text: "A valid email address. All emails from the system will be sent to this address. The email address is not made public and will only be used if you wish to receive a new password or wish to receive certain news or notifications by email"
+          text: "Enter a valid email address. All emails from the system will be sent to this address. The email address is not made public and will only be used for emailing users the link to set or reset their password, or if they wish to receive certain news or notifications by email"
         },
         classes: "govuk-!-width-one-third",
         id: "email",
@@ -139,84 +139,6 @@
         value: displayedUser.username,
         errorMessage: validationErrors.errorList.email
       }) }}
-
-      {{
-        govukRadios({
-          fieldset: {
-            legend: {
-              text: "Auto-create a valid password?",
-              classes: "govuk-fieldset__legend--s"
-            }
-          },
-          idPrefix: "autoCreatePassword-",
-          name: "autoCreatePassword",
-          classes: "govuk-radios--inline",
-          items: [
-            {
-              value: "true",
-              text: "Yes",
-              attributes: {
-                "data-cy": "autoCreatePassword-true"
-              },
-              checked: displayedUser.autoCreatePassword !== 'true'
-            },
-            {
-              value: "false",
-              text: "No",
-              attributes: {
-                "data-cy": "autoCreatePassword-false"
-              },
-              checked: displayedUser.autoCreatePassword === 'false'
-            }
-          ]
-        })
-      }}
-
-      {% if displayedUser.autoCreatePassword === 'false' %}
-        {% set renderByDefault='true' %}
-      {% else %}
-        {% set renderByDefault='false' %}
-      {% endif %}
-
-      <div id="manuallyCreatePassword" class="{% if renderByDefault === 'false' %}govuk-visually-hidden{% endif %}">
-        <div class="govuk-form-group">
-            {{ govukInput({
-              attributes: {
-                "data-cy": "password",
-                "autocomplete": "off"
-                },
-              label: {
-                text: "New password",
-                classes: "govuk-label--s"
-              },
-              formGroup: {
-                classes: "govuk-!-width-one-third"
-              },
-              id: "password",
-              name: "password",
-              type: "password",
-              errorMessage: validationErrors.errorList.password
-            }) }}
-
-            {{ govukInput({
-              attributes: {
-                "data-cy": "confirm-password",
-                "autocomplete": "off"
-                },
-              label: {
-                text: "Confirm password",
-                classes: "govuk-label--s"
-              },
-              formGroup: {
-                classes: "govuk-!-width-one-third"
-              },
-              id: "passwordConfirm",
-              name: "passwordConfirm",
-              type: "password"
-            }) }}
-        </div>
-
-      </div>
 
     {% endif %}
 


### PR DESCRIPTION
### Introduction

In Portal UI, the admin create user page has a `"Auto-create a valid password?"` question to which you can select `"Yes"` or `"No"` (in the latter case the admin specifies the user's password). However, if `"Yes"` is selected, the password auto-creation does not work and the user is not created.

### Resolution

We can in fact remove "Auto-create a valid password?" question altogether. Instead:

- The user gets created without a password and cannot login until they set one via the link that gets emailed to them

- We can remove the Auto-create a valid password? : Yes / No component entirely

This ensures that a user must set their own password, and that admins have no way of knowing this.