### PR TITLE
Feat(FN-966): handle weird excel data that strips cell address

### DIFF
--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -58,7 +58,11 @@ const xlsxBasedCsvToJsonPromise = async (csvDataWithCellAddresses) => {
               const cellAddress = value.substring(lastDashIndex + 1);
 
               // Split the cell address into column and row
-              const [column, row] = cellAddress.match(CELL_ADDRESS_REGEX).slice(1);
+              const cellAddressMatch = cellAddress.match(CELL_ADDRESS_REGEX);
+              if (!cellAddressMatch) {
+                return { value: cellValue !== 'null' ? cellValue : null, column: null, row: null };
+              }
+              const [column, row] = cellAddressMatch.slice(1);
               if (!column || !row) {
                 throw new Error('Error parsing CSV data');
               }


### PR DESCRIPTION
## Introduction
Cell addresses weren't present on excel files with some inbuilt data from Bing in the cells. While we don't need to support this we need to avoid crashes as it wasn't getting picked up by the try/catch

## Resolution
Only split up the cell address to get column and row if we match the regex of the cell address