### PR TITLE
feat(FN-857): update waf policy application

### DIFF
--- a/infrastructure/resource_group_level/modules/front-door-portal.bicep
+++ b/infrastructure/resource_group_level/modules/front-door-portal.bicep
@@ -4,19 +4,14 @@ param wafPoliciesId string = ''
 
 var frontDoorPortalName = 'tfs-${environment}-fd'
 
-// If there isn't a wafPoliciesId set, we don't want to attempt to link it
-var defaultFrontendPropertiesNoWaf = {
-    hostName: '${frontDoorPortalName}.azurefd.net'
-    sessionAffinityEnabledState: 'Disabled'
-    sessionAffinityTtlSeconds: 0
-  }
-
-var defaultFrontendProperties = union(defaultFrontendPropertiesNoWaf, wafPoliciesId != '' ? {
+var defaultFrontendProperties = {
+  hostName: '${frontDoorPortalName}.azurefd.net'
+  sessionAffinityEnabledState: 'Disabled'
+  sessionAffinityTtlSeconds: 0
   webApplicationFirewallPolicyLink: {
     id: wafPoliciesId
     }
-  } : {})
-
+}
 
 // NOTE: Until the following issue is resolved, we need to self-reference the frontdoor 
 // using resourceId() for the various sub-components that need to be created.

--- a/infrastructure/resource_group_level/modules/front-door-tfm.bicep
+++ b/infrastructure/resource_group_level/modules/front-door-tfm.bicep
@@ -1,22 +1,17 @@
 param environment string
 param backendPoolIp string
-param wafPoliciesId string = ''
+param wafPoliciesId string
 
 var frontDoorTfmName = 'tfs-${environment}-tfm-fd'
 
-// If there isn't a wafPoliciesId set, we don't want to attempt to link it
-var defaultFrontendPropertiesNoWaf = {
+var defaultFrontendProperties = {
     hostName: '${frontDoorTfmName}.azurefd.net'
     sessionAffinityEnabledState: 'Disabled'
     sessionAffinityTtlSeconds: 0
+    webApplicationFirewallPolicyLink: {
+      id: wafPoliciesId
+      }
   }
-
-var defaultFrontendProperties = union(defaultFrontendPropertiesNoWaf, wafPoliciesId != '' ? {
-  webApplicationFirewallPolicyLink: {
-    id: wafPoliciesId
-    }
-  } : {})
-
 
 // NOTE: Until the following issue is resolved, we need to self-reference the frontdoor 
 // using resourceId() for the various sub-components that need to be created.


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
The first phase is to be able to:

- produce a complete new deployment environment (feature) mirroring the current ones.
- be in a position to take over the extant environments.
- Note that there have been some manual changes to the environments. This work also functions as an audit of the current infrastructure.

Possible enhancements / updates will be noted but not implemented in the first phase.

This card covers
* Enabling the `prod` environment to have the WAF rules applied to Portal without the IP restriction
### Resolution
* Create a second set of WAF rules, only on `prod` and apply them to Portal
