### PR TITLE
feat(dtfs2-6716):replace graphql update task in tfm with rest

### DIFF
--- a/trade-finance-manager-api/api-tests/api.js
+++ b/trade-finance-manager-api/api-tests/api.js
@@ -18,10 +18,7 @@ module.exports = (app) => ({
 
     return {
       post: (data) => ({
-        to: async (url) => request(app)
-          .post(url)
-          .send(data)
-          .set(headers(token)),
+        to: async (url) => request(app).post(url).send(data).set(headers(token)),
       }),
 
       postEach: (list) => ({
@@ -29,10 +26,7 @@ module.exports = (app) => ({
           const results = [];
 
           for (const data of list) {
-            const result = await request(app)
-              .post(url)
-              .send(data)
-              .set(headers(token));
+            const result = await request(app).post(url).send(data).set(headers(token));
 
             results.push(result);
           }
@@ -42,17 +36,12 @@ module.exports = (app) => ({
       }),
 
       put: (data) => ({
-        to: async (url) => request(app)
-          .put(url)
-          .send(data)
-          .set(headers(token)),
+        to: async (url) => request(app).put(url).send(data).set(headers(token)),
       }),
 
       putMultipartForm: (data, files = []) => ({
         to: async (url) => {
-          const apiRequest = request(app)
-            .put(url)
-            .set(headers(token));
+          const apiRequest = request(app).put(url).set(headers(token));
 
           if (files.length) {
             files.forEach((file) => apiRequest.attach(file.fieldname, file.filepath));
@@ -66,24 +55,15 @@ module.exports = (app) => ({
         },
       }),
 
-      get: async (url) => request(app)
-        .get(url)
-        .set(headers(token)),
+      get: async (url) => request(app).get(url).set(headers(token)),
 
       remove: (data) => ({
-        to: async (url) =>
-          request(app)
-            .delete(url)
-            .send(data)
-            .set(headers(token)),
+        to: async (url) => request(app).delete(url).send(data).set(headers(token)),
       }),
-    }
+    };
   },
   post: (data) => ({
-    to: async (url) => request(app)
-      .post(url)
-      .send(data)
-      .set(headers(null)),
+    to: async (url) => request(app).post(url).send(data).set(headers(null)),
   }),
   get: (url, { headers, query } = {}) => {
     const requestInProgress = request(app).get(url);
@@ -94,6 +74,13 @@ module.exports = (app) => ({
       requestInProgress.query(query);
     }
     return requestInProgress;
+  },
+  put: (url, data, { headers } = {}) => {
+    const requestInProgress = request(app).put(url);
+    if (headers) {
+      requestInProgress.set(headers);
+    }
+    return requestInProgress.send(data);
   },
 });
 

--- a/trade-finance-manager-api/api-tests/v1/tasks/tasks-update-task.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/tasks/tasks-update-task.api-test.js
@@ -1,0 +1,129 @@
+const { withClientAuthenticationTests } = require('../../common-tests/client-authentication-tests');
+const app = require('../../../src/createApp');
+const { as, put } = require('../../api')(app);
+const testUserCache = require('../../api-test-users');
+const MOCK_DEAL_MIA_SUBMITTED = require('../../../src/v1/__mocks__/mock-deal-MIA-submitted');
+const MOCK_MIA_TASKS = require('../../../src/v1/__mocks__/mock-MIA-tasks');
+const MOCK_USERS = require('../../../src/v1/__mocks__/mock-users');
+const CONSTANTS = require('../../../src/constants');
+const { mockFindOneDeal, mockUpdateDeal, mockFindUserById, mockFindOneDealFailure } = require('../../../src/v1/__mocks__/common-api-mocks');
+
+describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
+  const mockUser = MOCK_USERS[0];
+  const { firstName, lastName } = mockUser;
+  const userId = mockUser._id;
+  const taskDealId = '61f6b18502fade01b1e8f07f';
+
+  const groupId = MOCK_MIA_TASKS[0].id;
+  const task = MOCK_MIA_TASKS[0].groupTasks[0];
+  const taskId = task.id;
+  const taskUpdateBase = {
+    id: taskId,
+    groupId,
+    assignedTo: {
+      userId,
+    },
+    updatedBy: userId,
+  };
+
+  const taskUpdate = {
+    ...taskUpdateBase,
+    status: CONSTANTS.TASKS.STATUS.COMPLETED,
+  };
+
+  const validUrlToUpdateTask = `/v1/deals/${taskDealId}/tasks/${groupId}/${taskId}`;
+
+  let tokenUser;
+
+  beforeAll(async () => {
+    tokenUser = await testUserCache.initialise(app);
+  });
+
+  withClientAuthenticationTests({
+    makeRequestWithoutAuthHeader: () => put(validUrlToUpdateTask, taskUpdate),
+    makeRequestWithAuthHeader: (authHeader) => put(validUrlToUpdateTask, taskUpdate, { headers: { Authorization: authHeader } }),
+  });
+
+  it('returns a 200 if updateTfmTask is successful', async () => {
+    mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindUserById();
+
+    const { status, body } = await as(tokenUser).put(taskUpdate).to(validUrlToUpdateTask);
+    const expectedUpdatedTask = {
+      id: taskId,
+      title: MOCK_MIA_TASKS[0].groupTasks[0].title,
+      groupId,
+      assignedTo: {
+        userId: taskUpdate.assignedTo.userId,
+        userFullName: `${firstName} ${lastName}`,
+      },
+      team: MOCK_MIA_TASKS[0].groupTasks[0].team,
+      previousStatus: CONSTANTS.TASKS.STATUS.TO_DO,
+      status: taskUpdate.status,
+      updatedAt: expect.any(Number),
+      dateStarted: expect.any(Number),
+      dateCompleted: expect.any(Number),
+      history: expect.any(Array),
+    };
+
+    expect(status).toBe(200);
+    expect(body).toEqual(expectedUpdatedTask);
+  });
+
+  it('returns a 400 if deal id is invalid', async () => {
+    mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindUserById();
+
+    const invalidDealId = 'invalid-deal-id';
+    const { status, body } = await as(tokenUser).put(taskUpdate).to(`/v1/deals/${invalidDealId}/tasks/${groupId}/${taskId}`);
+
+    expect(status).toBe(400);
+    expect(body).toEqual({
+      errors: [{ location: 'params', msg: 'The Deal ID (dealId) provided should be a Mongo ID', path: 'dealId', type: 'field', value: 'invalid-deal-id' }],
+      status: 400,
+    });
+  });
+
+  it('returns a 400 if group id is invalid', async () => {
+    mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindUserById();
+
+    const invalidGroupId = 'invalid-group-id';
+    const { status, body } = await as(tokenUser).put(taskUpdate).to(`/v1/deals/${taskDealId}/tasks/${invalidGroupId}/${taskId}`);
+
+    expect(status).toBe(400);
+    expect(body).toEqual({
+      errors: [{ location: 'params', msg: 'The Group ID (groupId) provided should be an integer', path: 'groupId', type: 'field', value: 'invalid-group-id' }],
+      status: 400,
+    });
+  });
+
+  it('returns a 400 if task id is invalid', async () => {
+    mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindUserById();
+
+    const invalidTaskId = 'invalid-task-id';
+    const { status, body } = await as(tokenUser).put(taskUpdate).to(`/v1/deals/${taskDealId}/tasks/${groupId}/${invalidTaskId}`);
+
+    expect(status).toBe(400);
+    expect(body).toEqual({
+      errors: [{ location: 'params', msg: 'The Task ID (taskId) provided should be an integer', path: 'taskId', type: 'field', value: 'invalid-task-id' }],
+      status: 400,
+    });
+  });
+
+  it('returns a 500 if an error is thrown', async () => {
+    mockFindOneDealFailure();
+    mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindUserById();
+
+    const { status, body } = await as(tokenUser).put(taskUpdate).to(validUrlToUpdateTask);
+
+    expect(status).toBe(500);
+    expect(body).toEqual({ data: 'Unable to update the task' });
+  });
+});

--- a/trade-finance-manager-api/api-tests/v1/tasks/tasks-update-task.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/tasks/tasks-update-task.api-test.js
@@ -6,7 +6,7 @@ const MOCK_DEAL_MIA_SUBMITTED = require('../../../src/v1/__mocks__/mock-deal-MIA
 const MOCK_MIA_TASKS = require('../../../src/v1/__mocks__/mock-MIA-tasks');
 const MOCK_USERS = require('../../../src/v1/__mocks__/mock-users');
 const CONSTANTS = require('../../../src/constants');
-const { mockFindOneDeal, mockUpdateDeal, mockFindUserById, mockFindOneDealFailure } = require('../../../src/v1/__mocks__/common-api-mocks');
+const { mockFindOneDeal, mockUpdateDeal, mockFindUserById, mockFindOneDealFailure, mockFindOneTeam } = require('../../../src/v1/__mocks__/common-api-mocks');
 
 describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
   const mockUser = MOCK_USERS[0];
@@ -47,6 +47,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
   it('returns a 200 if updateTfmTask is successful', async () => {
     mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
     mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindOneTeam();
     mockFindUserById();
 
     const { status, body } = await as(tokenUser).put(taskUpdate).to(validUrlToUpdateTask);
@@ -74,6 +75,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
   it('returns a 400 if deal id is invalid', async () => {
     mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
     mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindOneTeam();
     mockFindUserById();
 
     const invalidDealId = 'invalid-deal-id';
@@ -89,6 +91,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
   it('returns a 400 if group id is invalid', async () => {
     mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
     mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindOneTeam();
     mockFindUserById();
 
     const invalidGroupId = 'invalid-group-id';
@@ -104,6 +107,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
   it('returns a 400 if task id is invalid', async () => {
     mockFindOneDeal(MOCK_DEAL_MIA_SUBMITTED);
     mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindOneTeam();
     mockFindUserById();
 
     const invalidTaskId = 'invalid-task-id';
@@ -119,6 +123,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
   it('returns a 500 if an error is thrown', async () => {
     mockFindOneDealFailure();
     mockUpdateDeal(MOCK_DEAL_MIA_SUBMITTED);
+    mockFindOneTeam();
     mockFindUserById();
 
     const { status, body } = await as(tokenUser).put(taskUpdate).to(validUrlToUpdateTask);

--- a/trade-finance-manager-api/src/graphql/resolvers/mutation-update-task.js
+++ b/trade-finance-manager-api/src/graphql/resolvers/mutation-update-task.js
@@ -1,7 +1,8 @@
 const { updateTfmTask } = require('../../v1/controllers/tasks.controller');
 
 const updateTask = async ({ dealId, taskUpdate }) => {
-  const update = await updateTfmTask(dealId, taskUpdate);
+  const { groupId, id: taskId } = taskUpdate;
+  const update = await updateTfmTask({ dealId, groupId, taskId, taskUpdate });
   return update;
 };
 

--- a/trade-finance-manager-api/src/v1/controllers/tasks.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tasks.controller.js
@@ -10,7 +10,7 @@ const mapSubmittedDeal = require('../mappings/map-submitted-deal');
 /**
  * Update a task in the task's group.
  * */
-const updateTask = (allTaskGroups, taskUpdate) =>
+const createUpdatedTask = (allTaskGroups, taskUpdate) =>
   allTaskGroups.map((tGroup) => {
     let group = tGroup;
 
@@ -37,7 +37,7 @@ const updateTask = (allTaskGroups, taskUpdate) =>
  * Update all tasks canEdit flag and status
  * Depending on what task has been changed.
  * */
-const updateAllTasks = async (allTaskGroups, groupId, taskUpdate, statusFrom, deal, urlOrigin) => {
+const createAllUpdatedTasks = async (allTaskGroups, groupId, taskUpdate, statusFrom, deal, urlOrigin) => {
   const taskEmailsToSend = [];
 
   let taskGroups = allTaskGroups.map((tGroup) => {
@@ -174,70 +174,96 @@ const updateAllTasks = async (allTaskGroups, groupId, taskUpdate, statusFrom, de
  * - Change the TFM dealStage (if deal is MIA and taskUpdate is first task).
  * - Updates the deal.
  * */
-const updateTfmTask = async (dealId, taskUpdate) => {
+const updateTfmTask = async ({ dealId, groupId, taskId, taskUpdate }) => {
   const unmappedDeal = await api.findOneDeal(dealId);
-  const deal = await mapSubmittedDeal(unmappedDeal);
+  if (!unmappedDeal) {
+    throw new Error(`Deal not found ${dealId}`);
+  }
+
+  const deal = mapSubmittedDeal(unmappedDeal);
 
   const allTasks = deal.tfm.tasks;
 
-  const { id: taskIdToUpdate, groupId, status: statusTo, urlOrigin } = taskUpdate;
+  const taskUpdateWithIds = { ...taskUpdate, groupId, id: taskId };
 
-  const group = getGroupById(allTasks, groupId);
-  const originalTask = getTaskInGroupById(group.groupTasks, taskIdToUpdate);
-  const statusFrom = originalTask.status;
+  const { status: statusTo, urlOrigin } = taskUpdate;
 
-  const updatedTask = await mapTaskObject(originalTask, taskUpdate, statusFrom);
-
-  const canUpdateTask = previousTaskIsComplete(allTasks, group, updatedTask.id) || taskCanBeEditedWithoutPreviousTaskComplete(group, updatedTask);
-
-  if (canUpdateTask) {
-    /**
-     * Update the task in the array
-     * */
-    const modifiedTasks = updateTask(allTasks, updatedTask);
-
-    /**
-     * Map over every task in all groups and
-     * update other tasks so they can be started.
-     * E.g If task 1 is completed, task 2 can then be started.
-     * Some other special conditions are in here:
-     * - e.g if X task is completed, an entire group of tasks can be started.
-     * */
-    const modifiedTasksWithEditStatus = await updateAllTasks(modifiedTasks, groupId, updatedTask, statusFrom, deal, urlOrigin);
-
-    /**
-     * Construct TFM update object
-     * */
-    const tfmDealUpdate = {
-      tfm: {
-        tasks: modifiedTasksWithEditStatus,
-      },
-    };
-
-    /**
-     * If the deal is MIA
-     * and the first task status is being changed to in progress or is completed immediately,
-     * the TFM deal stage needs to change to 'in progress'.
-     * */
-    const updateDealStage = shouldUpdateDealStage(deal.submissionType, taskIdToUpdate, groupId, statusFrom, statusTo);
-
-    if (updateDealStage) {
-      tfmDealUpdate.tfm.stage = CONSTANTS.DEALS.DEAL_STAGE_TFM.IN_PROGRESS_BY_UKEF;
-    }
-
-    /**
-     * Update the deal
-     * */
-    await api.updateDeal(dealId, tfmDealUpdate);
-
-    return updatedTask;
+  const group = getGroupById(allTasks, Number(groupId));
+  if (!group) {
+    throw new Error(`Group not found ${groupId}`);
   }
 
-  return originalTask;
+  const originalTask = getTaskInGroupById(group.groupTasks, taskId);
+  if (!originalTask) {
+    throw new Error(`Task not found ${taskId}`);
+  }
+  const statusFrom = originalTask.status;
+
+  const updatedTask = await mapTaskObject(originalTask, taskUpdateWithIds);
+
+  const canUpdateTask = previousTaskIsComplete(allTasks, group, taskId) || taskCanBeEditedWithoutPreviousTaskComplete(group, updatedTask);
+  if (!canUpdateTask) {
+    return originalTask;
+  }
+
+  /**
+   * Update the task in the array
+   * */
+  const modifiedTasks = createUpdatedTask(allTasks, updatedTask);
+
+  /**
+   * Map over every task in all groups and
+   * update other tasks so they can be started.
+   * E.g If task 1 is completed, task 2 can then be started.
+   * Some other special conditions are in here:
+   * - e.g if X task is completed, an entire group of tasks can be started.
+   * */
+  const modifiedTasksWithEditStatus = await createAllUpdatedTasks(modifiedTasks, groupId, updatedTask, statusFrom, deal, urlOrigin);
+
+  /**
+   * Construct TFM update object
+   * */
+  const tfmDealUpdate = {
+    tfm: {
+      tasks: modifiedTasksWithEditStatus,
+    },
+  };
+
+  /**
+   * If the deal is MIA
+   * and the first task status is being changed to in progress or is completed immediately,
+   * the TFM deal stage needs to change to 'in progress'.
+   * */
+  const updateDealStage = shouldUpdateDealStage(deal.submissionType, taskId, groupId, statusFrom, statusTo);
+
+  if (updateDealStage) {
+    tfmDealUpdate.tfm.stage = CONSTANTS.DEALS.DEAL_STAGE_TFM.IN_PROGRESS_BY_UKEF;
+  }
+
+  /**
+   * Update the deal
+   * */
+  await api.updateDeal(dealId, tfmDealUpdate);
+
+  return updatedTask;
+};
+
+const updateTask = async (req, res) => {
+  const { dealId, groupId, taskId } = req.params;
+  const taskUpdate = req.body;
+
+  try {
+    const result = await updateTfmTask({ dealId, groupId: parseInt(groupId, 10), taskId, taskUpdate });
+    return res.status(200).send(result);
+  } catch (error) {
+    console.error('Unable to update the task %s in group %s deal %s: %O', taskId, groupId, dealId, error);
+    return res.status(500).send({ data: 'Unable to update the task' });
+  }
 };
 
 module.exports = {
-  updateTask,
-  updateAllTasks,
+  createUpdatedTask,
+  createAllUpdatedTasks,
   updateTfmTask,
+  updateTask,
 };

--- a/trade-finance-manager-api/src/v1/graphql-mappings/mappings/facilities/mapPremiumSchedule.api-test.js
+++ b/trade-finance-manager-api/src/v1/graphql-mappings/mappings/facilities/mapPremiumSchedule.api-test.js
@@ -4,11 +4,11 @@ describe('mapPremiumSchedule', () => {
   it('should return array with formattedIncome', () => {
     const mockPremiumSchedule = [
       {
-        test: true,
+        testField: true,
         income: 1200,
       },
       {
-        test: true,
+        testField: true,
         income: 2200,
       },
     ];

--- a/trade-finance-manager-api/src/v1/graphql-mappings/mappings/facilities/mapTenor.js
+++ b/trade-finance-manager-api/src/v1/graphql-mappings/mappings/facilities/mapTenor.js
@@ -18,7 +18,7 @@ const mapTenor = (facilitySnapshot, facilityTfm, facility) => {
   if (facility?.amendments?.length) {
     const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
 
-    // checks if exposure period in months in latest completed amendment
+    // checks if exposure period in months is latest completed amendment
     if (latestAmendmentTFM?.amendmentExposurePeriodInMonths) {
       // sets updatedExposurePeriodInMonths as amendment exposure period
       exposurePeriod = latestAmendmentTFM.amendmentExposurePeriodInMonths;

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -18,6 +18,7 @@ const handleValidationResult = require('./validation/route-validators/validation
 const checkApiKey = require('./middleware/headers/check-api-key');
 const { teamsRoutes } = require('./teams/routes');
 const { dealsOpenRouter, dealsAuthRouter } = require('./deals/routes');
+const { tasksRouter } = require('./tasks/routes');
 
 openRouter.use(checkApiKey);
 authRouter.use(passport.authenticate('jwt', { session: false }));
@@ -26,6 +27,10 @@ authRouter.route('/api-docs').get(swaggerUi.setup(swaggerSpec, swaggerUiOptions)
 
 openRouter.use('/', dealsOpenRouter);
 authRouter.use('/', dealsAuthRouter);
+
+authRouter.use('/', teamsRoutes);
+
+authRouter.use('/', tasksRouter);
 
 /**
  * @openapi
@@ -115,7 +120,5 @@ authRouter.route('/amendments/:status?').get(amendmentController.getAllAmendment
 
 authRouter.route('/party/urn/:urn').get(validation.partyUrnValidation, handleValidationResult, party.getCompany);
 authRouter.route('/parties/:dealId').put(validation.dealIdValidation, handleValidationResult, partyController.updateParty);
-
-authRouter.use('/', teamsRoutes);
 
 module.exports = { authRouter, openRouter };

--- a/trade-finance-manager-api/src/v1/tasks/routes.js
+++ b/trade-finance-manager-api/src/v1/tasks/routes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const tasksController = require('../controllers/tasks.controller');
+const validation = require('../validation/route-validators/route-validators');
+const handleValidationResult = require('../validation/route-validators/validation-handler');
+
+const tasksRouter = express.Router();
+
+tasksRouter
+  .route('/deals/:dealId/tasks/:groupId/:taskId')
+  .put(validation.dealIdValidation, validation.groupIdValidation, validation.taskIdValidation, handleValidationResult, tasksController.updateTask);
+
+module.exports = {
+  tasksRouter,
+};

--- a/trade-finance-manager-api/src/v1/validation/route-validators/route-validators.js
+++ b/trade-finance-manager-api/src/v1/validation/route-validators/route-validators.js
@@ -5,10 +5,9 @@ const userParamValidation = param('user').isMongoId().withMessage('The User ID (
 const facilityIdValidation = param('facilityId').isMongoId().withMessage('The Facility ID (facilityId) provided should be a Mongo ID');
 const amendmentIdValidation = param('amendmentId').isMongoId().withMessage('The Amendment ID (amendmentId) provided should be a Mongo ID');
 const dealIdValidation = param('dealId').isMongoId().withMessage('The Deal ID (dealId) provided should be a Mongo ID');
-const partyURNValidation = param('urn')
-  .isString()
-  .matches(/^\d+$/)
-  .withMessage('The party URN (urn) provided should be a string of numbers');
+const groupIdValidation = param('groupId').isInt().withMessage('The Group ID (groupId) provided should be an integer');
+const taskIdValidation = param('taskId').isInt().withMessage('The Task ID (taskId) provided should be an integer');
+const partyURNValidation = param('urn').isString().matches(/^\d+$/).withMessage('The party URN (urn) provided should be a string of numbers');
 
 exports.userIdEscapingSanitization = [userParamEscapingSanitization];
 
@@ -19,5 +18,9 @@ exports.facilityIdValidation = [facilityIdValidation];
 exports.facilityIdAndAmendmentIdValidations = [facilityIdValidation, amendmentIdValidation];
 
 exports.dealIdValidation = [dealIdValidation];
+
+exports.groupIdValidation = [groupIdValidation];
+
+exports.taskIdValidation = [taskIdValidation];
 
 exports.partyUrnValidation = [partyURNValidation];

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1,5 +1,4 @@
 const axios = require('axios');
-const apollo = require('./graphql/apollo');
 const { isValidMongoId, isValidPartyUrn, isValidGroupId, isValidTaskId } = require('./helpers/validateIds');
 
 require('dotenv').config();

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1,7 +1,6 @@
 const axios = require('axios');
 const apollo = require('./graphql/apollo');
-const updateTaskMutation = require('./graphql/mutations/update-task');
-const { isValidMongoId, isValidPartyUrn } = require('./helpers/validateIds');
+const { isValidMongoId, isValidPartyUrn, isValidGroupId, isValidTaskId } = require('./helpers/validateIds');
 
 require('dotenv').config();
 
@@ -188,15 +187,37 @@ const updateFacilityRiskProfile = async (id, facilityUpdate, token) => {
   }
 };
 
-const updateTask = async (dealId, taskUpdate) => {
-  const updateVariables = {
-    dealId,
-    taskUpdate,
-  };
+const updateTask = async (dealId, groupId, taskId, taskUpdate, token) => {
+  try {
+    const isValidDealId = isValidMongoId(dealId);
 
-  const response = await apollo('PUT', updateTaskMutation, updateVariables);
+    if (!isValidDealId) {
+      console.error('updateTask: Invalid deal id provided: %s', dealId);
+      return { status: 400, data: 'Invalid deal id' };
+    }
 
-  return response;
+    if (!isValidGroupId(groupId)) {
+      console.error('updateTask: Invalid group id provided: %s', groupId);
+      return { status: 400, data: 'Invalid group id' };
+    }
+
+    if (!isValidTaskId(taskId)) {
+      console.error('updateTask: Invalid task id provided: %s', taskId);
+      return { status: 400, data: 'Invalid task id' };
+    }
+
+    const response = await axios({
+      method: 'put',
+      url: `${TFM_API_URL}/v1/deals/${dealId}/tasks/${groupId}/${taskId}`,
+      headers: generateHeaders(token),
+      data: taskUpdate,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Unable to update task %O', error);
+    return { status: error?.response?.status || 500, data: 'Failed to update task' };
+  }
 };
 
 const updateCreditRating = async (dealId, creditRatingUpdate, token) => {

--- a/trade-finance-manager-ui/server/constants/regex.js
+++ b/trade-finance-manager-ui/server/constants/regex.js
@@ -1,3 +1,4 @@
 module.exports = {
   PARTY_URN: /^\d{8}$/,
+  INT: /^-?\d+$/,
 };

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -207,8 +207,6 @@ const putCaseTask = async (req, res) => {
   } = req.body;
 
   const update = {
-    id: taskId,
-    groupId: Number(groupId),
     status,
     assignedTo: {
       userId: assignedToValue,
@@ -217,7 +215,7 @@ const putCaseTask = async (req, res) => {
     urlOrigin: req.headers.origin,
   };
 
-  await api.updateTask(dealId, update);
+  await api.updateTask(dealId, groupId, taskId, update, userToken);
 
   return res.redirect(`/case/${dealId}/tasks`);
 };

--- a/trade-finance-manager-ui/server/controllers/case/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.test.js
@@ -8,7 +8,9 @@ import CONSTANTS from '../../constants';
 
 const res = mockRes();
 
-const session = {
+const TOKEN = 'test-token';
+
+const SESSION = {
   user: {
     _id: '12345678',
     username: 'testUser',
@@ -16,6 +18,7 @@ const session = {
     lastName: 'Bloggs',
     teams: ['TEAM1'],
   },
+  userToken: TOKEN,
 };
 
 describe('controllers - case', () => {
@@ -33,12 +36,14 @@ describe('controllers - case', () => {
         mock: true,
       };
 
-      const mockAmendments = [{
-        ukefFacilityId: '1234',
-        facilityId: '12345',
-        submittedByPim: false,
-        status: CONSTANTS.AMENDMENTS.AMENDMENT_STATUS.IN_PROGRESS,
-      }];
+      const mockAmendments = [
+        {
+          ukefFacilityId: '1234',
+          facilityId: '12345',
+          submittedByPim: false,
+          status: CONSTANTS.AMENDMENTS.AMENDMENT_STATUS.IN_PROGRESS,
+        },
+      ];
 
       beforeEach(() => {
         api.getDeal = () => Promise.resolve(mockDeal);
@@ -54,7 +59,7 @@ describe('controllers - case', () => {
           params: {
             _id: mockDeal._id,
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseDeal(req, res);
@@ -65,7 +70,7 @@ describe('controllers - case', () => {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'deal',
           dealId: req.params._id,
-          user: session.user,
+          user: SESSION.user,
           hasAmendmentInProgress: true,
           amendments: mockAmendments,
           amendmentsInProgress: mockAmendments,
@@ -83,7 +88,7 @@ describe('controllers - case', () => {
           params: {
             _id: '1',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseDeal(req, res);
@@ -122,7 +127,7 @@ describe('controllers - case', () => {
           params: {
             _id: mockDeal._id,
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseTasks(req, res);
@@ -132,7 +137,7 @@ describe('controllers - case', () => {
           userId: req.session.user._id,
         };
 
-        expect(apiGetDealSpy).toHaveBeenCalledWith(mockDeal._id, undefined, expectedTaskFiltersObj);
+        expect(apiGetDealSpy).toHaveBeenCalledWith(mockDeal._id, TOKEN, expectedTaskFiltersObj);
 
         expect(res.render).toHaveBeenCalledWith('case/tasks/tasks.njk', {
           deal: mockDeal.dealSnapshot,
@@ -141,7 +146,7 @@ describe('controllers - case', () => {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'tasks',
           dealId: req.params._id,
-          user: session.user,
+          user: SESSION.user,
           selectedTaskFilter: 'user',
           amendments: [],
           hasAmendmentInProgress: false,
@@ -160,7 +165,7 @@ describe('controllers - case', () => {
           params: {
             _id: '1',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseTasks(req, res);
@@ -199,7 +204,7 @@ describe('controllers - case', () => {
           params: {
             _id: mockDeal._id,
           },
-          session,
+          session: SESSION,
           body: {
             filterType: 'team',
           },
@@ -213,7 +218,7 @@ describe('controllers - case', () => {
           userId: req.session.user._id,
         };
 
-        expect(apiGetDealSpy).toHaveBeenCalledWith(mockDeal._id, undefined, expectedTaskFiltersObj);
+        expect(apiGetDealSpy).toHaveBeenCalledWith(mockDeal._id, TOKEN, expectedTaskFiltersObj);
 
         expect(res.render).toHaveBeenCalledWith('case/tasks/tasks.njk', {
           deal: mockDeal.dealSnapshot,
@@ -222,7 +227,7 @@ describe('controllers - case', () => {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'tasks',
           dealId: req.params._id,
-          user: session.user,
+          user: SESSION.user,
           selectedTaskFilter: req.body.filterType,
           amendments: [],
           hasAmendmentInProgress: false,
@@ -241,7 +246,7 @@ describe('controllers - case', () => {
           params: {
             _id: '1',
           },
-          session,
+          session: SESSION,
           body: {
             filterType: 'team',
           },
@@ -271,7 +276,7 @@ describe('controllers - case', () => {
                   id: '123',
                   groupId: 1,
                   assignedTo: {
-                    userId: session.user._id,
+                    userId: SESSION.user._id,
                   },
                   team: {
                     id: 'TEAM_1',
@@ -282,7 +287,7 @@ describe('controllers - case', () => {
                   groupId: 1,
                   canEdit: true,
                   assignedTo: {
-                    userId: session.user._id,
+                    userId: SESSION.user._id,
                   },
                   team: {
                     id: 'TEAM_1',
@@ -309,7 +314,7 @@ describe('controllers - case', () => {
           teams: ['TEAM_1'],
         },
         {
-          _id: session.user._id,
+          _id: SESSION.user._id,
           firstName: 'a',
           lastName: 'b',
           teams: ['TEAM_1'],
@@ -328,7 +333,7 @@ describe('controllers - case', () => {
             groupId: '1',
             taskId: '456',
           },
-          session,
+          session: SESSION,
         };
 
         const expectedTask = getTask(Number(req.params.groupId), req.params.taskId, mockDeal.tfm.tasks);
@@ -341,9 +346,9 @@ describe('controllers - case', () => {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'tasks',
           dealId: req.params._id,
-          user: session.user,
+          user: SESSION.user,
           task: expectedTask,
-          assignToSelectOptions: mapAssignToSelectOptions(expectedTask.assignedTo.userId, session.user, mockTeamMembers),
+          assignToSelectOptions: mapAssignToSelectOptions(expectedTask.assignedTo.userId, SESSION.user, mockTeamMembers),
         });
       });
     });
@@ -364,7 +369,7 @@ describe('controllers - case', () => {
                   id: '123',
                   groupId: 1,
                   assignedTo: {
-                    userId: session.user._id,
+                    userId: SESSION.user._id,
                   },
                   team: {
                     id: 'TEAM_1',
@@ -374,7 +379,7 @@ describe('controllers - case', () => {
                   id: '456',
                   groupId: 1,
                   assignedTo: {
-                    userId: session.user._id,
+                    userId: SESSION.user._id,
                   },
                   team: {
                     id: 'TEAM_1',
@@ -398,7 +403,7 @@ describe('controllers - case', () => {
             groupId: '1',
             taskId: '123',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseTask(req, res);
@@ -434,7 +439,7 @@ describe('controllers - case', () => {
             _id: mockDeal._id,
             taskId: '12345678',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseTask(req, res);
@@ -471,7 +476,7 @@ describe('controllers - case', () => {
             groupId: '1',
             taskId: '123',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseTask(req, res);
@@ -490,7 +495,7 @@ describe('controllers - case', () => {
           params: {
             _id: '1',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseTask(req, res);
@@ -505,6 +510,9 @@ describe('controllers - case', () => {
         Promise.resolve({
           test: true,
         }));
+
+      const groupId = '1';
+      const taskId = '456';
 
       const mockDeal = {
         _id: '61f6ac5b02fade01b1e8efef',
@@ -527,12 +535,12 @@ describe('controllers - case', () => {
         const req = {
           params: {
             _id: mockDeal._id,
-            groupId: '1',
-            taskId: '456',
+            groupId,
+            taskId,
           },
-          session,
+          session: SESSION,
           body: {
-            assignedTo: session.user._id,
+            assignedTo: SESSION.user._id,
             status: 'In progress',
           },
           headers: {
@@ -543,8 +551,6 @@ describe('controllers - case', () => {
         await caseController.putCaseTask(req, res);
 
         const expectedUpdateObj = {
-          id: req.params.taskId,
-          groupId: Number(req.params.groupId),
           status: req.body.status,
           assignedTo: {
             userId: req.body.assignedTo,
@@ -553,7 +559,7 @@ describe('controllers - case', () => {
           urlOrigin: req.headers.origin,
         };
 
-        expect(apiUpdateSpy).toHaveBeenCalledWith(mockDeal._id, expectedUpdateObj);
+        expect(apiUpdateSpy).toHaveBeenCalledWith(mockDeal._id, groupId, taskId, expectedUpdateObj, TOKEN);
 
         expect(res.redirect).toHaveBeenCalledWith(`/case/${mockDeal._id}/tasks`);
       });
@@ -571,7 +577,7 @@ describe('controllers - case', () => {
             groupId: '1',
             taskId: '456',
           },
-          session,
+          session: SESSION,
           headers: {
             origin: 'http://test.com',
           },
@@ -644,7 +650,7 @@ describe('controllers - case', () => {
           params: {
             facilityId: mockFacility._id,
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseFacility(req, res);
@@ -657,7 +663,7 @@ describe('controllers - case', () => {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'facility',
           facilityId: req.params.facilityId,
-          user: session.user,
+          user: SESSION.user,
           showAmendmentButton: false,
           showContinueAmendmentButton: false,
           amendmentId: '626bae8c43c01e02076352e1',
@@ -681,7 +687,7 @@ describe('controllers - case', () => {
           params: {
             _id: '1',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseFacility(req, res);
@@ -710,7 +716,7 @@ describe('controllers - case', () => {
           params: {
             _id: mockDeal._id,
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseDocuments(req, res);
@@ -721,7 +727,7 @@ describe('controllers - case', () => {
           activePrimaryNavigation: 'manage work',
           activeSubNavigation: 'documents',
           dealId: req.params._id,
-          user: session.user,
+          user: SESSION.user,
           amendmentsInProgress: [],
           hasAmendmentInProgress: false,
         });
@@ -739,7 +745,7 @@ describe('controllers - case', () => {
           params: {
             _id: '1',
           },
-          session,
+          session: SESSION,
         };
 
         await caseController.getCaseDocuments(req, res);

--- a/trade-finance-manager-ui/server/helpers/validateIds.js
+++ b/trade-finance-manager-ui/server/helpers/validateIds.js
@@ -11,6 +11,22 @@ const REGEX = require('../constants/regex');
 const isValidRegex = (regex, value) => regex.test(value);
 
 /**
+  Validates if a value is a valid group id
+
+ * @param groupId - the value to validate
+ * @returns Boolean - true if valid, false if not
+ */
+const isValidGroupId = (groupId) => isValidRegex(REGEX.INT, groupId);
+
+/**
+  Validates if a value is a valid group id
+
+ * @param taskId - the value to validate
+ * @returns Boolean - true if valid, false if not
+ */
+const isValidTaskId = (taskId) => isValidRegex(REGEX.INT, taskId);
+
+/**
   Validates if a value is a valid mongo id
 
  * @param mongoId - the value to validate
@@ -28,5 +44,7 @@ const isValidPartyUrn = (partyUrn) => isValidRegex(REGEX.PARTY_URN, partyUrn);
 
 module.exports = {
   isValidMongoId,
+  isValidGroupId,
+  isValidTaskId,
   isValidPartyUrn,
 };


### PR DESCRIPTION
Introduction
We want to replace TFM API's update task GraphQL query with a REST endpoint.

Resolution
In TFM API, I've created a new endpoint (PUT /deals/:dealId/tasks/:groupId/:taskId). This has existing dealId validation applied to it, as well as additional basic groupId validation applied.
