### PR TITLE
fix(DTFS2-6182): remove passport from put deals submit

### DIFF
--- a/trade-finance-manager-api/src/v1/deals/routes.js
+++ b/trade-finance-manager-api/src/v1/deals/routes.js
@@ -138,7 +138,6 @@ dealsRouter
     handleValidationResult,
     dealUnderwriterManagersDecisionController.updateUnderwriterManagersDecision,
   );
-// TODO DTFS2-6718: error handling?
 
 module.exports = {
   dealsRouter,

--- a/trade-finance-manager-api/src/v1/deals/routes.js
+++ b/trade-finance-manager-api/src/v1/deals/routes.js
@@ -6,7 +6,7 @@ const dealUnderwriterManagersDecisionController = require('../controllers/deal-u
 const validation = require('../validation/route-validators/route-validators');
 const handleValidationResult = require('../validation/route-validators/validation-handler');
 
-const dealsRouter = express.Router();
+const dealsAuthRouter = express.Router();
 /**
  * @openapi
  * /deals/submit:
@@ -66,21 +66,21 @@ const dealsRouter = express.Router();
  *       404:
  *         description: Not found
  */
-dealsRouter.route('/deals/submit').put(dealSubmit.submitDealPUT);
+dealsAuthRouter.route('/deals/submit').put(dealSubmit.submitDealPUT);
 
-dealsRouter.route('/deals/submitDealAfterUkefIds').put(dealSubmit.submitDealAfterUkefIdsPUT);
+dealsAuthRouter.route('/deals/submitDealAfterUkefIds').put(dealSubmit.submitDealAfterUkefIdsPUT);
 
-dealsRouter.route('/deals').get(dealController.getDeals);
-dealsRouter
+dealsAuthRouter.route('/deals').get(dealController.getDeals);
+dealsAuthRouter
   .route('/deals/:dealId')
   .get(validation.dealIdValidation, handleValidationResult, dealController.getDeal)
   .put(validation.dealIdValidation, handleValidationResult, dealController.updateDeal);
 
-dealsRouter
+dealsAuthRouter
   .route('/deals/:dealId/amendments/:status?/:type?')
   .get(validation.dealIdValidation, handleValidationResult, amendmentController.getAmendmentsByDealId);
 
-dealsRouter
+dealsAuthRouter
   .route('/deals/:dealId/underwriting/lead-underwriter')
   .put(validation.dealIdValidation, handleValidationResult, dealController.updateLeadUnderwriter);
 
@@ -131,7 +131,7 @@ dealsRouter
 *       400:
 *         description: Bad Request.
 */
-dealsRouter
+dealsAuthRouter
   .route('/deals/:dealId/underwriting/managers-decision')
   .put(
     validation.dealIdValidation,
@@ -140,5 +140,5 @@ dealsRouter
   );
 
 module.exports = {
-  dealsRouter,
+  dealsAuthRouter,
 };

--- a/trade-finance-manager-api/src/v1/deals/routes.js
+++ b/trade-finance-manager-api/src/v1/deals/routes.js
@@ -6,7 +6,8 @@ const dealUnderwriterManagersDecisionController = require('../controllers/deal-u
 const validation = require('../validation/route-validators/route-validators');
 const handleValidationResult = require('../validation/route-validators/validation-handler');
 
-const dealsAuthRouter = express.Router();
+const dealsOpenRouter = express.Router();
+
 /**
  * @openapi
  * /deals/submit:
@@ -66,7 +67,11 @@ const dealsAuthRouter = express.Router();
  *       404:
  *         description: Not found
  */
-dealsAuthRouter.route('/deals/submit').put(dealSubmit.submitDealPUT);
+// `PUT /deals/submit` is called by portal API (without a TFM user to authenticate as)
+// so this endpoint cannot be on the auth router
+dealsOpenRouter.route('/deals/submit').put(dealSubmit.submitDealPUT);
+
+const dealsAuthRouter = express.Router();
 
 dealsAuthRouter.route('/deals/submitDealAfterUkefIds').put(dealSubmit.submitDealAfterUkefIdsPUT);
 
@@ -140,5 +145,6 @@ dealsAuthRouter
   );
 
 module.exports = {
+  dealsOpenRouter,
   dealsAuthRouter,
 };

--- a/trade-finance-manager-api/src/v1/graphql-mappings/filters/filterActivities.api-test.js
+++ b/trade-finance-manager-api/src/v1/graphql-mappings/filters/filterActivities.api-test.js
@@ -51,7 +51,7 @@ describe('filterActivities', () => {
       const mockFilterValue = 'OTHER';
       const result = filter(mockActivities, mockFilterValue);
 
-      const expected = mockActivities.filter((activitiy) => activitiy.type === mockFilterValue);
+      const expected = mockActivities.filter((activity) => activity.type === mockFilterValue);
       expect(result).toEqual(expected);
     });
   });
@@ -60,7 +60,7 @@ describe('filterActivities', () => {
     it('should filter activity types by `COMMENT`', () => {
       const result = filterByComment(mockActivities);
 
-      const expected = mockActivities.filter((activitiy) => activitiy.type === 'COMMENT');
+      const expected = mockActivities.filter((activity) => activity.type === 'COMMENT');
       expect(result).toEqual(expected);
     });
   });

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -17,14 +17,14 @@ const validation = require('./validation/route-validators/route-validators');
 const handleValidationResult = require('./validation/route-validators/validation-handler');
 const checkApiKey = require('./middleware/headers/check-api-key');
 const { teamsRoutes } = require('./teams/routes');
-const { dealsRouter } = require('./deals/routes');
+const { dealsAuthRouter } = require('./deals/routes');
 
 openRouter.use(checkApiKey);
 authRouter.use(passport.authenticate('jwt', { session: false }));
 
 authRouter.route('/api-docs').get(swaggerUi.setup(swaggerSpec, swaggerUiOptions));
 
-authRouter.use('/', dealsRouter);
+authRouter.use('/', dealsAuthRouter);
 
 /**
  * @openapi

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -17,13 +17,14 @@ const validation = require('./validation/route-validators/route-validators');
 const handleValidationResult = require('./validation/route-validators/validation-handler');
 const checkApiKey = require('./middleware/headers/check-api-key');
 const { teamsRoutes } = require('./teams/routes');
-const { dealsAuthRouter } = require('./deals/routes');
+const { dealsOpenRouter, dealsAuthRouter } = require('./deals/routes');
 
 openRouter.use(checkApiKey);
 authRouter.use(passport.authenticate('jwt', { session: false }));
 
 authRouter.route('/api-docs').get(swaggerUi.setup(swaggerSpec, swaggerUiOptions));
 
+openRouter.use('/', dealsOpenRouter);
 authRouter.use('/', dealsAuthRouter);
 
 /**


### PR DESCRIPTION
## Introduction
In #2149 we changed `PUT /deals/submit` in TFM API to require a valid TFM user token instead of requiring an API key.
This breaks the functionality of submitting deals from Portal to TFM, as portal-api calls this endpoint (and doesn't have a logged in TFM user to authenticate as).

## Resolution
I've reverted the change to `PUT /deals/submit` in TFM API