### PR TITLE
feat(FN-715):deploy stbr infra

### DIFF
--- a/.github/workflows/bicep_workflow_feature.yml
+++ b/.github/workflows/bicep_workflow_feature.yml
@@ -3,7 +3,7 @@ name: Deploy Feature Infrastructure using Bicep
 on:
   push:
     branches:
-      - feat/DTFS2-6422
+      - feat/stbr-infra
     paths:
       - '.github/workflows/bicep_workflow.yml'
       - '.github/workflows/bicep_deploy.yml'


### PR DESCRIPTION
### Introduction

We need to be able to manage the infrastructure in declarative IaC - we've chosen Bicep.
Now we have it ready, we need to deploy infrastructure to `feature` that the ETETF project needs. This is very slightly different from the the dev infrastructure.

This card covers
* trigger deploys only from `feat/stbr-infra`
### Resolution
* Update GHA to deploy only from `feat/stbr-infra`
