### PR TITLE
feat(DTFS2-6733): add 'Check your email' screen

### DIFF
--- a/portal/server/routes/login.js
+++ b/portal/server/routes/login.js
@@ -121,4 +121,8 @@ router.post('/reset-password/:pwdResetToken', async (req, res) => {
   return res.redirect('/login?passwordupdated=1');
 });
 
+router.get('/check-your-email', (req, res) => {
+  res.render('check-your-email.njk');
+});
+
 module.exports = router;

--- a/portal/templates/check-your-email.njk
+++ b/portal/templates/check-your-email.njk
@@ -1,0 +1,30 @@
+{% extends "index.njk" %}
+
+{% block pageTitle %}
+  Check your email
+{% endblock %}
+
+{% block content %}
+
+  <h1 class="govuk-heading-xl">
+    Check your email
+  </h1>
+
+  <div class="govuk-grid-row govuk-body">
+    <div class="govuk-grid-column-three-quarters">
+      <p class="govuk-!-margin-bottom-6">We've sent you an email with a link to sign in. This link will expire after 30 minutes.</p>
+
+      <p class="govuk-!-margin-bottom-6">You have <b>2</b> attempts remaining.</p>
+
+      <p class="govuk-!-margin-bottom-6">If you request too many links your account will be suspended for security purposes and you will be prompted to contact us.</p>
+
+      <form method="POST">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <button type="submit" class="button-as-link govuk-!-padding-0 moj-sub-navigation__item">
+          Request a new sign in link
+        </button>
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
### Introduction

As part of the new 2FA login flow, we need to add a 'Check your email' screen to Portal UI matching [this design](https://www.figma.com/file/L67W3CbcKYmFYqDUhaSG7A/User-admin?type=design&node-id=897-8999&mode=design&t=qRlYdl79ZXiZi09t-0) that will be (but not as part of this ticket) shown to the user after they click login.

### Resolution

Added the screen.

![image](https://github.com/UK-Export-Finance/dtfs2/assets/116292912/2a72ffdb-c56c-4363-a19f-8c842c9c7b0c)
