### PR TITLE
fix(DTFS2-6746): do not remove parties after updating bond beneficiary or issuer urns

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-beneficiary.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-beneficiary.spec.js
@@ -208,6 +208,29 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
 
         pages.partiesPage.bondBeneficiaryEditLink().should('exist');
       });
+
+      it('should not remove the exporter party URN when the beneficiary URNs are submitted', () => {
+        const exporterUrn = CONSTANTS.PARTY_URN.ANOTHER_VALID;
+        submitExporterUrn(exporterUrn);
+        pages.partiesPage.bondBeneficiaryEditLink().click();
+        pages.bondBeneficiaryPage.urnInput(1).clear();
+        pages.bondBeneficiaryPage.urnInput(2).clear();
+        pages.bondBeneficiaryPage.urnInput(1).type(partyUrn[0]);
+        pages.bondBeneficiaryPage.urnInput(2).type(partyUrn[1]);
+
+        pages.bondBeneficiaryPage.saveButton().click();
+        pages.bondBeneficiaryPage.saveButton().click();
+
+        pages.partiesPage.exporterUrn().should('contain', exporterUrn);
+      });
+
+      function submitExporterUrn(urn) {
+        pages.partiesPage.exporterEditLink().click();
+        pages.exporterPage.urnInput().clear();
+        pages.exporterPage.urnInput().type(urn);
+        pages.exporterPage.saveButton().click();
+        pages.exporterPage.saveButton().click();
+      }
     });
 
     describe('when the TFM user is NOT in `BUSINESS_SUPPORT` team', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-issuer.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-issuer.spec.js
@@ -208,6 +208,29 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
 
         pages.partiesPage.bondIssuerEditLink().should('exist');
       });
+
+      it('should not remove the exporter party URN when the issuer URNs are submitted', () => {
+        const exporterUrn = CONSTANTS.PARTY_URN.ANOTHER_VALID;
+        submitExporterUrn(exporterUrn);
+        pages.partiesPage.bondIssuerEditLink().click();
+        pages.bondIssuerPage.urnInput(1).clear();
+        pages.bondIssuerPage.urnInput(2).clear();
+        pages.bondIssuerPage.urnInput(1).type(partyUrn[0]);
+        pages.bondIssuerPage.urnInput(2).type(partyUrn[1]);
+
+        pages.bondIssuerPage.saveButton().click();
+        pages.bondIssuerPage.saveButton().click();
+
+        pages.partiesPage.exporterUrn().should('contain', exporterUrn);
+      });
+
+      function submitExporterUrn(urn) {
+        pages.partiesPage.exporterEditLink().click();
+        pages.exporterPage.urnInput().clear();
+        pages.exporterPage.urnInput().type(urn);
+        pages.exporterPage.saveButton().click();
+        pages.exporterPage.saveButton().click();
+      }
     });
 
     describe('when the TFM user is NOT in `BUSINESS_SUPPORT` team', () => {

--- a/e2e-tests/tfm/cypress/e2e/pages/partiesPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/partiesPage.js
@@ -2,6 +2,7 @@ const partiesPage = {
   partiesHeading: () => cy.get('[data-cy="parties-heading"]'),
   exporterArea: () => cy.get('[data-cy="parties-exporter"]'),
   exporterEditLink: () => cy.get('[data-cy="parties-exporter"] [data-cy="edit-party-link"]'),
+  exporterUrn: () => cy.get('[data-cy="exporter-unique-ref"]'),
   buyerArea: () => cy.get('[data-cy="parties-buyer"]'),
   buyerEditLink: () => cy.get('[data-cy="parties-buyer"] [data-cy="edit-party-link"]'),
   agentArea: () => cy.get('[data-cy="parties-agent"]'),

--- a/e2e-tests/tfm/cypress/fixtures/constants.js
+++ b/e2e-tests/tfm/cypress/fixtures/constants.js
@@ -73,6 +73,7 @@ const PARTIES = {
 const PARTY_URN = {
   INVALID: '1234',
   VALID: '00307249',
+  ANOTHER_VALID: '00307250',
 };
 
 module.exports = {

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -533,7 +533,7 @@ const postTfmFacility = async (req, res) => {
      * Trigger's ACBS upon bond `beneficiary`
      * and `issuer` URN criteria match.
      * */
-    await api.updateParty(dealId, deal.parties, userToken);
+    await api.updateParty(dealId, deal.tfm.parties, userToken);
 
     return res.redirect(`/case/${dealId}/parties`);
   } catch (error) {


### PR DESCRIPTION
## Introduction

After TFM UI updates the URN for the bond issuer/beneficiary, it calls `api.updateParty(dealId, deal.parties);` where `deal` is the response from `GET deals/:dealId` from TFM API (see `postTfmFacility` in TFM-UI for this). It does this because when TFM API receives updates a party, it then checks if the deal can be created in ACBS which relies on the parties that require URNs having URNs set and (for BSS/EWCS deals) the bond issuer and beneficiary having URNs set.

However `deal.parties` is always `undefined` on the response from `GET deals/:dealId` from TFM API.

The GraphQL endpoints that we had before DTFS2-6182 meant that no change was made to the deal's parties when we call `api.updateParty(dealId, undefined);` (but the logic to create the deal in ACBS still worked), but the REST endpoints we changed to in DTFS2-6182 delete the deal's parties when we call `api.updateParty(dealId, undefined);`,

This causes a bug that deletes the deal's party info after the bond issuer/beneficiary URNs are set.

## Resolution

I've changed the TFM UI to call `api.updateParty(dealId, deal.tfm.parties);` where `deal` is the response from `GET deals/:dealId` from TFM API, since `deal.tfm.parties` are the deal's parties.

I've added 2 e2e tests that check the exporter URN is not deleted when the bond issuer/beneficiary URNs are set