### PR TITLE
feat(DTFS2-6747): update login token handling

### DIFF
--- a/portal-api/api-tests/v1/users/reset-password.api-test.js
+++ b/portal-api/api-tests/v1/users/reset-password.api-test.js
@@ -15,6 +15,7 @@ const utils = require('../../../src/crypto/utils');
 
 jest.mock('../../../src/v1/email');
 const sendEmail = require('../../../src/v1/email');
+const { FEATURE_FLAGS } = require('../../../src/config/feature-flag.config');
 
 jest.mock('../../../src/v1/users/login.controller', () => ({
   ...jest.requireActual('../../../src/v1/users/login.controller'),
@@ -152,10 +153,18 @@ describe('password reset', () => {
           timestamp: expect.any(String),
         });
         const login = await as().post({ username: MOCK_USER.username, password: newPassword }).to('/v1/login');
-        expect(login.body).toMatchObject({
-          success: true,
-          user: { email: MOCK_USER.email },
-        });
+
+        // TODO DTFS2-6680: remove this feature flag check
+        if (!FEATURE_FLAGS.MAGIC_LINK) {
+          expect(login.body).toMatchObject({
+            success: true,
+            user: { email: MOCK_USER.email },
+          });
+        } else {
+          expect(login.body).toMatchObject({
+            success: true,
+          });
+        }
       });
     });
   });

--- a/portal-api/api-tests/v1/users/users.api-test.js
+++ b/portal-api/api-tests/v1/users/users.api-test.js
@@ -7,6 +7,8 @@ const { as } = require('../../api')(app);
 const users = require('./test-data');
 const { READ_ONLY, MAKER, CHECKER } = require('../../../src/v1/roles/roles');
 const { NON_READ_ONLY_ROLES } = require('../../../test-helpers/common-role-lists');
+const { LOGIN_STATUSES } = require('../../../src/constants');
+const { FEATURE_FLAGS } = require('../../../src/config/feature-flag.config');
 
 const aMaker = users.find((user) => user.username === 'MAKER');
 const MOCK_USER = { ...aMaker, username: 'TEMPORARY_USER' };
@@ -102,7 +104,7 @@ describe('a user', () => {
     it('rejects if the provided email address is not in valid format', async () => {
       const newUser = {
         ...MOCK_USER,
-        email: 'abc'
+        email: 'abc',
       };
 
       const { status, body } = await as(loggedInUser).post(newUser).to('/v1/users');
@@ -115,7 +117,7 @@ describe('a user', () => {
     it('rejects if the provided email address is empty', async () => {
       const newUser = {
         ...MOCK_USER,
-        email: ''
+        email: '',
       };
 
       const { status, body } = await as(loggedInUser).post(newUser).to('/v1/users');
@@ -153,10 +155,7 @@ describe('a user', () => {
     it.each(NON_READ_ONLY_ROLES)('rejects if the user creation request has the read-only role and the %s role', async (otherRole) => {
       const newUser = {
         ...MOCK_USER,
-        roles: [
-          READ_ONLY,
-          otherRole,
-        ]
+        roles: [READ_ONLY, otherRole],
       };
 
       const { status, body } = await as(loggedInUser).post(newUser).to('/v1/users');
@@ -169,10 +168,7 @@ describe('a user', () => {
     it('creates the user if the user creation request has the read-only role repeated', async () => {
       const newUser = {
         ...MOCK_USER,
-        roles: [
-          READ_ONLY,
-          READ_ONLY,
-        ]
+        roles: [READ_ONLY, READ_ONLY],
       };
 
       await as(loggedInUser).post(newUser).to('/v1/users');
@@ -185,9 +181,7 @@ describe('a user', () => {
     it('creates the user the user creation request has the read-only role only', async () => {
       const newUser = {
         ...MOCK_USER,
-        roles: [
-          READ_ONLY,
-        ]
+        roles: [READ_ONLY],
       };
 
       await as(loggedInUser).post(newUser).to('/v1/users');
@@ -319,7 +313,7 @@ describe('a user', () => {
     expect(body).toEqual({ msg: 'user is disabled', success: false });
   });
 
-  it('a known user can log in', async () => {
+  it('a known user can log in with a valid username and password', async () => {
     const { username, password } = MOCK_USER;
     await as(loggedInUser).post(MOCK_USER).to('/v1/users');
 
@@ -334,27 +328,102 @@ describe('a user', () => {
     delete expectedUserData.password;
 
     expect(status).toEqual(200);
-    expect(body).toEqual({
-      success: true,
-      token: expect.any(String),
-      user: expectedUserData,
-      expiresIn: '12h',
-    });
+
+    // TODO DTFS2-6680: remove this feature flag check
+    if (!FEATURE_FLAGS.MAGIC_LINK) {
+      expect(body).toEqual({
+        success: true,
+        token: expect.any(String),
+        user: expectedUserData,
+        expiresIn: '12h',
+      });
+    } else {
+      expect(body).toEqual({
+        success: true,
+        token: expect.any(String),
+        loginStatus: LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD,
+        expiresIn: '30m',
+      });
+    }
   });
 
-  it('a token can be validated', async () => {
+  // TODO DTFS2-6680: remove this feature flag check
+  if (FEATURE_FLAGS.MAGIC_LINK) {
+    it('a known user with an email link can log in', async () => {
+      const { username, password } = MOCK_USER;
+      await as(loggedInUser).post(MOCK_USER).to('/v1/users');
+
+      const { body: loginBody } = await as().post({ username, password }).to('/v1/login');
+      const { status: validateAuthenticationEmailStatus, body: validateAuthenticationEmailBody } = await as({ ...MOCK_USER, token: loginBody.token })
+        .post()
+        .to('/v1/users/validate-authentication-email/123');
+      const expectedUserData = {
+        ...MOCK_USER,
+        _id: expect.any(String),
+        timezone: 'Europe/London',
+        'user-status': 'active',
+      };
+      delete expectedUserData.password;
+
+      expect(validateAuthenticationEmailStatus).toEqual(200);
+      expect(validateAuthenticationEmailBody).toEqual({
+        success: true,
+        token: expect.any(String),
+        user: expectedUserData,
+        loginStatus: LOGIN_STATUSES.VALID_2FA,
+        expiresIn: '12h',
+      });
+    });
+
+    it('a known user with an email link without a token cannot log in', async () => {
+      await as(loggedInUser).post(MOCK_USER).to('/v1/users');
+
+      const { status: validateAuthenticationEmailStatus } = await as({ ...MOCK_USER })
+        .post()
+        .to('/v1/users/validate-authentication-email/123');
+      const expectedUserData = {
+        ...MOCK_USER,
+        _id: expect.any(String),
+        timezone: 'Europe/London',
+        'user-status': 'active',
+      };
+      delete expectedUserData.password;
+
+      expect(validateAuthenticationEmailStatus).toEqual(401);
+    });
+  }
+
+  it('a token from a fully logged in user can be validated', async () => {
     const { username, password } = MOCK_USER;
     await as(loggedInUser).post(MOCK_USER).to('/v1/users');
 
-    const loginResult = await as().post({ username, password }).to('/v1/login');
-
-    const { token } = loginResult.body;
+    const { body: loginBody } = await as().post({ username, password }).to('/v1/login');
+    const { body: validateAuthenticationEmailBody } = await as({ ...MOCK_USER, token: loginBody.token })
+      .post()
+      .to('/v1/users/validate-authentication-email/123');
+    // TODO DTFS2-6680: remove this feature flag check
+    const { token } = FEATURE_FLAGS.MAGIC_LINK ? validateAuthenticationEmailBody : loginBody;
 
     const { status } = await as({ token }).get('/v1/validate');
 
     expect(status).toEqual(200);
   });
 
+  // TODO DTFS2-6680: remove this feature flag check
+  if (FEATURE_FLAGS.MAGIC_LINK) {
+    it('a token from a partially logged in user cannot be validated', async () => {
+      const { username, password } = MOCK_USER;
+      await as(loggedInUser).post(MOCK_USER).to('/v1/users');
+
+      const { body: loginBody } = await as().post({ username, password }).to('/v1/login');
+
+      const { token } = loginBody;
+
+      const { status } = await as({ token }).get('/v1/validate');
+
+      expect(status).toEqual(401);
+    });
+  }
   it('invalid tokens fail validation', async () => {
     const token = 'some characters i think maybe look like a token';
 

--- a/portal-api/src/constants/index.js
+++ b/portal-api/src/constants/index.js
@@ -1,16 +1,18 @@
 const FACILITIES = require('./facilities');
 const DEAL = require('./deal');
-const LOGINRESULTS = require('./login-results');
+const LOGIN_RESULTS = require('./login-results');
 const USER = require('./user');
 const EMAIL_TEMPLATE_IDS = require('./email-template-ids');
 const CURRENCY = require('./currency');
 const PAYLOAD = require('./payloads');
+const LOGIN_STATUSES = require('./login-statuses');
 const SIGN_IN_LINK_EXPIRY_MINUTES = require('./sign-in-link-expiry-minutes');
 
 module.exports = {
   FACILITIES,
   DEAL,
-  LOGINRESULTS,
+  LOGIN_RESULTS,
+  LOGIN_STATUSES,
   USER,
   EMAIL_TEMPLATE_IDS,
   CURRENCY,

--- a/portal-api/src/constants/login-statuses.js
+++ b/portal-api/src/constants/login-statuses.js
@@ -1,0 +1,4 @@
+module.exports = {
+  VALID_USERNAME_AND_PASSWORD: 'Valid username and password',
+  VALID_2FA: 'Valid 2FA',
+};

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -1,0 +1,87 @@
+const jsonwebtoken = require('jsonwebtoken');
+const crypto = require('crypto');
+const { issueValidUsernameAndPasswordJWT, issueValid2faJWT } = require('./utils');
+const { MAKER } = require('../v1/roles/roles');
+const { LOGIN_STATUSES } = require('../constants');
+
+describe('crypto utils', () => {
+  const user = {
+    username: 'HSBC-maker-1',
+    password: 'P@ssword1234',
+    firstname: 'Mister',
+    surname: 'One',
+    email: 'one@email.com',
+    timezone: 'Europe/London',
+    roles: [MAKER],
+    bank: {
+      id: '961',
+      name: 'HSBC',
+      emails: ['maker1@ukexportfinance.gov.uk', 'maker2@ukexportfinance.gov.uk'],
+    },
+  };
+
+  const existingSessionIdentifier = crypto.randomBytes(32).toString('hex');
+
+  const userWithExistingSessionIdentifier = { ...user, sessionIdentifier: existingSessionIdentifier };
+
+  describe('issueValidUsernameAndPasswordJWT', () => {
+    it('should not use an existing session identifier', () => {
+      const { sessionIdentifier } = issueValidUsernameAndPasswordJWT(userWithExistingSessionIdentifier);
+      expect(sessionIdentifier).not.toEqual(existingSessionIdentifier);
+    });
+
+    it('should return a session identifier', () => {
+      const { sessionIdentifier } = issueValidUsernameAndPasswordJWT(user);
+      expect(is32ByteHex(sessionIdentifier)).toEqual(true);
+    });
+
+    it('should return a token with the expected payload', () => {
+      const { token, sessionIdentifier } = issueValidUsernameAndPasswordJWT(user);
+      const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
+      expect(decodedToken.iat).toBeDefined();
+      expect(decodedToken.exp).toBeDefined();
+      expect(decodedToken.username).toEqual(user.username);
+      expect(decodedToken.loginStatus).toEqual(LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD);
+      expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);
+    });
+
+    it('should return the correct expiry time', () => {
+      const { expires } = issueValidUsernameAndPasswordJWT(user);
+      expect(expires).toEqual('30m');
+    });
+  });
+
+  describe('issueValid2faJWT', () => {
+    it('should throw an error if no existing session identifier is present', () => {
+      expect(() => issueValid2faJWT(user)).toThrow('User does not have a session identifier');
+    });
+
+    it('should return the input session identifier', () => {
+      const { sessionIdentifier } = issueValid2faJWT(userWithExistingSessionIdentifier);
+      expect(is32ByteHex(sessionIdentifier)).toEqual(true);
+      expect(sessionIdentifier).toEqual(existingSessionIdentifier);
+    });
+
+    it('should return a token with the expected payload', () => {
+      const { token, sessionIdentifier } = issueValid2faJWT(userWithExistingSessionIdentifier);
+      const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
+      expect(decodedToken.iat).toBeDefined();
+      expect(decodedToken.exp).toBeDefined();
+      expect(decodedToken.username).toEqual(user.username);
+      expect(decodedToken.loginStatus).toEqual(LOGIN_STATUSES.VALID_2FA);
+      expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);
+      expect(decodedToken.sessionIdentifier).toEqual(existingSessionIdentifier);
+      expect(decodedToken.roles).toEqual(user.roles);
+      expect(decodedToken.bank).toEqual(user.bank);
+    });
+
+    it('should return the correct expiry time', () => {
+      const { expires } = issueValid2faJWT(userWithExistingSessionIdentifier);
+      expect(expires).toEqual('12h');
+    });
+  });
+
+  function is32ByteHex(str) {
+    return /^[0-9a-fA-F]{64}$/.test(str);
+  }
+});

--- a/portal-api/src/generateApp.js
+++ b/portal-api/src/generateApp.js
@@ -8,7 +8,7 @@ const healthcheck = require('./healthcheck');
 
 dotenv.config();
 const { CORS_ORIGIN } = process.env;
-const configurePassport = require('./v1/users/passport');
+const { loginInProcessAuth, loginCompleteAuth } = require('./v1/users/passport');
 const { authRouter, openRouter } = require('./v1/routes');
 const seo = require('./v1/middleware/headers/seo');
 const security = require('./v1/middleware/headers/security');
@@ -16,7 +16,9 @@ const removeCsrfToken = require('./v1/middleware/remove-csrf-token');
 const createRateLimit = require('./v1/middleware/rateLimit');
 
 const generateApp = () => {
-  configurePassport(passport);
+  // Setup for token authentication via Passport
+  loginInProcessAuth(passport);
+  loginCompleteAuth(passport);
 
   const app = express();
 
@@ -30,14 +32,18 @@ const generateApp = () => {
   app.use(removeCsrfToken);
 
   // MongoDB sanitisation
-  app.use(mongoSanitise({
-    allowDots: true,
-  }));
+  app.use(
+    mongoSanitise({
+      allowDots: true,
+    }),
+  );
 
-  app.use(cors({
-    origin: CORS_ORIGIN,
-    allowedHeaders: ['Content-Type', 'Authorization'],
-  }));
+  app.use(
+    cors({
+      origin: CORS_ORIGIN,
+      allowedHeaders: ['Content-Type', 'Authorization'],
+    }),
+  );
 
   app.use('/v1', openRouter);
   app.use('/v1', authRouter);
@@ -54,10 +60,12 @@ const generateApp = () => {
 
   app.use('/', rootRouter);
 
-  app.use((error) => { console.error(error); });
+  app.use((error) => {
+    console.error(error);
+  });
   return app;
 };
 
 module.exports = {
-  generateApp
+  generateApp,
 };

--- a/portal-api/src/v1/routes.js
+++ b/portal-api/src/v1/routes.js
@@ -2,12 +2,7 @@ const express = require('express');
 const passport = require('passport');
 
 const { validateUserHasAtLeastOneAllowedRole } = require('./roles/validate-user-has-at-least-one-allowed-role');
-const {
-  MAKER,
-  CHECKER,
-  READ_ONLY,
-  ADMIN,
-} = require('./roles/roles');
+const { MAKER, CHECKER, READ_ONLY, ADMIN } = require('./roles/roles');
 
 const dealsController = require('./controllers/deal.controller');
 const dealName = require('./controllers/deal-name.controller');
@@ -55,11 +50,18 @@ openRouter.route('/feedback').post(checkApiKey, feedback.create);
 // This endpoint is only used by mock-data-loader, for setting up an initial user
 openRouter.route('/user').post(checkApiKey, users.create);
 
+// TODO DTFS2-6680: ensure this endpoint is used
+openRouter.route('/users/send-authentication-email').post(passport.authenticate('login-in-progress', { session: false }), users.sendAuthenticationEmail);
+
+openRouter
+  .route('/users/validate-authentication-email/:loginAuthenticationToken')
+  .post(passport.authenticate('login-in-progress', { session: false }), users.validateAuthenticationEmail);
+
 // Auth router requires authentication
 const authRouter = express.Router();
 
 // Authentication type: JWT + Passport
-authRouter.use(passport.authenticate('jwt', { session: false }));
+authRouter.use(passport.authenticate('login-complete', { session: false }));
 
 /**
  * Mandatory Criteria routes
@@ -90,7 +92,9 @@ authRouter.route('/users/:_id/disable').delete(users.disable);
 authRouter.use('/gef', gef);
 
 authRouter.route('/deals').post(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), dealsController.create);
-authRouter.route('/deals').get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), dealsController.getQueryAllDeals);
+authRouter
+  .route('/deals')
+  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), dealsController.getQueryAllDeals);
 
 authRouter
   .route('/deals/:id/status')
@@ -111,8 +115,12 @@ authRouter
   .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), loans.updateLoan)
   .delete(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), loans.deleteLoan);
 
-authRouter.route('/deals/:id/loan/:loanId/issue-facility').put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), loanIssueFacility.updateLoanIssueFacility);
-authRouter.route('/deals/:id/loan/:loanId/change-cover-start-date').put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), loanChangeCoverStartDate.updateLoanCoverStartDate);
+authRouter
+  .route('/deals/:id/loan/:loanId/issue-facility')
+  .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), loanIssueFacility.updateLoanIssueFacility);
+authRouter
+  .route('/deals/:id/loan/:loanId/change-cover-start-date')
+  .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), loanChangeCoverStartDate.updateLoanCoverStartDate);
 authRouter.route('/deals/:id/bond/create').put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bonds.create);
 
 authRouter
@@ -121,11 +129,19 @@ authRouter
   .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bonds.updateBond)
   .delete(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bonds.deleteBond);
 
-authRouter.route('/deals/:id/bond/:bondId/issue-facility').put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bondIssueFacility.updateBondIssueFacility);
-authRouter.route('/deals/:id/bond/:bondId/change-cover-start-date').put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bondChangeCoverStartDate.updateBondCoverStartDate);
-authRouter.route('/deals/:id/multiple-facilities').post(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), facilitiesController.createMultiple);
+authRouter
+  .route('/deals/:id/bond/:bondId/issue-facility')
+  .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bondIssueFacility.updateBondIssueFacility);
+authRouter
+  .route('/deals/:id/bond/:bondId/change-cover-start-date')
+  .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), bondChangeCoverStartDate.updateBondCoverStartDate);
+authRouter
+  .route('/deals/:id/multiple-facilities')
+  .post(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), facilitiesController.createMultiple);
 
-authRouter.route('/facilities').get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), facilitiesController.getQueryAllFacilities);
+authRouter
+  .route('/facilities')
+  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), facilitiesController.getQueryAllFacilities);
 
 authRouter
   .route('/deals/:id')
@@ -134,7 +150,9 @@ authRouter
   .delete(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), dealsController.delete);
 
 authRouter.route('/deals/:id/clone').post(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), dealClone.clone);
-authRouter.route('/deals/:id/eligibility-criteria').put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), dealEligibilityCriteria.update);
+authRouter
+  .route('/deals/:id/eligibility-criteria')
+  .put(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), dealEligibilityCriteria.update);
 authRouter.route('/deals/:id/eligibility-documentation').put(
   validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }),
   (req, res, next) => {
@@ -194,8 +212,13 @@ authRouter
   .delete(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [ADMIN] }), eligibilityCriteria.delete);
 
 // Portal reports
-authRouter.route('/reports/unissued-facilities').get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), unissuedFacilitiesReport.findUnissuedFacilitiesReports);
-authRouter.route('/reports/review-ukef-decision').get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), ukefDecisionReport.reviewUkefDecisionReports);
+authRouter
+  .route('/reports/unissued-facilities')
+  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), unissuedFacilitiesReport.findUnissuedFacilitiesReports);
+
+authRouter
+  .route('/reports/review-ukef-decision')
+  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER, READ_ONLY, ADMIN] }), ukefDecisionReport.reviewUkefDecisionReports);
 
 // token-validator
 authRouter.get('/validate', (req, res) => {

--- a/portal-api/src/v1/users/authentication-email.controller.js
+++ b/portal-api/src/v1/users/authentication-email.controller.js
@@ -1,0 +1,26 @@
+const sendEmail = require('../email');
+const { updateLastLogin } = require('./controller');
+const utils = require('../../crypto/utils');
+
+const sendAuthenticationEmail = async (emailAddress, token) => {
+  // TODO DTFS2-6680: update template Id
+  // TODO DTFS2-6680: check email address against user email
+  const EMAIL_TEMPLATE_ID = '6935e539-1a0c-4eca-a6f3-f239402c0987';
+
+  await sendEmail(EMAIL_TEMPLATE_ID, emailAddress, {
+    token,
+  });
+};
+
+// eslint-disable-next-line no-unused-vars
+const validateAuthenticationEmailToken = async (user, loginAuthenticationToken) => {
+  // TODO DTFS2-6680: Check that the user here has the loginAuthenticationToken
+  // TODO DTFS2-6680: Remove this lint disable
+  const { sessionIdentifier, ...tokenObject } = utils.issueValid2faJWT(user);
+  return new Promise((resolve) => {
+    updateLastLogin(user, sessionIdentifier, () => resolve({ tokenObject, user }));
+  });
+};
+
+module.exports.sendAuthenticationEmail = sendAuthenticationEmail;
+module.exports.validateAuthenticationEmailToken = validateAuthenticationEmailToken;

--- a/portal-api/src/v1/users/authentication-email.controller.test.js
+++ b/portal-api/src/v1/users/authentication-email.controller.test.js
@@ -1,0 +1,91 @@
+const { when } = require('jest-when');
+const { sendAuthenticationEmail, validateAuthenticationEmailToken } = require('./authentication-email.controller');
+
+jest.mock('../email');
+const sendEmail = require('../email');
+
+jest.mock('../../crypto/utils');
+const utils = require('../../crypto/utils');
+
+jest.mock('./controller');
+const userController = require('./controller');
+const { MAKER } = require('../roles/roles');
+
+describe('authentication email controller', () => {
+  describe('sendAuthenticationEmail', () => {
+    const EXPECTED_EMAIL_TEMPLATE_ID = '6935e539-1a0c-4eca-a6f3-f239402c0987';
+    const EMAIL_ADDRESS = 'example@example.com';
+    const TOKEN = '1234567890';
+
+    it('should call sendEmail with expected parameters', async () => {
+      await sendAuthenticationEmail(EMAIL_ADDRESS, TOKEN);
+      expect(sendEmail).toHaveBeenCalledWith(EXPECTED_EMAIL_TEMPLATE_ID, EMAIL_ADDRESS, { token: TOKEN });
+    });
+  });
+
+  describe('validateAuthenticationEmailToken', () => {
+    const TEST_USER = {
+      username: 'HSBC-maker-1',
+      password: 'P@ssword1234',
+      firstname: 'Mister',
+      surname: 'One',
+      email: 'one@email.com',
+      timezone: 'Europe/London',
+      roles: [MAKER],
+      bank: {
+        id: '961',
+        name: 'HSBC',
+        emails: ['maker1@ukexportfinance.gov.uk', 'maker2@ukexportfinance.gov.uk'],
+      },
+    };
+
+    const TEST_TOKEN = '1234567890';
+
+    const SUCCESSFUL_JWT = {
+      token: `Bearer ${TEST_TOKEN}`,
+      expires: '12h',
+      sessionIdentifier: 'MockSessionId',
+    };
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('should return the token and user if the validation is successful', async () => {
+      when(utils.issueValid2faJWT).calledWith(TEST_USER).mockReturnValue(SUCCESSFUL_JWT);
+      when(userController.updateLastLogin)
+        .calledWith(TEST_USER, SUCCESSFUL_JWT.sessionIdentifier, expect.any(Function))
+        .mockImplementation((user, sessionIdentifier, callback) => callback());
+
+      const { tokenObject, user } = await validateAuthenticationEmailToken(TEST_USER, TEST_TOKEN);
+
+      expect(tokenObject).toEqual({ token: SUCCESSFUL_JWT.token, expires: SUCCESSFUL_JWT.expires });
+      expect(user).toEqual(TEST_USER);
+    });
+
+    it('should throw an error if issuing of the JWT fails', async () => {
+      when(utils.issueValid2faJWT)
+        .calledWith(TEST_USER)
+        .mockImplementation(() => {
+          throw new Error('User does not have a session identifier');
+        });
+      when(userController.updateLastLogin)
+        .calledWith(TEST_USER, SUCCESSFUL_JWT.sessionIdentifier, expect.any(Function))
+        .mockImplementation((user, sessionIdentifier, callback) => callback());
+
+      await expect(validateAuthenticationEmailToken(TEST_USER, TEST_TOKEN)).rejects.toThrow('User does not have a session identifier');
+    });
+
+    it('should throw an error if updating last login fails', async () => {
+      when(utils.issueValid2faJWT).calledWith(TEST_USER).mockReturnValue(SUCCESSFUL_JWT);
+
+      when(userController.updateLastLogin)
+        .calledWith(TEST_USER, SUCCESSFUL_JWT.sessionIdentifier, expect.any(Function))
+        .mockImplementation(() => {
+          throw new Error('Invalid User Id');
+        });
+
+      await expect(validateAuthenticationEmailToken(TEST_USER, TEST_TOKEN)).rejects.toThrow('Invalid User Id');
+    });
+  });
+});

--- a/portal-api/src/v1/users/controller.test.js
+++ b/portal-api/src/v1/users/controller.test.js
@@ -1,0 +1,66 @@
+jest.mock('../../drivers/db-client');
+const { ObjectId } = require('mongodb');
+const { when } = require('jest-when');
+const db = require('../../drivers/db-client');
+const { MAKER } = require('../roles/roles');
+const { updateSessionIdentifier, updateLastLogin } = require('./controller');
+
+describe('user controller', () => {
+  const TEST_USER = {
+    _id: '075bcd157dcb851180e02a7c',
+    username: 'HSBC-maker-1',
+    password: 'P@ssword1234',
+    firstname: 'Mister',
+    surname: 'One',
+    email: 'one@email.com',
+    timezone: 'Europe/London',
+    roles: [MAKER],
+    bank: {
+      id: '961',
+      name: 'HSBC',
+      emails: ['maker1@ukexportfinance.gov.uk', 'maker2@ukexportfinance.gov.uk'],
+    },
+  };
+
+  const SESSION_IDENTIFIER = 'MockSessionId';
+
+  describe.each([
+    {
+      testName: 'updateSessionIdentifier',
+      callTestMethod: (user, sessionIdentifier, callback) => updateSessionIdentifier(user, sessionIdentifier, callback),
+      expectedUpdate: { sessionIdentifier: SESSION_IDENTIFIER },
+    },
+    {
+      testName: 'updateLastLogin',
+      callTestMethod: (user, sessionIdentifier, callback) => updateLastLogin(user, sessionIdentifier, callback),
+      expectedUpdate: { lastLogin: expect.any(String), loginFailureCount: 0, sessionIdentifier: SESSION_IDENTIFIER },
+    },
+  ])('$testName', ({ callTestMethod, expectedUpdate }) => {
+    let mockUpdateOne;
+
+    beforeEach(() => {
+      mockUpdateOne = jest.fn();
+      when(db.getCollection).calledWith('users').mockResolvedValue({ updateOne: mockUpdateOne });
+    });
+
+    it('should throw an error if the user id is invalid', async () => {
+      const TEST_USER_INVALID_ID = { ...TEST_USER, _id: 'invalid' };
+      await expect(callTestMethod(TEST_USER_INVALID_ID, SESSION_IDENTIFIER, () => {})).rejects.toThrow('Invalid User Id');
+    });
+
+    it('should throw an error if the session identifier is not provided', async () => {
+      await expect(callTestMethod(TEST_USER, null, () => {})).rejects.toThrow('No session identifier was provided');
+    });
+
+    it('should update the session identifier', async () => {
+      await callTestMethod(TEST_USER, SESSION_IDENTIFIER, () => {});
+      expect(mockUpdateOne).toHaveBeenCalledWith({ _id: { $eq: ObjectId(TEST_USER._id) } }, { $set: expectedUpdate }, {});
+    });
+
+    it('should call the callback if successful', async () => {
+      const mockCallback = jest.fn();
+      await callTestMethod(TEST_USER, SESSION_IDENTIFIER, mockCallback);
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/portal-api/src/v1/users/login.controller.js
+++ b/portal-api/src/v1/users/login.controller.js
@@ -1,6 +1,7 @@
 const utils = require('../../crypto/utils');
 const { userIsBlocked, userIsDisabled, usernameOrPasswordIncorrect } = require('../../constants/login-results');
-const { findByUsername, updateLastLogin, incrementFailedLoginCount } = require('./controller');
+const { findByUsername, updateLastLogin, incrementFailedLoginCount, updateSessionIdentifier } = require('./controller');
+const { FEATURE_FLAGS } = require('../../config/feature-flag.config');
 const sendEmail = require('../email');
 const CONSTANTS = require('../../constants');
 
@@ -30,9 +31,14 @@ module.exports.login = (username, password) =>
         return resolve({ error: userIsBlocked });
       }
 
-      const { sessionIdentifier, ...tokenObject } = utils.issueJWT(user);
-
-      return updateLastLogin(user, sessionIdentifier, () => resolve({ user, tokenObject }));
+      let sessionIdentifier;
+      let tokenObject;
+      if (!FEATURE_FLAGS.MAGIC_LINK) {
+        ({ sessionIdentifier, ...tokenObject } = utils.issueJWT(user));
+        return updateLastLogin(user, sessionIdentifier, () => resolve({ user, tokenObject }));
+      }
+      ({ sessionIdentifier, ...tokenObject } = utils.issueValidUsernameAndPasswordJWT(user));
+      return updateSessionIdentifier(user, sessionIdentifier, () => resolve({ tokenObject }));
     });
   });
 

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -7,6 +7,8 @@ const { sanitizeUser, sanitizeUsers } = require('./sanitizeUserData');
 const { applyCreateRules, applyUpdateRules } = require('./validation');
 const { isValidEmail } = require('../../utils/string');
 const { FEATURE_FLAGS } = require('../../config/feature-flag.config');
+const { LOGIN_STATUSES } = require('../../constants');
+const { validateAuthenticationEmailToken } = require('./authentication-email.controller');
 
 module.exports.list = (req, res, next) => {
   list((error, users) => {
@@ -203,7 +205,36 @@ const sendSignInLinkEmailAndHandleErrors = (next) => async (error, user) => {
 module.exports.sendSignInLinkEmailAndHandleErrors = sendSignInLinkEmailAndHandleErrors;
 
 module.exports.login = async (req, res, next) => {
-  // TODO DTFS2-6680: Remove old login functionality
+  if (!FEATURE_FLAGS.MAGIC_LINK) {
+    // TODO DTFS2-6680: Remove old login functionality
+    const { username, password } = req.body;
+
+    const loginResult = await login(username, password);
+
+    if (loginResult.error) {
+      // pick out the specific cases we understand and could treat differently
+      if (usernameOrPasswordIncorrect === loginResult.error) {
+        return res.status(401).json({ success: false, msg: 'email or password is incorrect' });
+      }
+      if (userIsBlocked === loginResult.error) {
+        return res.status(401).json({ success: false, msg: 'user is blocked' });
+      }
+      if (userIsDisabled === loginResult.error) {
+        return res.status(401).json({ success: false, msg: 'user is disabled' });
+      }
+
+      // otherwise this is a technical failure during the lookup
+      return next(loginResult.error);
+    }
+    const { tokenObject, user } = loginResult;
+
+    return res.status(200).json({
+      success: true,
+      token: tokenObject.token,
+      user: sanitizeUser(user),
+      expiresIn: tokenObject.expires,
+    });
+  }
   const { username, password } = req.body;
 
   const loginResult = await login(username, password);
@@ -224,16 +255,36 @@ module.exports.login = async (req, res, next) => {
     return next(loginResult.error);
   }
 
-  if (FEATURE_FLAGS.MAGIC_LINK) {
-    findByUsername(username, sendSignInLinkEmailAndHandleErrors(next));
-  }
+  findByUsername(username, sendSignInLinkEmailAndHandleErrors(next));
 
-  const { tokenObject, user } = loginResult;
+  const { tokenObject } = loginResult;
+  return res.status(200).json({
+    success: true,
+    token: tokenObject.token,
+    loginStatus: LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD,
+    expiresIn: tokenObject.expires,
+  });
+};
+
+// eslint-disable-next-line no-unused-vars
+module.exports.sendAuthenticationEmail = async (req, res) =>
+  // TODO DTFS2-6680: This actually needs to send an email
+  // TODO DTFS2-6680: Remove this lint disable
+  res.status(200).send();
+
+module.exports.validateAuthenticationEmail = async (req, res) => {
+  // TODO DTFS2-6680: This actually needs to validate the email guid
+  // TODO DTFS2-6680: When validating the email link we need to make sure the email in the token matches the email for which the link was generated
+  const { loginAuthenticationToken } = req.params;
+  const { user } = req;
+
+  const { tokenObject, user: completeUser } = await validateAuthenticationEmailToken(user, loginAuthenticationToken);
 
   return res.status(200).json({
     success: true,
     token: tokenObject.token,
-    user: sanitizeUser(user),
+    user: sanitizeUser(completeUser),
+    loginStatus: LOGIN_STATUSES.VALID_2FA,
     expiresIn: tokenObject.expires,
   });
 };

--- a/portal/api-tests/admin-routes.api-test.js
+++ b/portal/api-tests/admin-routes.api-test.js
@@ -1,10 +1,12 @@
 jest.mock('csurf', () => () => (req, res, next) => next());
 jest.mock('../server/routes/middleware/csrf', () => ({
-  ...(jest.requireActual('../server/routes/middleware/csrf')),
+  ...jest.requireActual('../server/routes/middleware/csrf'),
   csrfToken: () => (req, res, next) => next(),
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
   updateUser: jest.fn(),
   banks: jest.fn(),
@@ -14,10 +16,11 @@ jest.mock('../server/helpers/getApiData', () => () => []);
 
 const app = require('../server/createApp');
 const { ADMIN } = require('../server/constants/roles');
-const loginAsRole = require('./helpers/loginAsRole');
+const mockLogin = require('./helpers/login');
 const extractSessionCookie = require('./helpers/extractSessionCookie');
-const { login, updateUser } = require('../server/api');
+const { login, updateUser, validateAuthenticationEmail } = require('../server/api');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
+const validateAuthenticationEmailAsRole = require('./helpers/validateAuthenticationEmailAsRole');
 const { get, post } = require('./create-api').createApi(app);
 
 const email = 'mock email';
@@ -27,8 +30,10 @@ let sessionCookie;
 
 describe('user routes', () => {
   beforeEach(async () => {
-    login.mockImplementation(loginAsRole(ADMIN));
+    login.mockImplementation(mockLogin());
+    validateAuthenticationEmail.mockImplementation(validateAuthenticationEmailAsRole(ADMIN));
     sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
+    await get('/login/validate-email-link/123', {}, { Cookie: [sessionCookie] });
     updateUser.mockImplementation(() => Promise.resolve({ status: 200 }));
   });
 
@@ -77,7 +82,7 @@ describe('user routes', () => {
     });
 
     describe('happy path', () => {
-      it('redirects to \'/admin/users\' if the Portal API call to update the user returns a 200', async () => {
+      it("redirects to '/admin/users' if the Portal API call to update the user returns a 200", async () => {
         const response = await post({}, { Cookie: [sessionCookie] }).to(`/admin/users/edit/${_id}`);
 
         expect(response.status).toBe(302);

--- a/portal/api-tests/common-tests/role-validation-api-tests.js
+++ b/portal/api-tests/common-tests/role-validation-api-tests.js
@@ -1,9 +1,10 @@
-const { login } = require('../../server/api');
+const { login, validateAuthenticationEmail } = require('../../server/api');
 const { ROLES } = require('../../server/constants');
 const app = require('../../server/createApp');
 const extractSessionCookie = require('../helpers/extractSessionCookie');
-const loginAsRole = require('../helpers/loginAsRole');
-const { post } = require('../create-api').createApi(app);
+const mockLogin = require('../helpers/login');
+const validateAuthenticationEmailAsRole = require('../helpers/validateAuthenticationEmailAsRole');
+const { post, get } = require('../create-api').createApi(app);
 
 const allRoles = Object.values(ROLES);
 const email = 'mock email';
@@ -20,47 +21,45 @@ const withRoleValidationApiTests = ({
   const nonWhitelistedRoles = allRoles.filter((role) => !whitelistedRoles.includes(role));
 
   describe('role validation', () => {
-    if (!disableHappyPath) { // TODO DTFS2-6654: remove and test happy paths.
+    if (!disableHappyPath) {
+      // TODO DTFS2-6654: remove and test happy paths.
       if (whitelistedRoles.length) {
         describe('whitelisted roles', () => {
-          it.each(whitelistedRoles)(
-            `returns a ${successCode} response if the user only has the '%s' role`,
-            async (allowedRole) => {
-              login.mockImplementation(loginAsRole(allowedRole));
+          it.each(whitelistedRoles)(`returns a ${successCode} response if the user only has the '%s' role`, async (allowedRole) => {
+            login.mockImplementation(mockLogin());
+            validateAuthenticationEmail.mockImplementation(validateAuthenticationEmailAsRole(allowedRole));
 
-              const sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
+            const sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
+            await get('/login/validate-email-link/123', {}, { Cookie: sessionCookie })
+              .then(extractSessionCookie);
+            const response = await makeRequestWithHeaders({ Cookie: [sessionCookie] });
 
-              const response = await makeRequestWithHeaders({ Cookie: [sessionCookie] });
+            expect(response.status).toBe(successCode);
 
-              expect(response.status).toBe(successCode);
-
-              if (successHeaders) {
-                for (const [key, value] of Object.entries(successHeaders)) {
-                  expect(response.headers[key]).toBe(value);
-                }
+            if (successHeaders) {
+              for (const [key, value] of Object.entries(successHeaders)) {
+                expect(response.headers[key]).toBe(value);
               }
-            },
-          );
+            }
+          });
         });
       }
     }
 
     if (nonWhitelistedRoles.length) {
       describe('non-whitelisted roles', () => {
-        it.each(nonWhitelistedRoles)(
-          'returns a 302 response if the user only has the \'%s\' role',
-          async (disallowedRole) => {
-            login.mockImplementation(loginAsRole(disallowedRole));
+        it.each(nonWhitelistedRoles)("returns a 302 response if the user only has the '%s' role", async (disallowedRole) => {
+          login.mockImplementation(mockLogin());
+          validateAuthenticationEmail.mockImplementation(validateAuthenticationEmailAsRole(disallowedRole));
 
-            const sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
+          const sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
 
-            const response = await makeRequestWithHeaders({ Cookie: [sessionCookie] });
+          const response = await makeRequestWithHeaders({ Cookie: [sessionCookie] });
 
-            expect(response.status).toBe(302);
-            const redirectUrl = redirectUrlForInvalidRoles ?? '/';
-            expect(response.headers.location).toBe(redirectUrl);
-          },
-        );
+          expect(response.status).toBe(302);
+          const redirectUrl = redirectUrlForInvalidRoles ?? '/';
+          expect(response.headers.location).toBe(redirectUrl);
+        });
       });
     }
   });

--- a/portal/api-tests/contract/about-routes.api-test.js
+++ b/portal/api-tests/contract/about-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/contract/bond-routes.api-test.js
+++ b/portal/api-tests/contract/bond-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/contract/contract-routes.api-test.js
+++ b/portal/api-tests/contract/contract-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/contract/loan-routes.api-test.js
+++ b/portal/api-tests/contract/loan-routes.api-test.js
@@ -1,15 +1,20 @@
 jest.mock('csurf', () => () => (req, res, next) => next());
 jest.mock('../../server/routes/middleware/csrf', () => ({
-  ...(jest.requireActual('../../server/routes/middleware/csrf')),
+  ...jest.requireActual('../../server/routes/middleware/csrf'),
   csrfToken: () => (req, res, next) => next(),
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 jest.mock('../../server/routes/api-data-provider', () => ({
-  ...(jest.requireActual('../../server/routes/api-data-provider')),
-  provide: () => (req, res, next) => { req.apiData = { deal: { details: {} }, loan: { validationErrors: {} } }; return next(); },
+  ...jest.requireActual('../../server/routes/api-data-provider'),
+  provide: () => (req, res, next) => {
+    req.apiData = { deal: { details: {} }, loan: { validationErrors: {} } };
+    return next();
+  },
 }));
 
 const { withRoleValidationApiTests } = require('../common-tests/role-validation-api-tests');

--- a/portal/api-tests/dashboard-routes.api-test.js
+++ b/portal/api-tests/dashboard-routes.api-test.js
@@ -1,10 +1,12 @@
 jest.mock('csurf', () => () => (req, res, next) => next());
 jest.mock('../server/routes/middleware/csrf', () => ({
-  ...(jest.requireActual('../server/routes/middleware/csrf')),
+  ...jest.requireActual('../server/routes/middleware/csrf'),
   csrfToken: () => (req, res, next) => next(),
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/eligibility-routes.api-test.js
+++ b/portal/api-tests/eligibility-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/feedback-routes.api-test.js
+++ b/portal/api-tests/feedback-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/footer-routes.api-test.js
+++ b/portal/api-tests/footer-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/helpers/login.js
+++ b/portal/api-tests/helpers/login.js
@@ -1,0 +1,7 @@
+const login = () => () => ({
+  success: true,
+  token: 'mock login token',
+  loginStatus: 'Valid username and password',
+});
+
+module.exports = login;

--- a/portal/api-tests/helpers/loginAsRole.js
+++ b/portal/api-tests/helpers/loginAsRole.js
@@ -1,7 +1,0 @@
-const loginAsRole = (role) => () => ({
-  success: true,
-  token: 'mock token',
-  user: { roles: [role] },
-});
-
-module.exports = loginAsRole;

--- a/portal/api-tests/helpers/validateAuthenticationEmailAsRole.js
+++ b/portal/api-tests/helpers/validateAuthenticationEmailAsRole.js
@@ -1,0 +1,7 @@
+const validateAuthenticationEmailAsRole = (role) => () => ({
+  success: true,
+  token: 'mock 2FA validated token',
+  user: { roles: [role] },
+});
+
+module.exports = validateAuthenticationEmailAsRole;

--- a/portal/api-tests/login-routes.api-test.js
+++ b/portal/api-tests/login-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 
@@ -29,6 +31,22 @@ describe('login routes', () => {
   describe('POST /login', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to('/login'),
+      whitelistedRoles: allRoles,
+      successCode: 200,
+    });
+  });
+
+  describe('GET /login/validate-email-link/:loginAuthenticationToken', () => {
+    withRoleValidationApiTests({
+      makeRequestWithHeaders: (headers) => get('/login/validate-email-link/123', headers),
+      whitelistedRoles: allRoles,
+      successCode: 302,
+    });
+  });
+
+  describe('GET /login/check-your-email', () => {
+    withRoleValidationApiTests({
+      makeRequestWithHeaders: (headers) => get('/login/check-your-email', headers),
       whitelistedRoles: allRoles,
       successCode: 200,
     });

--- a/portal/api-tests/portal-routes.api-test.js
+++ b/portal/api-tests/portal-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/scheme-type-routes.api-test.js
+++ b/portal/api-tests/scheme-type-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/start-routes.api-test.js
+++ b/portal/api-tests/start-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/static-routes.api-test.js
+++ b/portal/api-tests/static-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/user-routes.api-test.js
+++ b/portal/api-tests/user-routes.api-test.js
@@ -5,6 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
+  sendAuthenticationEmail: jest.fn(),
+  validateAuthenticationEmail: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/component-tests/contract/components/bond-transactions-table.component-test.js
+++ b/portal/component-tests/contract/components/bond-transactions-table.component-test.js
@@ -76,7 +76,7 @@ describe(component, () => {
     });
 
     describe('when a bond Cover Date can be modified', () => {
-      it.only('should render `change or confirm cover start date` link and NOT `issue facility`', () => {
+      it('should render `change or confirm cover start date` link and NOT `issue facility`', () => {
         const wrapper = render({
           user,
           deal: dealWithBondsThatCanChangeCoverDate,

--- a/portal/server/helpers/requestParams.js
+++ b/portal/server/helpers/requestParams.js
@@ -4,6 +4,7 @@ const requestParams = (req) => {
     bondId,
     loanId,
     pwdResetToken,
+    loginAuthenticationToken,
   } = req.params;
   const { userToken } = req.session;
 
@@ -12,6 +13,7 @@ const requestParams = (req) => {
     bondId,
     loanId,
     pwdResetToken,
+    loginAuthenticationToken,
     userToken,
   };
 };

--- a/utils/mock-data-loader/api.js
+++ b/utils/mock-data-loader/api.js
@@ -4,10 +4,7 @@ require('dotenv').config();
 const { gef } = require('./gef/api');
 
 const {
-  PORTAL_API_URL,
-  PORTAL_API_KEY,
-  TFM_API_URL,
-  TFM_API_KEY
+  PORTAL_API_URL, PORTAL_API_KEY, TFM_API_URL, TFM_API_KEY, DTFS_FF_MAGIC_LINK
 } = process.env;
 
 const createBank = async (bank, token) => {
@@ -20,7 +17,9 @@ const createBank = async (bank, token) => {
     },
     url: `${PORTAL_API_URL}/v1/banks`,
     data: bank,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -35,7 +34,9 @@ const createCurrency = async (currency, token) => {
     },
     url: `${PORTAL_API_URL}/v1/currencies`,
     data: currency,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -50,7 +51,9 @@ const createCountry = async (country, token) => {
     },
     url: `${PORTAL_API_URL}/v1/countries`,
     data: country,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -65,7 +68,9 @@ const createDeal = async (deal, token) => {
     },
     url: `${PORTAL_API_URL}/v1/deals`,
     data: deal,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -79,7 +84,9 @@ const getDeal = async (dealId, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/deals/${dealId}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -94,7 +101,9 @@ const createIndustrySector = async (industrySector, token) => {
     },
     url: `${PORTAL_API_URL}/v1/industry-sectors`,
     data: industrySector,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -109,7 +118,9 @@ const createMandatoryCriteria = async (mandatoryCriteria, token) => {
     },
     url: `${PORTAL_API_URL}/v1/mandatory-criteria`,
     data: mandatoryCriteria,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -124,7 +135,9 @@ const createEligibilityCriteria = async (eligibilityCriteria, token) => {
     },
     url: `${PORTAL_API_URL}/v1/eligibility-criteria`,
     data: eligibilityCriteria,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -139,7 +152,9 @@ const createUser = async (user, token) => {
     },
     url: `${PORTAL_API_URL}/v1/users`,
     data: user,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -154,7 +169,9 @@ const createInitialUser = async (user) => {
     },
     url: `${PORTAL_API_URL}/v1/user`,
     data: user,
-  }).catch((error) => { console.error('Unable to create initial portal user %s', error); });
+  }).catch((error) => {
+    console.error('Unable to create initial portal user %s', error);
+  });
 
   return response.data;
 };
@@ -168,7 +185,9 @@ const createInitialTfmUser = async (user) => {
       'x-api-key': TFM_API_KEY,
     },
     data: user,
-  }).catch((error) => { console.error('Unable to create initial TFM user %s', error); });
+  }).catch((error) => {
+    console.error('Unable to create initial TFM user %s', error);
+  });
 };
 
 const loginTfmUser = async (user) => {
@@ -179,7 +198,9 @@ const loginTfmUser = async (user) => {
       'Content-Type': 'application/json',
     },
     data: { username: user.username, password: user.password },
-  }).catch((error) => { console.error('Unable to login as TFM user %s', error); });
+  }).catch((error) => {
+    console.error('Unable to login as TFM user %s', error);
+  });
 
   return response?.data?.token;
 };
@@ -193,7 +214,9 @@ const deleteBank = async (deal, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/banks/${deal.id}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -207,7 +230,9 @@ const deleteCurrency = async (currency, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/currencies/${currency.id}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -221,7 +246,9 @@ const deleteCountry = async (country, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/countries/${country.code}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -235,7 +262,9 @@ const deleteDeal = async (dealId, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/deals/${dealId}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -249,7 +278,9 @@ const deleteIndustrySector = async (industrySector, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/industry-sectors/${industrySector.code}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -263,7 +294,9 @@ const deleteMandatoryCriteria = async (version, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/mandatory-criteria/${version}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -277,7 +310,9 @@ const deleteEligibilityCriteria = async (version, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/eligibility-criteria/${version}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -291,7 +326,9 @@ const deleteUser = async (user, token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/users/${user._id}`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -305,7 +342,9 @@ const listBanks = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/banks`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.banks;
 };
@@ -319,7 +358,9 @@ const listCurrencies = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/currencies`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.currencies;
 };
@@ -333,7 +374,9 @@ const listCountries = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/countries`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.countries;
 };
@@ -347,7 +390,9 @@ const listDeals = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/deals`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.deals;
 };
@@ -361,7 +406,9 @@ const listIndustrySectors = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/industry-sectors`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.industrySectors;
 };
@@ -375,7 +422,9 @@ const listMandatoryCriteria = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/mandatory-criteria`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.mandatoryCriteria;
 };
@@ -389,7 +438,9 @@ const listEligibilityCriteria = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/eligibility-criteria`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.eligibilityCriteria;
 };
@@ -403,22 +454,40 @@ const listUsers = async (token) => {
       Authorization: token,
     },
     url: `${PORTAL_API_URL}/v1/users`,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data.users;
 };
 
-const login = async (user) => {
-  const response = await axios({
+const loginViaPortal = async (user) => {
+  const logInResponse = await axios({
     method: 'post',
     url: `${PORTAL_API_URL}/v1/login`,
     headers: {
       'Content-Type': 'application/json',
     },
     data: { username: user.username, password: user.password },
-  }).catch((error) => { console.error('Unable to login %s', error); });
+  }).catch((error) => {
+    console.error('Unable to login %s', error);
+  });
 
-  return response?.data?.token;
+  if (DTFS_FF_MAGIC_LINK !== 'true') {
+    return logInResponse?.data?.token;
+  }
+  const validationResponse = await axios({
+    method: 'post',
+    url: `${PORTAL_API_URL}/v1/users/validate-authentication-email/123`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: logInResponse?.data?.token,
+    },
+    data: { token: logInResponse?.data?.token },
+  }).catch((error) => {
+    console.error('Unable to validate token %s', error);
+  });
+  return validationResponse?.data?.token;
 };
 
 const updateCurrency = async (currency, token) => {
@@ -431,7 +500,9 @@ const updateCurrency = async (currency, token) => {
     },
     url: `${PORTAL_API_URL}/v1/currencies/${currency.id}`,
     data: currency,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -446,7 +517,9 @@ const updateCountry = async (country, token) => {
     },
     url: `${PORTAL_API_URL}/v1/countries/${country.code}`,
     data: country,
-  }).catch((error) => { console.error('Error calling API %s', error); });
+  }).catch((error) => {
+    console.error('Error calling API %s', error);
+  });
 
   return response.data;
 };
@@ -478,7 +551,7 @@ module.exports = {
   listMandatoryCriteria,
   listEligibilityCriteria,
   listUsers,
-  login,
+  loginViaPortal,
   updateCountry,
   updateCurrency,
   createInitialTfmUser,

--- a/utils/mock-data-loader/insert-mocks.js
+++ b/utils/mock-data-loader/insert-mocks.js
@@ -26,7 +26,7 @@ const insertMocks = async (mockDataLoaderToken) => {
   }
 
   const maker = PORTAL_MOCKS.USERS.find((user) => user.username === 'BANK1_MAKER3');
-  const makerToken = await api.login(maker);
+  const makerToken = await api.loginViaPortal(maker);
 
   console.info('inserting BSS deals');
   const insertedDeals = [];

--- a/utils/mock-data-loader/user-helper.js
+++ b/utils/mock-data-loader/user-helper.js
@@ -25,13 +25,13 @@ const mockDataLoaderTFMUser = {
 
 const createAndLogInAsInitialUser = async () => {
   console.info('Portal login as user %s', mockDataLoaderUser.username);
-  let token = await api.login(mockDataLoaderUser);
+  let token = await api.loginViaPortal(mockDataLoaderUser);
 
   if (!token) {
     console.info('Creating portal user %s', mockDataLoaderUser.username);
 
     await api.createInitialUser(mockDataLoaderUser);
-    token = await api.login(mockDataLoaderUser);
+    token = await api.loginViaPortal(mockDataLoaderUser);
   }
 
   return token;


### PR DESCRIPTION
# Introduction
DTFS2-6747 updates how we handle tokens in preparation for 2fa. A user should only be able to log in from the same session, and now requires additional factors to login

This ticket does not cover email implementation, as such the new implementation journey below is not the definitive journey.

# Resolution

## Old implementation 
- User logs in via `/login` with a username and password. 
- We validate credentials in `portal-api`
- `portal-api` updates `lastLogin` and `sessionId` in the database
- `portal-api` returns a `payload` to `portal`
- this payload contains a token, and user information
- `portal` saves this payload in `session`.

## New implementation
- User logs in via `/login` with a username and password. 
- We validate credentials in `portal-api`
- `portal-api` updates `sessionId` in the database
- 'portal-api` returns a `payload` to `portal`
-  this payload contains a token, and a new `loginStatus` field
- `portal` saves this payload in `session`.
- user can now validate via the `/login/validate-email-link/:loginAuthenticationToken` endpoint
- currently, any guid works
- `portal-api` updates `lastLogin` in the database
- `portal-api` returns a new payload (with same sessionId) that contains `user` data
- `portal` saves this payload in `session`

# Misc

- I've added a lot of todo's in this ticket to be picked up later in the other tickets.
- I've linked up the "check your email" page in `portal` (hidden behind a ff).