### PR TITLE
feat(DTFS2-6756): update token expiry time

### DIFF
--- a/portal-api/api-tests/v1/users/users.api-test.js
+++ b/portal-api/api-tests/v1/users/users.api-test.js
@@ -342,7 +342,7 @@ describe('a user', () => {
         success: true,
         token: expect.any(String),
         loginStatus: LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD,
-        expiresIn: '30m',
+        expiresIn: '105m',
       });
     }
   });

--- a/portal-api/src/crypto/utils.js
+++ b/portal-api/src/crypto/utils.js
@@ -82,7 +82,7 @@ function issueJWTWithExpiryAndPayload({ user, sessionIdentifier = crypto.randomB
 function issueValidUsernameAndPasswordJWT(user) {
   return issueJWTWithExpiryAndPayload({
     user,
-    expiresIn: '30m',
+    expiresIn: '105m', 
     additionalPayload: { username: user.username, loginStatus: LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD },
   });
 }

--- a/portal-api/src/crypto/utils.js
+++ b/portal-api/src/crypto/utils.js
@@ -82,6 +82,7 @@ function issueJWTWithExpiryAndPayload({ user, sessionIdentifier = crypto.randomB
 function issueValidUsernameAndPasswordJWT(user) {
   return issueJWTWithExpiryAndPayload({
     user,
+    // Expiry time is 105 minutes to allow for 3 login emails to be sent (each with a 30 minute expiry, and 5 minute leeway) without need to re-login
     expiresIn: '105m',
     additionalPayload: { username: user.username, loginStatus: LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD },
   });

--- a/portal-api/src/crypto/utils.js
+++ b/portal-api/src/crypto/utils.js
@@ -82,7 +82,7 @@ function issueJWTWithExpiryAndPayload({ user, sessionIdentifier = crypto.randomB
 function issueValidUsernameAndPasswordJWT(user) {
   return issueJWTWithExpiryAndPayload({
     user,
-    expiresIn: '105m', 
+    expiresIn: '105m',
     additionalPayload: { username: user.username, loginStatus: LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD },
   });
 }

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -47,7 +47,7 @@ describe('crypto utils', () => {
 
     it('should return the correct expiry time', () => {
       const { expires } = issueValidUsernameAndPasswordJWT(user);
-      expect(expires).toEqual('30m');
+      expect(expires).toEqual('105m');
     });
   });
 

--- a/portal/server/routes/login.js
+++ b/portal/server/routes/login.js
@@ -58,7 +58,6 @@ router.post('/login', async (req, res) => {
   if (success) {
     req.session.userToken = token;
     req.session.loginStatus = loginStatus;
-    req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
 
     await api.sendAuthenticationEmail(token);
   } else {
@@ -165,7 +164,7 @@ router.get('/login/validate-email-link/:loginAuthenticationToken', async (req, r
     req.session.loginStatus = loginStatus;
     req.session.dashboardFilters = CONSTANTS.DASHBOARD.DEFAULT_FILTERS;
   } else {
-    console.error('Error validating login authentication email link');
+    console.error('Error validating sign in link');
     return res.status(500).render('_partials/problem-with-service.njk');
   }
   return res.redirect('/dashboard/deals/0');


### PR DESCRIPTION
# Introduction
When a user logs in with a username and password, we grant them a token lasting 30 minutes to complete the login process (clicking on an email link). We've updated this to 105minutes (35mins x 3) to allow for the token to live as long as to allow for three emails to be sent (and time out) with a bit of leeway.