### PR TITLE
fix(DTFS2-6759): fix token expiry

### DIFF
--- a/portal-api/src/crypto/utils.js
+++ b/portal-api/src/crypto/utils.js
@@ -61,7 +61,6 @@ function issueJWTWithExpiryAndPayload({ user, sessionIdentifier = crypto.randomB
 
   const payload = {
     sub: _id,
-    iat: Date.now(),
     sessionIdentifier,
     ...additionalPayload,
   };

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -26,9 +26,17 @@ describe('crypto utils', () => {
 
   const DATE_NOW_IN_UNIX_TIME = Math.floor(Date.now().valueOf() / 1000);
 
-  const SECONDS_IN_30_MINUTES = 30 * 60;
+  const SECONDS_IN_105_MINUTES = 105 * 60;
 
   const SECONDS_IN_12_HOURS = 12 * 60 * 60;
+  
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  })
 
   describe('issueValidUsernameAndPasswordJWT', () => {
     it('should not use an existing session identifier', () => {
@@ -45,14 +53,14 @@ describe('crypto utils', () => {
       const { token, sessionIdentifier } = issueValidUsernameAndPasswordJWT(USER);
       const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
       expect(decodedToken.iat).toBe(DATE_NOW_IN_UNIX_TIME);
-      expect(decodedToken.exp).toBe(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_30_MINUTES);
+      expect(decodedToken.exp).toBe(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_105_MINUTES);
       expect(decodedToken.username).toEqual(USER.username);
       expect(decodedToken.loginStatus).toEqual(LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD);
       expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);
     });
 
     it('should return the correct expiry time', () => {
-      const { expires } = issueValidUsernameAndPasswordJWT(user);
+      const { expires } = issueValidUsernameAndPasswordJWT(USER);
       expect(expires).toEqual('105m');
     });
   });

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -5,7 +5,7 @@ const { MAKER } = require('../v1/roles/roles');
 const { LOGIN_STATUSES } = require('../constants');
 
 describe('crypto utils', () => {
-  const user = {
+  const USER = {
     username: 'HSBC-maker-1',
     password: 'P@ssword1234',
     firstname: 'Mister',
@@ -20,27 +20,33 @@ describe('crypto utils', () => {
     },
   };
 
-  const existingSessionIdentifier = crypto.randomBytes(32).toString('hex');
+  const EXISTING_SESSION_IDENTIFIER = crypto.randomBytes(32).toString('hex');
 
-  const userWithExistingSessionIdentifier = { ...user, sessionIdentifier: existingSessionIdentifier };
+  const USER_WITH_EXISTING_SESSION_IDENTIFIER = { ...USER, sessionIdentifier: EXISTING_SESSION_IDENTIFIER };
+
+  const DATE_NOW_IN_UNIX_TIME = Math.floor(Date.now().valueOf()/1000);
+
+  const SECONDS_IN_30_MINUTES = 30 * 60;
+
+  const SECONDS_IN_12_HOURS = 12 * 60 * 60;
 
   describe('issueValidUsernameAndPasswordJWT', () => {
     it('should not use an existing session identifier', () => {
-      const { sessionIdentifier } = issueValidUsernameAndPasswordJWT(userWithExistingSessionIdentifier);
-      expect(sessionIdentifier).not.toEqual(existingSessionIdentifier);
+      const { sessionIdentifier } = issueValidUsernameAndPasswordJWT(USER_WITH_EXISTING_SESSION_IDENTIFIER);
+      expect(sessionIdentifier).not.toEqual(EXISTING_SESSION_IDENTIFIER);
     });
 
     it('should return a session identifier', () => {
-      const { sessionIdentifier } = issueValidUsernameAndPasswordJWT(user);
+      const { sessionIdentifier } = issueValidUsernameAndPasswordJWT(USER);
       expect(is32ByteHex(sessionIdentifier)).toEqual(true);
     });
 
     it('should return a token with the expected payload', () => {
-      const { token, sessionIdentifier } = issueValidUsernameAndPasswordJWT(user);
+      const { token, sessionIdentifier } = issueValidUsernameAndPasswordJWT(USER);
       const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
-      expect(decodedToken.iat).toBeDefined();
-      expect(decodedToken.exp).toBeDefined();
-      expect(decodedToken.username).toEqual(user.username);
+      expect(decodedToken.iat).toBe(DATE_NOW_IN_UNIX_TIME);
+      expect(decodedToken.exp).toBe(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_30_MINUTES);
+      expect(decodedToken.username).toEqual(USER.username);
       expect(decodedToken.loginStatus).toEqual(LOGIN_STATUSES.VALID_USERNAME_AND_PASSWORD);
       expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);
     });
@@ -53,30 +59,30 @@ describe('crypto utils', () => {
 
   describe('issueValid2faJWT', () => {
     it('should throw an error if no existing session identifier is present', () => {
-      expect(() => issueValid2faJWT(user)).toThrow('User does not have a session identifier');
+      expect(() => issueValid2faJWT(USER)).toThrow('User does not have a session identifier');
     });
 
     it('should return the input session identifier', () => {
-      const { sessionIdentifier } = issueValid2faJWT(userWithExistingSessionIdentifier);
+      const { sessionIdentifier } = issueValid2faJWT(USER_WITH_EXISTING_SESSION_IDENTIFIER);
       expect(is32ByteHex(sessionIdentifier)).toEqual(true);
-      expect(sessionIdentifier).toEqual(existingSessionIdentifier);
+      expect(sessionIdentifier).toEqual(EXISTING_SESSION_IDENTIFIER);
     });
 
     it('should return a token with the expected payload', () => {
-      const { token, sessionIdentifier } = issueValid2faJWT(userWithExistingSessionIdentifier);
+      const { token, sessionIdentifier } = issueValid2faJWT(USER_WITH_EXISTING_SESSION_IDENTIFIER);
       const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
-      expect(decodedToken.iat).toBeDefined();
-      expect(decodedToken.exp).toBeDefined();
-      expect(decodedToken.username).toEqual(user.username);
+      expect(decodedToken.iat).toBe(DATE_NOW_IN_UNIX_TIME);
+      expect(decodedToken.exp).toBe(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_12_HOURS);
+      expect(decodedToken.username).toEqual(USER.username);
       expect(decodedToken.loginStatus).toEqual(LOGIN_STATUSES.VALID_2FA);
       expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);
-      expect(decodedToken.sessionIdentifier).toEqual(existingSessionIdentifier);
-      expect(decodedToken.roles).toEqual(user.roles);
-      expect(decodedToken.bank).toEqual(user.bank);
+      expect(decodedToken.sessionIdentifier).toEqual(EXISTING_SESSION_IDENTIFIER);
+      expect(decodedToken.roles).toEqual(USER.roles);
+      expect(decodedToken.bank).toEqual(USER.bank);
     });
 
     it('should return the correct expiry time', () => {
-      const { expires } = issueValid2faJWT(userWithExistingSessionIdentifier);
+      const { expires } = issueValid2faJWT(USER_WITH_EXISTING_SESSION_IDENTIFIER);
       expect(expires).toEqual('12h');
     });
   });

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -24,7 +24,7 @@ describe('crypto utils', () => {
 
   const USER_WITH_EXISTING_SESSION_IDENTIFIER = { ...USER, sessionIdentifier: EXISTING_SESSION_IDENTIFIER };
 
-  const DATE_NOW_IN_UNIX_TIME = Math.floor(Date.now().valueOf()/1000);
+  const DATE_NOW_IN_UNIX_TIME = Math.floor(Date.now().valueOf() / 1000);
 
   const SECONDS_IN_30_MINUTES = 30 * 60;
 

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -29,14 +29,14 @@ describe('crypto utils', () => {
   const SECONDS_IN_105_MINUTES = 105 * 60;
 
   const SECONDS_IN_12_HOURS = 12 * 60 * 60;
-  
+
   beforeAll(() => {
     jest.useFakeTimers();
   });
 
   afterAll(() => {
     jest.useRealTimers();
-  })
+  });
 
   describe('issueValidUsernameAndPasswordJWT', () => {
     it('should not use an existing session identifier', () => {

--- a/portal-api/src/v1/users/login.controller.test.js
+++ b/portal-api/src/v1/users/login.controller.test.js
@@ -5,6 +5,7 @@ const controller = require('./controller');
 const utils = require('../../crypto/utils');
 const sendEmail = require('../email');
 const CONSTANTS = require('../../constants');
+const { FEATURE_FLAGS } = require('../../config/feature-flag.config');
 
 jest.mock('./controller', () => ({
   findByUsername: jest.fn(),
@@ -38,17 +39,29 @@ describe('login', () => {
     hash: HASH,
     salt: SALT,
   };
+  if (!FEATURE_FLAGS.MAGIC_LINK) {
+    it('returns the user and token when the user exists and the password is correct', async () => {
+      mockFindByUsernameSuccess(USER);
+      mockValidPasswordSuccess();
+      mockIssueJWTSuccess(USER);
+      mockUpdateLastLoginSuccess(USER);
 
-  it('returns the user and token when the user exists and the password is correct', async () => {
-    mockFindByUsernameSuccess(USER);
-    mockValidPasswordSuccess();
-    mockIssueJWTSuccess(USER);
-    mockUpdateLastLoginSuccess(USER);
+      const result = await login(USERNAME, PASSWORD);
 
-    const result = await login(USERNAME, PASSWORD);
+      expect(result).toEqual({ user: USER, tokenObject: TOKEN_OBJECT });
+    });
+  } else {
+    it('returns the token when the user exists and the password is correct', async () => {
+      mockFindByUsernameSuccess(USER);
+      mockValidPasswordSuccess();
+      mockIssueJWTSuccess(USER);
+      mockUpdateLastLoginSuccess(USER);
 
-    expect(result).toEqual({ user: USER, tokenObject: TOKEN_OBJECT });
-  });
+      const result = await login(USERNAME, PASSWORD);
+
+      expect(result).toEqual({ tokenObject: TOKEN_OBJECT });
+    });
+  }
 
   it("returns a 'usernameOrPasswordIncorrect' error when the user doesn't exist", async () => {
     mockFindByUsernameReturnsNullUser();
@@ -193,19 +206,23 @@ describe('sendSignInLinkEmail', () => {
     await sendSignInLinkEmail(EMAIL, FIRST_NAME, LAST_NAME, SIGN_IN_LINK);
 
     expect(sendEmail).toHaveBeenCalledTimes(1);
-    expect(sendEmail).toHaveBeenCalledWith(
-      CONSTANTS.EMAIL_TEMPLATE_IDS.SIGN_IN_LINK,
-      EMAIL,
-      { firstName: FIRST_NAME, lastName: LAST_NAME, signInLink: SIGN_IN_LINK, signInLinkExpiryMinutes: CONSTANTS.SIGN_IN_LINK_EXPIRY_MINUTES }
-    );
+    expect(sendEmail).toHaveBeenCalledWith(CONSTANTS.EMAIL_TEMPLATE_IDS.SIGN_IN_LINK, EMAIL, {
+      firstName: FIRST_NAME,
+      lastName: LAST_NAME,
+      signInLink: SIGN_IN_LINK,
+      signInLinkExpiryMinutes: CONSTANTS.SIGN_IN_LINK_EXPIRY_MINUTES,
+    });
   });
 
   it('returns the response from sendEmail', async () => {
-    when(sendEmail).calledWith(
-      CONSTANTS.EMAIL_TEMPLATE_IDS.SIGN_IN_LINK,
-      EMAIL,
-      { firstName: FIRST_NAME, lastName: LAST_NAME, signInLink: SIGN_IN_LINK, signInLinkExpiryMinutes: CONSTANTS.SIGN_IN_LINK_EXPIRY_MINUTES }
-    ).mockResolvedValueOnce(SEND_EMAIL_RESPONSE);
+    when(sendEmail)
+      .calledWith(CONSTANTS.EMAIL_TEMPLATE_IDS.SIGN_IN_LINK, EMAIL, {
+        firstName: FIRST_NAME,
+        lastName: LAST_NAME,
+        signInLink: SIGN_IN_LINK,
+        signInLinkExpiryMinutes: CONSTANTS.SIGN_IN_LINK_EXPIRY_MINUTES,
+      })
+      .mockResolvedValueOnce(SEND_EMAIL_RESPONSE);
 
     const result = await sendSignInLinkEmail(EMAIL, FIRST_NAME, LAST_NAME, SIGN_IN_LINK);
 

--- a/trade-finance-manager-api/src/utils/crypto.util.js
+++ b/trade-finance-manager-api/src/utils/crypto.util.js
@@ -54,7 +54,6 @@ function issueJWT(user) {
 
   const payload = {
     sub: _id,
-    iat: Date.now(),
     username: user.username,
     teams: user.teams,
     firstName: user.firstName,


### PR DESCRIPTION
# Introduction
Currently, token expiry is non-functional. We are setting the token expiry based on Date.now() which uses milliseconds since epoch. JWTs work with seconds since epoch ([RFC 7519: JSON Web Token (JWT) (rfc-editor.org)](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6))

# Resolution
This fix removes setting `ias` as it is unneeded. 

# Misc
I have checked to see what happens when a token is no longer valid in `portal-api`. Portal logs the user out and their session data is deleted.