### PR TITLE
feat(DTFS2-6767): update login naming conventions

### DIFF
--- a/portal-api/api-tests/v1/facility-dates/cover-end-date.api-test.js
+++ b/portal-api/api-tests/v1/facility-dates/cover-end-date.api-test.js
@@ -64,6 +64,14 @@ describe('hasAllCoverEndDateValues()', () => {
 });
 
 describe('updateCoverEndDate', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('should return facility.coverEndDate if facility has valid day, month, year', () => {
     const facility = {
       'coverEndDate-day': '12',

--- a/portal-api/api-tests/v1/users/users.api-test.js
+++ b/portal-api/api-tests/v1/users/users.api-test.js
@@ -354,9 +354,9 @@ describe('a user', () => {
       await as(loggedInUser).post(MOCK_USER).to('/v1/users');
 
       const { body: loginBody } = await as().post({ username, password }).to('/v1/login');
-      const { status: validateAuthenticationEmailStatus, body: validateAuthenticationEmailBody } = await as({ ...MOCK_USER, token: loginBody.token })
+      const { status: validateSignInLinkStatus, body: validateSignInLinkBody } = await as({ ...MOCK_USER, token: loginBody.token })
         .post()
-        .to('/v1/users/validate-authentication-email/123');
+        .to('/v1/users/me/validate-sign-in-link/123');
       const expectedUserData = {
         ...MOCK_USER,
         _id: expect.any(String),
@@ -365,8 +365,8 @@ describe('a user', () => {
       };
       delete expectedUserData.password;
 
-      expect(validateAuthenticationEmailStatus).toEqual(200);
-      expect(validateAuthenticationEmailBody).toEqual({
+      expect(validateSignInLinkStatus).toEqual(200);
+      expect(validateSignInLinkBody).toEqual({
         success: true,
         token: expect.any(String),
         user: expectedUserData,
@@ -378,9 +378,9 @@ describe('a user', () => {
     it('a known user with an email link without a token cannot log in', async () => {
       await as(loggedInUser).post(MOCK_USER).to('/v1/users');
 
-      const { status: validateAuthenticationEmailStatus } = await as({ ...MOCK_USER })
+      const { status: validateSignInLinkStatus } = await as({ ...MOCK_USER })
         .post()
-        .to('/v1/users/validate-authentication-email/123');
+        .to('/v1/users/me/validate-sign-in-link/123');
       const expectedUserData = {
         ...MOCK_USER,
         _id: expect.any(String),
@@ -389,7 +389,7 @@ describe('a user', () => {
       };
       delete expectedUserData.password;
 
-      expect(validateAuthenticationEmailStatus).toEqual(401);
+      expect(validateSignInLinkStatus).toEqual(401);
     });
   }
 
@@ -398,11 +398,11 @@ describe('a user', () => {
     await as(loggedInUser).post(MOCK_USER).to('/v1/users');
 
     const { body: loginBody } = await as().post({ username, password }).to('/v1/login');
-    const { body: validateAuthenticationEmailBody } = await as({ ...MOCK_USER, token: loginBody.token })
+    const { body: validateSignInLinkBody } = await as({ ...MOCK_USER, token: loginBody.token })
       .post()
-      .to('/v1/users/validate-authentication-email/123');
+      .to('/v1/users/me/validate-sign-in-link/123');
     // TODO DTFS2-6680: remove this feature flag check
-    const { token } = FEATURE_FLAGS.MAGIC_LINK ? validateAuthenticationEmailBody : loginBody;
+    const { token } = FEATURE_FLAGS.MAGIC_LINK ? validateSignInLinkBody : loginBody;
 
     const { status } = await as({ token }).get('/v1/validate');
 

--- a/portal-api/src/v1/routes.js
+++ b/portal-api/src/v1/routes.js
@@ -51,11 +51,11 @@ openRouter.route('/feedback').post(checkApiKey, feedback.create);
 openRouter.route('/user').post(checkApiKey, users.create);
 
 // TODO DTFS2-6680: ensure this endpoint is used
-openRouter.route('/users/send-authentication-email').post(passport.authenticate('login-in-progress', { session: false }), users.sendAuthenticationEmail);
+openRouter.route('/users/me/send-sign-in-link').post(passport.authenticate('login-in-progress', { session: false }), users.sendSignInLink);
 
 openRouter
-  .route('/users/validate-authentication-email/:loginAuthenticationToken')
-  .post(passport.authenticate('login-in-progress', { session: false }), users.validateAuthenticationEmail);
+  .route('/users/me/validate-sign-in-link/:signInToken')
+  .post(passport.authenticate('login-in-progress', { session: false }), users.validateSignInLink);
 
 // Auth router requires authentication
 const authRouter = express.Router();

--- a/portal-api/src/v1/users/authentication-email.controller.js
+++ b/portal-api/src/v1/users/authentication-email.controller.js
@@ -2,7 +2,7 @@ const sendEmail = require('../email');
 const { updateLastLogin } = require('./controller');
 const utils = require('../../crypto/utils');
 
-const sendAuthenticationEmail = async (emailAddress, token) => {
+const sendSignInLink = async (emailAddress, token) => {
   // TODO DTFS2-6680: update template Id
   // TODO DTFS2-6680: check email address against user email
   const EMAIL_TEMPLATE_ID = '6935e539-1a0c-4eca-a6f3-f239402c0987';
@@ -13,8 +13,8 @@ const sendAuthenticationEmail = async (emailAddress, token) => {
 };
 
 // eslint-disable-next-line no-unused-vars
-const validateAuthenticationEmailToken = async (user, loginAuthenticationToken) => {
-  // TODO DTFS2-6680: Check that the user here has the loginAuthenticationToken
+const validateSignInLinkToken = async (user, signInToken) => {
+  // TODO DTFS2-6680: Check that the user here has the signInToken
   // TODO DTFS2-6680: Remove this lint disable
   const { sessionIdentifier, ...tokenObject } = utils.issueValid2faJWT(user);
   return new Promise((resolve) => {
@@ -22,5 +22,5 @@ const validateAuthenticationEmailToken = async (user, loginAuthenticationToken) 
   });
 };
 
-module.exports.sendAuthenticationEmail = sendAuthenticationEmail;
-module.exports.validateAuthenticationEmailToken = validateAuthenticationEmailToken;
+module.exports.sendSignInLink = sendSignInLink;
+module.exports.validateSignInLinkToken = validateSignInLinkToken;

--- a/portal-api/src/v1/users/authentication-email.controller.test.js
+++ b/portal-api/src/v1/users/authentication-email.controller.test.js
@@ -1,5 +1,5 @@
 const { when } = require('jest-when');
-const { sendAuthenticationEmail, validateAuthenticationEmailToken } = require('./authentication-email.controller');
+const { sendSignInLink, validateSignInLinkToken } = require('./authentication-email.controller');
 
 jest.mock('../email');
 const sendEmail = require('../email');
@@ -12,18 +12,18 @@ const userController = require('./controller');
 const { MAKER } = require('../roles/roles');
 
 describe('authentication email controller', () => {
-  describe('sendAuthenticationEmail', () => {
+  describe('sendSignInLink', () => {
     const EXPECTED_EMAIL_TEMPLATE_ID = '6935e539-1a0c-4eca-a6f3-f239402c0987';
     const EMAIL_ADDRESS = 'example@example.com';
     const TOKEN = '1234567890';
 
     it('should call sendEmail with expected parameters', async () => {
-      await sendAuthenticationEmail(EMAIL_ADDRESS, TOKEN);
+      await sendSignInLink(EMAIL_ADDRESS, TOKEN);
       expect(sendEmail).toHaveBeenCalledWith(EXPECTED_EMAIL_TEMPLATE_ID, EMAIL_ADDRESS, { token: TOKEN });
     });
   });
 
-  describe('validateAuthenticationEmailToken', () => {
+  describe('validateSignInLinkToken', () => {
     const TEST_USER = {
       username: 'HSBC-maker-1',
       password: 'P@ssword1234',
@@ -57,7 +57,7 @@ describe('authentication email controller', () => {
         .calledWith(TEST_USER, SUCCESSFUL_JWT.sessionIdentifier, expect.any(Function))
         .mockImplementation((user, sessionIdentifier, callback) => callback());
 
-      const { tokenObject, user } = await validateAuthenticationEmailToken(TEST_USER, TEST_TOKEN);
+      const { tokenObject, user } = await validateSignInLinkToken(TEST_USER, TEST_TOKEN);
 
       expect(tokenObject).toEqual({ token: SUCCESSFUL_JWT.token, expires: SUCCESSFUL_JWT.expires });
       expect(user).toEqual(TEST_USER);
@@ -73,7 +73,7 @@ describe('authentication email controller', () => {
         .calledWith(TEST_USER, SUCCESSFUL_JWT.sessionIdentifier, expect.any(Function))
         .mockImplementation((user, sessionIdentifier, callback) => callback());
 
-      await expect(validateAuthenticationEmailToken(TEST_USER, TEST_TOKEN)).rejects.toThrow('User does not have a session identifier');
+      await expect(validateSignInLinkToken(TEST_USER, TEST_TOKEN)).rejects.toThrow('User does not have a session identifier');
     });
 
     it('should throw an error if updating last login fails', async () => {
@@ -85,7 +85,7 @@ describe('authentication email controller', () => {
           throw new Error('Invalid User Id');
         });
 
-      await expect(validateAuthenticationEmailToken(TEST_USER, TEST_TOKEN)).rejects.toThrow('Invalid User Id');
+      await expect(validateSignInLinkToken(TEST_USER, TEST_TOKEN)).rejects.toThrow('Invalid User Id');
     });
   });
 });

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -8,7 +8,7 @@ const { applyCreateRules, applyUpdateRules } = require('./validation');
 const { isValidEmail } = require('../../utils/string');
 const { FEATURE_FLAGS } = require('../../config/feature-flag.config');
 const { LOGIN_STATUSES } = require('../../constants');
-const { validateAuthenticationEmailToken } = require('./authentication-email.controller');
+const { validateSignInLinkToken } = require('./authentication-email.controller');
 
 module.exports.list = (req, res, next) => {
   list((error, users) => {
@@ -267,18 +267,18 @@ module.exports.login = async (req, res, next) => {
 };
 
 // eslint-disable-next-line no-unused-vars
-module.exports.sendAuthenticationEmail = async (req, res) =>
+module.exports.sendSignInLink = async (req, res) =>
   // TODO DTFS2-6680: This actually needs to send an email
   // TODO DTFS2-6680: Remove this lint disable
   res.status(200).send();
 
-module.exports.validateAuthenticationEmail = async (req, res) => {
+module.exports.validateSignInLink = async (req, res) => {
   // TODO DTFS2-6680: This actually needs to validate the email guid
   // TODO DTFS2-6680: When validating the email link we need to make sure the email in the token matches the email for which the link was generated
-  const { loginAuthenticationToken } = req.params;
+  const { signInToken } = req.params;
   const { user } = req;
 
-  const { tokenObject, user: completeUser } = await validateAuthenticationEmailToken(user, loginAuthenticationToken);
+  const { tokenObject, user: completeUser } = await validateSignInLinkToken(user, signInToken);
 
   return res.status(200).json({
     success: true,

--- a/portal/api-tests/admin-routes.api-test.js
+++ b/portal/api-tests/admin-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
   updateUser: jest.fn(),
   banks: jest.fn(),
@@ -18,9 +18,9 @@ const app = require('../server/createApp');
 const { ADMIN } = require('../server/constants/roles');
 const mockLogin = require('./helpers/login');
 const extractSessionCookie = require('./helpers/extractSessionCookie');
-const { login, updateUser, validateAuthenticationEmail } = require('../server/api');
+const { login, updateUser, validateSignInLink } = require('../server/api');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
-const validateAuthenticationEmailAsRole = require('./helpers/validateAuthenticationEmailAsRole');
+const validateSignInLinkAsRole = require('./helpers/validateSignInLinkAsRole');
 const { get, post } = require('./create-api').createApi(app);
 
 const email = 'mock email';
@@ -31,7 +31,7 @@ let sessionCookie;
 describe('user routes', () => {
   beforeEach(async () => {
     login.mockImplementation(mockLogin());
-    validateAuthenticationEmail.mockImplementation(validateAuthenticationEmailAsRole(ADMIN));
+    validateSignInLink.mockImplementation(validateSignInLinkAsRole(ADMIN));
     sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
     await get('/login/validate-email-link/123', {}, { Cookie: [sessionCookie] });
     updateUser.mockImplementation(() => Promise.resolve({ status: 200 }));

--- a/portal/api-tests/common-tests/role-validation-api-tests.js
+++ b/portal/api-tests/common-tests/role-validation-api-tests.js
@@ -1,9 +1,9 @@
-const { login, validateAuthenticationEmail } = require('../../server/api');
+const { login, validateSignInLink } = require('../../server/api');
 const { ROLES } = require('../../server/constants');
 const app = require('../../server/createApp');
 const extractSessionCookie = require('../helpers/extractSessionCookie');
 const mockLogin = require('../helpers/login');
-const validateAuthenticationEmailAsRole = require('../helpers/validateAuthenticationEmailAsRole');
+const validateSignInLinkAsRole = require('../helpers/validateSignInLinkAsRole');
 const { post, get } = require('../create-api').createApi(app);
 
 const allRoles = Object.values(ROLES);
@@ -27,7 +27,7 @@ const withRoleValidationApiTests = ({
         describe('whitelisted roles', () => {
           it.each(whitelistedRoles)(`returns a ${successCode} response if the user only has the '%s' role`, async (allowedRole) => {
             login.mockImplementation(mockLogin());
-            validateAuthenticationEmail.mockImplementation(validateAuthenticationEmailAsRole(allowedRole));
+            validateSignInLink.mockImplementation(validateSignInLinkAsRole(allowedRole));
 
             const sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
             await get('/login/validate-email-link/123', {}, { Cookie: sessionCookie })
@@ -50,7 +50,7 @@ const withRoleValidationApiTests = ({
       describe('non-whitelisted roles', () => {
         it.each(nonWhitelistedRoles)("returns a 302 response if the user only has the '%s' role", async (disallowedRole) => {
           login.mockImplementation(mockLogin());
-          validateAuthenticationEmail.mockImplementation(validateAuthenticationEmailAsRole(disallowedRole));
+          validateSignInLink.mockImplementation(validateSignInLinkAsRole(disallowedRole));
 
           const sessionCookie = await post({ email, password }).to('/login').then(extractSessionCookie);
 

--- a/portal/api-tests/contract/about-routes.api-test.js
+++ b/portal/api-tests/contract/about-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/contract/bond-routes.api-test.js
+++ b/portal/api-tests/contract/bond-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/contract/contract-routes.api-test.js
+++ b/portal/api-tests/contract/contract-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/contract/loan-routes.api-test.js
+++ b/portal/api-tests/contract/loan-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 jest.mock('../../server/routes/api-data-provider', () => ({

--- a/portal/api-tests/dashboard-routes.api-test.js
+++ b/portal/api-tests/dashboard-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/eligibility-routes.api-test.js
+++ b/portal/api-tests/eligibility-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/feedback-routes.api-test.js
+++ b/portal/api-tests/feedback-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/footer-routes.api-test.js
+++ b/portal/api-tests/footer-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/helpers/validateAuthenticationEmailAsRole.js
+++ b/portal/api-tests/helpers/validateAuthenticationEmailAsRole.js
@@ -1,7 +1,0 @@
-const validateAuthenticationEmailAsRole = (role) => () => ({
-  success: true,
-  token: 'mock 2FA validated token',
-  user: { roles: [role] },
-});
-
-module.exports = validateAuthenticationEmailAsRole;

--- a/portal/api-tests/helpers/validateSignInLinkAsRole.js
+++ b/portal/api-tests/helpers/validateSignInLinkAsRole.js
@@ -1,0 +1,7 @@
+const validateSignInLinkAsRole = (role) => () => ({
+  success: true,
+  token: 'mock 2FA validated token',
+  user: { roles: [role] },
+});
+
+module.exports = validateSignInLinkAsRole;

--- a/portal/api-tests/login-routes.api-test.js
+++ b/portal/api-tests/login-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 
@@ -36,7 +36,7 @@ describe('login routes', () => {
     });
   });
 
-  describe('GET /login/validate-email-link/:loginAuthenticationToken', () => {
+  describe('GET /login/validate-email-link/:signInToken', () => {
     withRoleValidationApiTests({
       makeRequestWithHeaders: (headers) => get('/login/validate-email-link/123', headers),
       whitelistedRoles: allRoles,

--- a/portal/api-tests/portal-routes.api-test.js
+++ b/portal/api-tests/portal-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/scheme-type-routes.api-test.js
+++ b/portal/api-tests/scheme-type-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/start-routes.api-test.js
+++ b/portal/api-tests/start-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/static-routes.api-test.js
+++ b/portal/api-tests/static-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/api-tests/user-routes.api-test.js
+++ b/portal/api-tests/user-routes.api-test.js
@@ -5,8 +5,8 @@ jest.mock('../server/routes/middleware/csrf', () => ({
 }));
 jest.mock('../server/api', () => ({
   login: jest.fn(),
-  sendAuthenticationEmail: jest.fn(),
-  validateAuthenticationEmail: jest.fn(),
+  sendSignInLink: jest.fn(),
+  validateSignInLink: jest.fn(),
   validateToken: () => true,
 }));
 

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -39,10 +39,10 @@ const login = async (username, password) => {
   }
 };
 
-const sendAuthenticationEmail = async (token) => {
+const sendSignInLink = async (token) => {
   const response = await axios({
     method: 'post',
-    url: `${PORTAL_API_URL}/v1/users/send-authentication-email`,
+    url: `${PORTAL_API_URL}/v1/users/me/send-sign-in-link`,
     headers: {
       'Content-Type': 'application/json',
       Authorization: token,
@@ -52,16 +52,16 @@ const sendAuthenticationEmail = async (token) => {
   return { success: response.status === 200 };
 };
 
-const validateAuthenticationEmail = async ({ token, loginAuthenticationToken }) => {
+const validateSignInLink = async ({ token, signInToken }) => {
   try {
     const response = await axios({
       method: 'post',
-      url: `${PORTAL_API_URL}/v1/users/validate-authentication-email/${loginAuthenticationToken}`,
+      url: `${PORTAL_API_URL}/v1/users/me/validate-sign-in-link/${signInToken}`,
       headers: {
         'Content-Type': 'application/json',
         Authorization: token,
       },
-      data: { loginAuthenticationToken },
+      data: { signInToken },
     });
 
     return response.data
@@ -881,8 +881,8 @@ module.exports = {
   users,
   user,
   createUser,
-  sendAuthenticationEmail,
-  validateAuthenticationEmail,
+  sendSignInLink,
+  validateSignInLink,
   updateUser,
   getCurrencies,
   getCountries,

--- a/portal/server/helpers/requestParams.js
+++ b/portal/server/helpers/requestParams.js
@@ -4,7 +4,7 @@ const requestParams = (req) => {
     bondId,
     loanId,
     pwdResetToken,
-    loginAuthenticationToken,
+    signInToken,
   } = req.params;
   const { userToken } = req.session;
 
@@ -13,7 +13,7 @@ const requestParams = (req) => {
     bondId,
     loanId,
     pwdResetToken,
-    loginAuthenticationToken,
+    signInToken,
     userToken,
   };
 };

--- a/portal/server/routes/login.js
+++ b/portal/server/routes/login.js
@@ -59,7 +59,7 @@ router.post('/login', async (req, res) => {
     req.session.userToken = token;
     req.session.loginStatus = loginStatus;
 
-    await api.sendAuthenticationEmail(token);
+    await api.sendSignInLink(token);
   } else {
     loginErrors.push(emailError);
     loginErrors.push(passwordError);
@@ -153,9 +153,9 @@ router.get('/sign-in-link-expired', (req, res) => {
 // TODO DTFS2-6680 add send new email on this endpoint
 router.post('/login/check-your-email', async (req, res) => res.redirect('/login/check-your-email'));
 
-router.get('/login/validate-email-link/:loginAuthenticationToken', async (req, res) => {
-  const { loginAuthenticationToken, userToken } = requestParams(req);
-  const tokenResponse = await api.validateAuthenticationEmail({ token: userToken, loginAuthenticationToken });
+router.get('/login/validate-email-link/:signInToken', async (req, res) => {
+  const { signInToken, userToken } = requestParams(req);
+  const tokenResponse = await api.validateSignInLink({ token: userToken, signInToken });
   const { success, token: newUserToken, loginStatus, user } = tokenResponse;
 
   if (success) {

--- a/utils/mock-data-loader/api.js
+++ b/utils/mock-data-loader/api.js
@@ -478,7 +478,7 @@ const loginViaPortal = async (user) => {
   }
   const validationResponse = await axios({
     method: 'post',
-    url: `${PORTAL_API_URL}/v1/users/validate-authentication-email/123`,
+    url: `${PORTAL_API_URL}/v1/users/me/validate-sign-in-link/123`,
     headers: {
       'Content-Type': 'application/json',
       Authorization: logInResponse?.data?.token,


### PR DESCRIPTION
# Introduction
We have many different names for sign in links.

# Resolution
I've commonised `signInLink` as the name for referring to this process