### PR TITLE
feat(FN-1294): allow admin to see all portal nav items

### DIFF
--- a/gef-ui/component-tests/includes/primary-navigation.component-test.js
+++ b/gef-ui/component-tests/includes/primary-navigation.component-test.js
@@ -40,10 +40,9 @@ describe(page, () => {
 
     itRendersAHomeLink();
     itRendersAReportsLink();
+    itRendersAUtilisationReportUploadLink();
+    itRendersAPreviousReportsLink();
     itRendersAUsersLink();
-
-    itDoesNotRenderAUtilisationReportUploadLink();
-    itDoesNotRenderAPreviousReportsLink();
   });
 
   describe(`viewed by role '${ROLES.READ_ONLY}'`, () => {

--- a/gef-ui/templates/includes/primary-navigation.njk
+++ b/gef-ui/templates/includes/primary-navigation.njk
@@ -57,7 +57,7 @@
   {% set navItems = (navItems.push(reportsNavItem), navItems) %}
 {% endif %}
 
-{% if isPaymentReportOfficer %}
+{% if isAdmin or isPaymentReportOfficer %}
   {% set navItems = (navItems.push(reportGefUtilisationAndFeesNavItem, previousGefReportsNavItem), navItems) %}
 {% endif %}
 

--- a/portal/component-tests/partials/primary-navigation.component-test.js
+++ b/portal/component-tests/partials/primary-navigation.component-test.js
@@ -40,10 +40,9 @@ describe(page, () => {
 
     itRendersAHomeLink();
     itRendersAReportsLink();
+    itRendersAUtilisationReportUploadLink();
+    itRendersAPreviousReportsLink();
     itRendersAUsersLink();
-
-    itDoesNotRenderAUtilisationReportUploadLink();
-    itDoesNotRenderAPreviousReportsLink();
   });
 
   describe(`viewed by role '${ROLES.READ_ONLY}'`, () => {

--- a/portal/templates/_partials/primary-navigation.njk
+++ b/portal/templates/_partials/primary-navigation.njk
@@ -57,7 +57,7 @@
   {% set navItems = (navItems.push(reportsNavItem), navItems) %}
 {% endif %}
 
-{% if isPaymentReportOfficer %}
+{% if isAdmin or isPaymentReportOfficer %}
   {% set navItems = (navItems.push(reportGefUtilisationAndFeesNavItem, previousGefReportsNavItem), navItems) %}
 {% endif %}
 


### PR DESCRIPTION
Allow admins to see all the nav items in portal (per ACs in [FN-1294](https://ukef-dtfs.atlassian.net/browse/FN-1294)) 