### PR TITLE
feat(DTFS2-6762): create environment variable for Portal website domain in Portal API

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,6 +25,7 @@ MONGODB_URI=
 
 # MICROSERVICES
 PORTAL_API_URL=http://localhost:5001
+PORTAL_UI_URL=http://localhost
 EXTERNAL_API_URL=http://localhost:5002
 TFM_API_URL=http://localhost:5004
 TFM_UI_URL=http://localhost:5003

--- a/portal-api/api-tests/v1/users/post-sign-in-link.api-test.js
+++ b/portal-api/api-tests/v1/users/post-sign-in-link.api-test.js
@@ -13,6 +13,7 @@ const users = require('./test-data');
 const { withPartial2FaOnlyAuthenticationTests } = require('../../common-tests/client-authentication-tests');
 const { SIGN_IN_LINK_EXPIRY_MINUTES } = require('../../../src/constants');
 const { FEATURE_FLAGS } = require('../../../src/config/feature-flag.config');
+const { PORTAL_UI_URL } = require('../../../src/config/sign-in-link.config');
 
 const aMaker = users.find((user) => user.username === 'MAKER');
 
@@ -137,7 +138,7 @@ jest.mock('node:crypto', () => ({
           expect(sendEmail).toHaveBeenCalledWith('2eab0ad2-eb92-43a4-b04c-483c28a4da18', user.email, {
             firstName: user.firstname,
             lastName: user.surname,
-            signInLink: `http://localhost/login/sign-in-link?t=${signInCode}`,
+            signInLink: `${PORTAL_UI_URL}/login/sign-in-link?t=${signInCode}`,
             signInLinkExpiryMinutes: SIGN_IN_LINK_EXPIRY_MINUTES,
           });
         });

--- a/portal-api/src/config/sign-in-link.config.js
+++ b/portal-api/src/config/sign-in-link.config.js
@@ -1,0 +1,9 @@
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const { PORTAL_UI_URL } = process.env;
+
+module.exports = {
+  PORTAL_UI_URL,
+};

--- a/portal-api/src/v1/users/sign-in-link.service.js
+++ b/portal-api/src/v1/users/sign-in-link.service.js
@@ -21,7 +21,7 @@ class SignInLinkService {
     await this.#saveSignInCodeHashAndSalt({ userId, signInCode });
 
     return this.#sendSignInLinkEmail({
-      signInLink: `${PORTAL_UI_URL}login/sign-in-link?t=${signInCode}`,
+      signInLink: `${PORTAL_UI_URL}/login/sign-in-link?t=${signInCode}`,
       userEmail,
       userFirstName,
       userLastName,

--- a/portal-api/src/v1/users/sign-in-link.service.js
+++ b/portal-api/src/v1/users/sign-in-link.service.js
@@ -1,5 +1,6 @@
 const sendEmail = require('../email');
 const { EMAIL_TEMPLATE_IDS, SIGN_IN_LINK_EXPIRY_MINUTES } = require('../../constants');
+const { PORTAL_UI_URL } = require('../../config/sign-in-link.config');
 
 class SignInLinkService {
   #randomGenerator;
@@ -7,33 +8,23 @@ class SignInLinkService {
   #userRepository;
   #signInCodeByteLength = 32;
 
-  constructor(
-    randomGenerator,
-    hasher,
-    userRepository,
-  ) {
+  constructor(randomGenerator, hasher, userRepository) {
     this.#randomGenerator = randomGenerator;
     this.#hasher = hasher;
     this.#userRepository = userRepository;
   }
 
   async createAndEmailSignInLink(user) {
-    const {
-      _id: userId,
-      email: userEmail,
-      firstname: userFirstName,
-      surname: userLastName,
-    } = user;
+    const { _id: userId, email: userEmail, firstname: userFirstName, surname: userLastName } = user;
 
     const signInCode = this.#createSignInCode();
     await this.#saveSignInCodeHashAndSalt({ userId, signInCode });
 
     return this.#sendSignInLinkEmail({
-      // TODO DTFS-6680: update local host to envvar
-      signInLink: `http://localhost/login/sign-in-link?t=${signInCode}`,
+      signInLink: `${PORTAL_UI_URL}login/sign-in-link?t=${signInCode}`,
       userEmail,
       userFirstName,
-      userLastName
+      userLastName,
     });
   }
 
@@ -64,16 +55,12 @@ class SignInLinkService {
 
   async #sendSignInLinkEmail({ userEmail, userFirstName, userLastName, signInLink }) {
     try {
-      await sendEmail(
-        EMAIL_TEMPLATE_IDS.SIGN_IN_LINK,
-        userEmail,
-        {
-          firstName: userFirstName,
-          lastName: userLastName,
-          signInLink,
-          signInLinkExpiryMinutes: SIGN_IN_LINK_EXPIRY_MINUTES,
-        },
-      );
+      await sendEmail(EMAIL_TEMPLATE_IDS.SIGN_IN_LINK, userEmail, {
+        firstName: userFirstName,
+        lastName: userLastName,
+        signInLink,
+        signInLinkExpiryMinutes: SIGN_IN_LINK_EXPIRY_MINUTES,
+      });
     } catch (e) {
       const error = new Error('Failed to email the sign in code.');
       error.cause = e;
@@ -83,5 +70,5 @@ class SignInLinkService {
 }
 
 module.exports = {
-  SignInLinkService
+  SignInLinkService,
 };

--- a/portal-api/src/v1/users/sign-in-link.service.test.js
+++ b/portal-api/src/v1/users/sign-in-link.service.test.js
@@ -3,6 +3,7 @@ const sendEmail = require('../email');
 
 const { SignInLinkService } = require('./sign-in-link.service');
 const { SIGN_IN_LINK_EXPIRY_MINUTES, EMAIL_TEMPLATE_IDS } = require('../../constants');
+const { PORTAL_UI_URL } = require('../../config/sign-in-link.config');
 
 jest.mock('../email');
 
@@ -20,13 +21,13 @@ describe('SignInLinkService', () => {
     surname: 'a last name',
     email: 'an email',
   };
-  const signInLink = `http://localhost/login/sign-in-link?t=${token}`;
 
   let service;
 
   let randomGenerator;
   let hasher;
   let userRepository;
+  const signInLink = `${PORTAL_UI_URL}/login/sign-in-link?t=${token}`;
 
   beforeEach(() => {
     jest.resetAllMocks();


### PR DESCRIPTION
### Introduction

In the new Portal 2FA flow, the sign in link needs to link to the Portal website to log the user in. The Portal website URL varies per-environment, so we need to introduce an environment variable that configures the Portal website URL and use this for the sign in link that we send to the user.

### Resolution

- Added a new environment variable `PORTAL_UI_URL`
- @abhi-markan will need to add this to GitHub and ensure it has the correct value per environment
- It also needs to be added to the `feat/stbr-infra` branch, so I'll raise another PR against that branch

### Misc

**NOTE:** This branch was created from Luke's branch https://github.com/UK-Export-Finance/dtfs2/pull/2200 (which has not yet been merged), so also contains those changes. The only additional changes I have made are to the files:

- .env.sample
- portal-api/src/config/sign-in-link.config.js
- portal-api/src/v1/users/sign-in-link.service.js
- portal-api/src/v1/users/sign-in-link.service.test.js