### PR TITLE
chore: print the page body to the console when e2e tests error for investigations

### DIFF
--- a/e2e-tests/gef/cypress/support/e2e.js
+++ b/e2e-tests/gef/cypress/support/e2e.js
@@ -12,6 +12,18 @@ import submitDealAfterUkefIdsCall from './commands/submitDealAfterUkefIds';
 // Mitigates test fails due to js errors (third-party js)
 Cypress.on('uncaught:exception', () => false);
 
+// eslint-disable-next-line no-unused-vars
+Cypress.on('fail', (err, _runnable) => {
+  const pageBodyHtml = Cypress.$('body').html();
+
+  // Print the page body HTML to the console as part of the error if a test fails
+  // TODO: Remove this extra logging information when there are no more flakey e2e tests
+  // to investigate.
+  // eslint-disable-next-line no-param-reassign
+  err.message += `\n\n[DEBUG] The HTML of the page body is: ${JSON.stringify(pageBodyHtml)}`;
+  throw err;
+});
+
 // Preserve session cookie
 Cypress.Commands.add('saveSession', require('./commands/saveSession'));
 

--- a/e2e-tests/portal/cypress/support/e2e.js
+++ b/e2e-tests/portal/cypress/support/e2e.js
@@ -3,3 +3,15 @@ import './commands';
 
 // Mitigates test fails due to js errors (third-party js)
 Cypress.on('uncaught:exception', () => false);
+
+// eslint-disable-next-line no-unused-vars
+Cypress.on('fail', (err, _runnable) => {
+  const pageBodyHtml = Cypress.$('body').html();
+
+  // Print the page body HTML to the console as part of the error if a test fails
+  // TODO: Remove this extra logging information when there are no more flakey e2e tests
+  // to investigate.
+  // eslint-disable-next-line no-param-reassign
+  err.message += `\n\n[DEBUG] The HTML of the page body is: ${JSON.stringify(pageBodyHtml)}`;
+  throw err;
+});

--- a/e2e-tests/tfm/cypress/support/e2e.js
+++ b/e2e-tests/tfm/cypress/support/e2e.js
@@ -2,3 +2,15 @@ import './commands';
 
 // Mitigates test fails due to js errors (third-party js)
 Cypress.on('uncaught:exception', () => false);
+
+// eslint-disable-next-line no-unused-vars
+Cypress.on('fail', (err, _runnable) => {
+  const pageBodyHtml = Cypress.$('body').html();
+
+  // Print the page body HTML to the console as part of the error if a test fails
+  // TODO: Remove this extra logging information when there are no more flakey e2e tests
+  // to investigate.
+  // eslint-disable-next-line no-param-reassign
+  err.message += `\n\n[DEBUG] The HTML of the page body is: ${JSON.stringify(pageBodyHtml)}`;
+  throw err;
+});

--- a/e2e-tests/ukef/cypress/support/e2e.js
+++ b/e2e-tests/ukef/cypress/support/e2e.js
@@ -2,3 +2,15 @@ import './commands';
 
 // Mitigates test fails due to js errors (third-party js)
 Cypress.on('uncaught:exception', () => false);
+
+// eslint-disable-next-line no-unused-vars
+Cypress.on('fail', (err, _runnable) => {
+  const pageBodyHtml = Cypress.$('body').html();
+
+  // Print the page body HTML to the console as part of the error if a test fails
+  // TODO: Remove this extra logging information when there are no more flakey e2e tests
+  // to investigate.
+  // eslint-disable-next-line no-param-reassign
+  err.message += `\n\n[DEBUG] The HTML of the page body is: ${JSON.stringify(pageBodyHtml)}`;
+  throw err;
+});


### PR DESCRIPTION
## Introduction

We have some flakey e2e tests that fail sporadically, but it's very difficult to understand why they are failing because we can't reproduce it locally and the error message doesn't give enough information.
I want to add some temporary extra error logging to help us investigate why the tests are failing.

## Resolution

I've added a global on-'fail' handler to all the Cypress e2e tests.
The handler appends the current HTML of the page to the failure error message, so that it gets printed to the Node console alongside the error.

I originally tried making the handler log to the Node console itself. However it can't because:
- Cypress prevents using `console.log` to do this, and
- the handler cannot access a `cy` instance so we cannot set up a Cypress `task` to log to the Node console instead

