### PR TITLE
feat(FN-1472): remove commas from cell values

### DIFF
--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -14,13 +14,13 @@ const columnIndexToExcelColumn = (index) => {
 };
 
 /**
- * Extracts the value in the cell of an excel cell and removes any new lines so that it doesn't affect parsing as a csv.
+ * Extracts the value in the cell of an excel cell and removes any new lines or commas so that it doesn't affect parsing as a csv.
  * @param {Object} cell - excel cell.
  * @returns {string | number} - cell value.
  */
 const extractCellValue = (cell) => {
   const cellValue = cell.value?.result ?? cell.value;
-  const cellValueWithoutNewLines = typeof cellValue === 'string' ? cellValue?.replace(/\r\n|\r|\n/g, ' ').trim() : cellValue;
+  const cellValueWithoutNewLines = typeof cellValue === 'string' ? cellValue?.replace(/\r\n|\r|\n/g, ' ').replace(/,/g, '').trim() : cellValue;
   return cellValueWithoutNewLines;
 };
 

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -143,6 +143,22 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
+    it('returns the cell value without commas', async () => {
+      const cellValue = { value: 'GBP,' };
+
+      const extractedValue = extractCellValue(cellValue);
+
+      expect(extractedValue).toEqual('GBP');
+    });
+
+    it('returns the cell value without commas or new lines', async () => {
+      const cellValue = { value: '\n100,000' };
+
+      const extractedValue = extractCellValue(cellValue);
+
+      expect(extractedValue).toEqual('100000');
+    });
+
     it('returns the cell value if the value is a number', async () => {
       const cellValue = { value: 123 };
 


### PR DESCRIPTION
## Introduction
We had issues parsing cell values with commas due to us going to csv first and then parsing the csv to JSON

## Resolution
No commas are needed in the values so strip the values of any commas. Added benefit that if someone has a string representing a number with commas they are removed and it is easier to parse