### PR TITLE
fix: lock down report upload journey

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirm-and-send.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirm-and-send.spec.js
@@ -5,32 +5,43 @@ const relativeURL = require('../../../relativeURL');
 const { BANK1_PAYMENT_REPORT_OFFICER1 } = MOCK_USERS;
 
 context('Confirm and send', () => {
-  beforeEach(() => {
-    cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
-    cy.visit(relativeURL('/utilisation-report-upload'));
+  describe('After logging in and submitting a valid file', () => {
+    beforeEach(() => {
+      cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+      cy.visit(relativeURL('/utilisation-report-upload'));
 
-    utilisationReportUpload.utilisationReportFileInput().attachFile('valid-utilisation-report.xlsx');
-    utilisationReportUpload.continueButton().click();
+      utilisationReportUpload.utilisationReportFileInput().attachFile('valid-utilisation-report.xlsx');
+      utilisationReportUpload.continueButton().click();
+    });
+
+    it('Should route to the Upload Report page when the back button is selected', () => {
+      confirmAndSend.backLink().click();
+
+      confirmAndSend.mainHeading().should('not.exist');
+      confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+    });
+
+    it('Should route to the Upload Report page when the change button is selected', () => {
+      confirmAndSend.changeLink().click();
+
+      confirmAndSend.mainHeading().should('not.exist');
+      confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+    });
+
+    it('Should route to the Confirmation page when the Confirm and Send button is selected', () => {
+      confirmAndSend.confirmAndSendButton().click();
+
+      confirmAndSend.mainHeading().should('not.exist');
+      confirmAndSend.currentUrl().should('contain', '/confirmation');
+    });
   });
 
-  it('Should route to the Upload Report page when the back button is selected', () => {
-    confirmAndSend.backLink().click();
+  describe('After logging in but not submitting a file', () => {
+    it('Should route to the Upload Report page when you try and access the confirm and send page directly', () => {
+      cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+      cy.visit(relativeURL('/utilisation-report-upload/confirm-and-send'));
 
-    confirmAndSend.mainHeading().should('not.exist');
-    confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
-  });
-
-  it('Should route to the Upload Report page when the change button is selected', () => {
-    confirmAndSend.changeLink().click();
-
-    confirmAndSend.mainHeading().should('not.exist');
-    confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
-  });
-
-  it('Should route to the Confirmation page when the Confirm and Send button is selected', () => {
-    confirmAndSend.confirmAndSendButton().click();
-
-    confirmAndSend.mainHeading().should('not.exist');
-    confirmAndSend.currentUrl().should('contain', '/confirmation');
+      confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+    });
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirmation.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirmation.spec.js
@@ -5,23 +5,34 @@ const relativeURL = require('../../../relativeURL');
 const { BANK1_PAYMENT_REPORT_OFFICER1 } = MOCK_USERS;
 
 context('Confirmation', () => {
-  beforeEach(() => {
-    cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
-    cy.visit(relativeURL('/utilisation-report-upload'));
+  describe('After logging in, submitting a file and clicking the confirm and send button', () => {
+    beforeEach(() => {
+      cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+      cy.visit(relativeURL('/utilisation-report-upload'));
 
-    utilisationReportUpload.utilisationReportFileInput().attachFile('valid-utilisation-report.xlsx');
-    utilisationReportUpload.continueButton().click();
-    confirmAndSend.confirmAndSendButton().click();
+      utilisationReportUpload.utilisationReportFileInput().attachFile('valid-utilisation-report.xlsx');
+      utilisationReportUpload.continueButton().click();
+      confirmAndSend.confirmAndSendButton().click();
+    });
+
+    it('Should render confirmation heading', () => {
+      confirmation.mainHeading().should('exist');
+    });
+
+    it('Should route to the login page when the sign-out button is selected', () => {
+      confirmation.signOutButton().click();
+
+      confirmation.mainHeading().should('not.exist');
+      confirmation.currentUrl().should('contain', '/login');
+    });
   });
 
-  it('Should render confirmation heading', () => {
-    confirmation.mainHeading().should('exist');
-  });
+  describe('After logging in but not submitting a file', () => {
+    it('Should route to the Upload Report page when you try and access the confirm and send page directly', () => {
+      cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+      cy.visit(relativeURL('/utilisation-report-upload/confirm-and-send'));
 
-  it('Should route to the login page when the sign-out button is selected', () => {
-    confirmation.signOutButton().click();
-
-    confirmation.mainHeading().should('not.exist');
-    confirmation.currentUrl().should('contain', '/login');
+      confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+    });
   });
 });

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -132,10 +132,6 @@ const getReportConfirmAndSend = async (req, res) => {
 
 const postReportConfirmAndSend = async (req, res) => {
   try {
-    if (!req.session.utilisationReport) {
-      return res.redirect('/utilisation-report-upload');
-    }
-
     const { user, userToken, utilisationReport } = req.session;
     const { fileBuffer, month, year, reportData, reportPeriod } = utilisationReport;
 
@@ -161,6 +157,9 @@ const postReportConfirmAndSend = async (req, res) => {
 
 const getReportConfirmation = async (req, res) => {
   try {
+    if (!req.session.utilisationReport) {
+      return res.redirect('/utilisation-report-upload');
+    }
     const { reportPeriod, paymentOfficerEmail } = req.session.utilisationReport;
     delete req.session.utilisationReport;
     return res.render('utilisation-report-service/utilisation-report-upload/confirmation.njk', {

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -116,6 +116,10 @@ const postUtilisationReportUpload = async (req, res) => {
 
 const getReportConfirmAndSend = async (req, res) => {
   try {
+    if (!req.session.utilisationReport) {
+      return res.redirect('/utilisation-report-upload');
+    }
+
     return res.render('utilisation-report-service/utilisation-report-upload/confirm-and-send.njk', {
       user: req.session.user,
       primaryNav: 'utilisation_report_upload',
@@ -128,6 +132,10 @@ const getReportConfirmAndSend = async (req, res) => {
 
 const postReportConfirmAndSend = async (req, res) => {
   try {
+    if (!req.session.utilisationReport) {
+      return res.redirect('/utilisation-report-upload');
+    }
+
     const { user, userToken, utilisationReport } = req.session;
     const { fileBuffer, month, year, reportData, reportPeriod } = utilisationReport;
 
@@ -154,6 +162,7 @@ const postReportConfirmAndSend = async (req, res) => {
 const getReportConfirmation = async (req, res) => {
   try {
     const { reportPeriod, paymentOfficerEmail } = req.session.utilisationReport;
+    delete req.session.utilisationReport;
     return res.render('utilisation-report-service/utilisation-report-upload/confirmation.njk', {
       user: req.session.user,
       primaryNav: 'utilisation_report_upload',

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -20,7 +20,12 @@ const columnIndexToExcelColumn = (index) => {
  */
 const extractCellValue = (cell) => {
   const cellValue = cell.value?.result ?? cell.value;
-  const cellValueWithoutNewLines = typeof cellValue === 'string' ? cellValue?.replace(/\r\n|\r|\n/g, ' ').replace(/,/g, '').trim() : cellValue;
+  const cellValueWithoutNewLines = typeof cellValue === 'string'
+    ? cellValue
+      ?.replace(/\r\n|\r|\n/g, ' ')
+      .replace(/,/g, '')
+      .trim()
+    : cellValue;
   return cellValueWithoutNewLines;
 };
 

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -22,7 +22,7 @@ const extractCellValue = (cell) => {
   const cellValue = cell.value?.result ?? cell.value;
   const cellValueWithoutNewLines = typeof cellValue === 'string'
     ? cellValue
-      ?.replace(/\r\n|\r|\n/g, ' ')
+      .replace(/\r\n|\r|\n/g, ' ')
       .replace(/,/g, '')
       .trim()
     : cellValue;


### PR DESCRIPTION
## Introduction
Trying to access one of the pages in the journey of the utilisation report upload (e.g. if you had it bookmarked) would crash the page as the utilisation report would not be in the session.

## Resolution
Route the user back to the start of the journey if the user does not have a utilisationReport in their session.