### PR TITLE
feat(DTFS2-6780): add typescript compatibility to dtfs-central-api

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,7 +37,6 @@ services:
       - EXTERNAL_API_KEY
       - NODE_ENV=${NODE_ENV}
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon --inspect=0.0.0.0:9223 src/index.js -L
 
   trade-finance-manager-ui:
     build: ./trade-finance-manager-ui

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -134,7 +134,6 @@ services:
       - TZ=Europe/London
       - NODE_ENV=${NODE_ENV}
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon --inspect=0.0.0.0:9226 server/index.js -L
 
   portal-api:
     build: ./portal-api
@@ -247,7 +246,6 @@ services:
       - DTFS_CENTRAL_API_KEY
       - EXTERNAL_API_KEY
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon --inspect=0.0.0.0:9229 server/index.js -L --max_old_space_size=250
 
   number-generator-function:
     build: ./azure-functions/number-generator-function

--- a/docker-compose.gha.yml
+++ b/docker-compose.gha.yml
@@ -35,7 +35,7 @@ services:
       - DTFS_CENTRAL_API_KEY
       - EXTERNAL_API_KEY
       - RATE_LIMIT_THRESHOLD
-    entrypoint: npx nodemon src/index.js -L
+    entrypoint: npx ts-node src/index.ts
 
   trade-finance-manager-ui:
     build: ./trade-finance-manager-ui

--- a/docker-compose.gha.yml
+++ b/docker-compose.gha.yml
@@ -130,7 +130,6 @@ services:
       - NODE_ENV=${NODE_ENV}
       - REDIS_HOSTNAME=redis
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon server/index.js -L
 
   portal-api:
     build: ./portal-api
@@ -237,7 +236,6 @@ services:
       - TFM_API_KEY
       - DTFS_CENTRAL_API_KEY
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon server/index.js -L
 
   number-generator-function:
     build: ./azure-functions/number-generator-function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,6 @@ services:
       - COMPANIES_HOUSE_API_URL=https://api.companieshouse.gov.uk
       - EXTERNAL_API_URL=http://external-api:5002
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon server/index.js -L
 
   portal-api:
     build: ./portal-api
@@ -277,7 +276,6 @@ services:
       - NODE_ENV=${NODE_ENV}
       - EXTERNAL_API_URL=http://external-api:5002
       - RATE_LIMIT_THRESHOLD
-    command: npx nodemon server/index.js -L
 
   number-generator-function:
     build: ./azure-functions/number-generator-function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - EXTERNAL_API_KEY
       - NODE_ENV=${NODE_ENV}
       - RATE_LIMIT_THRESHOLD
-    entrypoint: npx nodemon src/index.js -L
+    entrypoint: npx ts-node src/index.ts
 
   trade-finance-manager-ui:
     build: ./trade-finance-manager-ui

--- a/dtfs-central-api/.eslintrc.js
+++ b/dtfs-central-api/.eslintrc.js
@@ -38,4 +38,9 @@ module.exports = {
     ecmaVersion: 2020,
   },
   ignorePatterns: ['**/node_modules/**'],
+  settings: {
+    'import/resolver': {
+      typescript: {},
+    },
+  },
 };

--- a/dtfs-central-api/init.sh
+++ b/dtfs-central-api/init.sh
@@ -16,4 +16,4 @@ echo "cd /home" >> /etc/profile
 rc-service sshd start
 
 echo "Intialising Node..."
-node src/index.js
+npx ts-node src/index.ts

--- a/dtfs-central-api/package-lock.json
+++ b/dtfs-central-api/package-lock.json
@@ -28,7 +28,8 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.29.0",
         "jest": "29.5.0",
-        "supertest": "6.3.3"
+        "supertest": "6.3.3",
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18",
@@ -6753,6 +6754,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -8128,6 +8135,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/dtfs-central-api/package-lock.json
+++ b/dtfs-central-api/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "eslint": "^8.53.0",
         "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.0",
         "jest": "29.5.0",
         "supertest": "6.3.3",
@@ -3869,6 +3870,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4095,6 +4109,54 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/eslint-module-utils": {
@@ -4450,6 +4512,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4776,6 +4866,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -6344,6 +6446,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -7234,6 +7345,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -7910,6 +8030,15 @@
       },
       "peerDependencies": {
         "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/test-exclude": {

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "eslint": "^8.53.0",
     "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",
     "jest": "29.5.0",
     "supertest": "6.3.3",

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -16,15 +16,15 @@
   },
   "license": "MIT",
   "author": "UK Export Finance",
-  "main": "src/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "api-test": "jest --coverage --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
     "api-test-dev": "jest --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
     "api-test-file": "jest --config=api-test-file.jest.config.js --runInBand --verbose --testMatch ",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
-    "start": "node src/index.js",
-    "start:dev": "npx nodemon src/index.js",
+    "start": "npx ts-node src/index.ts",
+    "start:dev": "npx nodemon --exec npm run start",
     "unit-test": "jest --coverage --verbose --config=unit.jest.config.js",
     "unit-test-quick": "jest --config=unit.jest.config.js --testTimeout=10000"
   },
@@ -48,7 +48,8 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.0",
     "jest": "29.5.0",
-    "supertest": "6.3.3"
+    "supertest": "6.3.3",
+    "typescript": "^5.2.2"
   },
   "engines": {
     "node": ">=18",

--- a/dtfs-central-api/src/azure-env/index.js
+++ b/dtfs-central-api/src/azure-env/index.js
@@ -1,8 +1,0 @@
-// Fix Azure environment variables
-Object.keys(process.env).forEach((key) => {
-  if (key.startsWith('CUSTOMCONNSTR_')) {
-    const fixedKey = key.substr('CUSTOMCONNSTR_'.length);
-    process.env[fixedKey] = process.env[key];
-    console.info('Fixed %s to %s', key, fixedKey);
-  }
-});

--- a/dtfs-central-api/src/azure-env/index.ts
+++ b/dtfs-central-api/src/azure-env/index.ts
@@ -1,0 +1,11 @@
+const fixAzureEnvironmentVariables = () => {
+  Object.keys(process.env).forEach((key) => {
+    if (key.startsWith('CUSTOMCONNSTR_')) {
+      const fixedKey = key.substr('CUSTOMCONNSTR_'.length);
+      process.env[fixedKey] = process.env[key];
+      console.info('Fixed %s to %s', key, fixedKey);
+    }
+  });
+};
+
+export default fixAzureEnvironmentVariables;

--- a/dtfs-central-api/src/index.ts
+++ b/dtfs-central-api/src/index.ts
@@ -1,6 +1,7 @@
-import fixAxureEnvironmentVariables from './azure-env'
+import fixAzureEnvironmentVariables from './azure-env/index.ts'
+fixAzureEnvironmentVariables();
+
 import app from './createApp';
-fixAxureEnvironmentVariables();
 
 const PORT = process.env.PORT || 5005;
 

--- a/dtfs-central-api/src/index.ts
+++ b/dtfs-central-api/src/index.ts
@@ -1,5 +1,6 @@
-require('./azure-env');
-const app = require('./createApp');
+import fixAxureEnvironmentVariables from './azure-env'
+import app from './createApp';
+fixAxureEnvironmentVariables();
 
 const PORT = process.env.PORT || 5005;
 

--- a/dtfs-central-api/tsconfig.eslint.json
+++ b/dtfs-central-api/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "src",
+        "api-tests",
+        "./*.jest.config.js/",
+        ".eslintrc.js"
+    ],
+    "exclude": []
+ }

--- a/dtfs-central-api/tsconfig.json
+++ b/dtfs-central-api/tsconfig.json
@@ -1,0 +1,102 @@
+{
+    "compilerOptions": {
+      /* Visit https://aka.ms/tsconfig.json to read more about this file */
+  
+      /* Projects */
+      // "incremental": true,                              /* Enable incremental compilation */
+      // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+      // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+      // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+      // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+      // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+  
+      /* Language and Environment */
+      "target": "es5",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+      "lib": ["dom", "esnext"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+      // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+      // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+      // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+      // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+      // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+      // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+      // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+      // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+  
+      /* Modules */
+      "module": "CommonJS",                             /* Specify what module code is generated. */
+      "rootDir": "./",                                  /* Specify the root folder within your source files. */
+      "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+      "baseUrl": ".",                        /* Specify the base directory to resolve non-relative module names. */
+      "paths": {},                                  /* Specify a set of entries that re-map imports to additional lookup locations. */
+      // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+      // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+      "types": ["node", "jest"],                                      /* Specify type package names to be included without being referenced in a source file. */
+      // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+      // "resolveJsonModule": true,                        /* Enable importing .json files */
+      // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+  
+      /* JavaScript Support */
+      "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+      "checkJs": false,                                  /* Enable error reporting in type-checked JavaScript files. */
+      // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+  
+      /* Emit */
+      // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+      // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+      // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+      // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+      // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+      // "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
+      // "removeComments": true,                           /* Disable emitting comments. */
+      // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+      "importHelpers": true,                               /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+      // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+      // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+      // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+      // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+      // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+      // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+      "newLine": "lf",                                     /* Set the newline character for emitting files. */
+      // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+      // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+      // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+      // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+      // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+  
+      /* Interop Constraints */
+      "isolatedModules": false,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
+      "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */
+      "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+      // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+      "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+  
+      /* Type Checking */
+      "strict": true,                                      /* Enable all strict type-checking options. */
+      // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+      // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+      // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+      // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+      // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+      "noImplicitThis": true,                              /* Enable error reporting when `this` is given the type `any`. */
+      // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+      "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+      "noUnusedLocals": true,                              /* Enable error reporting when a local variables aren't read. */
+      "noUnusedParameters": false,                         /* Raise an error when a function parameter isn't read */
+      // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+      // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+      // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+      // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+      // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+      // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+      // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+      // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+  
+      /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["./node_modules/*", "node_modules"]
+  }

--- a/dtfs-central-api/tsconfig.json
+++ b/dtfs-central-api/tsconfig.json
@@ -35,7 +35,8 @@
       // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
       // "resolveJsonModule": true,                        /* Enable importing .json files */
       // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-  
+      "allowImportingTsExtensions": true,
+
       /* JavaScript Support */
       "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
       "checkJs": false,                                  /* Enable error reporting in type-checked JavaScript files. */


### PR DESCRIPTION
## Introduction
Currently `dtfs-central-api` does not support Typescript. It would improve development efficiency and reduce the chance of bugs if it did.

## Resolution
- updated the `package.json`
    - changed the `start` script to `npx ts-node server/index.ts`
- Added `tsconfig.json`
    - This allows but does not check js files 
- Added `ts-config.eslint.json`
- Changed `server/index` and `server/azure-env/index` from js to ts to verify the change works.
    - replaced `require`/`module.exports` with `import`/`export`


## Note
- I haven't been able to run this on my VM yet, but it compiles to the point of needed environment variables.
- This is branched off #2279, this PR covers the changes to `dtfs-central-api`
