### PR TITLE
feat(FN-1480): remove duplicate bank routes in Central API

### DIFF
--- a/dtfs-central-api/src/v1/routes/portal-routes.js
+++ b/dtfs-central-api/src/v1/routes/portal-routes.js
@@ -16,9 +16,6 @@ const updateFacilityController = require('../controllers/portal/facility/update-
 const deleteFacilityController = require('../controllers/portal/facility/delete-facility.controller');
 const updateFacilityStatusController = require('../controllers/portal/facility/update-facility-status.controller');
 
-const getBankController = require('../controllers/bank/get-bank.controller');
-const createBankController = require('../controllers/bank/create-bank.controller');
-
 const createGefDealController = require('../controllers/portal/gef-deal/create-gef-deal.controller');
 const getGefDealController = require('../controllers/portal/gef-deal/get-gef-deal.controller');
 const updateGefDealController = require('../controllers/portal/gef-deal/update-deal.controller');
@@ -47,16 +44,6 @@ portalRouter.use((req, res, next) => {
   req.routePath = PORTAL_ROUTE;
   next();
 });
-
-portalRouter.route('/banks')
-  .post(
-    createBankController.createBankPost,
-  );
-
-portalRouter.route('/banks/:id')
-  .get(
-    getBankController.findOneBankGet,
-  );
 
 /**
  * @openapi


### PR DESCRIPTION
## Ticket

[FN-1480](https://ukef-dtfs.atlassian.net/browse/FN-1480)

## Introduction

There are two sets of endpoints for the fetching and creating of banks:

* bank-routes.js
  * POST /bank
  * GET /bank/:id
* portal-routes.js
  * POST /portal/banks
  * GET /portal/banks/:id

They point to the same controllers, so there is no functional difference. This appears to be some tech debt left over from when Central API / TFM was created (possibly the “bank routes" were added for TFM whilst the portal routes already existed).

Since the bank collection in MongoDB is generic, the “portal routes” version should be removed.

## Resolution

* Remove the routes from `portal-routes.js`, keeping the `bank-routes.js` versions.
* The portal routes endpoints do not appear to be used anywhere, so no further refactoring is required.