### PR TITLE
feat(FN-1295): back link and error positioning

### DIFF
--- a/portal/templates/admin/user-edit.njk
+++ b/portal/templates/admin/user-edit.njk
@@ -3,10 +3,9 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-
 
 {% extends "index.njk" %}
+{% set backLink = { href: "/admin/users" } %}
 
 {% block pageTitle %}
   {% if _id %}
@@ -17,14 +16,6 @@
 {% endblock %}
 
 {% block content %}
-
-  {{ govukBackLink({
-      text: "Back",
-      href: "/admin/users",
-      attributes: {
-        'data-cy': 'back-link'
-      }
-  }) }}
 
   <h1 class="govuk-heading-l">
     {% if _id %}

--- a/portal/templates/index.njk
+++ b/portal/templates/index.njk
@@ -33,6 +33,17 @@
 
     <div class="govuk-width-container">
 
+      {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+      {% if backLink and backLink.href %}
+        {{ govukBackLink({
+          text: "Back",
+          href: backLink.href,
+          attributes: {
+              "data-cy": "back-link"
+          }
+        }) }}
+      {% endif %}
+
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         {% block content %}{% endblock %}
       </main>

--- a/portal/templates/index.njk
+++ b/portal/templates/index.njk
@@ -21,6 +21,7 @@
   <body class="govuk-template__body ">
 
     <script src="/assets/js/jsEnabled.js" type="text/javascript" integrity="sha512-+oUPyU7P4RBV7u2B6RkjEWzdtDSbzvPyIOKS7YelVhYUftt4L261FozUDCXcQG6ITqkIPfZW91okPyupbLd0xA==" crossorigin="anonymous"></script>
+    {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
     {% include "_partials/skip-link.njk" %}
 
     {% if user and user.roles and user.roles.includes('admin') %}
@@ -33,13 +34,12 @@
 
     <div class="govuk-width-container">
 
-      {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
       {% if backLink and backLink.href %}
         {{ govukBackLink({
           text: "Back",
           href: backLink.href,
           attributes: {
-              "data-cy": "back-link"
+            "data-cy": "back-link"
           }
         }) }}
       {% endif %}

--- a/portal/templates/index.njk
+++ b/portal/templates/index.njk
@@ -1,3 +1,4 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
@@ -21,7 +22,6 @@
   <body class="govuk-template__body ">
 
     <script src="/assets/js/jsEnabled.js" type="text/javascript" integrity="sha512-+oUPyU7P4RBV7u2B6RkjEWzdtDSbzvPyIOKS7YelVhYUftt4L261FozUDCXcQG6ITqkIPfZW91okPyupbLd0xA==" crossorigin="anonymous"></script>
-    {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
     {% include "_partials/skip-link.njk" %}
 
     {% if user and user.roles and user.roles.includes('admin') %}

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/check-the-report.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/check-the-report.njk
@@ -1,13 +1,9 @@
 {% extends "index.njk" %}
+{% set backLink = { href: "/utilisation-report-upload" } %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% block pageTitle %}Utilisation Report Upload{% endblock %}
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: "/utilisation-report-upload"
-        }) }}
     <h1 class="govuk-heading-l" data-cy="check-the-report-title">
         Check the report
     </h1>

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/check-the-report.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/check-the-report.njk
@@ -4,9 +4,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% block pageTitle %}Utilisation Report Upload{% endblock %}
 {% block content %}
-    <h1 class="govuk-heading-l" data-cy="check-the-report-title">
-        Check the report
-    </h1>
     {% if errorSummary %}
         {{ govukErrorSummary({
           titleText: "There is a problem",
@@ -16,6 +13,9 @@
           }
         }) }}
     {% endif %}
+    <h1 class="govuk-heading-l" data-cy="check-the-report-title">
+        Check the report
+    </h1>
     {% if validationErrors %}
         <div class="govuk-form-group govuk-form-group--error govuk-!-margin-top-7">
             <h2 class="govuk-heading-m" id="validation-errors-table">Errors found in {{ filename }}</h2>

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/confirm-and-send.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/confirm-and-send.njk
@@ -1,15 +1,8 @@
 {% extends "index.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% set backLink = { href: "/utilisation-report-upload" } %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% block pageTitle %}File successfully validated{% endblock %}
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/utilisation-report-upload',
-        attributes: {
-            'data-cy': 'back-link'
-        }
-    }) }}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l" data-cy="confirm-and-send-main-heading">


### PR DESCRIPTION
# Introduction

The position of the error summary box and back button on some of the utilisation report upload pages doesn't match the designs.

# Resolution

The back link is placed into the top-level `index.njk` function so that it appears directly below the header. The back link can be used in a specific njk file by setting the `backLink` object via `{% set backLink = { href: '/[path]' } %}`. The back link will not appear if your njk template file doesn't include this line. The resulting appearance of `confirm-and-send.njk` and `check-the-report.njk` are shown below.

The error summary box is moved above the `<h1>` in the relevant njk file.

![image](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/cb3f2f3e-e321-4011-ae02-87c35974e613)
![image](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/b42e9206-e4ff-45de-80ca-614f6932ed0f)
