### PR TITLE
feat(FN-1432): handle formulas where value.result is undefined

### DIFF
--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -19,7 +19,8 @@ const columnIndexToExcelColumn = (index) => {
  * @returns {string | number} - cell value.
  */
 const extractCellValue = (cell) => {
-  const cellValue = cell.value?.result ?? cell.value;
+  /* eslint-disable-next-line no-underscore-dangle */
+  const cellValue = cell.value?.result ?? cell._value?.result ?? cell.value;
   const cellValueWithoutNewLines = typeof cellValue === 'string'
     ? cellValue
       .replace(/\r\n|\r|\n/g, ' ')

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -174,5 +174,13 @@ describe('csv-utils', () => {
 
       expect(extractedValue).toEqual(123);
     });
+
+    it('returns the cell value if the cell is using a formula to calculate the value and the result is missing in the value key', async () => {
+      const cellValue = { _value: { result: 123, formula: 'SUM(A1:A2)' } };
+
+      const extractedValue = extractCellValue(cellValue);
+
+      expect(extractedValue).toEqual(123);
+    });
   });
 });


### PR DESCRIPTION
## Introduction
For some cells fetching data from another sheet or document the package wouldn't populate cell.value.result correctly, instead we need to go through the hidden fields directly to _value.result to get it. I haven't figured out why it this is the case on some of the cells but have assumed there is something going wrong with the packages mapping of data from the workbook to the cell object and then how the value getter gets the result from the object.

## Resolution
Try and fetch cell.value?.result, if not look for cell._value.result and if not default to cell.value as it should be a plain value not using a formula to calculate it