### PR TITLE
fix(DTFS2-6789): allow read-only users to have access to all banks

### DIFF
--- a/gef-ui/server/constants/all-banks-id.js
+++ b/gef-ui/server/constants/all-banks-id.js
@@ -1,0 +1,3 @@
+const ALL_BANKS_ID = '*';
+
+module.exports = ALL_BANKS_ID;

--- a/gef-ui/server/constants/index.js
+++ b/gef-ui/server/constants/index.js
@@ -1,4 +1,5 @@
 const ROLES = require('./roles');
+const ALL_BANKS_ID = require('./all-banks-id');
 
 const DEAL_SUBMISSION_TYPE = {
   AIN: 'Automatic Inclusion Notice',
@@ -95,4 +96,5 @@ module.exports = {
   DATE_FORMAT,
   COMPANIES_HOUSE_NUMBER_REGEX,
   UK_POSTCODE_REGEX,
+  ALL_BANKS_ID,
 };

--- a/gef-ui/server/middleware/validateBank/index.js
+++ b/gef-ui/server/middleware/validateBank/index.js
@@ -1,4 +1,5 @@
 const { ADMIN, READ_ONLY } = require('../../constants/roles');
+const { ALL_BANKS_ID } = require('../../constants');
 const api = require('../../services/api');
 
 const validRolesForAccessingAllBanks = [
@@ -6,9 +7,14 @@ const validRolesForAccessingAllBanks = [
   READ_ONLY,
 ];
 
+/**
+ * Returns `true` if the user has permission to access data from all banks, and `false` otherwise.
+ * @param {{ bank: {id: string}, roles: string[] }} user
+ * @returns {Boolean}
+ */
 const userCanAccessAllBanks = (user) => {
   const userBankId = user?.bank?.id;
-  if (userBankId !== '*') {
+  if (userBankId !== ALL_BANKS_ID) {
     return false;
   }
 

--- a/gef-ui/server/middleware/validateBank/index.test.js
+++ b/gef-ui/server/middleware/validateBank/index.test.js
@@ -1,5 +1,6 @@
 const validateBank = require('.');
 const { ADMIN, READ_ONLY } = require('../../constants/roles');
+const { ALL_BANKS_ID } = require('../../constants');
 
 describe('validateBank', () => {
   const dealId = 'deal id';
@@ -12,8 +13,8 @@ describe('validateBank', () => {
     next = jest.fn();
   });
 
-  describe('when the current user has bankId *', () => {
-    const bankId = '*';
+  describe('when the current user has the ALL_BANKS_ID bankId ', () => {
+    const bankId = ALL_BANKS_ID;
 
     it('calls next if the current user has the admin role', async () => {
       const req = buildRequestFromUserWith({ roles: [ADMIN], bankId });

--- a/gef-ui/server/middleware/validateBank/index.test.js
+++ b/gef-ui/server/middleware/validateBank/index.test.js
@@ -1,0 +1,51 @@
+const validateBank = require('.');
+const { ADMIN, READ_ONLY } = require('../../constants/roles');
+
+describe('validateBank', () => {
+  const dealId = 'deal id';
+
+  let res;
+  let next;
+
+  beforeEach(() => {
+    res = { redirect: jest.fn() };
+    next = jest.fn();
+  });
+
+  describe('when the current user has bankId *', () => {
+    const bankId = '*';
+
+    it('calls next if the current user has the admin role', async () => {
+      const req = buildRequestFromUserWith({ roles: [ADMIN], bankId });
+
+      await validateBank(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('calls next if the current user has the read-only role', async () => {
+      const req = buildRequestFromUserWith({ roles: [READ_ONLY], bankId });
+
+      await validateBank(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  function buildRequestFromUserWith({ roles, bankId }) {
+    const user = {
+      bank: {
+        id: bankId,
+      },
+      roles,
+    };
+    return {
+      params: {
+        _id: dealId,
+      },
+      session: {
+        user,
+      },
+    };
+  }
+});

--- a/portal/server/constants/all-banks-id.js
+++ b/portal/server/constants/all-banks-id.js
@@ -1,0 +1,3 @@
+const ALL_BANKS_ID = '*';
+
+module.exports = ALL_BANKS_ID;

--- a/portal/server/constants/index.js
+++ b/portal/server/constants/index.js
@@ -12,6 +12,7 @@ const PORTAL_URL = require('./portalUrl.constant');
 const SORT_BY = require('./sort');
 const CURRENCY = require('./currency');
 const ROLES = require('./roles');
+const ALL_BANKS_ID = require('./all-banks-id');
 
 module.exports = {
   DASHBOARD,
@@ -28,4 +29,5 @@ module.exports = {
   SORT_BY,
   CURRENCY,
   ROLES,
+  ALL_BANKS_ID,
 };

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.test.js
@@ -3,6 +3,7 @@ import {
   STATUS,
   SUBMISSION_TYPE,
   FIELD_NAMES,
+  ALL_BANKS_ID,
 } from '../../../constants';
 import CONTENT_STRINGS from '../../../content-strings';
 import keywordQuery from './deals-filters-keyword-query';
@@ -109,7 +110,7 @@ describe('controllers/dashboard/deals - filters query', () => {
   describe('when user is a super user', () => {
     it('should not return any filters', () => {
       const mockFilters = [];
-      mockUser.bank.id = '*';
+      mockUser.bank.id = ALL_BANKS_ID;
       mockUser.roles = [];
 
       const result = dashboardDealsFiltersQuery(
@@ -134,7 +135,7 @@ describe('controllers/dashboard/deals - filters query', () => {
         ],
       },
     ];
-    mockUser.bank.id = '*';
+    mockUser.bank.id = ALL_BANKS_ID;
     mockUser.roles = [];
 
     const result = dashboardDealsFiltersQuery(
@@ -166,7 +167,7 @@ describe('controllers/dashboard/deals - filters query', () => {
     const mockFilters = [
       { status: [CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.DEALS.ALL_STATUSES] },
     ];
-    mockUser.bank.id = '*';
+    mockUser.bank.id = ALL_BANKS_ID;
     mockUser.roles = [];
 
     const result = dashboardDealsFiltersQuery(

--- a/portal/server/controllers/dashboard/deals/index.test.js
+++ b/portal/server/controllers/dashboard/deals/index.test.js
@@ -17,7 +17,7 @@ import { removeSessionFilter } from '../filters/remove-filter-from-session';
 import { dashboardDealsFiltersQuery } from './deals-filters-query';
 import { dealsTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
-import CONSTANTS, { ALL_BANKS_ID } from '../../../constants';
+import CONSTANTS from '../../../constants';
 import { MAKER, CHECKER } from '../../../constants/roles';
 
 jest.mock('../../../api', () => ({
@@ -47,13 +47,7 @@ jest.mock('../../../helpers', () => ({
   })),
   getFlashSuccessMessage: jest.fn(),
   requestParams: jest.fn(() => ({ userToken: 'mock-token' })),
-  isSuperUser: jest.fn((user) => {
-    if (user.bank.id === ALL_BANKS_ID) {
-      return true;
-    }
-
-    return false;
-  }),
+  isSuperUser: jest.requireActual('../../../helpers').isSuperUser,
   getUserRoles: jest.fn(() => ({ isMaker: true })),
 }));
 

--- a/portal/server/controllers/dashboard/deals/index.test.js
+++ b/portal/server/controllers/dashboard/deals/index.test.js
@@ -17,7 +17,7 @@ import { removeSessionFilter } from '../filters/remove-filter-from-session';
 import { dashboardDealsFiltersQuery } from './deals-filters-query';
 import { dealsTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
-import CONSTANTS from '../../../constants';
+import CONSTANTS, { ALL_BANKS_ID } from '../../../constants';
 import { MAKER, CHECKER } from '../../../constants/roles';
 
 jest.mock('../../../api', () => ({
@@ -48,7 +48,7 @@ jest.mock('../../../helpers', () => ({
   getFlashSuccessMessage: jest.fn(),
   requestParams: jest.fn(() => ({ userToken: 'mock-token' })),
   isSuperUser: jest.fn((user) => {
-    if (user.bank.id === '*') {
+    if (user.bank.id === ALL_BANKS_ID) {
       return true;
     }
 

--- a/portal/server/controllers/dashboard/facilities/facilities-filters-query.test.js
+++ b/portal/server/controllers/dashboard/facilities/facilities-filters-query.test.js
@@ -1,5 +1,5 @@
 import { dashboardFacilitiesFiltersQuery } from './facilities-filters-query';
-import CONSTANTS from '../../../constants';
+import CONSTANTS, { ALL_BANKS_ID } from '../../../constants';
 import CONTENT_STRINGS from '../../../content-strings';
 import keywordQuery from './facilities-filters-keyword-query';
 import { ADMIN, MAKER } from '../../../constants/roles';
@@ -14,7 +14,7 @@ describe('controllers/dashboard/facilities - filters query', () => {
   const mockUserAdmin = {
     _id: '123',
     roles: [ADMIN],
-    bank: { id: '*' },
+    bank: { id: ALL_BANKS_ID },
   };
 
   it('should return deal.bank.id filter', () => {

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -17,7 +17,7 @@ import {
 import { removeSessionFilter } from '../filters/remove-filter-from-session';
 import { facilitiesTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
-import CONSTANTS from '../../../constants';
+import CONSTANTS, { ALL_BANKS_ID } from '../../../constants';
 import { sanitiseBody } from './sanitise-body';
 import { CHECKER, MAKER } from '../../../constants/roles';
 
@@ -39,7 +39,7 @@ jest.mock('../../../helpers', () => ({
   getFlashSuccessMessage: jest.fn(),
   requestParams: jest.fn(() => ({ userToken: 'mock-token' })),
   isSuperUser: jest.fn((user) => {
-    if (user.bank.id === '*') {
+    if (user.bank.id === ALL_BANKS_ID) {
       return true;
     }
 

--- a/portal/server/controllers/dashboard/facilities/index.test.js
+++ b/portal/server/controllers/dashboard/facilities/index.test.js
@@ -17,7 +17,7 @@ import {
 import { removeSessionFilter } from '../filters/remove-filter-from-session';
 import { facilitiesTemplateFilters as templateFilters } from './template-filters';
 import { selectedFilters } from './selected-filters';
-import CONSTANTS, { ALL_BANKS_ID } from '../../../constants';
+import CONSTANTS from '../../../constants';
 import { sanitiseBody } from './sanitise-body';
 import { CHECKER, MAKER } from '../../../constants/roles';
 
@@ -38,13 +38,7 @@ jest.mock('../../../helpers', () => ({
   })),
   getFlashSuccessMessage: jest.fn(),
   requestParams: jest.fn(() => ({ userToken: 'mock-token' })),
-  isSuperUser: jest.fn((user) => {
-    if (user.bank.id === ALL_BANKS_ID) {
-      return true;
-    }
-
-    return false;
-  }),
+  isSuperUser: jest.requireActual('../../../helpers').isSuperUser,
   getUserRoles: jest.fn(() => ({ isMaker: true })),
 }));
 

--- a/portal/server/helpers/isSuperUser.js
+++ b/portal/server/helpers/isSuperUser.js
@@ -1,4 +1,6 @@
+const { ALL_BANKS_ID } = require('../constants');
+
 const isSuperUser = (user) =>
-  user && user.bank && user.bank.id === '*';
+  user && user.bank && user.bank.id === ALL_BANKS_ID;
 
 module.exports = isSuperUser;

--- a/portal/server/helpers/isSuperUser.test.js
+++ b/portal/server/helpers/isSuperUser.test.js
@@ -1,9 +1,10 @@
+const { ALL_BANKS_ID } = require('../constants');
 const isSuperUser = require('./isSuperUser');
 
 describe('isSuperUser', () => {
   it('should return true when user.bank.id is `*`', () => {
     const mockUser = {
-      bank: { id: '*' },
+      bank: { id: ALL_BANKS_ID },
     };
 
     const result = isSuperUser(mockUser);

--- a/portal/server/routes/admin/users.js
+++ b/portal/server/routes/admin/users.js
@@ -7,6 +7,7 @@ const {
   generateErrorSummary,
   constructPayload,
 } = require('../../helpers');
+const { ALL_BANKS_ID } = require('../../constants');
 
 const router = express.Router();
 
@@ -83,7 +84,7 @@ router.post('/users/create', async (req, res) => {
     // `fi` stands for `financial institution`
     if (bank === 'all') {
       user.bank = {
-        id: '*',
+        id: ALL_BANKS_ID,
         name: 'All',
         hasGefAccessOnly: false,
       };

--- a/portal/server/routes/middleware/validateBank/index.js
+++ b/portal/server/routes/middleware/validateBank/index.js
@@ -1,4 +1,5 @@
 const api = require('../../../api');
+const { ALL_BANKS_ID } = require('../../../constants');
 const { ADMIN, READ_ONLY } = require('../../../constants/roles');
 
 const validRolesForAccessingAllBanks = [
@@ -6,9 +7,14 @@ const validRolesForAccessingAllBanks = [
   READ_ONLY,
 ];
 
+/**
+ * Returns `true` if the user has permission to access data from all banks, and `false` otherwise.
+ * @param {{ bank: {id: string}, roles: string[] }} user
+ * @returns {Boolean}
+ */
 const userCanAccessAllBanks = (user) => {
   const userBankId = user?.bank?.id;
-  if (userBankId !== '*') {
+  if (userBankId !== ALL_BANKS_ID) {
     return false;
   }
 

--- a/portal/server/routes/middleware/validateBank/index.test.js
+++ b/portal/server/routes/middleware/validateBank/index.test.js
@@ -1,0 +1,51 @@
+const validateBank = require('.');
+const { ADMIN, READ_ONLY } = require('../../../constants/roles');
+
+describe('validateBank', () => {
+  const dealId = 'deal id';
+
+  let res;
+  let next;
+
+  beforeEach(() => {
+    res = { redirect: jest.fn() };
+    next = jest.fn();
+  });
+
+  describe('when the current user has bankId *', () => {
+    const bankId = '*';
+
+    it('calls next if the current user has the admin role', async () => {
+      const req = buildRequestFromUserWith({ roles: [ADMIN], bankId });
+
+      await validateBank(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('calls next if the current user has the read-only role', async () => {
+      const req = buildRequestFromUserWith({ roles: [READ_ONLY], bankId });
+
+      await validateBank(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  function buildRequestFromUserWith({ roles, bankId }) {
+    const user = {
+      bank: {
+        id: bankId,
+      },
+      roles,
+    };
+    return {
+      params: {
+        _id: dealId,
+      },
+      session: {
+        user,
+      },
+    };
+  }
+});

--- a/portal/server/routes/middleware/validateBank/index.test.js
+++ b/portal/server/routes/middleware/validateBank/index.test.js
@@ -1,4 +1,5 @@
 const validateBank = require('.');
+const { ALL_BANKS_ID } = require('../../../constants');
 const { ADMIN, READ_ONLY } = require('../../../constants/roles');
 
 describe('validateBank', () => {
@@ -12,8 +13,8 @@ describe('validateBank', () => {
     next = jest.fn();
   });
 
-  describe('when the current user has bankId *', () => {
-    const bankId = '*';
+  describe('when the current user has the ALL_BANKS_ID bankId ', () => {
+    const bankId = ALL_BANKS_ID;
 
     it('calls next if the current user has the admin role', async () => {
       const req = buildRequestFromUserWith({ roles: [ADMIN], bankId });


### PR DESCRIPTION
## Introduction

When we added the `read-only` role, we thought that only the `admin` role was able to have access to all banks (when the user object has `bank.id = '*'`). However, since deploying, we have realised that the `read-only` role should be able to have access to all banks too.

## Resolution

The `validateBank` middleware in `portal` and `gef-ui` now allows users to access all banks if they have `bank.id === '*'` and the user has the `admin` _or_ `read-only` role 

## Misc

There is a `isSuperUser` function in `portal`, `portal-api`, and `gef-ui` that checks `user.bank.id === '*'` but does not check the user roles so they do not need to change for this fix