### PR TITLE
fix(gef-readonly): added read-only to GEF deals users

### DIFF
--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -204,8 +204,10 @@ const applicationDetails = async (req, res, next) => {
 
     if (!application) {
       // 404 not found or unauthorised
+      console.error('Void application or access %s', dealId);
       return res.redirect('/dashboard');
     }
+
     const userAuthorisationLevels = getUserAuthorisationLevelsToApplication(user, application);
     const previewMode = !userAuthorisationLevels.includes(AUTHORISATION_LEVEL.EDIT);
 

--- a/gef-ui/server/models/application.js
+++ b/gef-ui/server/models/application.js
@@ -6,7 +6,9 @@ const {
 const { status } = require('../utils/deal-helpers');
 const { facilitiesChangedToIssuedAsArray } = require('../utils/facility-helpers');
 const { DEAL_STATUS, DEAL_SUBMISSION_TYPE } = require('../constants');
-const { MAKER, CHECKER, ADMIN, READ_ONLY } = require('../constants/roles');
+const {
+  MAKER, CHECKER, ADMIN, READ_ONLY,
+} = require('../constants/roles');
 
 const termToSupportDocuments = {
   coverStart: ['manualInclusion', 'yearToDateManagement', 'auditedFinancialStatements', 'financialForecasts', 'financialInformationCommentary', 'corporateStructure', 'debtorAndCreditorReports'],

--- a/gef-ui/server/models/application.js
+++ b/gef-ui/server/models/application.js
@@ -6,7 +6,7 @@ const {
 const { status } = require('../utils/deal-helpers');
 const { facilitiesChangedToIssuedAsArray } = require('../utils/facility-helpers');
 const { DEAL_STATUS, DEAL_SUBMISSION_TYPE } = require('../constants');
-const { MAKER, CHECKER, ADMIN } = require('../constants/roles');
+const { MAKER, CHECKER, ADMIN, READ_ONLY } = require('../constants/roles');
 
 const termToSupportDocuments = {
   coverStart: ['manualInclusion', 'yearToDateManagement', 'auditedFinancialStatements', 'financialForecasts', 'financialInformationCommentary', 'corporateStructure', 'debtorAndCreditorReports'],
@@ -93,8 +93,17 @@ class Application {
   static async findById(id, user, userToken) {
     try {
       const application = await getApplication({ dealId: id, userToken });
+      const validRolesForAccessingAllBanks = [
+        ADMIN,
+        READ_ONLY,
+      ];
 
-      if (application.bank.id !== user.bank.id && !user.roles.includes(ADMIN)) {
+      /**
+       * Deny access to the application if:
+       * 1. Application bank ID does not match with the logged-in user bank ID.
+       * 2. Logged-in user role is neither `admin` nor `read-only`.
+       */
+      if (application.bank.id !== user.bank.id && !validRolesForAccessingAllBanks.some((validRole) => user.roles.includes(validRole))) {
         return null;
       }
 


### PR DESCRIPTION
## Introduction ✏️ 
`read-only` user is unable to access `GEF` deal on Portal.

## Resolution ✔️ 
* Added `READ_ONLY` to valid list of users with bank set as `*`.
* Added `console.error` when unauthorised.
* Added documentation.