### PR TITLE
feat(DTFS2-6793): add e2e test for TFM Eligibility criteria

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,6 @@ jobs:
         run: |
           sleep 30s
           npm run load
-
       - name: Execute
         run: docker-compose exec -T ${{ matrix.services }} npm run api-test
 
@@ -315,7 +314,6 @@ jobs:
           sleep 30s
           npm run load
           curl "http://localhost:7072/api/orchestrators/numbergenerator" -d '{ "entityType":"facility", "entityId":"12211" }'
-
       - name: Execute
         working-directory: ./e2e-tests/portal
         run: npx cypress run --config video=false,screenshotOnRunFailure=false --project ./ --record false --spec "cypress/e2e/journeys/${{ matrix.spec }}" --env TZ=${{ vars.TIMEZONE }}
@@ -360,7 +358,6 @@ jobs:
           sleep 30s
           npm run load
           curl "http://localhost:7072/api/orchestrators/numbergenerator" -d '{ "entityType":"facility", "entityId":"12211" }'
-
       - name: Execute
         working-directory: ./e2e-tests/gef
         run: npx cypress run --config video=false,screenshotOnRunFailure=false --project ./ --record false --spec "cypress/e2e/${{ matrix.spec }}" --env TZ=${{ vars.TIMEZONE }}
@@ -368,15 +365,7 @@ jobs:
   #7. E2E - TFM
   e2e-tests-tfm:
     name: E2E TFM 👷
-    needs: setup
-    environment:
-      name: ${{ needs.setup.outputs.environment }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      # Do not cancel in-progress jobs upon failure
-      fail-fast: false
-      # Single dimension matrix
+@@ -380,13 +97,9 @@ jobs:
       matrix:
         spec:
           [
@@ -481,7 +470,6 @@ jobs:
           sleep 30s
           npm run load
           curl "http://localhost:7072/api/orchestrators/numbergenerator" -d '{ "entityType":"facility", "entityId":"12211" }'
-
       - name: Execute
         working-directory: ./e2e-tests/ukef
         run: npx cypress run --config video=false,screenshotOnRunFailure=false --project ./ --record false --spec "cypress/e2e/journeys/portal/${{ matrix.spec }}" --env TZ=${{ vars.TIMEZONE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,7 @@ jobs:
         run: |
           sleep 30s
           npm run load
+
       - name: Execute
         run: docker-compose exec -T ${{ matrix.services }} npm run api-test
 
@@ -314,6 +315,7 @@ jobs:
           sleep 30s
           npm run load
           curl "http://localhost:7072/api/orchestrators/numbergenerator" -d '{ "entityType":"facility", "entityId":"12211" }'
+
       - name: Execute
         working-directory: ./e2e-tests/portal
         run: npx cypress run --config video=false,screenshotOnRunFailure=false --project ./ --record false --spec "cypress/e2e/journeys/${{ matrix.spec }}" --env TZ=${{ vars.TIMEZONE }}
@@ -358,6 +360,7 @@ jobs:
           sleep 30s
           npm run load
           curl "http://localhost:7072/api/orchestrators/numbergenerator" -d '{ "entityType":"facility", "entityId":"12211" }'
+
       - name: Execute
         working-directory: ./e2e-tests/gef
         run: npx cypress run --config video=false,screenshotOnRunFailure=false --project ./ --record false --spec "cypress/e2e/${{ matrix.spec }}" --env TZ=${{ vars.TIMEZONE }}
@@ -365,7 +368,15 @@ jobs:
   #7. E2E - TFM
   e2e-tests-tfm:
     name: E2E TFM 👷
-@@ -380,13 +97,9 @@ jobs:
+    needs: setup
+    environment:
+      name: ${{ needs.setup.outputs.environment }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Do not cancel in-progress jobs upon failure
+      fail-fast: false
+      # Single dimension matrix
       matrix:
         spec:
           [
@@ -470,6 +481,7 @@ jobs:
           sleep 30s
           npm run load
           curl "http://localhost:7072/api/orchestrators/numbergenerator" -d '{ "entityType":"facility", "entityId":"12211" }'
+
       - name: Execute
         working-directory: ./e2e-tests/ukef
         run: npx cypress run --config video=false,screenshotOnRunFailure=false --project ./ --record false --spec "cypress/e2e/journeys/portal/${{ matrix.spec }}" --env TZ=${{ vars.TIMEZONE }}

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-AIN.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-AIN.spec.js
@@ -91,21 +91,17 @@ context('User can view a case deal', () => {
   describe('eligibility criteria', () => {
     it('should show the correct passed/failed criteria', () => {
       const { eligibilityCriteriaTable } = pages.caseDealPage;
-      eligibilityCriteriaTable.row(1).heading(11).should('exist');
-      eligibilityCriteriaTable.row(1).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(2).heading(12).should('exist');
-      eligibilityCriteriaTable.row(2).answerTag().contains('Failed');
-      eligibilityCriteriaTable.row(3).heading(13).should('exist');
-      eligibilityCriteriaTable.row(3).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(4).heading(14).should('exist');
-      eligibilityCriteriaTable.row(4).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(5).heading(15).should('exist');
-      eligibilityCriteriaTable.row(6).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(6).heading(16).should('exist');
-      eligibilityCriteriaTable.row(7).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(7).heading(17).should('exist');
-      eligibilityCriteriaTable.row(8).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(8).heading(18).should('exist');
+
+      MOCK_DEAL_AIN.eligibility.criteria.forEach(({ id, answer }, index) => {
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .heading(id)
+          .should('exist');
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .answerTag()
+          .contains(answer ? 'Passed' : 'Failed');
+      });
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-AIN.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-AIN.spec.js
@@ -100,7 +100,7 @@ context('User can view a case deal', () => {
         eligibilityCriteriaTable
           .row(index + 1)
           .answerTag()
-          .contains(answer ? 'Passed' : 'Failed');
+          .should('contain', answer ? 'Passed' : 'Failed');
       });
     });
   });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-AIN.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-AIN.spec.js
@@ -87,4 +87,25 @@ context('User can view a case deal', () => {
       cy.url().should('eq', relative(`/case/${dealId}/facility/${facilityId}`));
     });
   });
+
+  describe('eligibility criteria', () => {
+    it('should show the correct passed/failed criteria', () => {
+      const { eligibilityCriteriaTable } = pages.caseDealPage;
+      eligibilityCriteriaTable.row(1).heading(11).should('exist');
+      eligibilityCriteriaTable.row(1).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(2).heading(12).should('exist');
+      eligibilityCriteriaTable.row(2).answerTag().contains('Failed');
+      eligibilityCriteriaTable.row(3).heading(13).should('exist');
+      eligibilityCriteriaTable.row(3).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(4).heading(14).should('exist');
+      eligibilityCriteriaTable.row(4).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(5).heading(15).should('exist');
+      eligibilityCriteriaTable.row(6).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(6).heading(16).should('exist');
+      eligibilityCriteriaTable.row(7).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(7).heading(17).should('exist');
+      eligibilityCriteriaTable.row(8).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(8).heading(18).should('exist');
+    });
+  });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-MIA.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-MIA.spec.js
@@ -92,21 +92,17 @@ context('User can view a case deal', () => {
   describe('eligibility criteria', () => {
     it('should show the correct passed/failed criteria', () => {
       const { eligibilityCriteriaTable } = pages.caseDealPage;
-      eligibilityCriteriaTable.row(1).heading(11).should('exist');
-      eligibilityCriteriaTable.row(1).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(2).heading(12).should('exist');
-      eligibilityCriteriaTable.row(2).answerTag().contains('Failed');
-      eligibilityCriteriaTable.row(3).heading(13).should('exist');
-      eligibilityCriteriaTable.row(3).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(4).heading(14).should('exist');
-      eligibilityCriteriaTable.row(4).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(5).heading(15).should('exist');
-      eligibilityCriteriaTable.row(6).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(6).heading(16).should('exist');
-      eligibilityCriteriaTable.row(7).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(7).heading(17).should('exist');
-      eligibilityCriteriaTable.row(8).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(8).heading(18).should('exist');
+
+      MOCK_DEAL_MIA.eligibility.criteria.forEach(({ id, answer }, index) => {
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .heading(id)
+          .should('exist');
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .answerTag()
+          .contains(answer ? 'Passed' : 'Failed');
+      });
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-MIA.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-MIA.spec.js
@@ -101,7 +101,7 @@ context('User can view a case deal', () => {
         eligibilityCriteriaTable
           .row(index + 1)
           .answerTag()
-          .contains(answer ? 'Passed' : 'Failed');
+          .should('contain', answer ? 'Passed' : 'Failed');
       });
     });
   });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-MIA.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-MIA.spec.js
@@ -88,4 +88,25 @@ context('User can view a case deal', () => {
       cy.url().should('eq', relative(`/case/${dealId}/facility/${facilityId}`));
     });
   });
+
+  describe('eligibility criteria', () => {
+    it('should show the correct passed/failed criteria', () => {
+      const { eligibilityCriteriaTable } = pages.caseDealPage;
+      eligibilityCriteriaTable.row(1).heading(11).should('exist');
+      eligibilityCriteriaTable.row(1).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(2).heading(12).should('exist');
+      eligibilityCriteriaTable.row(2).answerTag().contains('Failed');
+      eligibilityCriteriaTable.row(3).heading(13).should('exist');
+      eligibilityCriteriaTable.row(3).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(4).heading(14).should('exist');
+      eligibilityCriteriaTable.row(4).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(5).heading(15).should('exist');
+      eligibilityCriteriaTable.row(6).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(6).heading(16).should('exist');
+      eligibilityCriteriaTable.row(7).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(7).heading(17).should('exist');
+      eligibilityCriteriaTable.row(8).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(8).heading(18).should('exist');
+    });
+  });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
@@ -190,6 +190,12 @@ context('User can view a GEF AIN case deal', () => {
   });
 
   describe('eligibility criteria', () => {
+    it('should show failed for EC-20', () => {
+      const { eligibilityCriteriaTable } = pages.caseDealPage;
+      eligibilityCriteriaTable.row(9).heading(20).should('exist');
+      eligibilityCriteriaTable.row(9).answerTag().contains('Failed');
+    });
+
     it('should show the correct passed/failed criteria', () => {
       const { eligibilityCriteriaTable } = pages.caseDealPage;
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
@@ -105,7 +105,7 @@ context('User can view a GEF MIA case deal', () => {
         eligibilityCriteriaTable
           .row(index + 1)
           .answerTag()
-          .contains(answer ? 'Passed' : 'Failed');
+          .should('contain', answer ? 'Passed' : 'Failed');
       });
     });
   });
@@ -218,7 +218,7 @@ context('User can view a GEF AIN case deal', () => {
         eligibilityCriteriaTable
           .row(index + 1)
           .answerTag()
-          .contains(answer ? 'Passed' : 'Failed');
+          .should('contain', answer ? 'Passed' : 'Failed');
       });
     });
   });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
@@ -192,21 +192,17 @@ context('User can view a GEF AIN case deal', () => {
   describe('eligibility criteria', () => {
     it('should show the correct passed/failed criteria', () => {
       const { eligibilityCriteriaTable } = pages.caseDealPage;
-      eligibilityCriteriaTable.row(1).heading(11).should('exist');
-      eligibilityCriteriaTable.row(1).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(2).heading(12).should('exist');
-      eligibilityCriteriaTable.row(2).answerTag().contains('Failed');
-      eligibilityCriteriaTable.row(3).heading(13).should('exist');
-      eligibilityCriteriaTable.row(3).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(4).heading(14).should('exist');
-      eligibilityCriteriaTable.row(4).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(5).heading(15).should('exist');
-      eligibilityCriteriaTable.row(6).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(6).heading(16).should('exist');
-      eligibilityCriteriaTable.row(7).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(7).heading(17).should('exist');
-      eligibilityCriteriaTable.row(8).answerTag().contains('Passed');
-      eligibilityCriteriaTable.row(8).heading(18).should('exist');
+
+      MOCK_APPLICATION_MIA.eligibility.criteria.forEach(({ id, answer }, index) => {
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .heading(id)
+          .should('exist');
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .answerTag()
+          .contains(answer ? 'Passed' : 'Failed');
+      });
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
@@ -188,4 +188,25 @@ context('User can view a GEF AIN case deal', () => {
       facilityPage.facilityFeeType().contains(dealFacilities.feeType);
     });
   });
+
+  describe('eligibility criteria', () => {
+    it('should show the correct passed/failed criteria', () => {
+      const { eligibilityCriteriaTable } = pages.caseDealPage;
+      eligibilityCriteriaTable.row(1).heading(11).should('exist');
+      eligibilityCriteriaTable.row(1).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(2).heading(12).should('exist');
+      eligibilityCriteriaTable.row(2).answerTag().contains('Failed');
+      eligibilityCriteriaTable.row(3).heading(13).should('exist');
+      eligibilityCriteriaTable.row(3).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(4).heading(14).should('exist');
+      eligibilityCriteriaTable.row(4).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(5).heading(15).should('exist');
+      eligibilityCriteriaTable.row(6).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(6).heading(16).should('exist');
+      eligibilityCriteriaTable.row(7).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(7).heading(17).should('exist');
+      eligibilityCriteriaTable.row(8).answerTag().contains('Passed');
+      eligibilityCriteriaTable.row(8).heading(18).should('exist');
+    });
+  });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/deal-page-GEF.spec.js
@@ -92,6 +92,23 @@ context('User can view a GEF MIA case deal', () => {
       facilityPage.facilityFeeType().contains(dealFacilities.feeType);
     });
   });
+
+  describe('eligibility criteria', () => {
+    it('should show the correct passed/failed criteria', () => {
+      const { eligibilityCriteriaTable } = pages.caseDealPage;
+
+      MOCK_APPLICATION_MIA.eligibility.criteria.forEach(({ id, answer }, index) => {
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .heading(id)
+          .should('exist');
+        eligibilityCriteriaTable
+          .row(index + 1)
+          .answerTag()
+          .contains(answer ? 'Passed' : 'Failed');
+      });
+    });
+  });
 });
 
 context('User can view a GEF AIN case deal', () => {
@@ -190,16 +207,10 @@ context('User can view a GEF AIN case deal', () => {
   });
 
   describe('eligibility criteria', () => {
-    it('should show failed for EC-20', () => {
-      const { eligibilityCriteriaTable } = pages.caseDealPage;
-      eligibilityCriteriaTable.row(9).heading(20).should('exist');
-      eligibilityCriteriaTable.row(9).answerTag().contains('Failed');
-    });
-
     it('should show the correct passed/failed criteria', () => {
       const { eligibilityCriteriaTable } = pages.caseDealPage;
 
-      MOCK_APPLICATION_MIA.eligibility.criteria.forEach(({ id, answer }, index) => {
+      MOCK_APPLICATION_AIN.eligibility.criteria.forEach(({ id, answer }, index) => {
         eligibilityCriteriaTable
           .row(index + 1)
           .heading(id)

--- a/e2e-tests/tfm/cypress/e2e/pages/caseDealPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/caseDealPage.js
@@ -13,28 +13,28 @@ const caseDealPage = {
 
   dealFacilitiesTable: {
     row: (facilityId) => {
-      cy.get(`[data-cy="facility-${facilityId}"]`).as('row');
+      cy.get(`[data-cy="facility-${facilityId}"]`).as(`facility${facilityId}`);
       return {
-        facilityId: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-facility-id-link"]`),
-        facilityTenor: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-tenor"]`),
-        facilityEndDate: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-cover-end-date"]`),
-        exportCurrency: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-value-export-currency"]`),
-        valueGBP: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-value-gbp"]`),
-        exposure: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-exposure"]`),
-        totalValue: () => cy.get('@row').get('[data-cy="facilities-total-value"]'),
-        totalExposure: () => cy.get('@row').get('[data-cy="facilities-total-ukef-exposure"]'),
-        facilityValueGBP: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-value-gbp"]`),
-        facilityExposure: () => cy.get('@row').get(`[data-cy="facility-${facilityId}-ukef-exposure"]`),
+        facilityId: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-ukef-facility-id-link"]`),
+        facilityTenor: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-tenor"]`),
+        facilityEndDate: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-cover-end-date"]`),
+        exportCurrency: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-value-export-currency"]`),
+        valueGBP: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-value-gbp"]`),
+        exposure: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-ukef-exposure"]`),
+        totalValue: () => cy.get(`@facility${facilityId}`).get('[data-cy="facilities-total-value"]'),
+        totalExposure: () => cy.get(`@facility${facilityId}`).get('[data-cy="facilities-total-ukef-exposure"]'),
+        facilityValueGBP: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-value-gbp"]`),
+        facilityExposure: () => cy.get(`@facility${facilityId}`).get(`[data-cy="facility-${facilityId}-ukef-exposure"]`),
       };
     },
   },
 
   eligibilityCriteriaTable: {
     row: (index) => {
-      cy.get(`[data-cy="criterion-${index}-row"]`).as('row');
+      cy.get(`[data-cy="criterion-${index}-row"]`).as(`eligibilityCriteriaRow${index}`);
       return {
-        answerTag: () => cy.get('@row').get('[data-cy="eligibility-criteria-answer-tag"'),
-        heading: (criterionId) => cy.get('@row').get(`[data-cy="criterion-${criterionId}-heading"]`),
+        answerTag: () => cy.get(`@eligibilityCriteriaRow${index}`).get('[data-cy="eligibility-criteria-answer-tag"'),
+        heading: (criterionId) => cy.get(`@eligibilityCriteriaRow${index}`).get(`[data-cy="criterion-${criterionId}-heading"]`),
       };
     },
   },

--- a/e2e-tests/tfm/cypress/e2e/pages/caseDealPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/caseDealPage.js
@@ -28,6 +28,16 @@ const caseDealPage = {
       };
     },
   },
+
+  eligibilityCriteriaTable: {
+    row: (index) => {
+      cy.get(`[data-cy="criterion-${index}-row"]`).as('row');
+      return {
+        answerTag: () => cy.get('@row').get('[data-cy="eligibility-criteria-answer-tag"'),
+        heading: (criterionId) => cy.get('@row').get(`[data-cy="criterion-${criterionId}-heading"]`),
+      };
+    },
+  },
 };
 
 module.exports = caseDealPage;


### PR DESCRIPTION
# Introduction
#2295 resolved a bug where eligibility criteria were not displayed correctly, there should be e2e tests to prevent this from reoccuring

# Resolution
Added tests to `deal-AIN.spec.js`, `deal-MIA.spec.js` and `deal-page-GEF.spec.js` to check that the eligibility criteria displayed matches that in the database.