### PR TITLE
feat(FN-1089): report is not due

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -90,6 +90,7 @@
     "mdm",
     "ministryofjustice",
     "mmdd",
+    "mmaaa",
     "MRUI",
     "Mulesoft",
     "nbsp",

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-no-longer-upload-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-no-longer-upload-report.spec.js
@@ -1,0 +1,25 @@
+const { utilisationReportUpload } = require('../../../pages');
+const MOCK_USERS = require('../../../../fixtures/users');
+const relativeURL = require('../../../relativeURL');
+const { upToDateReportDetails } = require('../../../../fixtures/mockUtilisationReportDetails');
+
+const { BANK1_PAYMENT_REPORT_OFFICER1 } = MOCK_USERS;
+
+context('Utilisation report upload', () => {
+  before(() => {
+    cy.removeAllUtilisationReportDetails();
+  });
+
+  after(() => {
+    cy.removeAllUtilisationReportDetails();
+  });
+
+  it('should not allow you to upload a report if the current report period report has been submitted', () => {
+    cy.insertUtilisationReportDetails(upToDateReportDetails);
+
+    cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+    cy.visit(relativeURL('/utilisation-report-upload'));
+
+    utilisationReportUpload.continueButton().should('not.exist');
+  });
+});

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -2,6 +2,7 @@ const {
   eachMonthOfInterval,
   getYear,
   getMonth,
+  subMonths,
 } = require('date-fns');
 const { BANK1_PAYMENT_REPORT_OFFICER1 } = require('./users');
 
@@ -47,7 +48,18 @@ const january2023ReportDetails = [{
   path: 'www.abc.com',
 }];
 
+const generateUpToDateReportDetails = () => {
+  const currentReportPeriod = subMonths(new Date(), 1);
+  const oneIndexedMonth = getMonth(currentReportPeriod) + 1;
+  const year = getYear(currentReportPeriod);
+  const reportDetails = generateReportDetails(year, oneIndexedMonth);
+  return [reportDetails];
+};
+
+const upToDateReportDetails = generateUpToDateReportDetails();
+
 module.exports = {
   previousReportDetails,
   january2023ReportDetails,
+  upToDateReportDetails,
 };

--- a/portal-api/api-tests/v1/utilisation-report-service/lastest-report.api-test.js
+++ b/portal-api/api-tests/v1/utilisation-report-service/lastest-report.api-test.js
@@ -1,0 +1,92 @@
+const wipeDB = require('../../wipeDB');
+const app = require('../../../src/createApp');
+const { as, get } = require('../../api')(app);
+const testUserCache = require('../../api-test-users');
+const { withClientAuthenticationTests } = require('../../common-tests/client-authentication-tests');
+const { withRoleAuthorisationTests } = require('../../common-tests/role-authorisation-tests');
+const { PAYMENT_REPORT_OFFICER } = require('../../../src/v1/roles/roles');
+const { DB_COLLECTIONS } = require('../../fixtures/constants');
+const { insertManyUtilisationReportDetails } = require('../../insertUtilisationReportDetails');
+
+describe('GET /v1/banks/:bankId/utilisation-reports/latest', () => {
+  const mostRecentReportUrl = (bankId) => `/v1/banks/${bankId}/utilisation-reports/latest`;
+  let aPaymentReportOfficer;
+  let mockUtilisationReports;
+  let testUsers;
+  let matchingBankId;
+  let expectedReportResponse;
+
+  beforeAll(async () => {
+    await wipeDB.wipe([DB_COLLECTIONS.UTILISATION_REPORTS]);
+
+    testUsers = await testUserCache.initialise(app);
+    aPaymentReportOfficer = testUsers().withRole(PAYMENT_REPORT_OFFICER).one();
+    matchingBankId = aPaymentReportOfficer.bank.id;
+
+    const { bank } = aPaymentReportOfficer;
+    const year = 2023;
+    mockUtilisationReports = [
+      {
+        bank,
+        month: 1,
+        year,
+        dateUploaded: new Date('2023-01-01'),
+        uploadedBy: aPaymentReportOfficer,
+        path: 'www.abc.com',
+      },
+      {
+        bank,
+        month: 2,
+        year,
+        dateUploaded: new Date('2023-02-01'),
+        uploadedBy: aPaymentReportOfficer,
+        path: 'www.abc.com',
+      },
+    ];
+    await insertManyUtilisationReportDetails(mockUtilisationReports);
+
+    const latestMockReport = mockUtilisationReports.at(-1);
+    expectedReportResponse = {
+      month: latestMockReport.month,
+      year: latestMockReport.year,
+      dateUploaded: latestMockReport.dateUploaded.toISOString(),
+      path: latestMockReport.path,
+    };
+  });
+
+  afterAll(async () => {
+    await wipeDB.wipe([DB_COLLECTIONS.UTILISATION_REPORTS]);
+  });
+
+  withClientAuthenticationTests({
+    makeRequestWithoutAuthHeader: () => get(mostRecentReportUrl(matchingBankId)),
+    makeRequestWithAuthHeader: (authHeader) => get(mostRecentReportUrl(matchingBankId), { headers: { Authorization: authHeader } }),
+  });
+
+  withRoleAuthorisationTests({
+    allowedRoles: [PAYMENT_REPORT_OFFICER],
+    getUserWithRole: (role) => testUsers().withRole(role).one(),
+    getUserWithoutAnyRoles: () => testUsers().withoutAnyRoles().one(),
+    makeRequestAsUser: (user) => as(user).get(mostRecentReportUrl(matchingBankId)),
+    successStatusCode: 200,
+  });
+
+  it('400s requests that do not have a valid bank id', async () => {
+    const { status } = await as(aPaymentReportOfficer).get(mostRecentReportUrl('620a1aa095a618b12da38c7b'));
+
+    expect(status).toEqual(400);
+  });
+
+  it('401s requests if users bank != request bank', async () => {
+    const { status } = await as(aPaymentReportOfficer).get(mostRecentReportUrl(matchingBankId - 1));
+
+    expect(status).toEqual(401);
+  });
+
+  it('returns the requested resource', async () => {
+    const response = await as(aPaymentReportOfficer).get(mostRecentReportUrl(matchingBankId));
+
+    expect(response.status).toEqual(200);
+    expect(JSON.parse(response.text)).toEqual(expect.objectContaining(expectedReportResponse));
+  });
+});

--- a/portal-api/api-tests/v1/utilisation-report-service/lastest-report.api-test.js
+++ b/portal-api/api-tests/v1/utilisation-report-service/lastest-report.api-test.js
@@ -9,7 +9,7 @@ const { DB_COLLECTIONS } = require('../../fixtures/constants');
 const { insertManyUtilisationReportDetails } = require('../../insertUtilisationReportDetails');
 
 describe('GET /v1/banks/:bankId/utilisation-reports/latest', () => {
-  const mostRecentReportUrl = (bankId) => `/v1/banks/${bankId}/utilisation-reports/latest`;
+  const latestReportUrl = (bankId) => `/v1/banks/${bankId}/utilisation-reports/latest`;
   let aPaymentReportOfficer;
   let mockUtilisationReports;
   let testUsers;
@@ -59,32 +59,32 @@ describe('GET /v1/banks/:bankId/utilisation-reports/latest', () => {
   });
 
   withClientAuthenticationTests({
-    makeRequestWithoutAuthHeader: () => get(mostRecentReportUrl(matchingBankId)),
-    makeRequestWithAuthHeader: (authHeader) => get(mostRecentReportUrl(matchingBankId), { headers: { Authorization: authHeader } }),
+    makeRequestWithoutAuthHeader: () => get(latestReportUrl(matchingBankId)),
+    makeRequestWithAuthHeader: (authHeader) => get(latestReportUrl(matchingBankId), { headers: { Authorization: authHeader } }),
   });
 
   withRoleAuthorisationTests({
     allowedRoles: [PAYMENT_REPORT_OFFICER],
     getUserWithRole: (role) => testUsers().withRole(role).one(),
     getUserWithoutAnyRoles: () => testUsers().withoutAnyRoles().one(),
-    makeRequestAsUser: (user) => as(user).get(mostRecentReportUrl(matchingBankId)),
+    makeRequestAsUser: (user) => as(user).get(latestReportUrl(matchingBankId)),
     successStatusCode: 200,
   });
 
   it('400s requests that do not have a valid bank id', async () => {
-    const { status } = await as(aPaymentReportOfficer).get(mostRecentReportUrl('620a1aa095a618b12da38c7b'));
+    const { status } = await as(aPaymentReportOfficer).get(latestReportUrl('620a1aa095a618b12da38c7b'));
 
     expect(status).toEqual(400);
   });
 
   it('401s requests if users bank != request bank', async () => {
-    const { status } = await as(aPaymentReportOfficer).get(mostRecentReportUrl(matchingBankId - 1));
+    const { status } = await as(aPaymentReportOfficer).get(latestReportUrl(matchingBankId - 1));
 
     expect(status).toEqual(401);
   });
 
   it('returns the requested resource', async () => {
-    const response = await as(aPaymentReportOfficer).get(mostRecentReportUrl(matchingBankId));
+    const response = await as(aPaymentReportOfficer).get(latestReportUrl(matchingBankId));
 
     expect(response.status).toEqual(200);
     expect(JSON.parse(response.text)).toEqual(expect.objectContaining(expectedReportResponse));

--- a/portal-api/src/v1/controllers/utilisation-report-service/due-report-dates.controller.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/due-report-dates.controller.js
@@ -48,7 +48,7 @@ const getNextDueReportDate = (latestReport, currentDueReportDate) => {
  * current report period is due and therefore that is returned. If the reports
  * are up to date, an empty array is returned.
  * @param {Object} latestReport - object containing details about the latest report
- * @returns {DueReportDate[]} dueReportDates - array of DueReportDate objects
+ * @returns {DueReportDate[]}
  */
 const getDueReportDatesList = (latestReport) => {
   const currentDate = new Date();

--- a/portal-api/src/v1/controllers/utilisation-report-service/due-report-dates.controller.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/due-report-dates.controller.js
@@ -4,6 +4,7 @@ const {
   getMonth,
   getYear,
   eachMonthOfInterval,
+  addMonths,
 } = require('date-fns');
 const api = require('../../api');
 
@@ -29,10 +30,15 @@ const getNextDueReportDate = (latestReport, currentDueReportDate) => {
   }
 
   const { month: oneIndexedMonth, year } = latestReport;
-  const zeroIndexedNextDueMonth = oneIndexedMonth === 12 ? 0 : oneIndexedMonth;
-  const nextDueYear = oneIndexedMonth === 12 ? year + 1 : year;
-  return new Date(nextDueYear, zeroIndexedNextDueMonth);
+  const latestReportDate = new Date(year, oneIndexedMonth - 1);
+  return addMonths(latestReportDate, 1);
 };
+
+/**
+ * @typedef {Object} DueReportDate
+ * @property {number} year - The report period year for the due report
+ * @property {number} month - The one-indexed report period month for the due report
+ */
 
 /**
  * Generates an array of due report dates containing the month and year by
@@ -42,7 +48,7 @@ const getNextDueReportDate = (latestReport, currentDueReportDate) => {
  * current report period is due and therefore that is returned. If the reports
  * are up to date, an empty array is returned.
  * @param {Object} latestReport - object containing details about the latest report
- * @returns {{month: number, year: number}[]} dueReportDates - due report month (number, one-indexed) and year (number)
+ * @returns {DueReportDate[]} dueReportDates - array of DueReportDate objects
  */
 const getDueReportDatesList = (latestReport) => {
   const currentDate = new Date();

--- a/portal-api/src/v1/controllers/utilisation-report-service/due-report-dates.controller.test.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/due-report-dates.controller.test.js
@@ -110,8 +110,8 @@ describe('controllers/utilisation-report-service/due-report-dates', () => {
     });
 
     it('should return an empty array if the most recent report is in the current reporting period', () => {
-      const mostRecentReport = upToDateReports.at(-1);
-      const result = getDueReportDatesList(mostRecentReport);
+      const latestReport = upToDateReports.at(-1);
+      const result = getDueReportDatesList(latestReport);
 
       expect(result).toEqual([]);
     });

--- a/portal-api/src/v1/controllers/utilisation-report-service/index.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/index.js
@@ -1,9 +1,11 @@
 const { uploadReportAndSendNotification } = require('./utilisation-report-upload.controller');
 const { getPreviousReportsByBankId } = require('./previous-reports.controller');
 const { getDueReportDates } = require('./due-report-dates.controller');
+const { getLatestReport } = require('./latest-report.controller');
 
 module.exports = {
   uploadReportAndSendNotification,
   getPreviousReportsByBankId,
   getDueReportDates,
+  getLatestReport,
 };

--- a/portal-api/src/v1/controllers/utilisation-report-service/latest-report.controller.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/latest-report.controller.js
@@ -5,9 +5,9 @@ const getLatestReport = async (req, res) => {
     const { bankId } = req.params;
 
     const reports = await api.getUtilisationReports(bankId);
-    const mostRecentReport = reports.at(-1);
+    const latestReport = reports.at(-1);
 
-    res.status(200).send(mostRecentReport);
+    res.status(200).send(latestReport);
   } catch (error) {
     console.error('Cannot get latest report %s', error);
     res.status(error.response?.status ?? 500).send({ message: 'Failed to get latest report' });

--- a/portal-api/src/v1/controllers/utilisation-report-service/latest-report.controller.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/latest-report.controller.js
@@ -1,0 +1,19 @@
+const api = require('../../api');
+
+const getLatestReport = async (req, res) => {
+  try {
+    const { bankId } = req.params;
+
+    const reports = await api.getUtilisationReports(bankId);
+    const mostRecentReport = reports.at(-1);
+
+    res.status(200).send(mostRecentReport);
+  } catch (error) {
+    console.error('Cannot get latest report %s', error);
+    res.status(error.response?.status ?? 500).send({ message: 'Failed to get latest report' });
+  }
+};
+
+module.exports = {
+  getLatestReport,
+};

--- a/portal-api/src/v1/routes.js
+++ b/portal-api/src/v1/routes.js
@@ -29,7 +29,7 @@ const bondIssueFacility = require('./controllers/bond-issue-facility.controller'
 const bondChangeCoverStartDate = require('./controllers/bond-change-cover-start-date.controller');
 const loanChangeCoverStartDate = require('./controllers/loan-change-cover-start-date.controller');
 const { ukefDecisionReport, unissuedFacilitiesReport } = require('./controllers/reports');
-const { getPreviousReportsByBankId, uploadReportAndSendNotification, getDueReportDates } = require('./controllers/utilisation-report-service');
+const { getPreviousReportsByBankId, uploadReportAndSendNotification, getDueReportDates, getLatestReport } = require('./controllers/utilisation-report-service');
 const { getBankHolidays } = require('./controllers/bank-holidays.controller');
 
 const { cleanXss, fileUpload } = require('./middleware');
@@ -242,6 +242,16 @@ authRouter
     handleValidationResult,
     validateUserAndBankIdMatch,
     getPreviousReportsByBankId,
+  );
+
+authRouter
+  .route('/banks/:bankId/utilisation-reports/latest')
+  .get(
+    validateUserHasAtLeastOneAllowedRole({ allowedRoles: [PAYMENT_REPORT_OFFICER] }),
+    bankIdValidation,
+    handleValidationResult,
+    validateUserAndBankIdMatch,
+    getLatestReport,
   );
 
 authRouter

--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -53,8 +53,7 @@ describe(page, () => {
     });
 
     it('should display generic inset text about which report needs to be sent', () => {
-      wrapper.expectText('[data-cy="inset-text"]')
-        .toRead("Once you've sent the December 2022 report, you can send subsequent reports.");
+      wrapper.expectText('[data-cy="inset-text"]').toRead("Once you've sent the December 2022 report, you can send subsequent reports.");
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
@@ -86,8 +85,7 @@ describe(page, () => {
     });
 
     it('should display specific inset text about which report needs to be sent and which report is now due', () => {
-      wrapper.expectText('[data-cy="inset-text"]')
-        .toRead("Once you've sent the January 2023 report, you can send the February 2023 report.");
+      wrapper.expectText('[data-cy="inset-text"]').toRead("Once you've sent the January 2023 report, you can send the February 2023 report.");
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
@@ -120,8 +118,42 @@ describe(page, () => {
     });
   });
 
-  // TODO: FN-1089 add behaviour for reports being up to date
-  // describe('when the reports are all up to date', () => {
+  describe('when no reports are due', () => {
+    const nextReportPeriod = 'March 2023';
+    const nextReportPeriodStart = '1 March 2023';
+    const lastUploadedReportPeriod = 'February 2023';
+    const uploadedByFullName = 'John Smith';
+    const formattedDateAndTime = '25 February 2023 at 10:05 am';
+    let wrapper;
+    beforeEach(() => {
+      wrapper = render({
+        user,
+        primaryNav: 'utilisation_report_upload',
+        dueReportDates: [],
+        nextReportPeriod,
+        nextReportPeriodStart,
+        lastUploadedReportPeriod,
+        uploadedByFullName,
+        formattedDateAndTime,
+      });
+    });
 
-  // });
+    it('should render the correct heading', () => {
+      wrapper.expectText('[data-cy="main-heading"]').toRead('Report not currently due for upload');
+    });
+
+    it('should display specific text about the next report which can be uploaded', () => {
+      wrapper.expectText('[data-cy="next-due-report-text"]')
+        .toRead(`The ${nextReportPeriod} report can be uploaded from ${nextReportPeriodStart}.`);
+    });
+
+    it('should display details about the last uploaded report', () => {
+      wrapper.expectText('[data-cy="uploaded-report-details"]')
+        .toRead(`The ${lastUploadedReportPeriod} report was sent to UKEF by ${uploadedByFullName} on ${formattedDateAndTime}.`);
+    });
+
+    it('should not render the report submission form', () => {
+      wrapper.expectElement('[data-cy="form"]').notToExist();
+    });
+  });
 });

--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -123,7 +123,7 @@ describe(page, () => {
     const nextReportPeriodStart = '1 March 2023';
     const lastUploadedReportPeriod = 'February 2023';
     const uploadedByFullName = 'John Smith';
-    const formattedDateAndTime = '25 February 2023 at 10:05 am';
+    const formattedDateAndTimeUploaded = '25 February 2023 at 10:05 am';
     let wrapper;
     beforeEach(() => {
       wrapper = render({
@@ -134,7 +134,7 @@ describe(page, () => {
         nextReportPeriodStart,
         lastUploadedReportPeriod,
         uploadedByFullName,
-        formattedDateAndTime,
+        formattedDateAndTimeUploaded,
       });
     });
 
@@ -149,7 +149,7 @@ describe(page, () => {
 
     it('should display details about the last uploaded report', () => {
       wrapper.expectText('[data-cy="uploaded-report-details"]')
-        .toRead(`The ${lastUploadedReportPeriod} report was sent to UKEF by ${uploadedByFullName} on ${formattedDateAndTime}.`);
+        .toRead(`The ${lastUploadedReportPeriod} report was sent to UKEF by ${uploadedByFullName} on ${formattedDateAndTimeUploaded}.`);
     });
 
     it('should not render the report submission form', () => {

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -858,7 +858,7 @@ const getPreviousUtilisationReportsByBank = async (token, bankId) => {
 
 const getLastestReportByBank = async (token, bankId) => {
   if (!isValidBankId(bankId)) {
-    throw new Error(`Getting latest report failed for id ${bankId}`);
+    throw new Error(`Getting latest report failed - bank id '${bankId}' is invalid`);
   }
 
   const response = await axios({

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -835,24 +835,20 @@ const uploadUtilisationReportData = async (uploadingUser, month, year, csvData, 
 };
 
 const getPreviousUtilisationReportsByBank = async (token, bankId) => {
-  try {
-    if (!isValidBankId(bankId)) {
-      throw new Error(`Getting previous utilisation reports failed for id ${bankId}`);
-    }
-    const response = await axios({
-      method: 'get',
-      url: `${PORTAL_API_URL}/v1/banks/${bankId}/utilisation-reports`,
-      headers: {
-        Authorization: token,
-        'Content-Type': 'application/json',
-      },
-    });
-
-    return response.data;
-  } catch (error) {
-    console.error('Unable to get previous utilisation reports %s', error);
-    return { status: error?.code || 500, data: 'Error getting previous utilisation reports.' };
+  if (!isValidBankId(bankId)) {
+    throw new Error(`Getting previous utilisation reports failed for id ${bankId}`);
   }
+
+  const response = await axios({
+    method: 'get',
+    url: `${PORTAL_API_URL}/v1/banks/${bankId}/utilisation-reports`,
+    headers: {
+      Authorization: token,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response.data;
 };
 
 const getLastestReportByBank = async (token, bankId) => {

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -856,9 +856,27 @@ const getPreviousUtilisationReportsByBank = async (token, bankId) => {
   }
 };
 
+const getLastestReportByBank = async (token, bankId) => {
+  if (!isValidBankId(bankId)) {
+    throw new Error(`Getting latest report failed for id ${bankId}`);
+  }
+
+  const response = await axios({
+    method: 'get',
+    url: `${PORTAL_API_URL}/v1/banks/${bankId}/utilisation-reports/latest`,
+    headers: {
+      Authorization: token,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return response.data;
+};
+
 const getDueReportDatesByBank = async (token, bankId) => {
   if (!isValidBankId(bankId)) {
-    throw new Error(`Getting due utilisation reports failed for id ${bankId}`);
+    console.error('Getting due utilisation reports failed for id %s', bankId);
+    return false;
   }
 
   const response = await axios.get(`${PORTAL_API_URL}/v1/banks/${bankId}/due-report-dates`, {
@@ -934,5 +952,6 @@ module.exports = {
   uploadUtilisationReportData,
   getPreviousUtilisationReportsByBank,
   getDueReportDatesByBank,
+  getLastestReportByBank,
   getUkBankHolidays,
 };

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -837,8 +837,7 @@ const uploadUtilisationReportData = async (uploadingUser, month, year, csvData, 
 const getPreviousUtilisationReportsByBank = async (token, bankId) => {
   try {
     if (!isValidBankId(bankId)) {
-      console.error('Getting previous utilisation reports failed for id %s', bankId);
-      return false;
+      throw new Error(`Getting previous utilisation reports failed for id ${bankId}`);
     }
     const response = await axios({
       method: 'get',
@@ -875,8 +874,7 @@ const getLastestReportByBank = async (token, bankId) => {
 
 const getDueReportDatesByBank = async (token, bankId) => {
   if (!isValidBankId(bankId)) {
-    console.error('Getting due utilisation reports failed for id %s', bankId);
-    return false;
+    throw new Error(`Getting due utilisation reports failed for id ${bankId}`);
   }
 
   const response = await axios.get(`${PORTAL_API_URL}/v1/banks/${bankId}/due-report-dates`, {

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -31,17 +31,17 @@ const setSessionUtilisationReport = (req, nextDueReportDate) => {
 
 /**
  * @typedef {Object} ReportDetails
- * @property {string} uploadedByFullName - The index of the object with format '{firstname} {surname}'
+ * @property {string} uploadedByFullName - The uploaded by users full name with format '{firstname} {surname}'
  * @property {string} formattedDateAndTimeUploaded - The date uploaded formatted as 'd MMMM yyyy at h:mmaaa'
  * @property {string} lastUploadedReportPeriod - The report period of the report formatted as 'MMMM yyyy'
- * @property {string} nextReportPeriod - The upcoming report period (the current month)
- * @property {string} nextReportPeriodStart - The start of the upcoming report period
+ * @property {string} nextReportPeriod - The upcoming report period (the current month) with format 'MMMM yyyy'
+ * @property {string} nextReportPeriodStart - The start of the upcoming report period with format 'd MMMM yyyy'
  */
 
 /**
  * Gets details about the utilisation report which was most
  * recently uploaded to the bank with the bank ID provided
- * @param {Object} userToken - Token to validate session
+ * @param {string} userToken - Token to validate session
  * @param {string} bankId - ID of the bank
  * @returns {Promise<ReportDetails>}
  */

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -132,7 +132,6 @@ const renderPageWithError = (req, res, errorSummary, validationError, dueReportD
       errorSummary,
       user: req.session.user,
       primaryNav: 'utilisation_report_upload',
-      dueReportDates,
     });
   }
   return res.render('utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk', {

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -49,6 +49,9 @@ const getUtilisationReportUpload = async (req, res) => {
       user,
       primaryNav: 'utilisation_report_upload',
       dueReportDates,
+      reportPeriod: 'reportPeriod',
+      uploadedByFullName: 'John Smith',
+      formattedDateAndTime: 'tomorrow',
     });
   } catch (error) {
     return res.render('_partials/problem-with-service.njk', { user });

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -125,13 +125,14 @@ const getUploadErrors = (req, res) => {
   return {};
 };
 
-const renderPageWithError = (req, res, errorSummary, validationError) => {
+const renderPageWithError = (req, res, errorSummary, validationError, dueReportDates) => {
   if (req.query?.check_the_report) {
     return res.render('utilisation-report-service/utilisation-report-upload/check-the-report.njk', {
       fileUploadError: validationError,
       errorSummary,
       user: req.session.user,
       primaryNav: 'utilisation_report_upload',
+      dueReportDates,
     });
   }
   return res.render('utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk', {
@@ -139,6 +140,7 @@ const renderPageWithError = (req, res, errorSummary, validationError) => {
     errorSummary,
     user: req.session.user,
     primaryNav: 'utilisation_report_upload',
+    dueReportDates,
   });
 };
 
@@ -147,7 +149,10 @@ const postUtilisationReportUpload = async (req, res) => {
   try {
     const { uploadErrorSummary, uploadValidationError } = getUploadErrors(req, res);
     if (uploadValidationError || uploadErrorSummary) {
-      return renderPageWithError(req, res, uploadErrorSummary, uploadValidationError);
+      const { userToken } = req.session;
+      const bankId = user.bank.id;
+      const dueReportDates = await getDueReportDates(userToken, bankId);
+      return renderPageWithError(req, res, uploadErrorSummary, uploadValidationError, dueReportDates);
     }
 
     // File is valid so we can start processing and validating its data

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -31,11 +31,11 @@ const setSessionUtilisationReport = (req, nextDueReportDate) => {
 
 /**
  * @typedef {Object} ReportDetails
- * @property {number} index - The index of the object
- * @property {string} error - The error message of the object
  * @property {string} uploadedByFullName - The index of the object with format '{firstname} {surname}'
- * @property {string} formattedDateAndTime - The date uploaded formatted as 'h:mmaaa'
+ * @property {string} formattedDateAndTimeUploaded - The date uploaded formatted as 'd MMMM yyyy at h:mmaaa'
  * @property {string} lastUploadedReportPeriod - The report period of the report formatted as 'MMMM yyyy'
+ * @property {string} nextReportPeriod - The upcoming report period (the current month)
+ * @property {string} nextReportPeriodStart - The start of the upcoming report period
  */
 
 /**

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
@@ -1,0 +1,26 @@
+const { format, parseISO } = require('date-fns');
+
+const getReportAndUserDetails = (report) => {
+  if (!report) {
+    throw new Error('Cannot get report and user details');
+  }
+
+  const { dateUploaded, uploadedBy } = report;
+
+  const { firstname, surname } = uploadedBy;
+  const uploadedByFullName = `${firstname} ${surname}`;
+
+  const date = parseISO(dateUploaded);
+  const formattedDate = format(date, 'd MMMM yyyy');
+  const formattedTime = format(date, 'h:mmaaa');
+  const formattedDateAndTime = `${formattedDate} at ${formattedTime}`;
+
+  return {
+    uploadedByFullName,
+    formattedDateAndTime,
+  };
+};
+
+module.exports = {
+  getReportAndUserDetails,
+};

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
@@ -2,8 +2,8 @@ const { format, parseISO } = require('date-fns');
 
 /**
  * @typedef {Object} ReportAndUserDetails
- * @property {string} uploadedByFullName - The index of the object with format '{firstname} {surname}'
- * @property {string} formattedDateAndTime - The date uploaded formatted as 'h:mmaaa'
+ * @property {string} uploadedByFullName - The uploaded by users full name with format '{firstname} {surname}'
+ * @property {string} formattedDateAndTimeUploaded - The date uploaded formatted as 'd MMMM yyyy at h:mmaaa'
  * @property {string} lastUploadedReportPeriod - The report period of the report formatted as 'MMMM yyyy'
  */
 
@@ -26,14 +26,14 @@ const getReportAndUserDetails = (report) => {
   const date = parseISO(dateUploaded);
   const formattedDate = format(date, 'd MMMM yyyy');
   const formattedTime = format(date, 'h:mmaaa');
-  const formattedDateAndTime = `${formattedDate} at ${formattedTime}`;
+  const formattedDateAndTimeUploaded = `${formattedDate} at ${formattedTime}`;
 
   const lastUploadedReportDate = new Date(year, month - 1);
   const lastUploadedReportPeriod = format(lastUploadedReportDate, 'MMMM yyyy');
 
   return {
     uploadedByFullName,
-    formattedDateAndTime,
+    formattedDateAndTimeUploaded,
     lastUploadedReportPeriod,
   };
 };

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
@@ -1,11 +1,24 @@
 const { format, parseISO } = require('date-fns');
 
+/**
+ * @typedef {Object} ReportAndUserDetails
+ * @property {string} uploadedByFullName - The index of the object with format '{firstname} {surname}'
+ * @property {string} formattedDateAndTime - The date uploaded formatted as 'h:mmaaa'
+ * @property {string} lastUploadedReportPeriod - The report period of the report formatted as 'MMMM yyyy'
+ */
+
+/**
+ * Given a utilisation report, this returns an object containing formatted
+ * ifnroamtion about the report and the user who submitted the report
+ * @param {Object} report - A utilisation report
+ * @returns {ReportAndUserDetails}
+ */
 const getReportAndUserDetails = (report) => {
   if (!report) {
     throw new Error('Cannot get report and user details');
   }
 
-  const { dateUploaded, uploadedBy } = report;
+  const { dateUploaded, uploadedBy, year, month } = report;
 
   const { firstname, surname } = uploadedBy;
   const uploadedByFullName = `${firstname} ${surname}`;
@@ -15,9 +28,13 @@ const getReportAndUserDetails = (report) => {
   const formattedTime = format(date, 'h:mmaaa');
   const formattedDateAndTime = `${formattedDate} at ${formattedTime}`;
 
+  const lastUploadedReportDate = new Date(year, month - 1);
+  const lastUploadedReportPeriod = format(lastUploadedReportDate, 'MMMM yyyy');
+
   return {
     uploadedByFullName,
     formattedDateAndTime,
+    lastUploadedReportPeriod,
   };
 };
 

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
@@ -9,7 +9,7 @@ const { format, parseISO } = require('date-fns');
 
 /**
  * Given a utilisation report, this returns an object containing formatted
- * ifnroamtion about the report and the user who submitted the report
+ * information about the report and the user who submitted the report
  * @param {Object} report - A utilisation report
  * @returns {ReportAndUserDetails}
  */

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
@@ -29,18 +29,18 @@ describe('utilisation-report-details', () => {
   });
 
   it('should return the correct full name, date format and report period for a report uploaded in the morning', () => {
-    const { uploadedByFullName, formattedDateAndTime, lastUploadedReportPeriod } = getReportAndUserDetails(morningReport);
+    const { uploadedByFullName, formattedDateAndTimeUploaded, lastUploadedReportPeriod } = getReportAndUserDetails(morningReport);
 
     expect(uploadedByFullName).toBe('John Smith');
-    expect(formattedDateAndTime).toBe('8 April 2023 at 10:35am');
+    expect(formattedDateAndTimeUploaded).toBe('8 April 2023 at 10:35am');
     expect(lastUploadedReportPeriod).toBe('April 2023');
   });
 
   it('should return the correct full name, date format and report period for a report uploaded in the afternoon', () => {
-    const { uploadedByFullName, formattedDateAndTime, lastUploadedReportPeriod } = getReportAndUserDetails(afternoonReport);
+    const { uploadedByFullName, formattedDateAndTimeUploaded, lastUploadedReportPeriod } = getReportAndUserDetails(afternoonReport);
 
     expect(uploadedByFullName).toBe('John Smith');
-    expect(formattedDateAndTime).toBe('8 April 2023 at 3:23pm');
+    expect(formattedDateAndTimeUploaded).toBe('8 April 2023 at 3:23pm');
     expect(lastUploadedReportPeriod).toBe('April 2023');
   });
 });

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
@@ -28,17 +28,19 @@ describe('utilisation-report-details', () => {
     expect(() => getReportAndUserDetails(undefined)).toThrow(new Error('Cannot get report and user details'));
   });
 
-  it('should return the correct full name and date format for a report uploaded in the morning', () => {
-    const { uploadedByFullName, formattedDateAndTime } = getReportAndUserDetails(morningReport);
+  it('should return the correct full name, date format and report period for a report uploaded in the morning', () => {
+    const { uploadedByFullName, formattedDateAndTime, lastUploadedReportPeriod } = getReportAndUserDetails(morningReport);
 
     expect(uploadedByFullName).toBe('John Smith');
     expect(formattedDateAndTime).toBe('8 April 2023 at 10:35am');
+    expect(lastUploadedReportPeriod).toBe('April 2023');
   });
 
-  it('should return the correct full name and date format for a report uploaded in the afternoon', () => {
-    const { uploadedByFullName, formattedDateAndTime } = getReportAndUserDetails(afternoonReport);
+  it('should return the correct full name, date format and report period for a report uploaded in the afternoon', () => {
+    const { uploadedByFullName, formattedDateAndTime, lastUploadedReportPeriod } = getReportAndUserDetails(afternoonReport);
 
     expect(uploadedByFullName).toBe('John Smith');
     expect(formattedDateAndTime).toBe('8 April 2023 at 3:23pm');
+    expect(lastUploadedReportPeriod).toBe('April 2023');
   });
 });

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
@@ -1,0 +1,44 @@
+const { getReportAndUserDetails } = require('./utilisation-report-details');
+
+describe('utilisation-report-details', () => {
+  const user = {
+    firstname: 'John',
+    surname: 'Smith',
+  };
+  const morningReport = {
+    _id: 'abc',
+    bankId: '1',
+    month: 4,
+    year: 2023,
+    dateUploaded: '2023-04-08T10:35:31',
+    path: 'www.abc.com',
+    uploadedBy: user,
+  };
+  const afternoonReport = {
+    _id: 'def',
+    bankId: '1',
+    month: 4,
+    year: 2023,
+    dateUploaded: '2023-04-08T15:23:10',
+    path: 'www.abc.com',
+    uploadedBy: user,
+  };
+
+  it('should throw an error if the report is undefined', () => {
+    expect(() => getReportAndUserDetails(undefined)).toThrow(new Error('Cannot get report and user details'));
+  });
+
+  it('should return the correct full name and date format for a report uploaded in the morning', () => {
+    const { uploadedByFullName, formattedDateAndTime } = getReportAndUserDetails(morningReport);
+
+    expect(uploadedByFullName).toBe('John Smith');
+    expect(formattedDateAndTime).toBe('8 April 2023 at 10:35am');
+  });
+
+  it('should return the correct full name and date format for a report uploaded in the afternoon', () => {
+    const { uploadedByFullName, formattedDateAndTime } = getReportAndUserDetails(afternoonReport);
+
+    expect(uploadedByFullName).toBe('John Smith');
+    expect(formattedDateAndTime).toBe('8 April 2023 at 3:23pm');
+  });
+});

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
@@ -5,7 +5,7 @@
 {% set nextDueReport = dueReportDates[0] %}
 {% set genericWarningText = "There are overdue reports, please send them as soon as possible." %}
 {% set warningText %}
-{{ genericWarningText if dueReportDates.length > 2 else [nextDueReport.reportPeriod, " report is overdue, please send it as soon as possible."] | join }}
+    {{ genericWarningText if dueReportDates.length > 2 else [nextDueReport.reportPeriod, " report is overdue, please send it as soon as possible."] | join }}
 {% endset %}
 {% block pageTitle %}Utilisation Report Upload{% endblock %}
 {% block content %}
@@ -30,7 +30,7 @@
             The {{ nextReportPeriod }} report can be uploaded from {{ nextReportPeriodStart }}.
         </p>
         <p class="govuk-body" data-cy="uploaded-report-details">
-            The {{ lastUploadedReportPeriod }} report was sent to UKEF by {{ uploadedByFullName }} on {{ formattedDateAndTime }}.
+            The {{ lastUploadedReportPeriod }} report was sent to UKEF by {{ uploadedByFullName }} on {{ formattedDateAndTimeUploaded }}.
         </p>
     {% elif dueReportDates.length === 1 %}
         <h2 class="govuk-heading-m" data-cy="sub-heading">

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
@@ -5,7 +5,7 @@
 {% set nextDueReport = dueReportDates[0] %}
 {% set genericWarningText = "There are overdue reports, please send them as soon as possible." %}
 {% set warningText %}
-    {{ genericWarningText if dueReportDates.length > 2 else [nextDueReport.reportPeriod, " report is overdue, please send it as soon as possible."] | join }}
+{{ genericWarningText if dueReportDates.length > 2 else [nextDueReport.reportPeriod, " report is overdue, please send it as soon as possible."] | join }}
 {% endset %}
 {% block pageTitle %}Utilisation Report Upload{% endblock %}
 {% block content %}
@@ -19,17 +19,18 @@
         }) }}
     {% endif %}
     <h1 class="govuk-heading-l" data-cy="main-heading">
-        Report GEF utilisation and fees
+        {% if dueReportDates.length > 0 %}
+            Report GEF utilisation and fees
+        {% else %}
+            Report not currently due for upload
+        {% endif %}
     </h1>
     {% if dueReportDates.length === 0%}
-        <h1 class="govuk-heading-l" data-cy="main-heading">
-            Report not currently due for upload
-        </h1>
         <p class="govuk-body" data-cy="next-due-report-text">
             The {{ nextReportPeriod }} report can be uploaded from {{ nextReportPeriodStart }}.
         </p>
         <p class="govuk-body" data-cy="uploaded-report-details">
-            The {{ reportPeriod }} report was sent to UKEF by {{ uploadedByFullName }} on {{ formattedDateAndTime }}.
+            The {{ lastUploadedReportPeriod }} report was sent to UKEF by {{ uploadedByFullName }} on {{ formattedDateAndTime }}.
         </p>
     {% elif dueReportDates.length === 1 %}
         <h2 class="govuk-heading-m" data-cy="sub-heading">
@@ -63,46 +64,47 @@
             {% endif %}
         </div>
     {% endif %}
-    <p class="govuk-body">For each issued facility you must provide:</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li>facility utilisation accurate for the report month-end date</li>
-        <li>the total fees accrued</li>
-        <li>the fee payable to UKEF</li>
-    </ul>
-    <p class="govuk-body">If there has been no movement against a facility you must still report this.</p>
-    <form method="POST" data-cy="form" enctype="multipart/form-data">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <div class="govuk-form-group {% if validationError %}govuk-form-group--error{% endif %}">
-            <label class="govuk-label govuk-label--m" for="utilisation-report-file-upload" data-cy="upload-report-text">
-                Upload {{ nextDueReport.reportPeriod }} report
-            </label>
-            <div id="utilisation-report-file-upload-hint" class="govuk-hint">
-                The file must be an XLSX or CSV
+    {% if dueReportDates.length > 0 %}
+        <p class="govuk-body">For each issued facility you must provide:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>facility utilisation accurate for the report month-end date</li>
+            <li>the total fees accrued</li>
+            <li>the fee payable to UKEF</li>
+        </ul>
+        <p class="govuk-body">If there has been no movement against a facility you must still report this.</p>
+        <form method="POST" data-cy="form" enctype="multipart/form-data">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+            <div class="govuk-form-group {% if validationError %}govuk-form-group--error{% endif %}">
+                <label class="govuk-label govuk-label--m" for="utilisation-report-file-upload" data-cy="upload-report-text">
+                    Upload {{ nextDueReport.reportPeriod }} report
+                </label>
+                <div id="utilisation-report-file-upload-hint" class="govuk-hint">
+                    The file must be an XLSX or CSV
+                </div>
+                {% if validationError %}
+                    <span class="govuk-error-message" data-cy="utilisation-report-file-upload-error-message">
+                        <span class="govuk-visually-hidden">Error:</span>
+                        {{ validationError.text }}
+                    </span>
+                {% endif %}
+                <input
+                    class="govuk-file-upload govuk-!-width-one-half"
+                    id="utilisation-report-file-upload"
+                    name="utilisation-report-file-upload"
+                    data-cy="utilisation-report-file-upload"
+                    data-tag="govuk-file-upload"
+                    type="file"
+                    accept=".xlsx, .csv"/>
             </div>
-            {% if validationError %}
-                <span class="govuk-error-message" data-cy="utilisation-report-file-upload-error-message">
-                    <span class="govuk-visually-hidden">Error:</span>
-                    {{ validationError.text }}
-                </span>
-            {% endif %}
-            <input
-                class="govuk-file-upload govuk-!-width-one-half"
-                id="utilisation-report-file-upload"
-                name="utilisation-report-file-upload"
-                data-cy="utilisation-report-file-upload"
-                data-tag="govuk-file-upload"
-                type="file"
-                accept=".xlsx, .csv"
-                />
-        </div>
-        <div class="govuk-button-group">
-            <input
-                formaction="?_csrf={{ csrfToken }}"
-                type="submit"
-                class="govuk-button govuk-!-margin-right-1"
-                data-module="govuk-button"
-                value="Continue"
-                data-cy="continue-button"/>
-        </div>
-    </form>
+            <div class="govuk-button-group">
+                <input
+                    formaction="?_csrf={{ csrfToken }}"
+                    type="submit"
+                    class="govuk-button govuk-!-margin-right-1"
+                    data-module="govuk-button"
+                    value="Continue"
+                    data-cy="continue-button"/>
+            </div>
+        </form>
+    {% endif %}
 {% endblock %}

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
@@ -21,8 +21,17 @@
     <h1 class="govuk-heading-l" data-cy="main-heading">
         Report GEF utilisation and fees
     </h1>
-    {# TODO FN-1089 add behaviour for reports being up to date #}
-    {% if dueReportDates.length === 1 %}
+    {% if dueReportDates.length === 0%}
+        <h1 class="govuk-heading-l" data-cy="main-heading">
+            Report not currently due for upload
+        </h1>
+        <p class="govuk-body" data-cy="next-due-report-text">
+            The {{ nextReportPeriod }} report can be uploaded from {{ nextReportPeriodStart }}.
+        </p>
+        <p class="govuk-body" data-cy="uploaded-report-details">
+            The {{ reportPeriod }} report was sent to UKEF by {{ uploadedByFullName }} on {{ formattedDateAndTime }}.
+        </p>
+    {% elif dueReportDates.length === 1 %}
         <h2 class="govuk-heading-m" data-cy="sub-heading">
             {{ nextDueReport.reportPeriod }} report is due
         </h2>


### PR DESCRIPTION
# Introduction

When the report for the previous report period has been submitted, we want the 'Report GEF Utilisation and Fees' page to display a specific view.

# Resolution

- Added a new endpoint in `portal-api` to get the latest bank report
- Refactored the `utilisation-report-upload` controller in `portal` to behave differently depending on how many reports `/v1/banks/:bankId/due-report-dates` returns