### PR TITLE
fix: fix mock-data-loader clearing gef-eligibilityCriteria

### DIFF
--- a/utils/mock-data-loader/gef/api.js
+++ b/utils/mock-data-loader/gef/api.js
@@ -136,14 +136,14 @@ const createEligibilityCriteria = async (data, token) => {
   return response.data;
 };
 
-const deleteEligibilityCriteria = async (mandatoryCriteria, token) => {
+const deleteEligibilityCriteria = async (eligibilityCriteria, token) => {
   const response = await axios({
     method: 'delete',
     headers: {
       ...headers.portal,
       Authorization: token,
     },
-    url: `${PORTAL_API_URL}/v1/gef/eligibility-criteria/${mandatoryCriteria._id}`,
+    url: `${PORTAL_API_URL}/v1/gef/eligibility-criteria/${eligibilityCriteria.version}`,
   }).catch((error) => { console.error('Error calling API %s', error); });
 
   return response.data;


### PR DESCRIPTION
## Introduction

I noticed that the mock data loader does not clear the `gef-eligibilityCriteria` collection when it runs.

## Resolution

I corrected the API call that mock-data-loader uses to delete GEF eligibility criteria so that it does clear the collection when it runs