### PR TITLE
feat(FN-1041): add report period details to TFM 'Bank reports' screen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ run-name: Executing lint QA on ${{ github.repository }} 🚀
 
 on:
   pull_request:
-    branches: [main, main-stbr]
+    branches: [main, main-stbr, main-stbr-tfm-5]
     paths:
       - "package*.json"
       - "docker*.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ run-name: Executing test QA on ${{ github.repository }} 🚀
 
 on:
   pull_request:
-    branches: [main, main-stbr]
+    branches: [main, main-stbr, main-stbr-tfm-5]
     paths:
       - "package*.json"
       - "docker*.yml"

--- a/portal-api/src/external-api/bank-holidays.js
+++ b/portal-api/src/external-api/bank-holidays.js
@@ -11,7 +11,7 @@ const headers = {
 
 /**
  * Resolves to the response of `GET /bank-holidays` from external-api.
- * @returns {Promise<import('axios').AxiosResponse>}
+ * @returns {import('./types').BankHolidaysResponseBody}
  */
 const getBankHolidays = async () => {
   const response = await axios.get(`${EXTERNAL_API_URL}/bank-holidays`, { headers });
@@ -20,7 +20,7 @@ const getBankHolidays = async () => {
 
 /**
  * Fetches a list of bank holiday dates for the specified UK region
- * @param {'england-and-wales' | 'scotland' | 'northern-ireland'} region
+ * @param {import('./types').BankHolidayRegion} region
  * @returns {Promise<Date[]>}
  */
 const getBankHolidayDatesForRegion = async (region) => {

--- a/portal-api/src/external-api/types/bank-holidays.d.ts
+++ b/portal-api/src/external-api/types/bank-holidays.d.ts
@@ -1,0 +1,31 @@
+export type BankHolidayRegion = 'england-and-wales' | 'scotland' | 'northern-ireland';
+
+type BankHolidayEvent = {
+  /*
+   * Title of the event - e.g. 'New Year's Day'
+   */
+  title: string;
+  /*
+   * Date of the event ISO 8601 format - e.g. '2022-01-03'
+   */
+  date: string;
+  /*
+   * Additional notes about the event - e.g. 'Substitute day'
+   */
+  notes: string;
+  /*
+   * Indicates whether the bank holiday is a suitable occasion for hanging bunting
+   */
+  bunting: boolean;
+};
+
+type BankHolidayRegionEvents = {
+  division: BankHolidayRegion;
+  events: BankHolidayEvent[];
+};
+
+export type BankHolidaysResponseBody = {
+  'england-and-wales': BankHolidayRegionEvents;
+  scotland: BankHolidayRegionEvents;
+  'northern-ireland': BankHolidayRegionEvents;
+};

--- a/portal-api/src/scheduler/jobs/helpers/utilisation-report-helpers.test.js
+++ b/portal-api/src/scheduler/jobs/helpers/utilisation-report-helpers.test.js
@@ -167,6 +167,7 @@ describe('utilisation-report-helpers', () => {
       // Act
       const reportPeriod = getFormattedReportPeriod();
 
+      // Assert
       expect(reportPeriod).toEqual(expectedReportPeriod);
     });
   });

--- a/portal/component-tests/utilisation-report-service/previous-reports.component-test.js
+++ b/portal/component-tests/utilisation-report-service/previous-reports.component-test.js
@@ -59,7 +59,7 @@ describe(page, () => {
     });
 
     it('should render page heading', () => {
-      wrapper.expectText('[data-cy="main-heading"]').toRead('2023 reports');
+      wrapper.expectText('[data-cy="main-heading"]').toRead('2023 GEF reports');
     });
 
     it('should render paragraph', () => {
@@ -95,7 +95,7 @@ describe(page, () => {
     });
 
     it('should render page heading', () => {
-      wrapper.expectText('[data-cy="main-heading"]').toRead('2023 reports');
+      wrapper.expectText('[data-cy="main-heading"]').toRead('2023 GEF reports');
     });
 
     it('should render paragraph', () => {
@@ -109,7 +109,7 @@ describe(page, () => {
     });
 
     it('should render page heading', () => {
-      wrapper.expectText('[data-cy="main-heading"]').toRead('Previous reports');
+      wrapper.expectText('[data-cy="main-heading"]').toRead('Previous GEF reports');
     });
 
     it('should render paragraph', () => {

--- a/trade-finance-manager-api/.eslintrc.js
+++ b/trade-finance-manager-api/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  plugins: ['@typescript-eslint'],
   extends: 'airbnb-base',
   env: {
     jest: true,
@@ -40,6 +41,7 @@ module.exports = {
       },
     ],
   },
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2020,
   },

--- a/trade-finance-manager-api/api-tests/v1/bank-holidays/bank-holidays.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/bank-holidays/bank-holidays.api-test.js
@@ -1,0 +1,19 @@
+const app = require('../../../src/createApp');
+const testUserCache = require('../../api-test-users');
+const { as } = require('../../api')(app);
+
+describe('/v1/bank-holidays', () => {
+  describe('GET /v1/bank-holidays', () => {
+    it('gets bank holidays for authenticated user', async () => {
+      // Arrange
+      const user = await testUserCache.initialise(app);
+
+      // Act
+      const { status, body } = await as(user).get('/v1/bank-holidays');
+
+      // Assert
+      expect(status).toEqual(200);
+      expect(body).not.toBeNull();
+    });
+  });
+});

--- a/trade-finance-manager-api/package-lock.json
+++ b/trade-finance-manager-api/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-plugin-import": "^2.29.0",
         "jest": "29.5.0",
         "jest-when": "^3.6.0",
+        "node-mocks-http": "^1.13.0",
         "supertest": "^6.3.3",
         "typescript": "^5.2.2"
       },
@@ -6584,6 +6585,36 @@
       "version": "0.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-mocks-http": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.13.0.tgz",
+      "integrity": "sha512-lArD6sJMPJ53WF50GX0nJ89B1nkV1TdMvNwq8WXXFrUXF80ujSyye1T30mgiHh4h2It0/svpF3C4kZ2OAONVlg==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/node-mocks-http/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.13",

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-import": "^2.29.0",
     "jest": "29.5.0",
     "jest-when": "^3.6.0",
+    "node-mocks-http": "^1.13.0",
     "supertest": "^6.3.3",
     "typescript": "^5.2.2"
   },

--- a/trade-finance-manager-api/src/types/bank-holidays.d.ts
+++ b/trade-finance-manager-api/src/types/bank-holidays.d.ts
@@ -1,0 +1,31 @@
+export type BankHolidayRegion = 'england-and-wales' | 'scotland' | 'northern-ireland';
+
+type BankHolidayEvent = {
+  /*
+   * Title of the event - e.g. 'New Year's Day'
+   */
+  title: string;
+  /*
+   * Date of the event ISO 8601 format - e.g. '2022-01-03'
+   */
+  date: string;
+  /*
+   * Additional notes about the event - e.g. 'Substitute day'
+   */
+  notes: string;
+  /*
+   * Indicates whether the bank holiday is a suitable occasion for hanging bunting
+   */
+  bunting: boolean;
+};
+
+type BankHolidayRegionEvents = {
+  division: BankHolidayRegion;
+  events: BankHolidayEvent[];
+};
+
+export type BankHolidaysResponseBody = {
+  'england-and-wales': BankHolidayRegionEvents;
+  scotland: BankHolidayRegionEvents;
+  'northern-ireland': BankHolidayRegionEvents;
+};

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -3,6 +3,7 @@ const MOCK_BSS_FACILITIES_USD_CURRENCY = require('./mock-facilities-USD-currency
 const MOCK_CURRENCY_EXCHANGE_RATE = require('./mock-currency-exchange-rate');
 const MOCK_USERS = require('./mock-users');
 const MOCK_PREMIUM_SCHEDULE_RESPONSE = require('./mock-premium-schedule-response');
+const MOCK_BANK_HOLIDAYS = require('./mock-bank-holidays');
 
 const MOCK_CASH_CONTINGENT_FACILITIES = require('./mock-cash-contingent-facilities');
 
@@ -227,4 +228,5 @@ module.exports = {
 
     return Promise.resolve(mockResponse);
   }),
+  getBankHolidays: jest.fn(() => Promise.resolve(MOCK_BANK_HOLIDAYS)),
 };

--- a/trade-finance-manager-api/src/v1/__mocks__/mock-bank-holidays.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/mock-bank-holidays.js
@@ -1,0 +1,40 @@
+/**
+ * @type {import('../../types/bank-holidays').BankHolidaysResponseBody}
+ */
+const MOCK_BANK_HOLIDAYS = {
+  'england-and-wales': {
+    division: 'england-and-wales',
+    events: [
+      {
+        title: 'Christmas Day',
+        date: '2023-12-25',
+        notes: '',
+        bunting: true,
+      },
+    ],
+  },
+  scotland: {
+    division: 'scotland',
+    events: [
+      {
+        title: 'St Andrew’s Day',
+        date: '2023-11-30',
+        notes: '',
+        bunting: true,
+      },
+    ],
+  },
+  'northern-ireland': {
+    division: 'northern-ireland',
+    events: [
+      {
+        title: 'St Patrick’s Day',
+        date: '2023-03-17',
+        notes: '',
+        bunting: true,
+      },
+    ],
+  },
+};
+
+module.exports = MOCK_BANK_HOLIDAYS;

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -1182,6 +1182,18 @@ const getGefMandatoryCriteriaByVersion = async (version) => {
   }
 };
 
+/**
+ * Resolves to the response of `GET /bank-holidays` from external-api.
+ * @returns {import('../types/bank-holidays').BankHolidaysResponseBody}
+ */
+const getBankHolidays = async () => {
+  const response = await axios.get(`${EXTERNAL_API_URL}/bank-holidays`, {
+    headers: headers.external,
+  });
+
+  return response.data;
+};
+
 module.exports = {
   findOneDeal,
   findOnePortalDeal,
@@ -1236,4 +1248,5 @@ module.exports = {
   updateGefMINActivity,
   findBankById,
   getGefMandatoryCriteriaByVersion,
+  getBankHolidays,
 };

--- a/trade-finance-manager-api/src/v1/controllers/bank-holidays/get-bank-holidays.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/bank-holidays/get-bank-holidays.controller.js
@@ -1,0 +1,13 @@
+const api = require('../../api');
+
+const getBankHolidays = async (req, res) => {
+  try {
+    const bankHolidays = await api.getBankHolidays();
+    res.status(200).send(bankHolidays);
+  } catch (error) {
+    console.error('Unable to get UK bank holidays %s', error);
+    res.status(error.response?.status ?? 500).send('Failed to get bank holidays');
+  }
+};
+
+module.exports = getBankHolidays;

--- a/trade-finance-manager-api/src/v1/controllers/bank-holidays/get-bank-holidays.controller.test.js
+++ b/trade-finance-manager-api/src/v1/controllers/bank-holidays/get-bank-holidays.controller.test.js
@@ -1,0 +1,42 @@
+const httpMocks = require('node-mocks-http');
+const api = require('../../api');
+const { getBankHolidays } = require('.');
+const MOCK_BANK_HOLIDAYS = require('../../__mocks__/mock-bank-holidays');
+
+jest.mock('../../api');
+
+console.error = jest.fn();
+
+describe('get-bank-holidays.controller', () => {
+  it('returns bank holidays when the External API request is successful', async () => {
+    // Arrange
+    api.getBankHolidays.mockResolvedValue(MOCK_BANK_HOLIDAYS);
+    const { res, req } = httpMocks.createMocks();
+
+    // Act
+    await getBankHolidays(req, res);
+
+    // Assert
+    /* eslint-disable no-underscore-dangle */
+    expect(res._getStatusCode()).toEqual(200);
+    expect(res._getData()).toEqual(MOCK_BANK_HOLIDAYS);
+    /* eslint-enable no-underscore-dangle */
+  });
+
+  it('returns an error response when the External API request fails', async () => {
+    // Arrange
+    const axiosError = { response: { status: 404 } };
+    api.getBankHolidays.mockRejectedValue(axiosError);
+
+    const { res, req } = httpMocks.createMocks();
+
+    // Act
+    await getBankHolidays(req, res);
+
+    // Assert
+    /* eslint-disable no-underscore-dangle */
+    expect(res._getStatusCode()).toEqual(axiosError.response.status);
+    expect(res._getData()).toEqual('Failed to get bank holidays');
+    /* eslint-enable no-underscore-dangle */
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/bank-holidays/index.js
+++ b/trade-finance-manager-api/src/v1/controllers/bank-holidays/index.js
@@ -1,0 +1,5 @@
+const getBankHolidays = require('./get-bank-holidays.controller');
+
+module.exports = {
+  getBankHolidays,
+};

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -11,6 +11,7 @@ const feedbackController = require('./controllers/feedback-controller');
 const amendmentController = require('./controllers/amendment.controller');
 const facilityController = require('./controllers/facility.controller');
 const partyController = require('./controllers/party.controller');
+const bankHolidaysController = require('./controllers/bank-holidays');
 const users = require('./controllers/user/user.routes');
 const party = require('./controllers/deal.party-db');
 const validation = require('./validation/route-validators/route-validators');
@@ -120,5 +121,7 @@ authRouter.route('/amendments/:status?').get(amendmentController.getAllAmendment
 
 authRouter.route('/party/urn/:urn').get(validation.partyUrnValidation, handleExpressValidatorResult, party.getCompany);
 authRouter.route('/parties/:dealId').put(validation.dealIdValidation, handleExpressValidatorResult, partyController.updateParty);
+
+authRouter.route('/bank-holidays').get(bankHolidaysController.getBankHolidays);
 
 module.exports = { authRouter, openRouter };

--- a/trade-finance-manager-ui/package-lock.json
+++ b/trade-finance-manager-ui/package-lock.json
@@ -66,6 +66,7 @@
         "eslint-plugin-import": "^2.29.0",
         "file-loader": "^6.2.0",
         "jest": "29.5.0",
+        "node-mocks-http": "^1.13.0",
         "optimize-css-assets-webpack-plugin": "^6.0.1",
         "sass": "^1.69.5",
         "sass-loader": "13.2.2",
@@ -8741,6 +8742,36 @@
       "version": "0.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-mocks-http": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.13.0.tgz",
+      "integrity": "sha512-lArD6sJMPJ53WF50GX0nJ89B1nkV1TdMvNwq8WXXFrUXF80ujSyye1T30mgiHh4h2It0/svpF3C4kZ2OAONVlg==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/node-mocks-http/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.13",

--- a/trade-finance-manager-ui/package.json
+++ b/trade-finance-manager-ui/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-import": "^2.29.0",
     "file-loader": "^6.2.0",
     "jest": "29.5.0",
+    "node-mocks-http": "^1.13.0",
     "optimize-css-assets-webpack-plugin": "^6.0.1",
     "sass": "^1.69.5",
     "sass-loader": "13.2.2",

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -791,6 +791,19 @@ const getParty = async (partyUrn, token) => {
   }
 };
 
+const getUkBankHolidays = async (token) => {
+  try {
+    const { data } = await axios.get(`${TFM_API_URL}/v1/bank-holidays`, {
+      headers: generateHeaders(token),
+    });
+
+    return data;
+  } catch (error) {
+    console.error('Failed to get UK bank holidays', error);
+    throw error;
+  }
+};
+
 module.exports = {
   getDeal,
   getDeals,
@@ -825,4 +838,5 @@ module.exports = {
   getLatestCompletedAmendmentValue,
   getLatestCompletedAmendmentDate,
   getParty,
+  getUkBankHolidays,
 };

--- a/trade-finance-manager-ui/server/api.test.js
+++ b/trade-finance-manager-ui/server/api.test.js
@@ -1,17 +1,43 @@
-import api from './api';
-
 const axios = require('axios');
+const MockAdapter = require('axios-mock-adapter');
+const api = require('./api');
+const MOCK_BANK_HOLIDAYS = require('./test-mocks/mock-bank-holidays');
+const { getUkBankHolidays } = require('./api');
 
-jest.mock('axios');
+const mockAxios = new MockAdapter(axios);
+
+console.error = jest.fn();
 
 afterEach(() => {
   jest.clearAllMocks();
+  mockAxios.reset();
 });
 
 describe('getFacilities()', () => {
   it('returns the correct response', async () => {
-    axios.get.mockReturnValue(Promise.resolve({ data: { status: 200 } }));
+    mockAxios.onGet().reply(200);
     const response = await api.getFacilities();
     expect(response).toEqual({ facilities: [] });
+  });
+});
+
+describe('getUkBankHolidays', () => {
+  it('gets the bank holidays', async () => {
+    // Arrange
+    mockAxios.onGet().reply(200, MOCK_BANK_HOLIDAYS);
+
+    // Act
+    const response = await getUkBankHolidays('user-token');
+
+    // Assert
+    expect(response).toEqual(MOCK_BANK_HOLIDAYS);
+  });
+
+  it('throws when the api TFM API request fails', async () => {
+    // Arrange
+    mockAxios.onGet().reply(404);
+
+    // Act / Assert
+    await expect(getUkBankHolidays('user-token')).rejects.toThrowError('Request failed with status code 404');
   });
 });

--- a/trade-finance-manager-ui/server/constants/bank-holiday-region.js
+++ b/trade-finance-manager-ui/server/constants/bank-holiday-region.js
@@ -1,0 +1,7 @@
+const BANK_HOLIDAY_REGION = {
+  ENGLAND_AND_WALES: 'england-and-wales',
+  SCOTLAND: 'scotland',
+  NORTHERN_IRELAND: 'northern-ireland',
+};
+
+module.exports = BANK_HOLIDAY_REGION;

--- a/trade-finance-manager-ui/server/constants/index.js
+++ b/trade-finance-manager-ui/server/constants/index.js
@@ -7,6 +7,7 @@ const ACTIVITIES = require('./activities');
 const AMENDMENTS = require('./amendments');
 const DECISIONS = require('./decisions.constant');
 const PARTY = require('./party');
+const BANK_HOLIDAY_REGION = require('./bank-holiday-region');
 
 module.exports = {
   DEAL,
@@ -18,4 +19,5 @@ module.exports = {
   AMENDMENTS,
   DECISIONS,
   PARTY,
+  BANK_HOLIDAY_REGION,
 };

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/index.js
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/index.js
@@ -1,0 +1,23 @@
+const { getFormattedReportDueDate, getFormattedReportPeriod } = require('../../services/utilisation-report-service');
+
+const getUtilisationReports = async (req, res) => {
+  try {
+    const { userToken } = req.session;
+
+    const reportPeriod = getFormattedReportPeriod();
+    const reportDueDate = await getFormattedReportDueDate(userToken);
+
+    return res.render('utilisation-reports/utilisation-reports.njk', {
+      activePrimaryNavigation: 'utilisation reports',
+      reportPeriod,
+      reportDueDate,
+    });
+  } catch (error) {
+    console.error('Error rendering utilisation reports page', error);
+    return res.render('_partials/problem-with-service.njk');
+  }
+};
+
+module.exports = {
+  getUtilisationReports,
+};

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.js
@@ -1,0 +1,64 @@
+const httpMocks = require('node-mocks-http');
+const api = require('../../api');
+const { getUtilisationReports } = require('./index');
+const MOCK_BANK_HOLIDAYS = require('../../test-mocks/mock-bank-holidays');
+
+jest.mock('../../api');
+
+console.error = jest.fn();
+
+const originalProcessEnv = process.env;
+
+describe('controllers/utilisation-reports', () => {
+  afterEach(() => {
+    process.env = { ...originalProcessEnv };
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('getUtilisationReports', () => {
+    it("renders the 'problem-with-service' page on error", async () => {
+      // Arrange
+      const { res, req } = httpMocks.createMocks({
+        session: { userToken: 'user-token' },
+      });
+
+      api.getUkBankHolidays.mockRejectedValue({ response: { status: 404 } });
+
+      // Act
+      await getUtilisationReports(req, res);
+
+      // Assert
+      /* eslint-disable no-underscore-dangle */
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
+      /* eslint-enable no-underscore-dangle */
+    });
+
+    it('renders the utilisation-reports.njk view with required data', async () => {
+      // Arrange
+      const { res, req } = httpMocks.createMocks({
+        session: { userToken: 'user-token' },
+      });
+
+      process.env.UTILISATION_REPORT_DUE_DATE_BUSINESS_DAYS_FROM_START_OF_MONTH = 10;
+
+      const today = new Date('2023-11-05');
+      jest.useFakeTimers().setSystemTime(today);
+
+      api.getUkBankHolidays.mockResolvedValue(MOCK_BANK_HOLIDAYS);
+
+      // Act
+      await getUtilisationReports(req, res);
+
+      // Assert
+      /* eslint-disable no-underscore-dangle */
+      expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-reports.njk');
+      expect(res._getRenderData()).toMatchObject({
+        activePrimaryNavigation: 'utilisation reports',
+        reportPeriod: 'October 2023',
+        reportDueDate: '14 November 2023',
+      });
+      /* eslint-enable no-underscore-dangle */
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/helpers/date.js
+++ b/trade-finance-manager-ui/server/helpers/date.js
@@ -1,0 +1,69 @@
+const { addBusinessDays, isSameDay, isWeekend, startOfMonth } = require('date-fns');
+
+/**
+ * @param {Date} date
+ * @param {Date[]} holidays
+ * @returns {boolean}
+ */
+const isHoliday = (date, holidays) => holidays.some((holiday) => isSameDay(date, holiday));
+
+/**
+ * Adds one business day to the provided date, taking into account weekends and
+ * the provide list of holidays
+ * @param {Date} date
+ * @param {Date[]} holidays
+ * @returns {Date}
+ */
+const addOneBusinessDayWithHolidays = (date, holidays) => {
+  let nextBusinessDay = addBusinessDays(date, 1);
+
+  while (isHoliday(nextBusinessDay, holidays)) {
+    nextBusinessDay = addBusinessDays(nextBusinessDay, 1);
+  }
+
+  return nextBusinessDay;
+};
+
+/**
+ * Given a date in the month and an array of holidays, this returns the first
+ * non-weekend and non-holiday date in the month provided.
+ * @param {Date} dateInMonth - A date in the required month
+ * @param {Date[]} holidays - A list of dates which should be excluded as holidays
+ * @returns {Date}
+ */
+const getFirstBusinessDayOfMonth = (dateInMonth, holidays) => {
+  const firstBusinessDay = startOfMonth(dateInMonth);
+
+  if (isWeekend(firstBusinessDay) || isHoliday(firstBusinessDay, holidays)) {
+    return addOneBusinessDayWithHolidays(firstBusinessDay, holidays);
+  }
+
+  return firstBusinessDay;
+};
+
+/**
+ * Given a date in the month, an array of holidays and a businessDay, it will
+ * return the nth business day of the month. For example, a businessDay
+ * index of 10 will return the 10th business day of the month.
+ * @param {Date} dateInMonth - A date in the required month
+ * @param {Date[]} holidays - A list of dates which should be excluded as holidays
+ * @param {number} businessDay - The one-indexed business day to get
+ * @returns {Date}
+ */
+const getBusinessDayOfMonth = (dateInMonth, holidays, businessDay) => {
+  if (!Number.isInteger(businessDay) || businessDay < 1) {
+    throw new Error(`businessDay must be a positive integer. Found ${businessDay}`);
+  }
+
+  let result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
+
+  for (let i = 1; i < businessDay; i += 1) {
+    result = addOneBusinessDayWithHolidays(result, holidays);
+  }
+
+  return result;
+};
+
+module.exports = {
+  getBusinessDayOfMonth,
+};

--- a/trade-finance-manager-ui/server/helpers/date.test.js
+++ b/trade-finance-manager-ui/server/helpers/date.test.js
@@ -1,0 +1,103 @@
+import { isSameDay } from 'date-fns';
+import { getBusinessDayOfMonth } from './date';
+
+describe('date', () => {
+  describe('getBusinessDayOfMonth', () => {
+    it.each([
+      { businessDay: 0, testCase: 'less than 1' },
+      { businessDay: 1.5, testCase: 'not an integer' },
+      { businessDay: '1', testCase: 'not a number' },
+    ])('throws when businessDay is $testCase', ({ businessDay }) => {
+      // Arrange
+      const dateInMonth = new Date('2023-01-01');
+      const holidays = [];
+
+      // Act / Assert
+      expect(() => getBusinessDayOfMonth(dateInMonth, holidays, businessDay)).toThrow(
+        new Error(`businessDay must be a positive integer. Found ${businessDay}`),
+      );
+    });
+
+    describe('when there are no holidays', () => {
+      const holidays = [];
+
+      describe('when the first of the month is not a weekend date', () => {
+        const dateInMonth = new Date('2023-11-15');
+
+        it.each([
+          { businessDay: 1, expectedResult: new Date('2023-11-01') },
+          { businessDay: 2, expectedResult: new Date('2023-11-02') },
+          { businessDay: 3, expectedResult: new Date('2023-11-03') },
+          //                                               '2023-11-04' - Saturday
+          //                                               '2023-11-05' - Sunday
+          { businessDay: 4, expectedResult: new Date('2023-11-06') },
+          { businessDay: 5, expectedResult: new Date('2023-11-07') },
+          { businessDay: 6, expectedResult: new Date('2023-11-08') },
+          { businessDay: 7, expectedResult: new Date('2023-11-09') },
+          { businessDay: 8, expectedResult: new Date('2023-11-10') },
+          //                                               '2023-11-11' - Saturday
+          //                                               '2023-11-12' - Sunday
+          { businessDay: 9, expectedResult: new Date('2023-11-13') },
+        ])(`returns $expectedResult when dateInMonth is ${dateInMonth.toISOString()} and businessDay is $businessDay`, ({ businessDay, expectedResult }) => {
+          // Act
+          const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
+
+          // Assert
+          expect(isSameDay(result, expectedResult)).toBe(true);
+        });
+      });
+
+      describe('when the first of the month is a weekend date', () => {
+        const dateInMonth = new Date('2023-10-15');
+
+        it.each([
+          //                                               '2023-10-01' - Sunday
+          { businessDay: 1, expectedResult: new Date('2023-10-02') },
+          { businessDay: 2, expectedResult: new Date('2023-10-03') },
+        ])(`returns $expectedResult when dateInMonth is ${dateInMonth.toISOString()} and businessDay is $businessDay`, ({ businessDay, expectedResult }) => {
+          // Act
+          const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
+
+          // Assert
+          expect(isSameDay(result, expectedResult)).toBe(true);
+        });
+      });
+    });
+
+    describe('when there are holidays', () => {
+      it('takes into account consecutive holidays', () => {
+        // Arrange
+        const dateInMonth = new Date('2023-08-15');
+        const holidays = [
+          new Date('2023-08-02'), // Wednesday
+          new Date('2023-08-03'), // Thursday
+        ];
+        const businessDay = 2; // would expect '2023-08-02' without holidays
+        const expectedResult = new Date('2023-08-04');
+
+        // Act
+        const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
+
+        // Assert
+        expect(isSameDay(result, expectedResult)).toBe(true);
+      });
+
+      it('takes into account both holidays and weekend dates', () => {
+        // Arrange
+        const dateInMonth = new Date('2023-11-15');
+        const holidays = [
+          new Date('2023-11-03'), // Friday
+          new Date('2023-11-06'), // Monday
+        ];
+        const businessDay = 3; // would expect '2023-11-03' without holidays
+        const expectedResult = new Date('2023-11-07');
+
+        // Act
+        const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
+
+        // Assert
+        expect(isSameDay(result, expectedResult)).toBe(true);
+      });
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/routes/index.js
+++ b/trade-finance-manager-ui/server/routes/index.js
@@ -7,6 +7,7 @@ const facilitiesRoutes = require('./facilities');
 const feedbackRoutes = require('./feedback');
 const thankYouFeedbackRoutes = require('./feedback-thank-you');
 const userRoutes = require('./user');
+const utilisationReportsRoutes = require('./utilisation-reports');
 const footerRoutes = require('./footer');
 
 const { validateUser } = require('../middleware/user-validation');
@@ -20,6 +21,7 @@ router.use('/facilities', validateUser, facilitiesRoutes);
 router.use('/feedback', feedbackRoutes);
 router.use('/thank-you-feedback', thankYouFeedbackRoutes);
 router.use('/user', userRoutes);
+router.use('/utilisation-reports', validateUser, utilisationReportsRoutes);
 router.use('/', footerRoutes);
 
 module.exports = router;

--- a/trade-finance-manager-ui/server/routes/index.test.js
+++ b/trade-finance-manager-ui/server/routes/index.test.js
@@ -6,6 +6,7 @@ import facilitiesRoutes from './facilities';
 import feedbackRoutes from './feedback';
 import feedbackThankYouRoutes from './feedback-thank-you';
 import userRoutes from './user';
+import utilisationReportsRoutes from './utilisation-reports';
 import footerRoutes from './footer';
 import { validateUser } from '../middleware/user-validation';
 
@@ -19,7 +20,7 @@ describe('routes index', () => {
   });
 
   it('should setup all routes', () => {
-    expect(use).toHaveBeenCalledTimes(8);
+    expect(use).toHaveBeenCalledTimes(9);
     expect(use).toHaveBeenCalledWith('/', loginRoutes);
     expect(use).toHaveBeenCalledWith('/case', validateUser, caseRoutes);
     expect(use).toHaveBeenCalledWith('/deals', validateUser, dealsRoutes);
@@ -27,6 +28,7 @@ describe('routes index', () => {
     expect(use).toHaveBeenCalledWith('/feedback', feedbackRoutes);
     expect(use).toHaveBeenCalledWith('/thank-you-feedback', feedbackThankYouRoutes);
     expect(use).toHaveBeenCalledWith('/user', userRoutes);
+    expect(use).toHaveBeenCalledWith('/utilisation-reports', validateUser, utilisationReportsRoutes);
     expect(use).toHaveBeenCalledWith('/', footerRoutes);
   });
 });

--- a/trade-finance-manager-ui/server/routes/utilisation-reports/index.js
+++ b/trade-finance-manager-ui/server/routes/utilisation-reports/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { getUtilisationReports } = require('../../controllers/utilisation-reports');
+
+const router = express.Router();
+
+router.get('/', getUtilisationReports);
+
+module.exports = router;

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.js
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.js
@@ -1,0 +1,49 @@
+const { format, subMonths } = require('date-fns');
+const api = require('../api');
+const { getBusinessDayOfMonth } = require('../helpers/date');
+const { BANK_HOLIDAY_REGION } = require('../constants');
+
+/**
+ * Fetches a list of bank holiday dates for the specified UK region
+ * @param {string} userToken - Token to validate session
+ * @param {'england-and-wales' | 'scotland' | 'northern-ireland'} region
+ * @returns {Promise<Date[]>}
+ */
+const getBankHolidays = async (userToken, region) => {
+  const bankHolidays = await api.getUkBankHolidays(userToken);
+  return bankHolidays[region].events.map((event) => new Date(event.date));
+};
+
+/**
+ * Returns the utilisation report due date for the current month
+ * @returns {Promise<Date>}
+ */
+const getReportDueDate = async (userToken) => {
+  const bankHolidays = await getBankHolidays(userToken, BANK_HOLIDAY_REGION.ENGLAND_AND_WALES);
+  const businessDay = parseInt(process.env.UTILISATION_REPORT_DUE_DATE_BUSINESS_DAYS_FROM_START_OF_MONTH, 10);
+  const dateInReportMonth = new Date();
+  return getBusinessDayOfMonth(dateInReportMonth, bankHolidays, businessDay);
+};
+
+/**
+ * Returns the utilisation report due date for the current month in 'do MMMM yyyy' format
+ * @returns {Promise<string>}
+ */
+const getFormattedReportDueDate = async (userToken) => {
+  const reportDueDate = await getReportDueDate(userToken);
+  return format(reportDueDate, 'd MMMM yyyy');
+};
+
+/**
+ * Returns the current report period (i.e. the previous month) in 'MMMM yyyy' format
+ * @returns {string}
+ */
+const getFormattedReportPeriod = () => {
+  const lastMonthDate = subMonths(new Date(), 1);
+  return format(lastMonthDate, 'MMMM yyyy');
+};
+
+module.exports = {
+  getFormattedReportDueDate,
+  getFormattedReportPeriod,
+};

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
@@ -1,0 +1,74 @@
+const { getFormattedReportDueDate, getFormattedReportPeriod } = require('./utilisation-report-service');
+const api = require('../api');
+
+jest.mock('../api');
+
+const originalProcessEnv = process.env;
+
+describe('utilisation-report-service', () => {
+  afterEach(() => {
+    process.env = { ...originalProcessEnv };
+    jest.resetAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('getFormattedReportDueDate', () => {
+    it.each([
+      {
+        today: new Date('2023-11-10'),
+        businessDay: 5,
+        bankHolidays: { 'england-and-wales': { events: [] } },
+        // 2023-11-04 and 2023-11-05 are weekend dates.
+        expectedDueDate: '7 November 2023',
+      },
+      {
+        today: new Date('2023-11-10'),
+        businessDay: 5,
+        bankHolidays: {
+          'england-and-wales': {
+            events: [
+              { date: '2023-11-03' }, // Friday
+              { date: '2023-11-06' }, // Monday
+            ],
+          },
+        },
+        // 2023-11-04 and 2023-11-05 are weekend dates.
+        expectedDueDate: '9 November 2023',
+      },
+    ])(
+      'returns business day $businessDay as formatted due date $expectedDueDate based on bank holidays $bankHolidays',
+      async ({ today, businessDay, bankHolidays, expectedDueDate }) => {
+        // Arrange
+        const userToken = 'user-token';
+
+        jest.useFakeTimers().setSystemTime(today);
+        process.env.UTILISATION_REPORT_DUE_DATE_BUSINESS_DAYS_FROM_START_OF_MONTH = businessDay;
+
+        api.getUkBankHolidays.mockResolvedValue(bankHolidays);
+
+        // Act
+        const dueDate = await getFormattedReportDueDate(userToken);
+
+        // Assert
+        expect(dueDate).toEqual(expectedDueDate);
+      },
+    );
+  });
+
+  describe('getFormattedReportPeriod', () => {
+    it.each([
+      { today: new Date('2023-11-15'), expectedReportPeriod: 'October 2023' },
+      { today: new Date('2023-03-31'), expectedReportPeriod: 'February 2023' },
+      { today: new Date('2023-01-15'), expectedReportPeriod: 'December 2022' },
+    ])("returns '$expectedReportPeriod' when today is $today", ({ today, expectedReportPeriod }) => {
+      // Arrange
+      jest.useFakeTimers().setSystemTime(today);
+
+      // Act
+      const reportPeriod = getFormattedReportPeriod();
+
+      // Assert
+      expect(reportPeriod).toEqual(expectedReportPeriod);
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/test-mocks/mock-bank-holidays.js
+++ b/trade-finance-manager-ui/server/test-mocks/mock-bank-holidays.js
@@ -1,0 +1,37 @@
+const MOCK_BANK_HOLIDAYS = {
+  'england-and-wales': {
+    division: 'england-and-wales',
+    events: [
+      {
+        title: 'Christmas Day',
+        date: '2023-12-25',
+        notes: '',
+        bunting: true,
+      },
+    ],
+  },
+  scotland: {
+    division: 'scotland',
+    events: [
+      {
+        title: 'St Andrew’s Day',
+        date: '2023-11-30',
+        notes: '',
+        bunting: true,
+      },
+    ],
+  },
+  'northern-ireland': {
+    division: 'northern-ireland',
+    events: [
+      {
+        title: 'St Patrick’s Day',
+        date: '2023-03-17',
+        notes: '',
+        bunting: true,
+      },
+    ],
+  },
+};
+
+module.exports = MOCK_BANK_HOLIDAYS;

--- a/trade-finance-manager-ui/templates/_partials/primary-navigation.njk
+++ b/trade-finance-manager-ui/templates/_partials/primary-navigation.njk
@@ -5,21 +5,29 @@
     label: "Primary navigation",
     items: [
       {
+        text: "Bank reports",
+        href: "/utilisation-reports",
+        active: (activePrimaryNavigation === 'utilisation reports'),
+        attributes: {
+          "data-cy": "utilisation-reports-link"
+        }
+      },
+      {
         text: "All deals",
         href: "/deals",
         active: (activePrimaryNavigation === 'all deals'),
         attributes: {
           "data-cy": "all-deals-link"
         }
-    },
-    {
+      },
+      {
         text: "All facilities",
         href: "/facilities",
         active: (activePrimaryNavigation === 'all facilities'),
         attributes: {
           "data-cy": "all-facilities-link"
         }
-    }
+      }
     ]
   }) }}
 {% endif %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-reports.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-reports.njk
@@ -1,0 +1,22 @@
+{% extends "index.njk" %}
+
+{% block pageTitle %}
+  Trade Finance Manager
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Bank reports</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Current reporting period: {{ reportPeriod }} (monthly)</h2>
+      <p class="govuk-body">Reports due to be received by {{ reportDueDate }}.</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block sub_content %}{% endblock %}


### PR DESCRIPTION
## Ticket

[FN-1041](https://ukef-dtfs.atlassian.net/browse/FN-1041)

## Introduction

The "Bank reports" screen in TFM should show show details of the current utilisation report reporting period, and the date that this month's report is due.

## Resolution

* Add a basic page outline for the "Bank reports" page and add a link to the nav bar
* Add API calls through TFM UI -> TFM API -> External API to get details of UK bank holidays
* Use bank holiday details to calculate the current utilisation report reporting period, and the date that this month's report is due.
* Add to new "Bank reports" page