### PR TITLE
feat(FN-1134): fix validate filename year

### DIFF
--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-validator.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-validator.js
@@ -106,14 +106,20 @@ const validateFilenameContainsReportPeriod = (filename, dueReportPeriod) => {
     return { regex, regexWithExactYear };
   });
 
-  const firstMatchingRegex = regexPatterns.filter(({ regex }) => regex.test(filename)).at(0);
-  if (!firstMatchingRegex) {
+  const allMatchingRegex = regexPatterns.filter(({ regex }) => regex.test(filename));
+  if (allMatchingRegex.length === 0) {
     const filenameError = `The selected file must contain the reporting period as part of its name, for example '${expectedFilenameReportPeriod}'`;
     return { filenameError };
   }
 
-  const { regexWithExactYear } = firstMatchingRegex;
-  if (regexWithExactYear.test(expectedFilenameReportPeriod)) {
+  const specificReportPeriodRegex = allMatchingRegex.filter(({ regex }) => regex.test(expectedFilenameReportPeriod)).at(0);
+  if (!specificReportPeriodRegex) {
+    const filenameError = `The selected file must be the ${dueReportPeriod} report`;
+    return { filenameError };
+  }
+
+  const { regexWithExactYear } = specificReportPeriodRegex;
+  if (regexWithExactYear.test(filename)) {
     return {};
   }
 

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-validator.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-validator.test.js
@@ -163,9 +163,18 @@ describe('utilisation-report-validator', () => {
       expect(filenameError).toBeUndefined();
     });
 
-    it('should return specific error text when the filename contains the incorrect reporting period', () => {
+    it('should return specific error text when the filename contains the incorrect reporting period month', () => {
       const reportPeriod = 'December 2023';
       const filename = 'Bank_November_2023.xlsx';
+
+      const { filenameError } = validateFilenameContainsReportPeriod(filename, reportPeriod);
+
+      expect(filenameError).toEqual(`The selected file must be the ${reportPeriod} report`);
+    });
+
+    it('should return specific error text when the filename contains the incorrect reporting period year', () => {
+      const reportPeriod = 'December 2023';
+      const filename = 'Bank_December_2022.xlsx';
 
       const { filenameError } = validateFilenameContainsReportPeriod(filename, reportPeriod);
 


### PR DESCRIPTION
# Introduction

The old implementation of FN-1134 did not check the filename report period year correctly after it passed the month validation.

# Resolution

Fix the `validateFilenameContainsReportPeriod` function so that it checks the report period month and year and add a new test to check this.