### PR TITLE
feat(FN-1089): fix next report period start

### DIFF
--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -120,7 +120,7 @@ describe(page, () => {
 
   describe('when no reports are due', () => {
     const nextReportPeriod = 'March 2023';
-    const nextReportPeriodStart = '1 March 2023';
+    const nextReportPeriodStart = '1 April 2023';
     const lastUploadedReportPeriod = 'February 2023';
     const uploadedByFullName = 'John Smith';
     const formattedDateAndTimeUploaded = '25 February 2023 at 10:05 am';

--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -120,7 +120,7 @@ describe(page, () => {
 
   describe('when no reports are due', () => {
     const nextReportPeriod = 'March 2023';
-    const nextReportPeriodStart = '1 April 2023';
+    const nextReportPeriodSubmissionStart = '1 April 2023';
     const lastUploadedReportPeriod = 'February 2023';
     const uploadedByFullName = 'John Smith';
     const formattedDateAndTimeUploaded = '25 February 2023 at 10:05 am';
@@ -131,7 +131,7 @@ describe(page, () => {
         primaryNav: 'utilisation_report_upload',
         dueReportDates: [],
         nextReportPeriod,
-        nextReportPeriodStart,
+        nextReportPeriodSubmissionStart,
         lastUploadedReportPeriod,
         uploadedByFullName,
         formattedDateAndTimeUploaded,
@@ -144,7 +144,7 @@ describe(page, () => {
 
     it('should display specific text about the next report which can be uploaded', () => {
       wrapper.expectText('[data-cy="next-due-report-text"]')
-        .toRead(`The ${nextReportPeriod} report can be uploaded from ${nextReportPeriodStart}.`);
+        .toRead(`The ${nextReportPeriod} report can be uploaded from ${nextReportPeriodSubmissionStart}.`);
     });
 
     it('should display details about the last uploaded report', () => {

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -1,4 +1,4 @@
-const { format, startOfMonth } = require('date-fns');
+const { format, startOfMonth, addMonths } = require('date-fns');
 const { extractCsvData, removeCellAddressesFromArray } = require('../../../utils/csv-utils');
 const { validateCsvData, validateFilenameContainsReportPeriod } = require('./utilisation-report-validator');
 const { getReportDueDate } = require('./utilisation-report-status');
@@ -51,7 +51,9 @@ const getLastUploadedReportDetails = async (userToken, bankId) => {
 
   const nextReportDate = new Date();
   const nextReportPeriod = format(nextReportDate, 'MMMM yyyy');
-  const nextReportPeriodStart = format(startOfMonth(nextReportDate), 'd MMMM yyyy');
+
+  const nextReportPeriodStartDate = addMonths(nextReportDate, 1);
+  const nextReportPeriodStart = format(startOfMonth(nextReportPeriodStartDate), 'd MMMM yyyy');
 
   return { ...reportAndUserDetails, nextReportPeriod, nextReportPeriodStart };
 };

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -35,7 +35,7 @@ const setSessionUtilisationReport = (req, nextDueReportDate) => {
  * @property {string} formattedDateAndTimeUploaded - The date uploaded formatted as 'd MMMM yyyy at h:mmaaa'
  * @property {string} lastUploadedReportPeriod - The report period of the report formatted as 'MMMM yyyy'
  * @property {string} nextReportPeriod - The upcoming report period (the current month) with format 'MMMM yyyy'
- * @property {string} nextReportPeriodSubmissionStart - The start of the upcoming report period with format 'd MMMM yyyy'
+ * @property {string} nextReportPeriodSubmissionStart - The start of the month when the next report period report can be submitted with format 'd MMMM yyyy'
  */
 
 /**

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -35,7 +35,7 @@ const setSessionUtilisationReport = (req, nextDueReportDate) => {
  * @property {string} formattedDateAndTimeUploaded - The date uploaded formatted as 'd MMMM yyyy at h:mmaaa'
  * @property {string} lastUploadedReportPeriod - The report period of the report formatted as 'MMMM yyyy'
  * @property {string} nextReportPeriod - The upcoming report period (the current month) with format 'MMMM yyyy'
- * @property {string} nextReportPeriodStart - The start of the upcoming report period with format 'd MMMM yyyy'
+ * @property {string} nextReportPeriodSubmissionStart - The start of the upcoming report period with format 'd MMMM yyyy'
  */
 
 /**
@@ -52,10 +52,10 @@ const getLastUploadedReportDetails = async (userToken, bankId) => {
   const nextReportDate = new Date();
   const nextReportPeriod = format(nextReportDate, 'MMMM yyyy');
 
-  const nextReportPeriodStartDate = addMonths(nextReportDate, 1);
-  const nextReportPeriodStart = format(startOfMonth(nextReportPeriodStartDate), 'd MMMM yyyy');
+  const nextReportPeriodSubmissionStartDate = addMonths(nextReportDate, 1);
+  const nextReportPeriodSubmissionStart = format(startOfMonth(nextReportPeriodSubmissionStartDate), 'd MMMM yyyy');
 
-  return { ...reportAndUserDetails, nextReportPeriod, nextReportPeriodStart };
+  return { ...reportAndUserDetails, nextReportPeriod, nextReportPeriodSubmissionStart };
 };
 
 const getUtilisationReportUpload = async (req, res) => {

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
@@ -27,7 +27,7 @@
     </h1>
     {% if dueReportDates.length === 0%}
         <p class="govuk-body" data-cy="next-due-report-text">
-            The {{ nextReportPeriod }} report can be uploaded from {{ nextReportPeriodStart }}.
+            The {{ nextReportPeriod }} report can be uploaded from {{ nextReportPeriodSubmissionStart }}.
         </p>
         <p class="govuk-body" data-cy="uploaded-report-details">
             The {{ lastUploadedReportPeriod }} report was sent to UKEF by {{ uploadedByFullName }} on {{ formattedDateAndTimeUploaded }}.


### PR DESCRIPTION
# Introduction

The next report period start date was being calculated incorrectly. For example, if the next report due is April 2023, the next report period start date was being calculated as 1 April 2023 whilst it should be 1 May 2023.

# Resolution

Update the utilisation report upload controller to correctly calculate the next due report period start date. Also updates component tests to reflect the expected behaviour.