### PR TITLE
feat(FN-1089): fix report uploadedBy schema

### DIFF
--- a/dtfs-central-api/src/services/repositories/utilisation-reports-repo.js
+++ b/dtfs-central-api/src/services/repositories/utilisation-reports-repo.js
@@ -22,7 +22,8 @@ const saveUtilisationReportDetails = async (month, year, csvFilePath, uploadedBy
     path: csvFilePath,
     uploadedBy: {
       id: uploadedByUser._id,
-      name: `${uploadedByUser.firstname} ${uploadedByUser.surname}`,
+      firstname: uploadedByUser.firstname,
+      surname: uploadedByUser.surname,
     },
   };
 

--- a/dtfs-central-api/src/services/repositories/utilisation-reports-repo.test.js
+++ b/dtfs-central-api/src/services/repositories/utilisation-reports-repo.test.js
@@ -36,7 +36,8 @@ describe('utilisation-reports-repo', () => {
         path: 'test path',
         uploadedBy: {
           id: '123',
-          name: 'test user',
+          firstname: 'test',
+          surname: 'user',
         },
       });
     });
@@ -54,7 +55,8 @@ describe('utilisation-reports-repo', () => {
       path: 'test path',
       uploadedBy: {
         id: '123',
-        name: 'test user',
+        firstname: 'test',
+        surname: 'user',
       },
     };
 

--- a/dtfs-central-api/src/v1/swagger-definitions/utilisationReport.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/utilisationReport.js
@@ -27,9 +27,12 @@
  *           id:
  *             type: string
  *             example: '9'
- *           name:
+ *           firstname:
  *             type: string
- *             example: 'John Smith'
+ *             example: 'John'
+ *           surname:
+ *             type: string
+ *             example: 'Smith'
  *       bank:
  *         type: object
  *         properties:

--- a/portal-api/test-helpers/mock-utilisation-reports.js
+++ b/portal-api/test-helpers/mock-utilisation-reports.js
@@ -9,7 +9,8 @@ const MOCK_UTILISATION_REPORT = {
   path: 'test path',
   uploadedBy: {
     id: '123',
-    name: 'test user',
+    firstname: 'test',
+    surname: 'user',
   },
 };
 


### PR DESCRIPTION
# Introduction

FN-1089 uses the `firstname` and `surname` properties from the `user` who uploaded the report. However, the `uploadedBy` user was stored in a way that did not match the other `user`s stored in portal.

# Resolution

Change how the utilisation reports are stored so that `firstname` and `surname` from the `user` are stored with the report. Updates other parts of the code where `uploadedBy.name` is used to match this new format.