### PR TITLE
feat(DTFS2-6461): change p to h2 tags for visual headings on TFM deal page

### DIFF
--- a/trade-finance-manager-ui/templates/case/deal/deal.njk
+++ b/trade-finance-manager-ui/templates/case/deal/deal.njk
@@ -21,7 +21,7 @@
 
   <div class="govuk-grid-row" data-cy="deal-facilities">
     <div class="govuk-grid-column-full separator-line deal">
-      <p class="ukef-heading-l" id="deal-ukef-heading">Facilities</p>
+      <h2 class="ukef-heading-l" id="deal-ukef-heading">Facilities</h2>
 
         {% if deal.dealType == 'GEF' %}
           {% if deal.isFinanceIncreasing %}
@@ -57,7 +57,7 @@
     <div class="govuk-grid-row" data-cy="deal-bank-security-details">
 
       <div class="govuk-grid-column-full separator-line deal">
-        <p class="ukef-heading-l" id="deal-supporting-information-bank-security" data-cy="bank-security-section-heading">Bank security</p>
+        <h2 class="ukef-heading-l" id="deal-supporting-information-bank-security" data-cy="bank-security-section-heading">Bank security</h2>
         <h4 class="govuk-heading-s govuk-!-padding-top-3 govuk-!-padding-bottom-0 govuk-!-margin-top-0" data-cy="bank-security-sub-heading">
         General bank security for this exporter
         </h4>
@@ -77,7 +77,7 @@
   <div class="govuk-grid-row" data-cy="deal-bank-details">
 
     <div class="govuk-grid-column-full separator-line deal">
-      <p class="ukef-heading-l" id="deal-bank-details-ukef-heading">Bank application or notice</p>
+      <h2 class="ukef-heading-l" id="deal-bank-details-ukef-heading">Bank application or notice</h2>
       <div class="govuk-grid-row govuk-!-margin-0 govuk-!-padding-top-6">
         <div class="govuk-grid-column-one-fifth govuk-!-padding-bottom-4 govuk-!-padding-left-0">
           <div class="ukef-heading-xs">Bank</div>


### PR DESCRIPTION
## Introduction
The tfm deal page has visual headings `Facilities`, `Bank Security` and `Bank Application or Notice` which are not semantically marked up with h tags. This is problematic for blind screen reader users

## Resolution
Replaced the `p` tags with `h2` tags.

### Before
![image_720](https://github.com/UK-Export-Finance/dtfs2/assets/108682750/68ebb882-96aa-4ab3-9753-7b69e737530a)

### After
![image_720](https://github.com/UK-Export-Finance/dtfs2/assets/108682750/cfc55c0f-0e33-4a14-8c97-2294b788e2b2)

## Notes
I cannot render this locally but have used inspect element on the dev site to check the change. There is a slight change to the styles with `margin-block-start` and `margin-block-end` going from `1em` to `.83em`.