### PR TITLE
feat(DTFS2-none): remove aria label tests and update underwriting heading test

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriting-page.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriting-page.spec.js
@@ -37,7 +37,7 @@ context('Underwriting page', () => {
 
     // go to lead underwriter page
     partials.caseSubNavigation.underwritingLink().click();
-    pages.underwritingPage.dealHeading().contains('Deal');
+    pages.underwritingPage.dealHeading().contains('Underwriting');
     pages.underwritingPage.underwritingAccordion().contains('Lead underwriter');
     pages.underwritingPage.underwritingAccordion().contains('Pricing and risk');
     pages.underwritingPage.underwritingAccordion().contains('Underwriter Manager\'s decision');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/activities/activities.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/activities/activities.spec.js
@@ -61,9 +61,6 @@ context('Users can create and submit comments', () => {
   describe('add a comment', () => {
     it('should show correct heading and aria-label for activities tab heading', () => {
       activitiesPage.mainHeading().contains('Activity and comments');
-      activitiesPage.mainHeading().invoke('attr', 'aria-label').then((label) => {
-        expect(label).to.equal('Activity and comments');
-      });
     });
 
     it('should go to add a comment page if add comment button clicked', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/parties.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/parties.spec.js
@@ -37,9 +37,6 @@ context('Parties page', () => {
 
     it('should render components', () => {
       pages.partiesPage.partiesHeading().contains('Parties');
-      pages.partiesPage.partiesHeading().invoke('attr', 'aria-label').then((label) => {
-        expect(label).to.equal('Parties');
-      });
       pages.partiesPage.exporterArea().should('exist');
       pages.partiesPage.buyerArea().should('exist');
       pages.partiesPage.agentArea().should('exist');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/tasks/tasks.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/tasks/tasks.spec.js
@@ -70,9 +70,6 @@ context('Case tasks - AIN deal', () => {
     cy.url().should('eq', relative(`/case/${dealId}/tasks`));
 
     pages.tasksPage.tasksHeading().contains('Tasks');
-    pages.tasksPage.tasksHeading().invoke('attr', 'aria-label').then((label) => {
-      expect(label).to.equal('Tasks for this deal');
-    });
     // user has 0 tasks assigned by default
     pages.tasksPage.tasksTableRows().should('have.length', 0);
   });


### PR DESCRIPTION
## Introduction
#2283 didnt update the e2e tests 

##Resolution
* remove redundant checks for `aria-labels` that have been removed
* update check for `deal` heading to `underwriting`