### PR TITLE
fix(DTFS2-6465): moving headers to date form component

### DIFF
--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-effective-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-effective-date.njk
@@ -20,71 +20,78 @@
       }) }}
   {% endif %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2" data-cy="amendment--banks-decision-effective-date-heading" aria-label="What date will the amendment be effective from?">What date will the amendment be effective from?</h1>
-   <div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <form method="POST">
+      <form method="POST" autocomplete="off" class="govuk-!-margin-top-4">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {{ govukDateInput({
-            id: "bankDecisionDate",
-            namePrefix: "amendment--bank-decision-date",
-            hint: {
-              text: "For example, 31 3 1980",
-              attributes: {
-                "data-cy": "amendment--receive-bank-decision-date-hint"
-              }
-            },
-            errorMessage: errors and errors.fieldErrors.bankDecisionDate and {
-              text: errors.fieldErrors.bankDecisionDate.text,
-              attributes: {
-                'data-cy': 'amendment--inline-error'
-              }
-            },
-            items: [
-              {
-                label: "Day",
-                classes: errors.fieldErrors.bankDecisionDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
-                name: "day",
-                value: bankDecisionDateDay,
-                attributes: {
-                  'data-cy': "amendment--bank-decision-date-day"
-                }
-              },
-              {
-                label: "Month",
-                classes: errors.fieldErrors.bankDecisionDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
-                name: "month",
-                value: bankDecisionDateMonth,
-                attributes: {
-                  'data-cy': "amendment--bank-decision-date-month"
-                }
-              },
-              {
-                label: "Year",
-                classes: errors.fieldErrors.bankDecisionDate and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
-                name: "year",
-                value: bankDecisionDateYear,
-                attributes: {
-                  'data-cy': "amendment--bank-decision-date-year"
-                }
-              }
-            ]
-          }) }}
 
-          <div class="govuk-button-group">
-            {% if isEditable %}
-              {{ govukButton({
-                text: "Continue",
-                attributes: {
-                    "data-cy": "amendment--continue-button"
-                }
-                })
-              }}
-            {% endif %}
-            <a class="govuk-body govuk-link govuk-!-margin-left-6 close-link" href="/case/{{ amendment.dealId }}/underwriting" data-cy="amendment--cancel-button">Cancel</a>
-          </div>
-        </form>
-      </div>
+        {{ govukDateInput({
+          id: "bankDecisionDate",
+          namePrefix: "amendment--bank-decision-date",
+          fieldset: {
+            legend: {
+              html: '<span data-cy="amendment--banks-decision-effective-date-heading">What date will the amendment be effective from?</span>',
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2"
+            }
+          },
+          hint: {
+            text: "For example, 31 3 1980",
+            attributes: {
+              "data-cy": "amendment--receive-bank-decision-date-hint"
+            }
+          },
+          errorMessage: errors and errors.fieldErrors.bankDecisionDate and {
+            text: errors.fieldErrors.bankDecisionDate.text,
+            attributes: {
+              'data-cy': 'amendment--inline-error'
+            }
+          },
+          items: [
+            {
+              label: "Day",
+              classes: errors.fieldErrors.bankDecisionDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+              name: "day",
+              value: bankDecisionDateDay,
+              attributes: {
+                'data-cy': "amendment--bank-decision-date-day"
+              }
+            },
+            {
+              label: "Month",
+              classes: errors.fieldErrors.bankDecisionDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+              name: "month",
+              value: bankDecisionDateMonth,
+              attributes: {
+                'data-cy': "amendment--bank-decision-date-month"
+              }
+            },
+            {
+              label: "Year",
+              classes: errors.fieldErrors.bankDecisionDate and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
+              name: "year",
+              value: bankDecisionDateYear,
+              attributes: {
+                'data-cy': "amendment--bank-decision-date-year"
+              }
+            }
+          ]
+        }) }}
+
+        <div class="govuk-button-group">
+          {% if isEditable %}
+            {{ govukButton({
+              text: "Continue",
+              attributes: {
+                  "data-cy": "amendment--continue-button"
+              }
+              })
+            }}
+          {% endif %}
+          <a class="govuk-body govuk-link govuk-!-margin-left-6 close-link" href="/case/{{ amendment.dealId }}/underwriting" data-cy="amendment--cancel-button">Cancel</a>
+        </div>
+      </form>
     </div>
+  </div>
 
 {% endblock %}

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-receive-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-receive-date.njk
@@ -20,16 +20,21 @@
       }) }}
   {% endif %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2" data-cy="amendment--banks-decision-receive-date-heading" aria-label="What date did UKEF receive the bank’s decision??">What date did UKEF receive the bank’s decision?</h1>
-
-
-   <div class="govuk-grid-row">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <form method="POST">
+      <form method="POST" autocomplete="off" class="govuk-!-margin-top-4">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
           {{ govukDateInput({
             id: "bankDecisionDate",
             namePrefix: "amendment--bank-decision-date",
+            fieldset: {
+              legend: {
+                html: '<span data-cy="amendment--banks-decision-receive-date-heading">What date did UKEF receive the bank’s decision?</span>',
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2"
+              }
+            },
             hint: {
               text: "For example, 31 3 1980",
               attributes: {

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-cover-end-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-cover-end-date.njk
@@ -20,59 +20,67 @@
       classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-4"
     }) }}
   {% endif %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2" data-cy="amendment--cover-end-date-heading" aria-label="Enter the new cover end date">Enter the new cover end date</h1>
 
-  <div class="govuk-body govuk-!-margin-bottom-4" data-cy="amendment--current-cover-end-date">
-    <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Current cover end date</p>
-    {{currentCoverEndDate}}
-  </div>
   <form method="POST" autocomplete="off">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-    {{ govukDateInput({
-      id: "coverEndDate",
-      namePrefix: "cover-end-date",
-      hint: {
-        text: "For example, 31 3 2022",
-        attributes: {
-          "data-cy": "cover-end-date-hint"
-        }
-      },
-      errorMessage: errors and errors.fieldErrors.coverEndDate and {
-        text: errors.fieldErrors.coverEndDate.text,
-        attributes: {
-          'data-cy': 'amendment--inline-error'
-        }
-      },
-      items: [
-        {
-          label: "Day",
-          classes: errors.fieldErrors.coverEndDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
-          name: "day",
-          value: coverEndDateDay,
+
+    <fieldset class="govuk-fieldset" role="group" aria-describedby="amendmentRequestDate-hint">
+
+      <legend class="govuk-fieldset__legend">
+        <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-0" data-cy="amendment--cover-end-date-heading">Enter the new cover end date</h1>
+      </legend>
+
+      <div class="govuk-body govuk-!-margin-bottom-4" data-cy="amendment--current-cover-end-date">
+        <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Current cover end date</p>
+        {{currentCoverEndDate}}
+      </div>
+
+      {{ govukDateInput({
+        id: "coverEndDate",
+        namePrefix: "cover-end-date",
+        hint: {
+          text: "For example, 31 3 2022",
           attributes: {
-            'data-cy': "amendment--cover-end-date-day"
+            "data-cy": "cover-end-date-hint"
           }
         },
-        {
-          label: "Month",
-          classes: errors.fieldErrors.coverEndDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
-          name: "month",
-          value: coverEndDateMonth,
+        errorMessage: errors and errors.fieldErrors.coverEndDate and {
+          text: errors.fieldErrors.coverEndDate.text,
           attributes: {
-            'data-cy': "amendment--cover-end-date-month"
+            'data-cy': 'amendment--inline-error'
           }
         },
-        {
-          label: "Year",
-          classes: errors.fieldErrors.coverEndDate and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
-          name: "year",
-          value: coverEndDateYear,
-          attributes: {
-            'data-cy': "amendment--cover-end-date-year"
+        items: [
+          {
+            label: "Day",
+            classes: errors.fieldErrors.coverEndDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+            name: "day",
+            value: coverEndDateDay,
+            attributes: {
+              'data-cy': "amendment--cover-end-date-day"
+            }
+          },
+          {
+            label: "Month",
+            classes: errors.fieldErrors.coverEndDate and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+            name: "month",
+            value: coverEndDateMonth,
+            attributes: {
+              'data-cy': "amendment--cover-end-date-month"
+            }
+          },
+          {
+            label: "Year",
+            classes: errors.fieldErrors.coverEndDate and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
+            name: "year",
+            value: coverEndDateYear,
+            attributes: {
+              'data-cy': "amendment--cover-end-date-year"
+            }
           }
-        }
-      ]
-    }) }}
+        ]
+      }) }}
+    </fieldset>
 
     <div class="govuk-button-group">
       {% if isEditable %}

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-effective-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-effective-date.njk
@@ -20,13 +20,20 @@
       classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-4"
     }) }}
   {% endif %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2" data-cy="amendment--effective-date-heading" aria-label="What date will the amendment be effective from?">What date will the amendment be effective from?</h1>
 
-  <form method="POST" autocomplete="off">
+  <form method="POST" autocomplete="off" class="govuk-!-margin-top-4">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
     {{ govukDateInput({
       id: "effectiveDate",
       namePrefix: "amendment-effective-date",
+      fieldset: {
+        legend: {
+          html: '<span data-cy="amendment--effective-date-heading">What date will the amendment be effective from?</span>',
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2"
+        }
+      },
       hint: {
         text: "For example, 31 3 1980",
         attributes: {

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-request-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-request-date.njk
@@ -20,13 +20,20 @@
       classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-4"
     }) }}
   {% endif %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2" data-cy="amendment--request-heading" aria-label="What date did the bank request the amendment?">What date did the bank request the amendment?</h1>
 
-  <form method="POST" autocomplete="off">
+  <form method="POST" autocomplete="off" class="govuk-!-margin-top-4">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
     {{ govukDateInput({
       id: "amendmentRequestDate",
       namePrefix: "amendment-request-date",
+      fieldset: {
+        legend: {
+          html: '<span data-cy="amendment--request-heading">What date did the bank request the amendment?</span>',
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2"
+        }
+      },
       hint: {
         text: "For example, 31 3 1980",
         attributes: {


### PR DESCRIPTION
### Introduction
Date form component consist from 3 text input fields with 3 labels: day, month, year. These 3 elements need 1 shared/common label. 

### Resolution
- All date components in TFM are used in pages with single question. Moving page header to `govukDateInput` fieldset label.
- `govukDateInput` `fieldset.label` doesn't support custom attributes, to have our `data-cy` I had to add extra `span` element.
- One govukDateInput uses different group approach because it was not possible to add custom element after heading.