### PR TITLE
fix(DTFS2-6468): fixing header level hierarchy

### DIFF
--- a/trade-finance-manager-ui/templates/case/amendments/amendment-managers-conditions-and-comments-summary.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-managers-conditions-and-comments-summary.njk
@@ -34,7 +34,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <h1 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2" aria-label="Conditions and comments">Conditions and comments</h1>
+      <h2 class="govuk-heading-m govuk-!-margin-top-4 govuk-!-margin-bottom-2" aria-label="Conditions and comments">Conditions and comments</h2>
 
       {% set rows = [] %}
       {% if amendment.ukefDecision.coverEndDate === 'Approved with conditions' or amendment.ukefDecision.value === 'Approved with conditions' %}


### PR DESCRIPTION
### Introduction
Accessibility test detected two h1 headers in one of TFM pages

### Resolution
- Changed header type
- Tested
- Searched code for files with multiple h1 headers, but none was found. 
- I am not 100% sure that other pages don't have same issue because of how we use partial templates.
- Other heading levels 2,3,4 also has interesting hierarchy on some pages, but it's not necessary wrong.