### PR TITLE
fix: fix e2e injection test for user creation

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/admin/create-user/create-a-user.spec.js
@@ -166,7 +166,7 @@ context('Admin user creates a new user', () => {
      * should be undefined
      */
     cy.listAllUsers(AN_ADMIN).then((usersInDb) => {
-      const injectedUser = usersInDb.find((user) => user.email === {});
+      const injectedUser = usersInDb.find((user) => Object.keys(user.email).length === 0);
 
       expect(injectedUser).to.be.an('undefined');
     });


### PR DESCRIPTION
## Introduction
In https://github.com/UK-Export-Finance/dtfs2/pull/2315, @MarRobSoftwire flagged that one of the e2e tests had an `=== {}` condition which would always return false.

## Resolution
I have replaced this with an accurate way to check for an empty object