### PR TITLE
fix(DTFS-6817): deal page had 2 unnecessary aria-labels

### DIFF
--- a/trade-finance-manager-ui/templates/case/deal/deal.njk
+++ b/trade-finance-manager-ui/templates/case/deal/deal.njk
@@ -15,7 +15,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <h1 class="govuk-heading-xl govuk-!-margin-top-6" data-cy="page-title" aria-label="Deal">Deal</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-top-6" data-cy="page-title">Deal</h1>
     </div>
   </div>
 

--- a/trade-finance-manager-ui/templates/case/underwriting/underwriting.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/underwriting.njk
@@ -22,7 +22,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-xl govuk-!-margin-top-6 govuk-!-margin-bottom-6" data-cy="underwriting-heading-amendment" aria-label="Underwriting page">Amendment for {{ amendment.type | lower }} facility {{amendment.ukefFacilityId}}</h2>
+        <h2 class="govuk-heading-xl govuk-!-margin-top-6 govuk-!-margin-bottom-6" data-cy="underwriting-heading-amendment">Amendment for {{ amendment.type | lower }} facility {{amendment.ukefFacilityId}}</h2>
       </div>
     </div>
 


### PR DESCRIPTION
### Introduction

We were removing aria-labels in Deals sub-pages and forgot to remove one from Deal

### Resolution

* Removed `aria-label` from Deal page to make it consistent 
* Removed misleading `aria-label` from `Underwriting` tab.