### PR TITLE
fix(DTFS2-6532): replace illogical facility heading levels

### DIFF
--- a/trade-finance-manager-ui/templates/case/facility/facility.njk
+++ b/trade-finance-manager-ui/templates/case/facility/facility.njk
@@ -50,10 +50,10 @@
   } %}
   {{ amendmentInProgressBar.render(amendmentBarParams) }}
 
-  <div>
-    <h2 class="ukef-heading-grey">Facility {{ facility.ukefFacilityId }}</h2>
-    <h3 class="govuk-heading-l">{{ facility.type }}</h3>
-  </div>
+  <hgroup>
+    <h1 class="ukef-heading-grey">Facility {{ facility.ukefFacilityId }}</h1>
+    <p class="govuk-heading-l">{{ facility.type }}</p>
+  </hgroup>
 
   <div class="ukef-tabs--no-border">
   {{ govukTabs({


### PR DESCRIPTION
## Introduction
Headings on the [facility page](https://tfs-staging-tfm-fd.azurefd.net/case/654d2b5686619e13af2fdc23/facility/654d2b7b86619e13af2fdc24) do not follow the correct hierarchical heading structure. Beneath heading level 2 `Facility 0040149939` there is level 3 `Cash Facility` and level 2 `contents`. Cash facility isnt really a separate heading & contents should be under the main Facility heading.

## Resolution
* Group the first two headings under a `hgroup` tab and upgrade Facility to a `h1`
    * The contents `h2`  is inherited from the imported[ tabs component](https://design-system.service.gov.uk/components/tabs/), so this has been left as is

|   Before   |   After   |
|-----------|----------|
|![image_720](https://github.com/UK-Export-Finance/dtfs2/assets/108682750/6b7104fb-e88f-4731-ab41-e28d52e11ba5)|![image_720](https://github.com/UK-Export-Finance/dtfs2/assets/108682750/52dec7c8-9990-436d-9d2b-151a6e1cb858)|
![image_720](https://github.com/UK-Export-Finance/dtfs2/assets/108682750/451853a2-58f8-4d25-b350-b88e9203bd64)|![image_720](https://github.com/UK-Export-Finance/dtfs2/assets/108682750/be38aa76-3521-4d8f-8fea-d755bc081752)|


## Notes
* I haven't been able to render this locally, screenshots attached are taken from editing elements on the dev page
* There is a slight changes to `margin-block` styles with the relabelling: `h2` was `0.83em` now `h1` has `0.67em`