### PR TITLE
fix(DTFS-6464): use summary lists on underwriting page

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk-risk-managers.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk-risk-managers.spec.js
@@ -36,8 +36,9 @@ context('Case Underwriting - Pricing and risk for Risk Managers', () => {
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
     });
 
-    it('submitting a rating displays the rating in table on `pricing and risk` page and does not render `add credit rating` link', () => {
-      pages.underwritingPage.addCreditRatingButton().click({ force: true });
+    it('submitting a rating displays the rating in table on `pricing and risk` page and renders `change credit rating` link', () => {
+      pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Add');
+      pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       // select option, submit
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputGood().click();
@@ -46,9 +47,7 @@ context('Case Underwriting - Pricing and risk for Risk Managers', () => {
       // assert elements/value in `pricing and risk` page
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
 
-      pages.underwritingPricingAndRiskPage.addRatingLink().should('not.exist');
-
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().should('exist');
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Change');
 
       pages.underwritingPricingAndRiskPage.exporterTableRatingValue().invoke('text').then((text) => {
         expect(text.trim()).to.equal('Good (BB-)');
@@ -61,7 +60,7 @@ context('Case Underwriting - Pricing and risk for Risk Managers', () => {
         expect(text.trim()).to.equal('Good (BB-)');
       });
 
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       // previously submitted value should be auto selected
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputGood().should('be.checked');
@@ -88,8 +87,7 @@ context('Case Underwriting - Pricing and risk for Risk Managers', () => {
     });
 
     it('edit button is visible as compared to add', () => {
-      pages.underwritingPage.addCreditRatingButton().should('not.exist');
-      pages.underwritingPage.exporterTableChangeCreditRatingLink().should('exist');
+      pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Change');
       pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().should('exist');
     });
   });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk.spec.js
@@ -44,8 +44,7 @@ context('Case Underwriting - Pricing and risk', () => {
     });
 
     it('should NOT display `change` links', () => {
-      pages.underwritingPage.addCreditRatingButton().should('not.exist');
-      pages.underwritingPage.exporterTableChangeCreditRatingLink().should('not.exist');
+      pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('not.exist');
       pages.underwritingPage.exporterTableChangeLossGivenDefaultLink().should('not.exist');
       pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().should('not.exist');
     });
@@ -64,8 +63,7 @@ context('Case Underwriting - Pricing and risk', () => {
     it('should display the correct change links', () => {
       pages.underwritingPage.showAllButton().click();
 
-      pages.underwritingPage.addCreditRatingButton().should('exist');
-      pages.underwritingPage.exporterTableChangeCreditRatingLink().should('not.exist');
+      pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Add');
       pages.underwritingPage.exporterTableChangeLossGivenDefaultLink().should('exist');
       pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().should('exist');
     });
@@ -77,15 +75,14 @@ context('Case Underwriting - Pricing and risk', () => {
         expect(text.trim()).to.equal('Not added');
       });
 
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().should('not.exist');
-
-      pages.underwritingPricingAndRiskPage.addRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Add');
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       cy.url().should('eq', relative(`/case/${dealId}/underwriting/pricing-and-risk/edit`));
     });
 
     it('submitting an empty edit form displays validation errors', () => {
-      pages.underwritingPricingAndRiskPage.addRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       pages.underwritingPricingAndRiskEditPage.submitButton().click();
 
@@ -94,7 +91,7 @@ context('Case Underwriting - Pricing and risk', () => {
     });
 
     it('selecting `Other` in edit form displays text input. After submit - displays validation errors if text input is empty', () => {
-      pages.underwritingPricingAndRiskPage.addRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('be.visible');
@@ -107,7 +104,7 @@ context('Case Underwriting - Pricing and risk', () => {
     });
 
     it('typing numbers into `Other` text input displays validation errors after submit', () => {
-      pages.underwritingPricingAndRiskPage.addRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('be.visible');
@@ -120,8 +117,8 @@ context('Case Underwriting - Pricing and risk', () => {
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOtherValidationError().should('be.visible');
     });
 
-    it('submitting a rating displays the rating in table on `pricing and risk` page and does not render `add credit rating` link', () => {
-      pages.underwritingPricingAndRiskPage.addRatingLink().click({ force: true });
+    it('submitting a rating displays the rating in table on `pricing and risk` page and renders `change credit rating` link', () => {
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       // select option, submit
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputGood().click();
@@ -130,9 +127,7 @@ context('Case Underwriting - Pricing and risk', () => {
       // assert elements/value in `pricing and risk` page
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
 
-      pages.underwritingPricingAndRiskPage.addRatingLink().should('not.exist');
-
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().should('exist');
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Change');
 
       pages.underwritingPricingAndRiskPage.exporterTableRatingValue().invoke('text').then((text) => {
         expect(text.trim()).to.equal('Good (BB-)');
@@ -145,7 +140,7 @@ context('Case Underwriting - Pricing and risk', () => {
         expect(text.trim()).to.equal('Good (BB-)');
       });
 
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       // previously submitted value should be auto selected
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputGood().should('be.checked');
@@ -163,7 +158,7 @@ context('Case Underwriting - Pricing and risk', () => {
     });
 
     it('submitting `Other` in edit form displays text input and auto populates values after submit', () => {
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('have.value', '');
@@ -175,7 +170,7 @@ context('Case Underwriting - Pricing and risk', () => {
         expect(text.trim()).to.equal(MOCK_CREDIT_RATING_TEXT_INPUT_VALUE);
       });
 
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().click({ force: true });
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().click({ force: true });
 
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().should('be.checked');
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('exist');
@@ -197,8 +192,7 @@ context('Case Underwriting - Pricing and risk', () => {
         expect(text.trim()).to.equal(MOCK_CREDIT_RATING_TEXT_INPUT_VALUE);
       });
 
-      pages.underwritingPricingAndRiskPage.addRatingLink().should('not.exist');
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().should('not.exist');
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('not.exist');
       pages.underwritingPricingAndRiskPage.exporterTableChangeProbabilityOfDefaultLink().should('not.exist');
     });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriting-page.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriting-page.spec.js
@@ -59,8 +59,7 @@ context('Underwriting page', () => {
     pages.underwritingPage.underwriterManagerDecisionNotAdded().contains('Not added yet');
     pages.underwritingPage.addUnderwriterManagerDecisionButton().should('not.exist');
 
-    pages.underwritingPage.addCreditRatingButton().should('not.exist');
-    pages.underwritingPage.exporterTableChangeCreditRatingLink().should('not.exist');
+    pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('not.exist');
     pages.underwritingPage.exporterTableChangeLossGivenDefaultLink().should('not.exist');
     pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().should('not.exist');
 
@@ -82,8 +81,7 @@ context('Underwriting page', () => {
     pages.underwritingPage.underwriterManagerDecisionNotAdded().should('not.exist');
     pages.underwritingPage.addUnderwriterManagerDecisionButton().contains('Add decision');
 
-    pages.underwritingPage.addCreditRatingButton().contains('Add');
-    pages.underwritingPage.exporterTableChangeCreditRatingLink().should('not.exist');
+    pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Add');
     pages.underwritingPage.exporterTableChangeLossGivenDefaultLink().contains('Change');
     pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().contains('Change');
 
@@ -105,8 +103,7 @@ context('Underwriting page', () => {
     pages.underwritingPage.underwriterManagerDecisionNotAdded().contains('Not added yet');
     pages.underwritingPage.addUnderwriterManagerDecisionButton().should('not.exist');
 
-    pages.underwritingPage.addCreditRatingButton().contains('Add');
-    pages.underwritingPage.exporterTableChangeCreditRatingLink().should('not.exist');
+    pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Add');
     pages.underwritingPage.exporterTableChangeLossGivenDefaultLink().contains('Change');
     pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().contains('Change');
 
@@ -128,8 +125,7 @@ context('Underwriting page', () => {
     pages.underwritingPage.underwriterManagerDecisionNotAdded().contains('Not added yet');
     pages.underwritingPage.addUnderwriterManagerDecisionButton().should('not.exist');
 
-    pages.underwritingPage.addCreditRatingButton().should('not.exist');
-    pages.underwritingPage.exporterTableChangeCreditRatingLink().should('not.exist');
+    pages.underwritingPage.exporterTableChangeOrAddCreditRatingLink().should('not.exist');
     pages.underwritingPage.exporterTableChangeLossGivenDefaultLink().should('not.exist');
     pages.underwritingPage.exporterTableChangeProbabilityOfDefaultLink().should('not.exist');
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/users/PIM_user.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/users/PIM_user.spec.js
@@ -52,8 +52,7 @@ context('PIM User', () => {
 
       facilityRow.changeRiskProfileLink().should('not.exist');
 
-      pages.underwritingPricingAndRiskPage.addRatingLink().should('not.exist');
-      pages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().should('not.exist');
+      pages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('not.exist');
       pages.underwritingPricingAndRiskPage.exporterTableChangeLossGivenDefaultLink().should('not.exist');
       pages.underwritingPricingAndRiskPage.exporterTableChangeProbabilityOfDefaultLink().should('not.exist');
     });

--- a/e2e-tests/tfm/cypress/e2e/pages/underwriting/pricingAndRiskPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/underwriting/pricingAndRiskPage.js
@@ -1,8 +1,7 @@
 const pricingAndRiskPage = {
-  addRatingLink: () => cy.get('[data-cy="add-credit-rating-link"]'),
   exporterTableCreditRatingNotAddedTag: () => cy.get('[data-cy="exporter-table-credit-rating-not-added"]'),
   exporterTableRatingValue: () => cy.get('[data-cy="exporter-table-credit-rating-value"]'),
-  exporterTableChangeCreditRatingLink: () => cy.get('[data-cy="exporter-table-change-credit-rating-link"]'),
+  exporterTableChangeOrAddCreditRatingLink: () => cy.get('[data-cy="exporter-table-credit-rating-action-link"]'),
   exporterTableLossGivenDefault: () => cy.get('[data-cy="exporter-table-loss-given-default-value"]'),
   exporterTableChangeLossGivenDefaultLink: () => cy.get('[data-cy="exporter-table-change-loss-given-default-link"]'),
   exporterTableProbabilityOfDefault: () => cy.get('[data-cy="exporter-table-probability-of-default-value"]'),

--- a/e2e-tests/tfm/cypress/e2e/pages/underwriting/underwritingPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/underwriting/underwritingPage.js
@@ -9,8 +9,7 @@ const underwritingPage = {
   leadUnderwriterUnassigned: () => cy.get('[data-cy="unassigned-underwriter-readonly"]'),
   changeLeadUnderwriterLink: () => cy.get('[data-cy="change-lead-underwriter-link"]'),
 
-  addCreditRatingButton: () => cy.get('[data-cy="add-credit-rating-link"]'),
-  exporterTableChangeCreditRatingLink: () => cy.get('[data-cy="exporter-table-change-credit-rating-link"]'),
+  exporterTableChangeOrAddCreditRatingLink: () => cy.get('[data-cy="exporter-table-credit-rating-action-link"]'),
   exporterTableChangeLossGivenDefaultLink: () => cy.get('[data-cy="exporter-table-change-loss-given-default-link"]'),
   exporterTableChangeProbabilityOfDefaultLink: () => cy.get('[data-cy="exporter-table-change-probability-of-default-link"]'),
   facilityTable: (facilityId) => {

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/submit-AIN-deal-creates-default-credit-rating-in-tfm/submit-AIN-deal-creates-default-credit-rating-in-tfm.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/submit-AIN-deal-creates-default-credit-rating-in-tfm/submit-AIN-deal-creates-default-credit-rating-in-tfm.spec.js
@@ -83,12 +83,10 @@ context('Portal to TFM deal submission', () => {
     cy.url().should('eq', `${TFM_URL}/case/${dealId}/underwriting`);
 
     // assert elements/value in `pricing and risk` page
-    tfmPages.underwritingPricingAndRiskPage.addRatingLink().should('not.exist');
-
     tfmPages.underwritingPricingAndRiskPage.exporterTableRatingValue().invoke('text').then((text) => {
       expect(text.trim()).to.equal('Acceptable (B+)');
     });
 
-    tfmPages.underwritingPricingAndRiskPage.exporterTableChangeCreditRatingLink().should('exist');
+    tfmPages.underwritingPricingAndRiskPage.exporterTableChangeOrAddCreditRatingLink().should('contain', 'Change');
   });
 });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
@@ -1,3 +1,4 @@
+const { it } = require('date-fns/locale');
 const componentRenderer = require('../../../../../../component-tests/componentRenderer');
 
 const component = '../templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk';
@@ -45,9 +46,22 @@ describe(component, () => {
     it('should NOT render `Change` link by default', () => {
       wrapper = render(defaultParams);
 
-      wrapper.expectElement('[data-cy="exporter-table-change-credit-rating-link"]').notToExist();
-      wrapper.expectElement('[data-cy="exporter-table-change-loss-given-default-link"]').notToExist();
-      wrapper.expectElement('[data-cy="exporter-table-change-probability-of-default-link"]').notToExist();
+      wrapper.expectElement('[data-cy="exporter-table-credit-rating-action-link"]').notToExist();
+    });
+
+    describe('with params.userCanEditGeneral but no params.exporterCreditRating', () => {
+      it('should render `Add` link', () => {
+        const params = {
+          ...defaultParams,
+          userCanEditGeneral: true,
+        };
+
+        wrapper = render(params);
+
+        wrapper
+          .expectLink('[data-cy="exporter-table-credit-rating-action-link"]')
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Add');
+      });
     });
 
     describe('with params.exporterCreditRating and params.userCanEditGeneral', () => {
@@ -60,7 +74,8 @@ describe(component, () => {
 
         wrapper = render(params);
 
-        wrapper.expectLink('[data-cy="exporter-table-change-credit-rating-link"]')
+        wrapper
+          .expectLink('[data-cy="exporter-table-credit-rating-action-link"]')
           .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Change');
       });
     });
@@ -87,15 +102,26 @@ describe(component, () => {
       });
     });
 
-    const params = {
-      ...defaultParams,
-      userCanEditGeneral: true,
-    };
+    it('should NOT render `Change` link by default', () => {
+      wrapper = render(defaultParams);
 
-    wrapper = render(params);
+      wrapper.expectElement('[data-cy="exporter-table-change-loss-given-default-link"]').notToExist();
+    });
 
-    wrapper.expectLink('[data-cy="exporter-table-change-loss-given-default-link"]')
-      .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/loss-given-default`, 'Change');
+    describe('when user can edit', () => {
+      it('should render a link to change link', () => {
+        const params = {
+          ...defaultParams,
+          userCanEditGeneral: true,
+        };
+
+        wrapper = render(params);
+
+        wrapper
+          .expectLink('[data-cy="exporter-table-change-loss-given-default-link"]')
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/loss-given-default`, 'Change');
+      });
+    });
   });
 
   describe('probability of default', () => {
@@ -108,8 +134,7 @@ describe(component, () => {
     it('should render value', () => {
       wrapper = render(defaultParams);
 
-      wrapper.expectText('[data-cy="exporter-table-probability-of-default-value"]')
-        .toRead(`Less than ${defaultParams.probabilityOfDefault}%`);
+      wrapper.expectText('[data-cy="exporter-table-probability-of-default-value"]').toRead(`Less than ${defaultParams.probabilityOfDefault}%`);
     });
 
     describe('when there is no probability of default', () => {
@@ -118,6 +143,12 @@ describe(component, () => {
 
         wrapper.expectText('[data-cy="exporter-table-probability-of-default-value"]').toRead('-');
       });
+    });
+
+    it('should NOT render `Change` link by default', () => {
+      wrapper = render(defaultParams);
+
+      wrapper.expectElement('[data-cy="exporter-table-change-probability-of-default-link"]').notToExist();
     });
 
     describe('when user can edit', () => {
@@ -129,7 +160,8 @@ describe(component, () => {
 
         wrapper = render(params);
 
-        wrapper.expectLink('[data-cy="exporter-table-change-probability-of-default-link"]')
+        wrapper
+          .expectLink('[data-cy="exporter-table-change-probability-of-default-link"]')
           .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/probability-of-default`, 'Change');
       });
     });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
@@ -1,4 +1,3 @@
-const { it } = require('date-fns/locale');
 const componentRenderer = require('../../../../../../component-tests/componentRenderer');
 
 const component = '../templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk';

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
@@ -64,23 +64,6 @@ describe(component, () => {
           .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Change');
       });
     });
-
-    describe('with params.userCanEditGeneral', () => {
-      it('should render `Change` link', () => {
-        const params = {
-          ...defaultParams,
-          userCanEditGeneral: true,
-        };
-
-        wrapper = render(params);
-
-        wrapper.expectLink('[data-cy="exporter-table-change-loss-given-default-link"]')
-          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/loss-given-default`, 'Change');
-
-        wrapper.expectLink('[data-cy="exporter-table-change-probability-of-default-link"]')
-          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/probability-of-default`, 'Change');
-      });
-    });
   });
 
   describe('loss given default', () => {
@@ -103,6 +86,16 @@ describe(component, () => {
         wrapper.expectText('[data-cy="exporter-table-loss-given-default-value"]').toRead('-');
       });
     });
+
+    const params = {
+      ...defaultParams,
+      userCanEditGeneral: true,
+    };
+
+    wrapper = render(params);
+
+    wrapper.expectLink('[data-cy="exporter-table-change-loss-given-default-link"]')
+      .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/loss-given-default`, 'Change');
   });
 
   describe('probability of default', () => {
@@ -124,6 +117,20 @@ describe(component, () => {
         wrapper = render({});
 
         wrapper.expectText('[data-cy="exporter-table-probability-of-default-value"]').toRead('-');
+      });
+    });
+
+    describe('when user can edit', () => {
+      it('should render change link', () => {
+        const params = {
+          ...defaultParams,
+          userCanEditGeneral: true,
+        };
+
+        wrapper = render(params);
+
+        wrapper.expectLink('[data-cy="exporter-table-change-probability-of-default-link"]')
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/probability-of-default`, 'Change');
       });
     });
   });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.component-test.js
@@ -53,13 +53,14 @@ describe(component, () => {
         const params = {
           ...defaultParams,
           userCanEditGeneral: true,
+          exporterCreditRating: undefined,
         };
 
         wrapper = render(params);
 
         wrapper
           .expectLink('[data-cy="exporter-table-credit-rating-action-link"]')
-          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Add');
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Add credit rating');
       });
     });
 
@@ -75,7 +76,7 @@ describe(component, () => {
 
         wrapper
           .expectLink('[data-cy="exporter-table-credit-rating-action-link"]')
-          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Change');
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Change credit rating');
       });
     });
   });
@@ -118,7 +119,7 @@ describe(component, () => {
 
         wrapper
           .expectLink('[data-cy="exporter-table-change-loss-given-default-link"]')
-          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/loss-given-default`, 'Change');
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/loss-given-default`, 'Change loss given default');
       });
     });
   });
@@ -161,7 +162,7 @@ describe(component, () => {
 
         wrapper
           .expectLink('[data-cy="exporter-table-change-probability-of-default-link"]')
-          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/probability-of-default`, 'Change');
+          .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/probability-of-default`, 'Change probability of default');
       });
     });
   });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -14,10 +14,16 @@
 
     {% set creditRatingRow = {
       key: {
-        text: "Credit rating"
+        text: "Credit rating",
+        attributes: {
+          "data-cy": "exporter-table-credit-rating-heading"
+        }
       },
       value: {
-        text: exporterCreditRating
+        text: exporterCreditRating,
+        attributes: {
+          "data-cy": "exporter-table-credit-rating-value"
+        }
       }
     } %}
 
@@ -54,7 +60,12 @@
     {% endset %}
 
     {% set creditRatingRow = {
-      key: { text: "Credit rating" },
+      key: {
+        text: "Credit rating",
+        attributes: {
+          "data-cy": "exporter-table-credit-rating-heading"
+        }
+      },
       value: { html: valueHtml }
     } %}
 
@@ -82,7 +93,10 @@
 
   {% set lossGivenDefaultRow = {
     key: {
-      text: "Loss given default"
+      text: "Loss given default",
+      attributes: {
+        "data-cy": "exporter-table-loss-given-default-heading"
+      }
     } 
   }%}
 
@@ -91,7 +105,10 @@
     {% set lossGivenDefaultRow = {
       key: lossGivenDefaultRow.key,
       value: {
-        text: lossGivenDefault
+        text: lossGivenDefault,
+        attributes: {
+          "data-cy": "exporter-table-loss-given-default-value"
+        }
       }
     } %}
 
@@ -101,7 +118,10 @@
       key: lossGivenDefaultRow.key,
       value: {
         text: "-"
-      }
+      },
+      attributes: {
+          "data-cy": "exporter-table-loss-given-default-value"
+        }
     } %}
 
   {% endif %}
@@ -128,7 +148,10 @@
 
   {% set probabilityOfDefaultRow = {
     key: {
-      text: "Probability of default"
+      text: "Probability of default",
+      attributes: {
+        "data-cy": "exporter-table-probability-of-default-heading"
+      }
     }
   } %}
 
@@ -136,14 +159,20 @@
     {% set probabilityOfDefaultRow = {
       key: probabilityOfDefaultRow.key,
       value: {
-        text: "Less than " + probabilityOfDefault
+        text: "Less than " + probabilityOfDefault,
+        attributes: {
+          "data-cy": "exporter-table-probability-of-default-value"
+        }
       }
     } %}
     {% else %}
     {% set probabilityOfDefaultRow = {
       key: probabilityOfDefaultRow.key,
       value: {
-        text: "-"
+        text: "-",
+        attributes: {
+          "data-cy": "exporter-table-probability-of-default-value"
+        }
       }
     } %}
   {% endif %}
@@ -169,7 +198,10 @@
   {% set rows = (rows.push(probabilityOfDefaultRow), rows) %}
 
   {{ govukSummaryList({
-    rows: rows
+    rows: rows,
+    attributes: {
+      "data-cy": "exporter-table"
+    }
   })
   }}
 {% endmacro %}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -8,29 +8,20 @@
   {% set probabilityOfDefault  = params.probabilityOfDefault  %}
   {% set userCanEditGeneral = params.userCanEditGeneral %}
   
-  {% set rows = [] %}
+    {% set exporterCreditRatingKeyHtml %}
+      <span data-cy="exporter-table-credit-rating-heading">Credit rating</span>
+    {% endset %}
 
   {% if exporterCreditRating %}
 
-    {% set creditRatingRow = {
-      key: {
-        text: "Credit rating",
-        attributes: {
-          "data-cy": "exporter-table-credit-rating-heading"
-        }
-      },
-      value: {
-        text: exporterCreditRating,
-        attributes: {
-          "data-cy": "exporter-table-credit-rating-value"
-        }
-      }
-    } %}
+    {% set exporterCreditRatingValueHtml %}
+      <span data-cy="exporter-table-credit-rating-value">{{ exporterCreditRating }}</span>
+    {% endset %}
 
     {% if userCanEditGeneral %}
       {% set creditRatingRow = {
-        key: creditRatingRow.key,
-        value: creditRatingRow.value,
+        key: { html: exporterCreditRatingKeyHtml },
+        value: { html: exporterCreditRatingValueHtml },
         actions: {
           items: [
             {
@@ -43,13 +34,16 @@
           ]
         }
       } %}
-    {% endif %}
-
-    {% set rows = (rows.push(creditRatingRow), rows) %}
-
     {% else %}
+      {% set creditRatingRow = {
+        key: { html: exporterCreditRatingKeyHtml },
+        value: { html: exporterCreditRatingValueHtml }
+      } %}
+    {% endif %}
+    
+  {% else %}
 
-    {% set valueHtml%}
+    {% set exporterCreditRatingValueHtml %}
       {{ govukTag({
         text: 'Not added',
         classes: 'govuk-tag--yellow',
@@ -59,21 +53,10 @@
       }) }}
     {% endset %}
 
-    {% set creditRatingRow = {
-      key: {
-        text: "Credit rating",
-        attributes: {
-          "data-cy": "exporter-table-credit-rating-heading"
-        }
-      },
-      value: { html: valueHtml }
-    } %}
-
-    
     {% if userCanEditGeneral %}
       {% set creditRatingRow = {
-        key: creditRatingRow.key,
-        value: creditRatingRow.value,
+      key: { html: exporterCreditRatingKeyHtml },
+      value: { html: exporterCreditRatingValueHtml },
         actions: {
           items: [
             {
@@ -86,50 +69,33 @@
           ]
         }
       } %}
+    {% else %}
+      {% set creditRatingRow = {
+        key: { html: exporterCreditRatingKeyHtml },
+        value: { html: exporterCreditRatingValueHtml }
+      } %}
     {% endif %}
 
-    {% set rows = (rows.push(creditRatingRow), rows) %}
   {% endif %}
 
-  {% set lossGivenDefaultRow = {
-    key: {
-      text: "Loss given default",
-      attributes: {
-        "data-cy": "exporter-table-loss-given-default-heading"
-      }
-    } 
-  }%}
+  {% set lossGivenDefaultKeyHtml %}
+    <span data-cy="exporter-table-loss-given-default-heading">Loss given default</span>
+  {% endset %}
 
   {% if lossGivenDefault %}
-
-    {% set lossGivenDefaultRow = {
-      key: lossGivenDefaultRow.key,
-      value: {
-        text: lossGivenDefault,
-        attributes: {
-          "data-cy": "exporter-table-loss-given-default-value"
-        }
-      }
-    } %}
-
+    {% set lossGivenDefaultValueHtml %}
+      <span "data-cy": "exporter-table-loss-given-default-value">{{ lossGivenDefault }}</span>
+    {% endset %}
   {% else %}
-
-    {% set lossGivenDefaultRow = {
-      key: lossGivenDefaultRow.key,
-      value: {
-        text: "-"
-      },
-      attributes: {
-          "data-cy": "exporter-table-loss-given-default-value"
-        }
-    } %}
-
+    {% set lossGivenDefaultValueHtml %}
+      <span "data-cy": "exporter-table-loss-given-default-value">-</span>
+    {% endset %}
   {% endif %}
 
   {% if userCanEditGeneral %}
     {% set lossGivenDefaultRow = {
-      key: lossGivenDefaultRow.key,
-      value: lossGivenDefaultRow.value,
+      key: { html: lossGivenDefaultKeyHtml },
+      value: { html: lossGivenDefaultValueHtml },
       actions: {
         items: [
           {
@@ -142,45 +108,31 @@
         ]
       }
     } %}
+  {% else %}
+    {% set lossGivenDefaultRow = {
+      key: { html: lossGivenDefaultKeyHtml},
+      value: { html: lossGivenDefaultValueHtml }
+    } %}
   {% endif %}
 
-  {% set rows = (rows.push(lossGivenDefaultRow), rows) %}
-
-  {% set probabilityOfDefaultRow = {
-    key: {
-      text: "Probability of default",
-      attributes: {
-        "data-cy": "exporter-table-probability-of-default-heading"
-      }
-    }
-  } %}
+  {% set probabilityOfDefaultKeyHtml %}
+    <span data-cy="exporter-table-probability-of-default-heading">Probability of default</span>
+  {% endset %}
 
   {% if probabilityOfDefault %}
-    {% set probabilityOfDefaultRow = {
-      key: probabilityOfDefaultRow.key,
-      value: {
-        text: "Less than " + probabilityOfDefault,
-        attributes: {
-          "data-cy": "exporter-table-probability-of-default-value"
-        }
-      }
-    } %}
-    {% else %}
-    {% set probabilityOfDefaultRow = {
-      key: probabilityOfDefaultRow.key,
-      value: {
-        text: "-",
-        attributes: {
-          "data-cy": "exporter-table-probability-of-default-value"
-        }
-      }
-    } %}
+    {% set probabilityOfDefaultValueHtml %}
+      <span data-cy="exporter-table-probability-of-default-value">Less than {{ probabilityOfDefault }}</span>
+    {% endset %}
+  {% else %}
+    {% set probabilityOfDefaultValueHtml %}
+      <span data-cy="exporter-table-probability-of-default-value">-</span>
+    {% endset %}
   {% endif %}
 
   {% if userCanEditGeneral %}
     {% set probabilityOfDefaultRow = {
-      key: probabilityOfDefaultRow.key,
-      value: probabilityOfDefaultRow.value,
+      key: { html: probabilityOfDefaultKeyHtml },
+      value: { html: probabilityOfDefaultValueHtml },
       actions: {
         items: [
           {
@@ -193,12 +145,15 @@
         ]
       }
     } %}
+  {% else %}
+    {% set probabilityOfDefaultRow = {
+      key: { html: probabilityOfDefaultKeyHtml },
+      value: { html: probabilityOfDefaultValueHtml }
+    } %}
   {% endif %}
 
-  {% set rows = (rows.push(probabilityOfDefaultRow), rows) %}
-
   {{ govukSummaryList({
-    rows: rows,
+    rows: [ creditRatingRow, lossGivenDefaultRow, probabilityOfDefaultRow],
     attributes: {
       "data-cy": "exporter-table"
     }

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -8,41 +8,16 @@
   {% set probabilityOfDefault  = params.probabilityOfDefault  %}
   {% set userCanEditGeneral = params.userCanEditGeneral %}
   
-    {% set exporterCreditRatingHeadingHtml %}
-      <span data-cy="exporter-table-credit-rating-heading">Credit rating</span>
-    {% endset %}
+  {% set exporterCreditRatingHeadingHtml %}
+    <span data-cy="exporter-table-credit-rating-heading">Credit rating</span>
+  {% endset %}
 
   {% if exporterCreditRating %}
-
     {% set exporterCreditRatingValueHtml %}
       <span data-cy="exporter-table-credit-rating-value">{{ exporterCreditRating }}</span>
     {% endset %}
-
-    {% if userCanEditGeneral %}
-      {% set creditRatingRow = {
-        key: { html: exporterCreditRatingHeadingHtml },
-        value: { html: exporterCreditRatingValueHtml },
-        actions: {
-          items: [
-            {
-              href: "/case/" + caseId + "/underwriting/pricing-and-risk/edit",
-              text: "Change",
-              attributes: {
-                "data-cy":"exporter-table-change-credit-rating-link"
-              }
-            }
-          ]
-        }
-      } %}
-    {% else %}
-      {% set creditRatingRow = {
-        key: { html: exporterCreditRatingHeadingHtml },
-        value: { html: exporterCreditRatingValueHtml }
-      } %}
-    {% endif %}
-    
+    {% set editExporterCreditRatingActionText = 'Change' %}
   {% else %}
-
     {% set exporterCreditRatingValueHtml %}
       {{ govukTag({
         text: 'Not added',
@@ -52,30 +27,30 @@
         }
       }) }}
     {% endset %}
+    {% set editExporterCreditRatingActionText = 'Add' %}
+  {% endif %}
 
-    {% if userCanEditGeneral %}
-      {% set creditRatingRow = {
+  {% if userCanEditGeneral %}
+    {% set creditRatingRow = {
       key: { html: exporterCreditRatingHeadingHtml },
       value: { html: exporterCreditRatingValueHtml },
-        actions: {
-          items: [
-            {
-              href: "/case/" + caseId + "/underwriting/pricing-and-risk/edit",
-              text: "Add",
-              attributes: {
-                "data-cy":"add-credit-rating-link"
-              }
+      actions: {
+        items: [
+          {
+            href: "/case/" + caseId + "/underwriting/pricing-and-risk/edit",
+            text: editExporterCreditRatingActionText,
+            attributes: {
+              "data-cy":"exporter-table-credit-rating-action-link"
             }
-          ]
-        }
-      } %}
-    {% else %}
-      {% set creditRatingRow = {
-        key: { html: exporterCreditRatingHeadingHtml },
-        value: { html: exporterCreditRatingValueHtml }
-      } %}
-    {% endif %}
-
+          }
+        ]
+      }
+    } %}
+  {% else %}
+    {% set creditRatingRow = {
+      key: { html: exporterCreditRatingHeadingHtml },
+      value: { html: exporterCreditRatingValueHtml }
+    } %}
   {% endif %}
 
   {% set lossGivenDefaultHeadingHtml %}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -84,7 +84,7 @@
 
   {% if lossGivenDefault %}
     {% set lossGivenDefaultValueHtml %}
-      <span data-cy="exporter-table-loss-given-default-value">{{ lossGivenDefault }}</span>
+      <span data-cy="exporter-table-loss-given-default-value">{{ lossGivenDefault }}%</span>
     {% endset %}
   {% else %}
     {% set lossGivenDefaultValueHtml %}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% macro render(params) %}
   {% set caseId = params.caseId %}
@@ -7,94 +7,169 @@
   {% set lossGivenDefault = params.lossGivenDefault %}
   {% set probabilityOfDefault  = params.probabilityOfDefault  %}
   {% set userCanEditGeneral = params.userCanEditGeneral %}
+  
+  {% set rows = [] %}
 
-  <table class="govuk-table govuk-!-margin-bottom-8" data-cy="exporter-table">
-    <tbody class="govuk-table__body">
+  {% if exporterCreditRating %}
 
-      <tr class="govuk-table__row">
+    {% set creditRatingRow = {
+      key: {
+        text: "Credit rating"
+      },
+      value: {
+        text: exporterCreditRating
+      }
+    } %}
 
-        <td scope="row" class="govuk-table__header govuk-body-s govuk-table__cell width-half" data-cy="exporter-table-credit-rating-heading">
-          Credit rating
-        </td>
-
-        <td class="govuk-table__cell">
-          {% if exporterCreditRating %}
-            <span data-cy="exporter-table-credit-rating-value">{{ exporterCreditRating }}</span>
-
-            {% else %}
-
-            {{ govukTag({
-              text: 'Not added',
-              classes: 'govuk-tag--yellow',
-              attributes: {
-                'data-cy': 'exporter-table-credit-rating-not-added'
-              }
-            }) }}
-
-          {% endif %}
-        </td>
-
-        <td class="govuk-table__cell text-align-right">
-          {% if exporterCreditRating and userCanEditGeneral %}
-            <a class="govuk-link" href="/case/{{ caseId }}/underwriting/pricing-and-risk/edit" data-cy="exporter-table-change-credit-rating-link">Change</a>
-          {% elseif not exporterCreditRating and userCanEditGeneral %}
-            {{ govukButton({
-              text: "Add",
+    {% if userCanEditGeneral %}
+      {% set creditRatingRow = {
+        key: creditRatingRow.key,
+        value: creditRatingRow.value,
+        actions: {
+          items: [
+            {
               href: "/case/" + caseId + "/underwriting/pricing-and-risk/edit",
+              text: "Change",
+              attributes: {
+                "data-cy":"exporter-table-change-credit-rating-link"
+              }
+            }
+          ]
+        }
+      } %}
+    {% endif %}
+
+    {% set rows = (rows.push(creditRatingRow), rows) %}
+
+    {% else %}
+
+    {% set valueHtml%}
+      {{ govukTag({
+        text: 'Not added',
+        classes: 'govuk-tag--yellow',
+        attributes: {
+          'data-cy': 'exporter-table-credit-rating-not-added'
+        }
+      }) }}
+    {% endset %}
+
+    {% set creditRatingRow = {
+      key: { text: "Credit rating" },
+      value: { html: valueHtml }
+    } %}
+
+    
+    {% if userCanEditGeneral %}
+      {% set creditRatingRow = {
+        key: creditRatingRow.key,
+        value: creditRatingRow.value,
+        actions: {
+          items: [
+            {
+              href: "/case/" + caseId + "/underwriting/pricing-and-risk/edit",
+              text: "Add",
               attributes: {
                 "data-cy":"add-credit-rating-link"
               }
-            }) }}
-          {% endif %}
-        </td>
+            }
+          ]
+        }
+      } %}
+    {% endif %}
 
-      </tr>
+    {% set rows = (rows.push(creditRatingRow), rows) %}
+  {% endif %}
 
-      <tr class="govuk-table__row">
+  {% set lossGivenDefaultRow = {
+    key: {
+      text: "Loss given default"
+    } 
+  }%}
 
-        <td scope="row" class="govuk-table__header govuk-body-s govuk-table__cell width-half" data-cy="exporter-table-loss-given-default-heading">
-          Loss given default
-        </td>
+  {% if lossGivenDefault %}
 
-        <td class="govuk-table__cell" data-cy="exporter-table-loss-given-default-value">
-          {% if lossGivenDefault %}
-            {{ lossGivenDefault }}%
-          {% else %}
-            -
-          {% endif %}
-        </td>
+    {% set lossGivenDefaultRow = {
+      key: lossGivenDefaultRow.key,
+      value: {
+        text: lossGivenDefault
+      }
+    } %}
 
-        <td class="govuk-table__cell govuk-table__cell--border-top text-align-right">
-          {% if userCanEditGeneral %}
-            <a class="govuk-link" href="/case/{{ caseId }}/underwriting/pricing-and-risk/loss-given-default" data-cy="exporter-table-change-loss-given-default-link">Change</a>
-          {% endif %}
-        </td>
+  {% else %}
 
-      </tr>
+    {% set lossGivenDefaultRow = {
+      key: lossGivenDefaultRow.key,
+      value: {
+        text: "-"
+      }
+    } %}
 
-      <tr class="govuk-table__row">
+  {% endif %}
 
-        <td scope="row" class="govuk-table__header govuk-body-s govuk-table__cell width-half" data-cy="exporter-table-probability-of-default-heading">
-          Probability of default
-        </td>
+  {% if userCanEditGeneral %}
+    {% set lossGivenDefaultRow = {
+      key: lossGivenDefaultRow.key,
+      value: lossGivenDefaultRow.value,
+      actions: {
+        items: [
+          {
+            href: "/case/" + caseId + "/underwriting/pricing-and-risk/loss-given-default",
+            text: "Change",
+            attributes: {
+              "data-cy":"exporter-table-change-loss-given-default-link"
+            }
+          }
+        ]
+      }
+    } %}
+  {% endif %}
 
-        <td class="govuk-table__cell" data-cy="exporter-table-probability-of-default-value">
+  {% set rows = (rows.push(lossGivenDefaultRow), rows) %}
 
-          {% if probabilityOfDefault %}
-            Less than {{ probabilityOfDefault }}%
+  {% set probabilityOfDefaultRow = {
+    key: {
+      text: "Probability of default"
+    }
+  } %}
 
-            {% else %}
-            -
-          {% endif %}
-        </td>
+  {% if probabilityOfDefault %}
+    {% set probabilityOfDefaultRow = {
+      key: probabilityOfDefaultRow.key,
+      value: {
+        text: "Less than " + probabilityOfDefault
+      }
+    } %}
+    {% else %}
+    {% set probabilityOfDefaultRow = {
+      key: probabilityOfDefaultRow.key,
+      value: {
+        text: "-"
+      }
+    } %}
+  {% endif %}
 
-        <td class="govuk-table__cell govuk-table__cell--border-top text-align-right">
-          {% if userCanEditGeneral %}
-            <a class="govuk-link" href="/case/{{ caseId }}/underwriting/pricing-and-risk/probability-of-default" data-cy="exporter-table-change-probability-of-default-link">Change</a>
-          {% endif %}
-        </td>
-      </tr>
+  {% if userCanEditGeneral %}
+    {% set probabilityOfDefaultRow = {
+      key: probabilityOfDefaultRow.key,
+      value: probabilityOfDefaultRow.value,
+      actions: {
+        items: [
+          {
+            href: "/case/" + caseId + "/underwriting/pricing-and-risk/probability-of-default",
+            text: "Change",
+            attributes: {
+              "data-cy":"exporter-table-change-probability-of-default-link"
+            }
+          }
+        ]
+      }
+    } %}
+  {% endif %}
 
-    </tbody>
-  </table>
+  {% set rows = (rows.push(probabilityOfDefaultRow), rows) %}
+
+  {{ govukSummaryList({
+    rows: rows
+  })
+  }}
 {% endmacro %}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -84,7 +84,7 @@
 
   {% if lossGivenDefault %}
     {% set lossGivenDefaultValueHtml %}
-      <span "data-cy": "exporter-table-loss-given-default-value">{{ lossGivenDefault }}</span>
+      <span data-cy="exporter-table-loss-given-default-value">{{ lossGivenDefault }}</span>
     {% endset %}
   {% else %}
     {% set lossGivenDefaultValueHtml %}
@@ -121,7 +121,7 @@
 
   {% if probabilityOfDefault %}
     {% set probabilityOfDefaultValueHtml %}
-      <span data-cy="exporter-table-probability-of-default-value">Less than {{ probabilityOfDefault }}</span>
+      <span data-cy="exporter-table-probability-of-default-value">Less than {{ probabilityOfDefault }}%</span>
     {% endset %}
   {% else %}
     {% set probabilityOfDefaultValueHtml %}
@@ -153,7 +153,7 @@
   {% endif %}
 
   {{ govukSummaryList({
-    rows: [ creditRatingRow, lossGivenDefaultRow, probabilityOfDefaultRow],
+    rows: [ creditRatingRow, lossGivenDefaultRow, probabilityOfDefaultRow ],
     attributes: {
       "data-cy": "exporter-table"
     }

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -8,7 +8,7 @@
   {% set probabilityOfDefault  = params.probabilityOfDefault  %}
   {% set userCanEditGeneral = params.userCanEditGeneral %}
   
-    {% set exporterCreditRatingKeyHtml %}
+    {% set exporterCreditRatingHeadingHtml %}
       <span data-cy="exporter-table-credit-rating-heading">Credit rating</span>
     {% endset %}
 
@@ -20,7 +20,7 @@
 
     {% if userCanEditGeneral %}
       {% set creditRatingRow = {
-        key: { html: exporterCreditRatingKeyHtml },
+        key: { html: exporterCreditRatingHeadingHtml },
         value: { html: exporterCreditRatingValueHtml },
         actions: {
           items: [
@@ -36,7 +36,7 @@
       } %}
     {% else %}
       {% set creditRatingRow = {
-        key: { html: exporterCreditRatingKeyHtml },
+        key: { html: exporterCreditRatingHeadingHtml },
         value: { html: exporterCreditRatingValueHtml }
       } %}
     {% endif %}
@@ -55,7 +55,7 @@
 
     {% if userCanEditGeneral %}
       {% set creditRatingRow = {
-      key: { html: exporterCreditRatingKeyHtml },
+      key: { html: exporterCreditRatingHeadingHtml },
       value: { html: exporterCreditRatingValueHtml },
         actions: {
           items: [
@@ -71,14 +71,14 @@
       } %}
     {% else %}
       {% set creditRatingRow = {
-        key: { html: exporterCreditRatingKeyHtml },
+        key: { html: exporterCreditRatingHeadingHtml },
         value: { html: exporterCreditRatingValueHtml }
       } %}
     {% endif %}
 
   {% endif %}
 
-  {% set lossGivenDefaultKeyHtml %}
+  {% set lossGivenDefaultHeadingHtml %}
     <span data-cy="exporter-table-loss-given-default-heading">Loss given default</span>
   {% endset %}
 
@@ -88,13 +88,13 @@
     {% endset %}
   {% else %}
     {% set lossGivenDefaultValueHtml %}
-      <span "data-cy": "exporter-table-loss-given-default-value">-</span>
+      <span data-cy="exporter-table-loss-given-default-value">-</span>
     {% endset %}
   {% endif %}
 
   {% if userCanEditGeneral %}
     {% set lossGivenDefaultRow = {
-      key: { html: lossGivenDefaultKeyHtml },
+      key: { html: lossGivenDefaultHeadingHtml },
       value: { html: lossGivenDefaultValueHtml },
       actions: {
         items: [
@@ -110,12 +110,12 @@
     } %}
   {% else %}
     {% set lossGivenDefaultRow = {
-      key: { html: lossGivenDefaultKeyHtml},
+      key: { html: lossGivenDefaultHeadingHtml},
       value: { html: lossGivenDefaultValueHtml }
     } %}
   {% endif %}
 
-  {% set probabilityOfDefaultKeyHtml %}
+  {% set probabilityOfDefaultHeadingHtml %}
     <span data-cy="exporter-table-probability-of-default-heading">Probability of default</span>
   {% endset %}
 
@@ -131,7 +131,7 @@
 
   {% if userCanEditGeneral %}
     {% set probabilityOfDefaultRow = {
-      key: { html: probabilityOfDefaultKeyHtml },
+      key: { html: probabilityOfDefaultHeadingHtml },
       value: { html: probabilityOfDefaultValueHtml },
       actions: {
         items: [
@@ -147,7 +147,7 @@
     } %}
   {% else %}
     {% set probabilityOfDefaultRow = {
-      key: { html: probabilityOfDefaultKeyHtml },
+      key: { html: probabilityOfDefaultHeadingHtml },
       value: { html: probabilityOfDefaultValueHtml }
     } %}
   {% endif %}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/exporter-table.njk
@@ -1,5 +1,5 @@
-{% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from 'govuk/components/tag/macro.njk' import govukTag %}
+{% from 'govuk/components/summary-list/macro.njk' import govukSummaryList %}
 
 {% macro render(params) %}
   {% set caseId = params.caseId %}
@@ -16,7 +16,9 @@
     {% set exporterCreditRatingValueHtml %}
       <span data-cy="exporter-table-credit-rating-value">{{ exporterCreditRating }}</span>
     {% endset %}
-    {% set editExporterCreditRatingActionText = 'Change' %}
+    {% set editExporterCreditRatingActionHtml %}
+      Change <span class="govuk-visually-hidden">credit rating</span>
+    {% endset %}
   {% else %}
     {% set exporterCreditRatingValueHtml %}
       {{ govukTag({
@@ -27,8 +29,9 @@
         }
       }) }}
     {% endset %}
-    {% set editExporterCreditRatingActionText = 'Add' %}
-  {% endif %}
+    {% set editExporterCreditRatingActionHtml %}
+      Add <span class="govuk-visually-hidden">credit rating</span>
+    {% endset %}  {% endif %}
 
   {% if userCanEditGeneral %}
     {% set creditRatingRow = {
@@ -37,10 +40,10 @@
       actions: {
         items: [
           {
-            href: "/case/" + caseId + "/underwriting/pricing-and-risk/edit",
-            text: editExporterCreditRatingActionText,
+            href: '/case/' + caseId + '/underwriting/pricing-and-risk/edit',
+            html: editExporterCreditRatingActionHtml,
             attributes: {
-              "data-cy":"exporter-table-credit-rating-action-link"
+              'data-cy': 'exporter-table-credit-rating-action-link'
             }
           }
         ]
@@ -74,10 +77,10 @@
       actions: {
         items: [
           {
-            href: "/case/" + caseId + "/underwriting/pricing-and-risk/loss-given-default",
-            text: "Change",
+            href: '/case/' + caseId + '/underwriting/pricing-and-risk/loss-given-default',
+            html: 'Change <span class="govuk-visually-hidden">loss given default</span>',
             attributes: {
-              "data-cy":"exporter-table-change-loss-given-default-link"
+              'data-cy': 'exporter-table-change-loss-given-default-link'
             }
           }
         ]
@@ -111,10 +114,10 @@
       actions: {
         items: [
           {
-            href: "/case/" + caseId + "/underwriting/pricing-and-risk/probability-of-default",
-            text: "Change",
+            href: '/case/' + caseId + '/underwriting/pricing-and-risk/probability-of-default',
+            html: 'Change <span class="govuk-visually-hidden">probability of default</span>',
             attributes: {
-              "data-cy":"exporter-table-change-probability-of-default-link"
+              'data-cy': 'exporter-table-change-probability-of-default-link'
             }
           }
         ]
@@ -130,7 +133,7 @@
   {{ govukSummaryList({
     rows: [ creditRatingRow, lossGivenDefaultRow, probabilityOfDefaultRow ],
     attributes: {
-      "data-cy": "exporter-table"
+      'data-cy': 'exporter-table'
     }
   })
   }}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/section-exporter.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/section-exporter.component-test.js
@@ -53,7 +53,7 @@ describe(component, () => {
 
       const wrapper = render(params);
       wrapper.expectLink('[data-cy="exporter-table-credit-rating-action-link"]')
-        .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Add');
+        .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Add credit rating');
     });
   });
 });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/section-exporter.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-exporter/section-exporter.component-test.js
@@ -18,7 +18,7 @@ describe(component, () => {
 
   it('should NOT render link to add credit rating', () => {
     const wrapper = render(params);
-    wrapper.expectElement('[data-cy="add-credit-rating-link"]').notToExist();
+    wrapper.expectElement('[data-cy="exporter-table-credit-rating-action-link"]').notToExist();
   });
 
   describe('with params.exporterCreditRating', () => {
@@ -29,7 +29,7 @@ describe(component, () => {
       };
 
       const wrapper = render(params);
-      wrapper.expectElement('[data-cy="add-credit-rating-link"]').notToExist();
+      wrapper.expectElement('[data-cy="exporter-table-credit-rating-action-link"]').notToExist();
     });
 
     it('should render exporter table', () => {
@@ -52,7 +52,7 @@ describe(component, () => {
       };
 
       const wrapper = render(params);
-      wrapper.expectLink('[data-cy="add-credit-rating-link"]')
+      wrapper.expectLink('[data-cy="exporter-table-credit-rating-action-link"]')
         .toLinkTo(`/case/${params.caseId}/underwriting/pricing-and-risk/edit`, 'Add');
     });
   });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.component-test.js
@@ -138,7 +138,7 @@ describe(component, () => {
         const expectedLink = `/case/${params.caseId}/underwriting/pricing-and-risk/facility/${params.facility._id}/risk-profile`;
 
         wrapper.expectLink(`[data-cy="facility-${params.facility._id}-change-risk-profile-link"]`)
-          .toLinkTo(expectedLink, 'Change');
+          .toLinkTo(expectedLink, 'Change risk profile');
       });
     });
   });

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.component-test.js
@@ -14,9 +14,6 @@ describe(component, () => {
         ukefFacilityId: '100',
         type: 'Loan',
       },
-      tfm: {
-        riskProfile: 'Flat',
-      },
     },
   };
 
@@ -35,6 +32,66 @@ describe(component, () => {
     wrapper.expectText(`[data-cy="facility-${params.facility._id}-type"]`).toRead(params.facility.facilitySnapshot.type);
   });
 
+  describe('guarantee fee payable to UKEF table row', () => {
+    it('should render heading', () => {
+      wrapper = render(params);
+
+      wrapper.expectText(`[data-cy=facility-${params.facility._id}-bank-guarantee-fee-heading]`).toRead('Guarantee fee % payable to UKEF');
+    });
+
+    it('should render value if defined', () => {
+      const paramsWithGuaranteeFee = {
+        ...params,
+        facility: {
+          ...params.facility,
+          facilitySnapshot: {
+            ...params.facility.facilitySnapshot,
+            guaranteeFeePayableToUkef: '7.0200%',
+          },
+        },
+      };
+      wrapper = render(paramsWithGuaranteeFee);
+
+      wrapper.expectText(`[data-cy="facility-${params.facility._id}-bank-guarantee-fee-value"]`).toRead(paramsWithGuaranteeFee.facility.facilitySnapshot.guaranteeFeePayableToUkef);
+    });
+
+    it('should render - for the value if undefined', () => {
+      wrapper = render(params);
+
+      wrapper.expectText(`[data-cy="facility-${params.facility._id}-bank-guarantee-fee-value"]`).toRead('-');
+    });
+  });
+
+  describe('banks interest margin table row', () => {
+    it('should render heading', () => {
+      wrapper = render(params);
+
+      wrapper.expectText(`[data-cy=facility-${params.facility._id}-bank-interest-heading]`).toRead("Bank's interest margin");
+    });
+
+    it('should render value if defined', () => {
+      const paramsWithInterestMargin = {
+        ...params,
+        facility: {
+          ...params.facility,
+          facilitySnapshot: {
+            ...params.facility.facilitySnapshot,
+            banksInterestMargin: '7.8%',
+          },
+        },
+      };
+      wrapper = render(paramsWithInterestMargin);
+
+      wrapper.expectText(`[data-cy="facility-${params.facility._id}-bank-interest-value"]`).toRead(paramsWithInterestMargin.facility.facilitySnapshot.banksInterestMargin);
+    });
+
+    it('should render - for the value if undefined', () => {
+      wrapper = render(params);
+
+      wrapper.expectText(`[data-cy="facility-${params.facility._id}-bank-interest-value"]`).toRead('-');
+    });
+  });
+
   describe('risk profile table row', () => {
     it('should render heading', () => {
       wrapper = render(params);
@@ -42,10 +99,25 @@ describe(component, () => {
       wrapper.expectText(`[data-cy="facility-${params.facility._id}-risk-profile-heading"]`).toRead('Risk profile');
     });
 
-    it('should render value', () => {
+    it('should render - for the value if undefined', () => {
       wrapper = render(params);
 
-      wrapper.expectText(`[data-cy="facility-${params.facility._id}-risk-profile-value"]`).toRead(params.facility.tfm.riskProfile);
+      wrapper.expectText(`[data-cy="facility-${params.facility._id}-risk-profile-value"]`).toRead('-');
+    });
+
+    it('should render value if defined', () => {
+      const paramsWithRiskProfile = {
+        ...params,
+        facility: {
+          ...params.facility,
+          tfm: {
+            riskProfile: 'Flat',
+          },
+        },
+      };
+      wrapper = render(paramsWithRiskProfile);
+
+      wrapper.expectText(`[data-cy="facility-${params.facility._id}-risk-profile-value"]`).toRead(paramsWithRiskProfile.facility.tfm.riskProfile);
     });
 
     it('should NOT render change link', () => {

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -63,7 +63,8 @@
   {{ govukSummaryList({
     card: {
       title: {
-        html: cardTitleHtml
+        html: cardTitleHtml,
+        headingLevel: 5
       }
     },
     rows: [ feePayableToUkefRow, banksInterestMarginRow, riskProfileRow ],

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -47,7 +47,7 @@
         items: [
         {
           href: '/case/' + caseId + '/underwriting/pricing-and-risk/facility/' + facility._id + '/risk-profile',
-          html: 'Change <span class="govuk-visually-hidden">risk profile</span>'',
+          html: 'Change <span class="govuk-visually-hidden">risk profile</span>',
           attributes: {
             'data-cy': facility- + facility._id + -change-risk-profile-link
           }

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -49,7 +49,7 @@
           href: '/case/' + caseId + '/underwriting/pricing-and-risk/facility/' + facility._id + '/risk-profile',
           html: 'Change <span class="govuk-visually-hidden">risk profile</span>',
           attributes: {
-            'data-cy': facility- + facility._id + -change-risk-profile-link
+            'data-cy': 'facility-' + facility._id + '-change-risk-profile-link'
           }
         }]
       }

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -1,4 +1,4 @@
-{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from 'govuk/components/summary-list/macro.njk' import govukSummaryList %}
 
 {% macro render(params) %}
   {% set facility = params.facility %}
@@ -46,10 +46,10 @@
       actions: {
         items: [
         {
-          href: "/case/" + caseId + "/underwriting/pricing-and-risk/facility/" + facility._id + "/risk-profile",
-          text: "Change",
+          href: '/case/' + caseId + '/underwriting/pricing-and-risk/facility/' + facility._id + '/risk-profile',
+          html: 'Change <span class="govuk-visually-hidden">risk profile</span>'',
           attributes: {
-            "data-cy": "facility-" + facility._id + "-change-risk-profile-link"
+            'data-cy': facility- + facility._id + -change-risk-profile-link
           }
         }]
       }
@@ -81,7 +81,7 @@
     },
     rows: [ feePayableToUkefRow, banksInterestMarginRow, riskProfileRow ],
     attributes: {
-      "data-cy": "facility-" + facility._id + "-pricing-risk-table"
+      'data-cy': 'facility-' + facility._id + '-pricing-risk-table'
     }
   })
   }}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -1,47 +1,76 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
 {% macro render(params) %}
   {% set facility = params.facility %}
   {% set caseId = params.caseId %}
   {% set userCanEdit = params.userCanEdit %}
 
-  <table class="govuk-table" data-cy="facility-{{ facility._id }}-pricing-risk-table">
-    <caption class="govuk-table__caption govuk-heading-s govuk-!-margin-bottom-6">
-      <a
-        class="govuk-link govuk-link--no-visited-state"
-        href="/case/{{ caseId }}/facility/{{ facility._id }}"
-        aria-label="View Facility details"
-        data-cy="facility-{{ facility._id }}-ukef-facility-id-link">
-        <span data-cy="facility-{{ facility._id }}-ukef-facility-id-link-text">{{ facility.facilitySnapshot.ukefFacilityId }}</span>
-      </a>
-      <span data-cy="facility-{{ facility._id }}-type">&nbsp;&nbsp;{{ facility.facilitySnapshot.type }}</span>
-    </caption>
+  {% set feePayableToUkefValueHtml %}
+    <span data-cy="facility-{{ facility._id}}-bank-guarantee-fee-value">{{ facility.facilitySnapshot.guaranteeFeePayableToUkef | dashIfEmpty}} </span>
+  {% endset %}
 
-    <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header govuk-body-s width-half govuk-table__cell--border-top">Guarantee fee % payable to UKEF</th>
-        <td class="govuk-table__cell govuk-table__cell--border-top" data-cy="facility-{{ facility._id}}-bank-guarantee-fee-value">{{ facility.facilitySnapshot.guaranteeFeePayableToUkef | dashIfEmpty}}</td>
-        <td class="govuk-table__cell govuk-table__cell--border-top"></td>
-      </tr>
+  {% set feePayableToUkefRow = { 
+    key: { text: "Guarantee fee % payable to UKEF" },
+    value: { html: feePayableToUkefValueHtml }
+  } %}
 
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header govuk-body-s width-half">Bank’s interest margin</th>
-        <td class="govuk-table__cell" data-cy="facility-{{ facility._id}}-bank-interest-value">{{ facility.facilitySnapshot.banksInterestMargin | dashIfEmpty}}</td>
-        <td class="govuk-table__cell"></td>
-      </tr>
+  {% set banksInterestMarginValueHtml %}
+    <span data-cy="facility-{{ facility._id}}-bank-interest-value">{{ facility.facilitySnapshot.banksInterestMargin | dashIfEmpty}} </span>
+  {% endset %}
 
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header govuk-body-s width-half" data-cy="facility-{{ facility._id}}-risk-profile-heading">Risk profile</th>
-        <td class="govuk-table__cell" data-cy="facility-{{ facility._id}}-risk-profile-value">{{ facility.tfm.riskProfile | dashIfEmpty }}</td>
+  {% set banksInterestMarginRow = {
+    key: { text: "Bank's interest margin" },
+    value: { html: banksInterestMarginValueHtml }
+  } %}
 
-        {% if userCanEdit %}
-          <td class="govuk-table__cell text-align-right">
-            <a class="govuk-link" href="/case/{{ caseId }}/underwriting/pricing-and-risk/facility/{{ facility._id }}/risk-profile" data-cy="facility-{{ facility._id}}-change-risk-profile-link">Change</a>
-          </td>
+  {% set riskProfileValueHtml %}
+    <span data-cy="facility-{{ facility._id}}-risk-profile-value">{{ facility.tfm.riskProfile | dashIfEmpty }}</span>
+  {% endset %}
 
-          {% else %}
-          <td class="govuk-table__cell"></td>
-        {% endif %}
-      </tr>
-    </tbody>
-  </table>
+  {% if userCanEdit %}
+    {% set riskProfileRow = {
+      key: { text: "Risk profile" },
+      value: { html: riskProfileValueHtml },
+      actions: {
+        items: [
+        {
+          href: "/case/" + caseId + "/underwriting/pricing-and-risk/facility/" + facility._id + "/risk-profile",
+          text: "Change",
+          attributes: {
+            "data-cy": "facility-" + facility._id + "-change-risk-profile-link"
+          }
+        }]
+      }
+    } %}
+  {% else %}  
+    {% set riskProfileRow = {
+      key: { text: "Risk profile" },
+      value: { html: riskProfileValueHtml }
+    } %}
+  {% endif %}
+
+  {% set cardTitleHtml %}
+    <a
+      class="govuk-link govuk-link--no-visited-state"
+      href="/case/{{ caseId }}/facility/{{ facility._id }}"
+      aria-label="View Facility details"
+      data-cy="facility-{{ facility._id }}-ukef-facility-id-link">
+      <span data-cy="facility-{{ facility._id }}-ukef-facility-id-link-text">{{ facility.facilitySnapshot.ukefFacilityId }}</span>
+    </a>
+    <span data-cy="facility-{{ facility._id }}-type">&nbsp;&nbsp;{{ facility.facilitySnapshot.type }}</span>
+  {% endset %}
+
+  {{ govukSummaryList({
+    card: {
+      title: {
+        html: cardTitleHtml
+      }
+    },
+    rows: [ feePayableToUkefRow, banksInterestMarginRow, riskProfileRow ],
+    attributes: {
+      "data-cy": "facility-" + facility._id + "-pricing-risk-table"
+    }
+  })
+  }}
 
 {% endmacro %}

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/_macros/section-facilities/facility-pricing-risk-table.njk
@@ -5,23 +5,35 @@
   {% set caseId = params.caseId %}
   {% set userCanEdit = params.userCanEdit %}
 
+  {% set feePayableToUkefHeadingHtml %}
+    <span data-cy="facility-{{ facility._id}}-bank-guarantee-fee-heading">Guarantee fee % payable to UKEF</span>
+  {% endset %}
+
   {% set feePayableToUkefValueHtml %}
-    <span data-cy="facility-{{ facility._id}}-bank-guarantee-fee-value">{{ facility.facilitySnapshot.guaranteeFeePayableToUkef | dashIfEmpty}} </span>
+    <span data-cy="facility-{{ facility._id}}-bank-guarantee-fee-value">{{ facility.facilitySnapshot.guaranteeFeePayableToUkef | dashIfEmpty }}</span>
   {% endset %}
 
   {% set feePayableToUkefRow = { 
-    key: { text: "Guarantee fee % payable to UKEF" },
+    key: { html: feePayableToUkefHeadingHtml },
     value: { html: feePayableToUkefValueHtml }
   } %}
 
+  {% set banksInterestMarginHeadingHtml %}
+    <span data-cy="facility-{{ facility._id}}-bank-interest-heading">Bank's interest margin</span>
+  {% endset %}
+
   {% set banksInterestMarginValueHtml %}
-    <span data-cy="facility-{{ facility._id}}-bank-interest-value">{{ facility.facilitySnapshot.banksInterestMargin | dashIfEmpty}} </span>
+    <span data-cy="facility-{{ facility._id}}-bank-interest-value">{{ facility.facilitySnapshot.banksInterestMargin | dashIfEmpty}}</span>
   {% endset %}
 
   {% set banksInterestMarginRow = {
-    key: { text: "Bank's interest margin" },
+    key: { html: banksInterestMarginHeadingHtml },
     value: { html: banksInterestMarginValueHtml }
   } %}
+
+  {% set riskProfileHeadingHtml %}
+    <span data-cy="facility-{{ facility._id}}-risk-profile-heading">Risk profile</span>
+  {% endset %}
 
   {% set riskProfileValueHtml %}
     <span data-cy="facility-{{ facility._id}}-risk-profile-value">{{ facility.tfm.riskProfile | dashIfEmpty }}</span>
@@ -29,7 +41,7 @@
 
   {% if userCanEdit %}
     {% set riskProfileRow = {
-      key: { text: "Risk profile" },
+      key: { html: riskProfileHeadingHtml },
       value: { html: riskProfileValueHtml },
       actions: {
         items: [
@@ -44,7 +56,7 @@
     } %}
   {% else %}  
     {% set riskProfileRow = {
-      key: { text: "Risk profile" },
+      key: { html: riskProfileHeadingHtml },
       value: { html: riskProfileValueHtml }
     } %}
   {% endif %}


### PR DESCRIPTION
## Introduction
On the underwriting page the exporter table does not have the headers semantically marked up

## Resolution
* Changed the exporter and facilities tables to use `govukSummaryList` components