### PR TITLE
fix: ensure pipeline fails if dtfs-central and external api tests fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm run api-test
 #### Run a Single API Test :heavy_check_mark:
 
 ```shell
-npm run api-test-file "**/*/deals-party-db.api-test.js"
+npm run api-test "**/*/deals-party-db.api-test.js"
 ```
 
 ### UI Tests :rocket:

--- a/azure-functions/acbs-function/api-test-file.jest.config.js
+++ b/azure-functions/acbs-function/api-test-file.jest.config.js
@@ -1,5 +1,0 @@
-const commonSettings = require('./api-test-common.jest.config');
-
-module.exports = {
-  ...commonSettings,
-};

--- a/dtfs-central-api/README.md
+++ b/dtfs-central-api/README.md
@@ -110,7 +110,7 @@ This will generate test coverage.
 You can run a specific API test file using the following command:
 
 ```shell
-npm run api-test-file "**/*/deals-party-db.api-test.js"
+npm run api-test "**/*/deals-party-db.api-test.js"
 ```
 
 ## Moving Forwards

--- a/dtfs-central-api/api-test-file.jest.config.js
+++ b/dtfs-central-api/api-test-file.jest.config.js
@@ -1,5 +1,0 @@
-const commonSettings = require('./api-test-common.jest.config');
-
-module.exports = {
-  ...commonSettings,
-};

--- a/dtfs-central-api/api-test.jest.config.js
+++ b/dtfs-central-api/api-test.jest.config.js
@@ -1,7 +1,6 @@
 const commonSettings = require('./api-test-common.jest.config');
 
 module.exports = {
-  globalTeardown: './test-teardown-globals.js',
   collectCoverageFrom: ['src/**/*.{js,}'],
   coverageDirectory: 'generated_reports/coverage/api-test',
   testMatch: ['**/*.api-test.js'],

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "api-test": "jest --coverage --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
     "api-test-dev": "jest --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
-    "api-test-file": "jest --config=api-test-file.jest.config.js --runInBand --verbose --testMatch ",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "start": "npx ts-node src/index.ts",

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -18,8 +18,8 @@
   "author": "UK Export Finance",
   "main": "src/index.ts",
   "scripts": {
-    "api-test": "jest --coverage --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
-    "api-test-dev": "jest --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
+    "api-test": "jest --coverage --verbose --forceExit --runInBand --config=api-test.jest.config.js",
+    "api-test-dev": "jest --verbose --forceExit --runInBand --config=api-test.jest.config.js",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "start": "npx ts-node src/index.ts",

--- a/dtfs-central-api/test-teardown-globals.js
+++ b/dtfs-central-api/test-teardown-globals.js
@@ -1,3 +1,0 @@
-module.exports = () => {
-  process.exit(0);
-};

--- a/external-api/README.md
+++ b/external-api/README.md
@@ -59,7 +59,7 @@ This will generate test coverage as well.
 If you want to run a specific API test file, you can use the following command by specifying the path to the test file:
 
 ```shell
-npm run api-test-file "**/*/deals-party-db.api-test.js"
+npm run api-test "**/*/deals-party-db.api-test.js"
 ```
 
 This allows you to focus on testing a particular aspect or functionality of the **EXTERNAL** service.

--- a/external-api/api-test-teardown.jest.config.js
+++ b/external-api/api-test-teardown.jest.config.js
@@ -1,3 +1,0 @@
-module.exports = () => {
-  process.exit(0);
-};

--- a/external-api/api-test.jest.config.js
+++ b/external-api/api-test.jest.config.js
@@ -5,6 +5,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globalTeardown: './api-test-teardown.jest.config.js',
   testTimeout: 80000,
 };

--- a/external-api/package.json
+++ b/external-api/package.json
@@ -19,7 +19,6 @@
   "main": "src/index.ts",
   "scripts": {
     "api-test": "jest --coverage --verbose --forceExit --runInBand --config=api-test.jest.config.js",
-    "api-test-file": "jest --config=api-test.jest.config.js --verbose --forceExit --detectOpenHandles --testMatch",
     "lint": "eslint ./src --ext .ts",
     "lint:fix": "eslint ./src --ext .ts --fix",
     "start": "ts-node src/index.ts",

--- a/portal-api/api-test-file.jest.config.js
+++ b/portal-api/api-test-file.jest.config.js
@@ -1,6 +1,0 @@
-const commonSettings = require('./api-test-common.jest.config');
-
-module.exports = {
-  globalTeardown: './test-teardown-globals.js',
-  ...commonSettings,
-};

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "api-test": "jest --coverage --verbose --runInBand --forceExit --clearMocks --config=api-test.jest.config.js",
     "api-test-dev": "jest --verbose --runInBand --forceExit --config=api-test.jest.config.js",
-    "api-test-file": "jest --config=api-test-file.jest.config.js --runInBand --verbose --testMatch",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "start": "npx ts-node src/index.ts",

--- a/portal-api/test-teardown-globals.js
+++ b/portal-api/test-teardown-globals.js
@@ -1,3 +1,0 @@
-module.exports = () => {
-  process.exit(0);
-};

--- a/trade-finance-manager-api/README.md
+++ b/trade-finance-manager-api/README.md
@@ -28,7 +28,7 @@ npm run api-test
 To run a specific API test, use the following command (replace the path accordingly):
 
 ```shell
-npm run api-test-file "**/*/deals-party-db.api-test.js"
+npm run api-test "**/*/deals-party-db.api-test.js"
 ```
 
 ## Functionality :gear:

--- a/trade-finance-manager-api/api-test-file.jest.config.js
+++ b/trade-finance-manager-api/api-test-file.jest.config.js
@@ -1,5 +1,0 @@
-const commonSettings = require('./api-test-common.jest.config');
-
-module.exports = {
-  ...commonSettings,
-};

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "api-test": "jest --coverage --verbose --runInBand --forceExit --config=api-test.jest.config.js",
     "api-test-dev": "jest --verbose --runInBand --detectOpenHandles --config=api-test.jest.config.js ",
-    "api-test-file": "jest --config=api-test-file.jest.config.js --runInBand --verbose --testMatch ",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "start": "npx ts-node src/index.ts",

--- a/trade-finance-manager-api/test-teardown-globals.js
+++ b/trade-finance-manager-api/test-teardown-globals.js
@@ -1,3 +1,0 @@
-module.exports = () => {
-  process.exit(0);
-};


### PR DESCRIPTION
## Introduction

@francescastocco and @JoshBinns2000 noticed that the pipeline was not failing if DTFS Central API or External API API tests were failing. We tracked this down to a test teardown that would always set the exit code to 0 regardless of the test result.

## Resolution

I've removed the test teardown files that would set the exit code to 0.
I've removed references to the "api-test-file" scripts as they're not needed at all, the "api-test" script does the same job