### PR TITLE
fix/add environment to clamav app name

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -74,6 +74,7 @@
     "MAKENCHECK",
     "Markan",
     "mdm",
+    "mkodockx",
     "MRUI",
     "Mulesoft",
     "nestjs",

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -660,7 +660,6 @@ module clamAv 'modules/clamav-aca.bicep' = {
   params: {
     location: location
     environment: environment
-    container: 'clamav'
     acaClamAvSubnetId: vnet.outputs.acaClamAvSubnetId
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
   }

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -660,7 +660,7 @@ module clamAv 'modules/clamav-aca.bicep' = {
   params: {
     location: location
     environment: environment
-    containerName: 'clamav'
+    container: 'clamav'
     acaClamAvSubnetId: vnet.outputs.acaClamAvSubnetId
     logAnalyticsWorkspaceName: logAnalyticsWorkspace.name
   }

--- a/infrastructure/resource_group_level/modules/clamav-aca.bicep
+++ b/infrastructure/resource_group_level/modules/clamav-aca.bicep
@@ -62,7 +62,7 @@ resource clamAvAca 'Microsoft.App/containerApps@2023-05-01' = {
     template: {
       containers: [
         {
-          image: 'mkodockx/docker-clamav:alpine'
+          image: 'mkodockx/docker-clamav:1.1.2-alpine'
           name: containerName
           resources: {
             // We need minimal CPU, but 4GiB of memory. 

--- a/infrastructure/resource_group_level/modules/clamav-aca.bicep
+++ b/infrastructure/resource_group_level/modules/clamav-aca.bicep
@@ -1,12 +1,11 @@
 param location string = resourceGroup().location
 param environment string
-param container string
 param acaClamAvSubnetId string
 param logAnalyticsWorkspaceName string
 
 var managedEnvironmentName = 'tfs-${environment}-clamav-env'
 var applicationInsightsName = 'tfs-${environment}-clamav-ai'
-var containerName = 'tfs-${environment}-${container}'
+var containerName = 'tfs-${environment}-clamav'
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
   name: logAnalyticsWorkspaceName

--- a/infrastructure/resource_group_level/modules/clamav-aca.bicep
+++ b/infrastructure/resource_group_level/modules/clamav-aca.bicep
@@ -1,11 +1,12 @@
 param location string = resourceGroup().location
 param environment string
-param containerName string
+param container string
 param acaClamAvSubnetId string
 param logAnalyticsWorkspaceName string
 
 var managedEnvironmentName = 'tfs-${environment}-clamav-env'
 var applicationInsightsName = 'tfs-${environment}-clamav-ai'
+var containerName = 'tfs-${environment}-${container}'
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
   name: logAnalyticsWorkspaceName


### PR DESCRIPTION
# Introduction
- App container for clamav should have the environment in the name
- We should use a specific version of the clamav docker image instead of using the latest