### PR TITLE
fix(DTFS2-6463): add 'Task' and 'Status' headings to deal tasks tables

### DIFF
--- a/trade-finance-manager-ui/templates/case/amendments/_macros/tasks-table-amendments.component-test.js
+++ b/trade-finance-manager-ui/templates/case/amendments/_macros/tasks-table-amendments.component-test.js
@@ -1,0 +1,70 @@
+const componentRenderer = require('../../../../component-tests/componentRenderer');
+
+const component = '../templates/case/amendments/_macros/tasks-table-amendments.njk';
+
+const render = componentRenderer(component);
+
+describe(component, () => {
+  let wrapper;
+  const params = {
+    tasks: [
+      {
+        groupTitle: 'Test title',
+        id: 1,
+        groupTasks: [
+          {
+            id: '1',
+            groupId: 1,
+            title: 'Title A',
+            assignedTo: {
+              userId: '1234',
+              userFullName: 'Joe Bloggs',
+            },
+            team: {
+              id: 'BUSINESS_SUPPORT',
+              name: 'Business support group',
+            },
+            status: 'To do',
+          },
+          {
+            id: '2',
+            groupId: 1,
+            title: 'Title B',
+            assignedTo: {
+              userId: '5678',
+              userFullName: 'Joe Bloggs',
+            },
+            team: {
+              id: 'BUSINESS_SUPPORT',
+              name: 'Business support group',
+            },
+            status: 'In progress',
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    wrapper = render(params);
+  });
+
+  describe('table headers', () => {
+    describe.each([
+      ['Task', 'tasks-table-header-task'],
+      ['Assigned to', 'tasks-table-header-assigned-to'],
+      ['Team', 'tasks-table-header-team'],
+      ['Date started', 'tasks-table-header-date-started'],
+      ['Date completed', 'tasks-table-header-date-completed'],
+      ['Status', 'tasks-table-header-status'],
+    ])('`%s` header', (headerText, dataCy) => {
+      it('should render the header', () => {
+        wrapper.expectText(`[data-cy="${dataCy}"]`).toRead(headerText);
+      });
+
+      it('should set the `scope` attribute of the header to `col`', () => {
+        wrapper.expectElement(`[data-cy="${dataCy}"]`).toHaveAttribute('scope', 'col');
+      });
+    });
+  });
+});

--- a/trade-finance-manager-ui/templates/case/amendments/_macros/tasks-table-amendments.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/_macros/tasks-table-amendments.njk
@@ -24,12 +24,12 @@
             {% if loop.index === 1 %}
               <thead class="govuk-table__head">
                 <tr>
-                  <th class="govuk-table__header govuk-body-s"></th>
-                  <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-assigned-to">Assigned to</th>
-                  <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-team">Team</th>
-                  <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-started">Date started</th>
-                  <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-completed">Date completed</th>
-                  <th class="govuk-table__header govuk-body-s"></th>
+                  <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-task">Task</th>
+                  <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-assigned-to">Assigned to</th>
+                  <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-team">Team</th>
+                  <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-started">Date started</th>
+                  <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-completed">Date completed</th>
+                  <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-status">Status</th>
                 </tr>
               </thead>
             {% endif %}

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.component-test.js
@@ -71,11 +71,10 @@ describe(component, () => {
       ['Date completed', 'tasks-table-header-date-completed'],
       ['Status', 'tasks-table-header-status'],
     ])('`%s` header', (headerText, dataCy) => {
-
       it('should render the header', () => {
         wrapper.expectText(`[data-cy="${dataCy}"]`).toRead(headerText);
       });
-  
+
       it('should set the `scope` attribute of the header to `col`', () => {
         wrapper.expectElement(`[data-cy="${dataCy}"]`).toHaveAttribute('scope', 'col');
       });

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.component-test.js
@@ -63,20 +63,52 @@ describe(component, () => {
   });
 
   describe('table headers', () => {
+    it('should render `task` header', () => {
+      wrapper.expectText('[data-cy="tasks-table-header-task"]').toRead('Task');
+    });
+
+    it('should set the `scope` attribute of the `task` header to `col`', () => {
+      wrapper.expectElement('[data-cy="tasks-table-header-task"]').toHaveAttribute('scope', 'col');
+    });
+
     it('should render `assigned to` header', () => {
       wrapper.expectText('[data-cy="tasks-table-header-assigned-to"]').toRead('Assigned to');
+    });
+
+    it('should set the `scope` attribute of the `assigned to` header to `col`', () => {
+      wrapper.expectElement('[data-cy="tasks-table-header-assigned-to"]').toHaveAttribute('scope', 'col');
     });
 
     it('should render `team` header', () => {
       wrapper.expectText('[data-cy="tasks-table-header-team"]').toRead('Team');
     });
 
+    it('should set the `scope` attribute of the `team` header to `col`', () => {
+      wrapper.expectElement('[data-cy="tasks-table-header-team"]').toHaveAttribute('scope', 'col');
+    });
+
     it('should render `date started` header', () => {
       wrapper.expectText('[data-cy="tasks-table-header-date-started"]').toRead('Date started');
     });
 
+    it('should set the `scope` attribute of the `date started` header to `col`', () => {
+      wrapper.expectElement('[data-cy="tasks-table-header-date-started"]').toHaveAttribute('scope', 'col');
+    });
+
     it('should render `date completed` header', () => {
       wrapper.expectText('[data-cy="tasks-table-header-date-completed"]').toRead('Date completed');
+    });
+
+    it('should set the `scope` attribute of the `date completed` header to `col`', () => {
+      wrapper.expectElement('[data-cy="tasks-table-header-date-completed"]').toHaveAttribute('scope', 'col');
+    });
+
+    it('should render `status` header', () => {
+      wrapper.expectText('[data-cy="tasks-table-header-status"]').toRead('Status');
+    });
+
+    it('should set the `scope` attribute of the `status` header to `col`', () => {
+      wrapper.expectElement('[data-cy="tasks-table-header-status"]').toHaveAttribute('scope', 'col');
     });
   });
 

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.component-test.js
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.component-test.js
@@ -63,52 +63,22 @@ describe(component, () => {
   });
 
   describe('table headers', () => {
-    it('should render `task` header', () => {
-      wrapper.expectText('[data-cy="tasks-table-header-task"]').toRead('Task');
-    });
+    describe.each([
+      ['Task', 'tasks-table-header-task'],
+      ['Assigned to', 'tasks-table-header-assigned-to'],
+      ['Team', 'tasks-table-header-team'],
+      ['Date started', 'tasks-table-header-date-started'],
+      ['Date completed', 'tasks-table-header-date-completed'],
+      ['Status', 'tasks-table-header-status'],
+    ])('`%s` header', (headerText, dataCy) => {
 
-    it('should set the `scope` attribute of the `task` header to `col`', () => {
-      wrapper.expectElement('[data-cy="tasks-table-header-task"]').toHaveAttribute('scope', 'col');
-    });
-
-    it('should render `assigned to` header', () => {
-      wrapper.expectText('[data-cy="tasks-table-header-assigned-to"]').toRead('Assigned to');
-    });
-
-    it('should set the `scope` attribute of the `assigned to` header to `col`', () => {
-      wrapper.expectElement('[data-cy="tasks-table-header-assigned-to"]').toHaveAttribute('scope', 'col');
-    });
-
-    it('should render `team` header', () => {
-      wrapper.expectText('[data-cy="tasks-table-header-team"]').toRead('Team');
-    });
-
-    it('should set the `scope` attribute of the `team` header to `col`', () => {
-      wrapper.expectElement('[data-cy="tasks-table-header-team"]').toHaveAttribute('scope', 'col');
-    });
-
-    it('should render `date started` header', () => {
-      wrapper.expectText('[data-cy="tasks-table-header-date-started"]').toRead('Date started');
-    });
-
-    it('should set the `scope` attribute of the `date started` header to `col`', () => {
-      wrapper.expectElement('[data-cy="tasks-table-header-date-started"]').toHaveAttribute('scope', 'col');
-    });
-
-    it('should render `date completed` header', () => {
-      wrapper.expectText('[data-cy="tasks-table-header-date-completed"]').toRead('Date completed');
-    });
-
-    it('should set the `scope` attribute of the `date completed` header to `col`', () => {
-      wrapper.expectElement('[data-cy="tasks-table-header-date-completed"]').toHaveAttribute('scope', 'col');
-    });
-
-    it('should render `status` header', () => {
-      wrapper.expectText('[data-cy="tasks-table-header-status"]').toRead('Status');
-    });
-
-    it('should set the `scope` attribute of the `status` header to `col`', () => {
-      wrapper.expectElement('[data-cy="tasks-table-header-status"]').toHaveAttribute('scope', 'col');
+      it('should render the header', () => {
+        wrapper.expectText(`[data-cy="${dataCy}"]`).toRead(headerText);
+      });
+  
+      it('should set the `scope` attribute of the header to `col`', () => {
+        wrapper.expectElement(`[data-cy="${dataCy}"]`).toHaveAttribute('scope', 'col');
+      });
     });
   });
 

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.njk
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/tasks-table.njk
@@ -16,12 +16,12 @@
 
           <thead class="govuk-table__head">
             <tr>
-              <th class="govuk-table__header govuk-body-s"></th>
-              <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-assigned-to">Assigned to</th>
-              <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-team">Team</th>
-              <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-started">Date started</th>
-              <th class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-completed">Date completed</th>
-              <th class="govuk-table__header govuk-body-s"></th>
+              <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-task">Task</th>
+              <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-assigned-to">Assigned to</th>
+              <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-team">Team</th>
+              <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-started">Date started</th>
+              <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-date-completed">Date completed</th>
+              <th scope="col" class="govuk-table__header govuk-body-s" data-cy="tasks-table-header-status">Status</th>
             </tr>
           </thead>
 


### PR DESCRIPTION
## Introduction :pencil2:
The tables on the TFM deal tasks page are missing some column headers. This can make it difficult for a blind screen reader user to understand what the columns are showing.

## Resolution :heavy_check_mark:
- Added 'Task' and 'Status' headings to the deal tasks tables.
- Added tests for this change.

## Miscellaneous :heavy_plus_sign:
- Added the `scope` attribute to the table headers to denote them as columns, as according to https://design-system.service.gov.uk/components/table/ this helps users of assistive technology distinguish between row and column headers.

