### PR TITLE
fix(FN-1686): update error copy for large file

### DIFF
--- a/portal/server/routes/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/routes/utilisation-report-service/utilisation-report-upload/index.js
@@ -29,7 +29,7 @@ router.post(
       }
       if (error.code === 'LIMIT_FILE_SIZE') {
         res.locals.fileUploadError = {
-          text: `File too large, must be smaller than ${formatBytes(parseInt(MAX_UTILISATION_REPORT_FILE_SIZE, 10))}`,
+          text: `The selected file must be smaller than ${formatBytes(parseInt(MAX_UTILISATION_REPORT_FILE_SIZE, 10))}`,
         };
       } else {
         res.locals.fileUploadError = {


### PR DESCRIPTION
## Introduction :pencil2:
Needed to update the copy to match designs when a large file was uploaded

## Resolution :heavy_check_mark:
Updated the file too large copy
