### PR TITLE
fix(DTFS-6466): accessibility - added text for screen readers to make input field prefix/suffix known

### DIFF
--- a/trade-finance-manager-ui/component-tests/case/underwriting/loss-given-default.component-test.js
+++ b/trade-finance-manager-ui/component-tests/case/underwriting/loss-given-default.component-test.js
@@ -25,7 +25,7 @@ describe(page, () => {
   describe('loss given default', () => {
     it('should render page label heading', () => {
       wrapper.expectText('[data-cy="label-heading"]').toRead(
-        `What’s the loss given default (LGD) for ${params.deal.submissionDetails.supplierName}`,
+        `What’s the loss given default (LGD) for ${params.deal.submissionDetails.supplierName}<span class="govuk-visually-hidden">&nbsp;in %</span>?`,
       );
     });
 

--- a/trade-finance-manager-ui/component-tests/case/underwriting/loss-given-default.component-test.js
+++ b/trade-finance-manager-ui/component-tests/case/underwriting/loss-given-default.component-test.js
@@ -25,7 +25,7 @@ describe(page, () => {
   describe('loss given default', () => {
     it('should render page label heading', () => {
       wrapper.expectText('[data-cy="label-heading"]').toRead(
-        `What’s the loss given default (LGD) for ${params.deal.submissionDetails.supplierName}<span class="govuk-visually-hidden">&nbsp;in %</span>?`,
+        `What’s the loss given default (LGD) for ${params.deal.submissionDetails.supplierName} in %?`,
       );
     });
 

--- a/trade-finance-manager-ui/component-tests/case/underwriting/probability-of-default.component-test.js
+++ b/trade-finance-manager-ui/component-tests/case/underwriting/probability-of-default.component-test.js
@@ -25,7 +25,7 @@ describe(page, () => {
   describe('loss given default', () => {
     it('should render page label heading', () => {
       wrapper.expectText('[data-cy="label-heading"]').toRead(
-        `What’s the probability of default for ${params.deal.submissionDetails.supplierName}?`,
+        `What’s the probability of default for ${params.deal.submissionDetails.supplierName}'<span class="govuk-visually-hidden">&nbsp;in %</span>?`,
       );
     });
 

--- a/trade-finance-manager-ui/component-tests/case/underwriting/probability-of-default.component-test.js
+++ b/trade-finance-manager-ui/component-tests/case/underwriting/probability-of-default.component-test.js
@@ -25,7 +25,7 @@ describe(page, () => {
   describe('loss given default', () => {
     it('should render page label heading', () => {
       wrapper.expectText('[data-cy="label-heading"]').toRead(
-        `What’s the probability of default for ${params.deal.submissionDetails.supplierName}'<span class="govuk-visually-hidden">&nbsp;in %</span>?`,
+        `What’s the probability of default for ${params.deal.submissionDetails.supplierName} in %?`,
       );
     });
 

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-facility-value.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-facility-value.njk
@@ -32,7 +32,7 @@
       id: "facilityValue",
       name: "value",
       label: {
-        text: "New facility value",
+        html: 'New facility value <span class="govuk-visually-hidden">in ' + currency + '</span>',
         classes: "govuk-label--s",
         isPageHeading: false
       },

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/loss-given-default.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/loss-given-default.njk
@@ -26,11 +26,11 @@
 
         <form method="POST" autocomplete="off">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% set labelText = 'What’s the loss given default (LGD) for ' + deal.submissionDetails.supplierName %}
+          {% set labelText = 'What’s the loss given default (LGD) for ' + deal.submissionDetails.supplierName + '<span class="govuk-visually-hidden">&nbsp;in %</span>?' %}
 
           {{ govukInput({
             label: {
-              text: labelText,
+              html: labelText,
               isPageHeading: true,
               classes: "govuk-label--l",
               attributes: {

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/loss-given-default.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/loss-given-default.njk
@@ -26,7 +26,7 @@
 
         <form method="POST" autocomplete="off">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% set labelText = 'What’s the loss given default (LGD) for ' + deal.submissionDetails.supplierName + '<span class="govuk-visually-hidden">&nbsp;in %</span>?' %}
+          {% set labelText = 'What’s the loss given default (LGD) for ' + deal.submissionDetails.supplierName + '<span class="govuk-visually-hidden"> in %</span>?' %}
 
           {{ govukInput({
             label: {

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/probability-of-default.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/probability-of-default.njk
@@ -26,11 +26,11 @@
 
         <form method="POST" autocomplete="off">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% set labelText = 'What’s the probability of default for ' + deal.submissionDetails.supplierName + '?'%}
+          {% set labelText = 'What’s the probability of default for ' + deal.submissionDetails.supplierName + '<span class="govuk-visually-hidden">&nbsp;in %</span>?' %}
 
           {{ govukInput({
             label: {
-              text: labelText,
+              html: labelText,
               isPageHeading: true,
               classes: "govuk-label--l",
               attributes: {

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/probability-of-default.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/probability-of-default.njk
@@ -26,7 +26,7 @@
 
         <form method="POST" autocomplete="off">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-          {% set labelText = 'What’s the probability of default for ' + deal.submissionDetails.supplierName + '<span class="govuk-visually-hidden">&nbsp;in %</span>?' %}
+          {% set labelText = 'What’s the probability of default for ' + deal.submissionDetails.supplierName + '<span class="govuk-visually-hidden"> in %</span>?' %}
 
           {{ govukInput({
             label: {


### PR DESCRIPTION
## Introduction :pencil2:
Input field in `govukInput` component can have prefix and suffix, but it is not read by screen readers.

## Resolution :heavy_check_mark:
Added:
  - `<span class="govuk-visually-hidden"> in ' + currency + '</span>'` 
  - `<span class="govuk-visually-hidden"> in %</span>?'`


