### PR TITLE
fix: fix about-facility UI test failing after 5/12/2023

### DIFF
--- a/gef-ui/server/controllers/about-facility/index.test.js
+++ b/gef-ui/server/controllers/about-facility/index.test.js
@@ -100,7 +100,7 @@ describe('controllers/about-facility', () => {
     const tomorrow = add(now, { days: 1 });
     const yesterday = sub(now, { days: 1 });
     const threeMonthsAndOneDayFromNow = add(now, { months: 3, days: 1 });
-    const oneDayoneDayLessThanThreeMonthsFromNow = sub(add(now, { months: 3 }), { days: 1 });
+    const oneDayLessThanThreeMonthsFromNow = sub(add(now, { months: 3 }), { days: 1 });
 
     it('redirects user to application page if save and return is set to true', async () => {
       mockRequest.query.saveAndReturn = 'true';
@@ -326,9 +326,9 @@ describe('controllers/about-facility', () => {
       mockRequest.body.facilityType = CONSTANTS.FACILITY_TYPE.CASH;
       mockRequest.body.hasBeenIssued = 'true';
       mockRequest.body.shouldCoverStartOnSubmission = 'false';
-      mockRequest.body['cover-start-date-day'] = format(oneDayoneDayLessThanThreeMonthsFromNow, 'd');
-      mockRequest.body['cover-start-date-month'] = format(oneDayoneDayLessThanThreeMonthsFromNow, 'M');
-      mockRequest.body['cover-start-date-year'] = format(oneDayoneDayLessThanThreeMonthsFromNow, 'yyyy');
+      mockRequest.body['cover-start-date-day'] = format(oneDayLessThanThreeMonthsFromNow, 'd');
+      mockRequest.body['cover-start-date-month'] = format(oneDayLessThanThreeMonthsFromNow, 'M');
+      mockRequest.body['cover-start-date-year'] = format(oneDayLessThanThreeMonthsFromNow, 'yyyy');
 
       await validateAboutFacility(mockRequest, mockResponse);
 
@@ -671,12 +671,9 @@ describe('controllers/about-facility', () => {
       mockRequest.body.shouldCoverStartOnSubmission = 'true';
       mockRequest.body.hasBeenIssued = 'true';
       mockRequest.body.monthsOfCover = '10';
-      mockRequest.body['cover-start-date-day'] = '01';
-      mockRequest.body['cover-start-date-month'] = '05';
-      mockRequest.body['cover-start-date-year'] = '2022';
-      mockRequest.body['cover-end-date-day'] = '05';
-      mockRequest.body['cover-end-date-month'] = '12';
-      mockRequest.body['cover-end-date-year'] = '2023';
+      mockRequest.body['cover-end-date-day'] = format(threeMonthsAndOneDayFromNow, 'd');
+      mockRequest.body['cover-end-date-month'] = format(threeMonthsAndOneDayFromNow, 'M');
+      mockRequest.body['cover-end-date-year'] = format(threeMonthsAndOneDayFromNow, 'yyyy');
 
       await validateAboutFacility(mockRequest, mockResponse);
 


### PR DESCRIPTION
## Introduction :pencil2:
The `controllers/about-facility > Validate About Facility > redirects user to provided facility page if all of method passes test in gef-ui/server/controllers/about-facility/index.test.js` started failing today.

The facility used by the test has `shouldCoverStartOnSubmission = true` so the cover start date is `5/12/2023` today. The cover end date for the facility is hard-coded to `5/12/2023`, and the cover end date has to be strictly after the cover start date, so the validation (and test) fails.

## Resolution :heavy_check_mark:
I've changed this test to always use a future date for the cover end date, so the test passes regardless of today's date.

## Miscellaneous :heavy_plus_sign:
I fixed a typo in one of the variables in the same test file.

