### PR TITLE
fix(DTFS2-6876): fix order dependency in Portal login journey E2E tests

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/login/login.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/login.spec.js
@@ -14,9 +14,11 @@ context('Login', () => {
   let bank1Maker1Id;
 
   beforeEach(() => {
-    cy.getUserByUsername(BANK1_MAKER1.username).then(({ _id }) => {
+    const { username } = BANK1_MAKER1;
+    cy.getUserByUsername(username).then(({ _id }) => {
       bank1Maker1Id = _id;
     });
+    cy.resetPortalUserStatusAndNumberOfSignInLinks(username);
     login.visit();
   });
 

--- a/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
@@ -3,6 +3,7 @@ const relative = require('../../relativeURL');
 const MOCK_USERS = require('../../../../../e2e-fixtures');
 
 const { BANK1_MAKER1 } = MOCK_USERS;
+const { username } = BANK1_MAKER1;
 const FIRST_SIGN_IN_TOKEN = '6569ca7a6fd828f925e07c6e';
 
 const userAnonymisedEmailAddress = 'm***1@ukexportfinance.gov.uk';
@@ -17,12 +18,15 @@ context('Resending sign in links', () => {
     let bank1Maker1Id;
 
     beforeEach(() => {
-      const { username } = BANK1_MAKER1;
       cy.getUserByUsername(username).then(({ _id }) => {
         bank1Maker1Id = _id;
       });
       cy.resetPortalUserStatusAndNumberOfSignInLinks(username);
       cy.enterUsernameAndPassword(BANK1_MAKER1);
+    });
+
+    after(() => {
+      cy.resetPortalUserStatusAndNumberOfSignInLinks(username);
     });
 
     it('Resending a sign in link invalidates the previous link', () => {

--- a/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
@@ -3,7 +3,6 @@ const relative = require('../../relativeURL');
 const MOCK_USERS = require('../../../../../e2e-fixtures');
 
 const { BANK1_MAKER1 } = MOCK_USERS;
-const { username } = BANK1_MAKER1;
 const FIRST_SIGN_IN_TOKEN = '6569ca7a6fd828f925e07c6e';
 
 const userAnonymisedEmailAddress = 'm***1@ukexportfinance.gov.uk';
@@ -18,15 +17,12 @@ context('Resending sign in links', () => {
     let bank1Maker1Id;
 
     beforeEach(() => {
+      const { username } = BANK1_MAKER1;
       cy.getUserByUsername(username).then(({ _id }) => {
         bank1Maker1Id = _id;
       });
       cy.resetPortalUserStatusAndNumberOfSignInLinks(username);
       cy.enterUsernameAndPassword(BANK1_MAKER1);
-    });
-
-    after(() => {
-      cy.resetPortalUserStatusAndNumberOfSignInLinks(username);
     });
 
     it('Resending a sign in link invalidates the previous link', () => {


### PR DESCRIPTION
## Introduction :pencil2:

Currently, `resend-sign-in-link.spec.js` in the Portal login journey E2E tests does not reset the user status and sign in link send count after running all of the tests. This creates an order dependency, whereby running `resend-sign-in-link.spec.js` first and then `login.spec.js` will cause the later to fail because the `BANK1_MAKER1` user is still blocked as a result of the first test suite.

## Resolution :heavy_check_mark:
- added an `after` block in `resend-sign-in-link.spec.js` to reset the `BANK1_MAKER1` after all the tests have run.
