### PR TITLE
fix(DTFS2-6672): check user authorisation when updating details

### DIFF
--- a/portal-api/api-tests/v1/users/users.api-test.js
+++ b/portal-api/api-tests/v1/users/users.api-test.js
@@ -1,5 +1,5 @@
 const databaseHelper = require('../../database-helper');
-const { setUpApiTestUser } = require('../../api-test-users');
+const testUserCache = require('../../api-test-users');
 
 const app = require('../../../src/createApp');
 const { as } = require('../../api')(app);
@@ -9,6 +9,8 @@ const { READ_ONLY, MAKER, CHECKER } = require('../../../src/v1/roles/roles');
 const { NON_READ_ONLY_ROLES } = require('../../../test-helpers/common-role-lists');
 const { LOGIN_STATUSES } = require('../../../src/constants');
 const { createPartiallyLoggedInUserSession, createLoggedInUserSession } = require('../../../test-helpers/api-test-helpers/database/user-repository');
+const { ADMIN } = require('../../../src/v1/roles/roles');
+const { STATUS } = require('../../../src/constants/user');
 
 const aMaker = users.find((user) => user.username === 'MAKER');
 const MOCK_USER = { ...aMaker, username: 'TEMPORARY_USER' };
@@ -20,11 +22,15 @@ const EMAIL_ERROR = { text: 'Enter an email address in the correct format, for e
 const READ_ONLY_ROLE_EXCLUSIVE_ERROR = { text: "You cannot combine 'Read-only' with any of the other roles" };
 
 describe('a user', () => {
-  let loggedInUser;
+  let aNonAdmin;
+  let anAdmin;
 
   beforeAll(async () => {
     await databaseHelper.wipe(['users']);
-    loggedInUser = await setUpApiTestUser(as);
+    const testUsers = await testUserCache.initialise(app);
+    anAdmin = testUsers().withRole(ADMIN).one();
+    aNonAdmin = testUsers().withoutRole(ADMIN).one();
+    // aNonAdmin = await setUpApiTestUser(as);
   });
 
   beforeEach(async () => {
@@ -129,27 +135,23 @@ describe('a user', () => {
 
     it('creates the user if all provided data is valid', async () => {
       await createUser(MOCK_USER);
-      const { status, body } = await as(loggedInUser).get('/v1/users');
+      const { status, body } = await as(aNonAdmin).get('/v1/users');
 
       expect(status).toEqual(200);
-      expect(body).toEqual({
+      expect(body).toStrictEqual(expect.objectContaining({
         success: true,
-        count: 2,
-        users: [
-          expect.objectContaining({ username: loggedInUser.username }),
-          {
-            username: MOCK_USER.username,
-            email: MOCK_USER.email,
-            roles: MOCK_USER.roles,
-            bank: MOCK_USER.bank,
-            _id: expect.any(String),
-            firstname: MOCK_USER.firstname,
-            surname: MOCK_USER.surname,
-            timezone: 'Europe/London',
-            'user-status': 'active',
-          },
-        ],
-      });
+        users: expect.arrayContaining([{
+          username: MOCK_USER.username,
+          email: MOCK_USER.email,
+          roles: MOCK_USER.roles,
+          bank: MOCK_USER.bank,
+          _id: expect.any(String),
+          firstname: MOCK_USER.firstname,
+          surname: MOCK_USER.surname,
+          timezone: 'Europe/London',
+          'user-status': 'active',
+        }])
+      }));
     });
 
     it('User already exists', async () => {
@@ -182,10 +184,10 @@ describe('a user', () => {
       };
 
       await createUser(newUser);
-      const { status, body } = await as(loggedInUser).get('/v1/users');
+      const { status, body } = await as(aNonAdmin).get('/v1/users');
 
       expect(status).toEqual(200);
-      expect(body.users[1].roles).toStrictEqual([READ_ONLY, READ_ONLY]);
+      expect(body.users.find((user) => user.username === 'TEMPORARY_USER').roles).toStrictEqual([READ_ONLY, READ_ONLY]);
     });
 
     it('creates the user the user creation request has the read-only role only', async () => {
@@ -195,75 +197,138 @@ describe('a user', () => {
       };
 
       await createUser(newUser);
-      const { status, body } = await as(loggedInUser).get('/v1/users');
+      const { status, body } = await as(aNonAdmin).get('/v1/users');
 
       expect(status).toEqual(200);
-      expect(body.users[1].roles).toStrictEqual([READ_ONLY]);
+      expect(body.users.find((user) => user.username === 'TEMPORARY_USER').roles).toStrictEqual([READ_ONLY]);
     });
   });
 
   describe('PUT /v1/users', () => {
-    it('a user can be updated', async () => {
-      const response = await createUser(MOCK_USER);
-      const createdUser = response.body.user;
+    describe('as admin', () => {
+      it('a user\'s details can be updated', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
 
-      const updatedUserCredentials = {
-        roles: [CHECKER, MAKER],
-      };
+        const updatedUserCredentials = {
+          roles: [CHECKER, MAKER],
+          firstname: 'NEW_FIRSTNAME',
+          surname: 'NEW_SURNAME',
+          'user-status': STATUS.BLOCKED,
+          password: 'AbC1234!'
+        };
 
-      await as(loggedInUser).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+        await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
 
-      const { status, body } = await as(loggedInUser).get(`/v1/users/${createdUser._id}`);
+        const { status, body } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
 
-      expect(status).toEqual(200);
-      expect(body.roles).toEqual([CHECKER, MAKER]);
+        expect(status).toEqual(200);
+        expect(body).toStrictEqual(expect.objectContaining({
+          roles: [CHECKER, MAKER],
+          firstname: 'NEW_FIRSTNAME',
+          surname: 'NEW_SURNAME',
+          'user-status': STATUS.BLOCKED,
+        }));
+      });
+
+      it.each(NON_READ_ONLY_ROLES)('rejects if the user update request has the read-only role with the %s role', async (otherRole) => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
+
+        const updatedUserCredentials = {
+          roles: [READ_ONLY, otherRole],
+        };
+
+        const { status, body } = await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+
+        expect(status).toEqual(400);
+        expect(body.success).toEqual(false);
+        expect(body.errors.errorList.roles).toStrictEqual(READ_ONLY_ROLE_EXCLUSIVE_ERROR);
+      });
+
+      it('updates the user if the user update request has the read-only role only', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
+
+        const updatedUserCredentials = {
+          roles: [READ_ONLY],
+        };
+
+        await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+
+        const { status, body } = await as(anAdmin).get(`/v1/users/${createdUser._id}`);
+
+        expect(status).toEqual(200);
+        expect(body.roles).toEqual([READ_ONLY]);
+      });
+
+      it('updates the user if the user update request has the read-only role repeated', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
+
+        const updatedUserCredentials = {
+          roles: [READ_ONLY, READ_ONLY],
+        };
+
+        await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+
+        const { status, body } = await as(anAdmin).get(`/v1/users/${createdUser._id}`);
+
+        expect(status).toEqual(200);
+        expect(body.roles).toStrictEqual([READ_ONLY, READ_ONLY]);
+      });
     });
+    describe('as non-admin', () => {
+      it('a user can update their own password', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
 
-    it.each(NON_READ_ONLY_ROLES)('rejects if the user update request has the read-only role with the %s role', async (otherRole) => {
-      const response = await createUser(MOCK_USER);
-      const createdUser = response.body.user;
+        const updatedUserCredentials = {
+          currentPassword: 'AbC!2345',
+          password: 'AbC1234!',
+          passwordConfirm: 'AbC1234!'
+        };
 
-      const updatedUserCredentials = {
-        roles: [READ_ONLY, otherRole],
-      };
+        await as(createdUser).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
 
-      const { status, body } = await as(loggedInUser).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+        const { status } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
 
-      expect(status).toEqual(400);
-      expect(body.success).toEqual(false);
-      expect(body.errors.errorList.roles).toStrictEqual(READ_ONLY_ROLE_EXCLUSIVE_ERROR);
-    });
+        expect(status).toEqual(200);
+        // Should check new password works
+      });
 
-    it('updates the user if the user update request has the read-only role only', async () => {
-      const response = await createUser(MOCK_USER);
-      const createdUser = response.body.user;
+      it('a user cannot update their role', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
 
-      const updatedUserCredentials = {
-        roles: [READ_ONLY],
-      };
+        const updatedUserCredentials = {
+          roles: [CHECKER, MAKER],
+        };
 
-      await as(loggedInUser).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+        await as(createdUser).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
 
-      const { status, body } = await as(loggedInUser).get(`/v1/users/${createdUser._id}`);
+        const { status, body } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
 
-      expect(status).toEqual(200);
-      expect(body.roles).toEqual([READ_ONLY]);
-    });
+        expect(status).toEqual(200);
+        expect(body.roles).toEqual(MOCK_USER.roles);
+      });
 
-    it('updates the user if the user update request has the read-only role repeated', async () => {
-      const response = await createUser(MOCK_USER);
-      const createdUser = response.body.user;
+      it('a non-admin cannot change someone elses password', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
 
-      const updatedUserCredentials = {
-        roles: [READ_ONLY, READ_ONLY],
-      };
+        const updatedUserCredentials = {
+          currentPassword: 'AbC!2345',
+          password: 'AbC1234!',
+          passwordConfirm: 'AbC1234!'
+        };
 
-      await as(loggedInUser).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+        await as(aNonAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
 
-      const { status, body } = await as(loggedInUser).get(`/v1/users/${createdUser._id}`);
+        const { status } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
 
-      expect(status).toEqual(200);
-      expect(body.roles).toStrictEqual([READ_ONLY, READ_ONLY]);
+        expect(status).toEqual(403);
+      });
     });
   });
 
@@ -272,9 +337,9 @@ describe('a user', () => {
       const response = await createUser(MOCK_USER);
       const createdUser = response.body.user;
 
-      await as(loggedInUser).remove(`/v1/users/${createdUser._id}`);
+      await as(aNonAdmin).remove(`/v1/users/${createdUser._id}`);
 
-      const { status, body } = await as(loggedInUser).get(`/v1/users/${createdUser._id}`);
+      const { status, body } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
 
       expect(status).toEqual(200);
       expect(body).toMatchObject({});
@@ -286,9 +351,9 @@ describe('a user', () => {
       const response = await createUser(MOCK_USER);
       const createdUser = response.body.user;
 
-      await as(loggedInUser).remove(`/v1/users/${createdUser._id}/disable`);
+      await as(aNonAdmin).remove(`/v1/users/${createdUser._id}/disable`);
 
-      const { status, body } = await as(loggedInUser).get(`/v1/users/${createdUser._id}`);
+      const { status, body } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
 
       expect(status).toEqual(200);
       expect(body).toMatchObject({
@@ -319,7 +384,7 @@ describe('a user', () => {
     it('a disabled user cannot log in', async () => {
       const response = await createUser(MOCK_USER);
       const createdUser = response.body.user;
-      await as(loggedInUser).remove(`/v1/users/${createdUser._id}/disable`);
+      await as(aNonAdmin).remove(`/v1/users/${createdUser._id}/disable`);
 
       const { username, password } = MOCK_USER;
       const { status, body } = await as().post({ username, password }).to('/v1/login');
@@ -386,11 +451,11 @@ describe('a user', () => {
 
   it('User already exists', async () => {
     // User creation - first instance
-    const first = await as(loggedInUser).post(MOCK_USER).to('/v1/users');
+    const first = await as(aNonAdmin).post(MOCK_USER).to('/v1/users');
     expect(first.status).toEqual(200);
 
     // User creation - second instance
-    const second = await as(loggedInUser).post(MOCK_USER).to('/v1/users');
+    const second = await as(aNonAdmin).post(MOCK_USER).to('/v1/users');
     expect(second.status).toEqual(400);
   });
 
@@ -420,7 +485,7 @@ describe('a user', () => {
     it('a disabled user cannot log in', async () => {
       const response = await createUser(MOCK_USER);
       const createdUser = response.body.user;
-      await as(loggedInUser).remove(`/v1/users/${createdUser._id}/disable`);
+      await as(aNonAdmin).remove(`/v1/users/${createdUser._id}/disable`);
 
       const { username, password } = MOCK_USER;
       const { status, body } = await as().post({ username, password }).to('/v1/login');
@@ -486,6 +551,6 @@ describe('a user', () => {
   });
 
   async function createUser(userToCreate) {
-    return as(loggedInUser).post(userToCreate).to('/v1/users');
+    return as(aNonAdmin).post(userToCreate).to('/v1/users');
   }
 });

--- a/portal-api/api-tests/v1/users/users.api-test.js
+++ b/portal-api/api-tests/v1/users/users.api-test.js
@@ -30,7 +30,6 @@ describe('a user', () => {
     const testUsers = await testUserCache.initialise(app);
     anAdmin = testUsers().withRole(ADMIN).one();
     aNonAdmin = testUsers().withoutRole(ADMIN).one();
-    // aNonAdmin = await setUpApiTestUser(as);
   });
 
   beforeEach(async () => {
@@ -214,21 +213,35 @@ describe('a user', () => {
           roles: [CHECKER, MAKER],
           firstname: 'NEW_FIRSTNAME',
           surname: 'NEW_SURNAME',
-          'user-status': STATUS.BLOCKED,
-          password: 'AbC1234!'
+          'user-status': STATUS.BLOCKED
         };
 
-        await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
-
-        const { status, body } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
+        const { status } = await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
 
         expect(status).toEqual(200);
-        expect(body).toStrictEqual(expect.objectContaining({
+
+        const { body } = await as(anAdmin).get(`/v1/users/${createdUser._id}`);
+
+        expect(body).toEqual(expect.objectContaining({
           roles: [CHECKER, MAKER],
           firstname: 'NEW_FIRSTNAME',
           surname: 'NEW_SURNAME',
           'user-status': STATUS.BLOCKED,
         }));
+      });
+
+      it('a user\'s password can be updated', async () => {
+        const response = await createUser(MOCK_USER);
+        const createdUser = response.body.user;
+
+        const updatedUserCredentials = {
+          password: 'AbC1234!',
+          passwordConfirm: 'AbC1234!'
+        };
+
+        const { status } = await as(anAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
+
+        expect(status).toEqual(200);
       });
 
       it.each(NON_READ_ONLY_ROLES)('rejects if the user update request has the read-only role with the %s role', async (otherRole) => {
@@ -323,9 +336,7 @@ describe('a user', () => {
           passwordConfirm: 'AbC1234!'
         };
 
-        await as(aNonAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
-
-        const { status } = await as(aNonAdmin).get(`/v1/users/${createdUser._id}`);
+        const { status } = await as(aNonAdmin).put(updatedUserCredentials).to(`/v1/users/${createdUser._id}`);
 
         expect(status).toEqual(403);
       });

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -182,8 +182,8 @@ module.exports.updateById = (req, res, next) => {
         res.status(404).send();
       }
     });
-  } else if (req.user._id === req.params._id) {
-    if (Object.keys(req.body).filter((property) => property !== 'password' && property !== 'passwordConfirm').length > 0) {
+  } else if (req.user._id.toString() === req.params._id) {
+    if (Object.keys(req.body).filter((property) => property !== 'password' && property !== 'passwordConfirm' && property !== 'currentPassword').length > 0) {
       res.status(403).send();
     } else {
       findOne(req.params._id, (error, user) => {

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -169,6 +169,7 @@ module.exports.updateById = (req, res, next) => {
         return next(error);
       }
       if (!user) {
+        console.error('Failed to find user with _id', req.params._id);
         return res.status(404).send();
       }
       const errors = applyUpdateRules(user, req.body);
@@ -190,7 +191,7 @@ module.exports.updateById = (req, res, next) => {
       });
     });
   } catch (e) {
-    console.error(e);
+    console.error('Error updating user', e);
     return res.status(500).send();
   }
 };

--- a/portal-api/src/v1/users/routes.test.js
+++ b/portal-api/src/v1/users/routes.test.js
@@ -28,6 +28,7 @@ const { update } = require('./controller');
 const { resetPasswordWithToken, loginWithSignInLink, updateById } = require('./routes');
 const utils = require('../../crypto/utils');
 const { ADMIN } = require('../roles/roles');
+const { USER } = require('../../constants');
 
 jest.mock('./reset-password.controller');
 jest.mock('./login.controller', () => ({
@@ -139,7 +140,7 @@ describe('users routes', () => {
       res.status.mockReturnThis();
     });
 
-    it('allows user to change their own details', () => {
+    it('allows user to change their own password', () => {
       const req = {
         params: {
           _id: '1234'
@@ -149,7 +150,8 @@ describe('users routes', () => {
           roles: []
         },
         body: {
-          _id: '1234'
+          password: 'AbC!234',
+          passwordConfirm: 'AbC!234'
         },
       };
 
@@ -160,7 +162,26 @@ describe('users routes', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('allows admin to change another users details', () => {
+    it('does not allow a user to change their status', () => {
+      const req = {
+        params: {
+          _id: '1234'
+        },
+        user: {
+          _id: '1234',
+          roles: []
+        },
+        body: {
+          'user-status': USER.STATUS.ACTIVE
+        },
+      };
+
+      updateById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+    });
+
+    it('allows admin to change another users status and password', () => {
       const req = {
         params: {
           _id: '1234'
@@ -170,7 +191,9 @@ describe('users routes', () => {
           roles: [ADMIN]
         },
         body: {
-          _id: '1234'
+          password: 'AbC!234',
+          passwordConfirm: 'AbC!234',
+          'user-status': USER.STATUS.ACTIVE
         },
       };
 
@@ -181,7 +204,7 @@ describe('users routes', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('does not allow a non-admin user to change someone elses details', () => {
+    it('does not allow a non-admin user to change someone elses password', () => {
       const req = {
         params: {
           _id: '1234'
@@ -191,7 +214,8 @@ describe('users routes', () => {
           roles: []
         },
         body: {
-          _id: '1234'
+          password: 'AbC!234',
+          passwordConfirm: 'AbC!234'
         },
       };
       updateById(req, res);


### PR DESCRIPTION
## Introduction :pencil2:
In `portal-api`,  `PUT /v1/users/:_id` does not check that the logged in user has the authorisation to update the details. Whilst the end-users shouldn't have direct access to the api this should still be added
## Resolution :heavy_check_mark:
* Check if the user has role `ADMIN` or is updating their own password
* Added api & unit tests

