### PR TITLE
feat(FN-1613): individual bank report page

### DIFF
--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.ts
@@ -5,8 +5,10 @@ import { MOCK_BANK_HOLIDAYS } from '../../test-mocks/mock-bank-holidays';
 import { MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY } from '../../test-mocks/mock-utilisation-report-reconciliation-summary';
 import { MOCK_TFM_SESSION_USER } from '../../test-mocks/mock-tfm-session-user';
 import { getReportReconciliationSummariesViewModel } from './helpers';
+import { PRIMARY_NAVIGATION_KEYS } from '../../constants';
 
 jest.mock('../../api');
+jest.mock('express-validator');
 
 console.error = jest.fn();
 
@@ -34,9 +36,8 @@ describe('controllers/utilisation-reports', () => {
       await getUtilisationReports(req, res);
 
       // Assert
-      /* eslint-disable no-underscore-dangle */
+      // eslint-disable-next-line no-underscore-dangle
       expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
-      /* eslint-enable no-underscore-dangle */
     });
 
     it('renders the utilisation-reports.njk view with required data', async () => {
@@ -63,7 +64,7 @@ describe('controllers/utilisation-reports', () => {
       /* eslint-disable no-underscore-dangle */
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-reports.njk');
       expect(res._getRenderData()).toMatchObject({
-        activePrimaryNavigation: 'utilisation reports',
+        activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
         reportPeriodSummaries: expectedViewModel,
       });
       /* eslint-enable no-underscore-dangle */

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-for-bank/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-for-bank/index.test.ts
@@ -1,0 +1,84 @@
+import httpMocks from 'node-mocks-http';
+import api from '../../../api';
+import { getUtilisationReportByBankId } from '.';
+import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user';
+import { MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY } from '../../../test-mocks/mock-utilisation-report-reconciliation-summary';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+import { getIsoMonth } from '../../../helpers/date';
+
+jest.mock('../../../api');
+jest.mock('../../../helpers/date');
+
+console.error = jest.fn();
+
+describe('controllers/utilisation-reports/utilisation-report-for-bank', () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getUtilisationReportByBankId', () => {
+    const session = {
+      user: MOCK_TFM_SESSION_USER,
+      userToken: 'user-token',
+    };
+
+    it("redirects to '/not-found' if reconciliation summary does not include the current submission month", async () => {
+      // Arrange
+      const bankId = '123';
+      const { req, res } = httpMocks.createMocks({
+        session, params: { bankId },
+      });
+
+      jest.mocked(api.getUtilisationReportsReconciliationSummary).mockResolvedValue([]);
+
+      // Act
+      await getUtilisationReportByBankId(req, res);
+    
+      // Assert
+      // eslint-disable-next-line no-underscore-dangle
+      expect(res._getRedirectUrl()).toEqual('/not-found');
+    });
+    
+    it("redirects to '/not-found' if reconciliation summary does not contain a report for the requested bank", async () => {
+      // Arrange
+      const bankId = '123';
+      const { req, res } = httpMocks.createMocks({
+        session, params: { bankId },
+      });
+
+      jest.mocked(api.getUtilisationReportsReconciliationSummary).mockResolvedValue(MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY);
+
+      // Act
+      await getUtilisationReportByBankId(req, res);
+    
+      // Assert
+      // eslint-disable-next-line no-underscore-dangle
+      expect(res._getRedirectUrl()).toEqual('/not-found');
+    });
+    
+    it("renders the 'utilisation-report-for-bank' page with the correct data", async () => {
+      // Arrange
+      const { submissionMonth } = MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY[0];
+      const { bank } = MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY[0].items[0];
+      const { req, res } = httpMocks.createMocks({
+        session, params: { bankId: bank.id },
+      });
+
+      jest.mocked(getIsoMonth).mockReturnValue(submissionMonth);
+      jest.mocked(api.getUtilisationReportsReconciliationSummary).mockResolvedValue(MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY);
+
+      // Act
+      await getUtilisationReportByBankId(req, res);
+    
+      // Assert
+      /* eslint-disable no-underscore-dangle */
+      expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-for-bank.njk');
+      expect(res._getRenderData()).toEqual({
+        user: MOCK_TFM_SESSION_USER,
+        activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+        bank,
+      });
+      /* eslint-enable no-underscore-dangle */
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-for-bank/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-for-bank/index.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import api from '../../../api';
+import { getIsoMonth } from '../../../helpers/date';
+import { asUserSession } from '../../../helpers/express-session';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+
+export const getUtilisationReportByBankId = async (req: Request, res: Response) => {
+  const { userToken, user } = asUserSession(req.session);
+  const { bankId } = req.params;
+
+  try {
+    const currentPeriodSubmissionMonth = getIsoMonth(new Date());
+    const reconciliationSummaryItems = await api.getUtilisationReportsReconciliationSummary(currentPeriodSubmissionMonth, userToken);
+    const bank = reconciliationSummaryItems
+      .find((summaryItem) => summaryItem.submissionMonth === currentPeriodSubmissionMonth)
+      ?.items.find((item) => item.bank.id === bankId)?.bank;
+    if (!bank) {
+      console.error(`Bank with id ${bankId} not found`);
+      return res.redirect('/not-found');
+    }
+
+    return res.render('utilisation-reports/utilisation-report-for-bank.njk', {
+      user,
+      activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+      bank,
+      // reportPeriod, // comes from new stuff Francesca is adding
+    });
+  } catch (error) {
+    console.error(`Error rendering utilisation reports for bank with id ${bankId}:`, error);
+    return res.render('_partials/problem-with-service.njk', { user });
+  }
+};


### PR DESCRIPTION
## Notes
Though the current target branch is `main-stbr-tfm-5`, this should be merged into a new feature branch for the `TFM-6` realease.

## Introduction :pencil2:
We want to allow `PDC_READ` and `PDC_RECONCILE` users to see the report data for a specific bank by clicking on that bank name. We want users to be routed to a page containing 4 tabs which are currently unpopulated. The page should have two headings - one for the bank name and one for the current report period.

EDIT: This PR now also addresses the changes required for FN-1603 (where a link to the bank's utilisation report page is only enabled if the bank report status is not `REPORT_NOT_RECEIVED` ie. if a report exists for that bank for the current report period). A screenshot has been added below to show that the link is only enabled if the report status is not `REPORT_NOT_RECEIVED`.

## Resolution :heavy_check_mark:
To TFM-UI:
- Adds a new `getUtilisationReportByBankId` controller
- Adds a new `/utilisation-reports/:submissionMonth/bank/:bankId` route
- Adds a new template
- Adds components tests

![FN-1613 (cropped)](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/c721d151-f197-4c51-843a-148692cabb6f)

![FN-1603 (cropped)](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/e1e1675f-d54f-41aa-a090-d823da6a467b)


