### PR TITLE
chore(DTFS2-6700): remove tfm search vulnerabilities

### DIFF
--- a/dtfs-central-api/.eslintrc.js
+++ b/dtfs-central-api/.eslintrc.js
@@ -26,7 +26,9 @@ module.exports = {
     'no-underscore-dangle': ['error', { allow: ['_id', '_csrf'] }],
     'import/no-named-as-default': 'off',
     'implicit-arrow-linebreak': 'off',
-    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.js', '**/*.spec.js', '**/webpack.*.js', '**/api-tests/**', '**/__mocks__/**'] }],
+    'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.{ts,js}', '**/*.spec.{ts,js}', '**/webpack.*.{ts,js}', '**/api-tests/**', '**/__mocks__/**'] }],
+    'import/extensions': 'off',
+    'import/prefer-default-export': 'off',
     'comma-dangle': 'off',
     'no-loop-func': 'off',
     'no-await-in-loop': 'off',
@@ -40,6 +42,11 @@ module.exports = {
   },
   ignorePatterns: ['**/node_modules/**'],
   parserOptions: baseParserOptions,
+  settings: {
+    'import/resolver': {
+      typescript: {}
+    }
+  },
   overrides: [
     {
       files: ['*.ts'],
@@ -56,6 +63,11 @@ module.exports = {
         project: './tsconfig.eslint.json',
         tsconfigRootDir: __dirname,
       },
+      rules: {
+        'consistent-return': 'off',
+        'import/extensions': 'off',
+        'import/prefer-default-export': 'off',
+      }
     },
   ],
 };

--- a/dtfs-central-api/api-test-common.jest.config.js
+++ b/dtfs-central-api/api-test-common.jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  preset: 'ts-jest',
   setupFilesAfterEnv: [
     './api-test-setup.jest.config.js',
   ],

--- a/dtfs-central-api/package-lock.json
+++ b/dtfs-central-api/package-lock.json
@@ -13,6 +13,7 @@
         "compression": "^1.7.4",
         "date-fns": "^2.30.0",
         "dotenv": "16.0.3",
+        "escape-string-regexp": "^4.0.0",
         "express": "4.18.2",
         "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^6.11.2",
@@ -4110,7 +4111,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/dtfs-central-api/package-lock.json
+++ b/dtfs-central-api/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-import": "^2.29.1",
         "jest": "29.5.0",
         "supertest": "6.3.3",
+        "ts-jest": "^29.1.1",
         "typescript": "^5.3.3"
       },
       "engines": {
@@ -3364,6 +3365,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -6438,6 +6451,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6504,6 +6523,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "node_modules/makeerror": {
@@ -6966,6 +6991,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.3",
@@ -8212,6 +8243,82 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
+      "integrity": "sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "^7.5.3",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -32,6 +32,7 @@
     "compression": "^1.7.4",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "escape-string-regexp": "^4.0.0",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.11.2",

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-import": "^2.29.1",
     "jest": "29.5.0",
     "supertest": "6.3.3",
+    "ts-jest": "^29.1.1",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/dtfs-central-api/src/helpers/escapeRegExp.ts
+++ b/dtfs-central-api/src/helpers/escapeRegExp.ts
@@ -1,1 +1,0 @@
-export const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/dtfs-central-api/src/helpers/escapeRegExp.ts
+++ b/dtfs-central-api/src/helpers/escapeRegExp.ts
@@ -1,3 +1,1 @@
-/* eslint-disable import/prefer-default-export */
-
 export const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/dtfs-central-api/src/helpers/escapeRegExp.ts
+++ b/dtfs-central-api/src/helpers/escapeRegExp.ts
@@ -1,0 +1,3 @@
+/* eslint-disable import/prefer-default-export */
+
+export const escapeRegExp = (string: string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const escapeStringRegexp = require('escape-string-regexp');
 const db = require('../../../../drivers/db-client');
 const CONSTANTS = require('../../../../constants');
 const getObjectPropertyValueFromStringPath = require('../../../../utils/getObjectPropertyValueFromStringPath');
@@ -8,7 +9,6 @@ const {
   isTimestampField,
   dayStartAndEndTimestamps,
 } = require('./tfm-get-deals-date-helpers');
-const { escapeRegExp } = require('../../../../helpers/escapeRegExp');
 
 const sortDeals = (deals, sortBy) =>
   deals.sort((xDeal, yDeal) => {
@@ -70,7 +70,7 @@ const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
       dateString = String(moment(date).format('DD-MM-YYYY'));
     }
 
-    const searchStringRegex = escapeRegExp(searchString);
+    const searchStringRegex = escapeStringRegexp(searchString);
 
     const query = {
       $or: [
@@ -87,9 +87,9 @@ const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
     };
 
     if (dateString) {
-      const dateStringRegex = escapeRegExp(dateString);
+      const dateStringEscaped = escapeStringRegexp(dateString);
       query.$or.push({
-        'tfm.dateReceived': { $regex: dateStringRegex, $options: 'i' },
+        'tfm.dateReceived': { $regex: dateStringEscaped, $options: 'i' },
       });
     }
 

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
@@ -8,7 +8,7 @@ const {
   isTimestampField,
   dayStartAndEndTimestamps,
 } = require('./tfm-get-deals-date-helpers');
-const { escapeRegExp } = require('../../../../helpers/escapeRegExp.ts');
+const { escapeRegExp } = require('../../../../helpers/escapeRegExp');
 
 const sortDeals = (deals, sortBy) =>
   deals.sort((xDeal, yDeal) => {

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
@@ -8,6 +8,7 @@ const {
   isTimestampField,
   dayStartAndEndTimestamps,
 } = require('./tfm-get-deals-date-helpers');
+const { escapeRegExp } = require('../../../../helpers/escapeRegExp.ts');
 
 const sortDeals = (deals, sortBy) =>
   deals.sort((xDeal, yDeal) => {
@@ -47,8 +48,6 @@ const sortDeals = (deals, sortBy) =>
 
     return 0;
   });
-
-const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
   const dealsCollection = await db.getCollection('tfm-deals');

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
@@ -71,15 +71,15 @@ const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
 
     const query = {
       $or: [
-        { 'dealSnapshot.details.ukefDealId': { $regex: searchString, $options: 'i' } }, // BSS
-        { 'dealSnapshot.ukefDealId': { $regex: searchString, $options: 'i' } }, // GEF
-        { 'dealSnapshot.bank.name': { $regex: searchString, $options: 'i' } },
-        { 'dealSnapshot.submissionDetails.supplier-name': { $regex: searchString, $options: 'i' } },
-        { 'dealSnapshot.exporter.companyName': { $regex: searchString, $options: 'i' } },
-        { 'dealSnapshot.submissionType': { $regex: searchString, $options: 'i' } },
-        { 'dealSnapshot.submissionDetails.buyer-name': { $regex: searchString, $options: 'i' } },
-        { 'tfm.stage': { $regex: searchString, $options: 'i' } },
-        { 'tfm.product': { $regex: searchString, $options: 'i' } },
+        { 'dealSnapshot.details.ukefDealId': { $text: { $search: searchString }, $options: 'i' } }, // BSS
+        { 'dealSnapshot.ukefDealId': { $text: { $search: searchString }, $options: 'i' } }, // GEF
+        { 'dealSnapshot.bank.name': { $text: { $search: searchString }, $options: 'i' } },
+        { 'dealSnapshot.submissionDetails.supplier-name': { $text: { $search: searchString }, $options: 'i' } },
+        { 'dealSnapshot.exporter.companyName': { $text: { $search: searchString }, $options: 'i' } },
+        { 'dealSnapshot.submissionType': { $text: { $search: searchString }, $options: 'i' } },
+        { 'dealSnapshot.submissionDetails.buyer-name': { $text: { $search: searchString }, $options: 'i' } },
+        { 'tfm.stage': { $text: { $search: searchString }, $options: 'i' } },
+        { 'tfm.product': { $text: { $search: searchString }, $options: 'i' } },
       ],
     };
 

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deals.controller.js
@@ -48,6 +48,8 @@ const sortDeals = (deals, sortBy) =>
     return 0;
   });
 
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
   const dealsCollection = await db.getCollection('tfm-deals');
 
@@ -69,23 +71,26 @@ const findDeals = async (searchString, sortBy, fieldQueries, callback) => {
       dateString = String(moment(date).format('DD-MM-YYYY'));
     }
 
+    const searchStringRegex = escapeRegExp(searchString);
+
     const query = {
       $or: [
-        { 'dealSnapshot.details.ukefDealId': { $text: { $search: searchString }, $options: 'i' } }, // BSS
-        { 'dealSnapshot.ukefDealId': { $text: { $search: searchString }, $options: 'i' } }, // GEF
-        { 'dealSnapshot.bank.name': { $text: { $search: searchString }, $options: 'i' } },
-        { 'dealSnapshot.submissionDetails.supplier-name': { $text: { $search: searchString }, $options: 'i' } },
-        { 'dealSnapshot.exporter.companyName': { $text: { $search: searchString }, $options: 'i' } },
-        { 'dealSnapshot.submissionType': { $text: { $search: searchString }, $options: 'i' } },
-        { 'dealSnapshot.submissionDetails.buyer-name': { $text: { $search: searchString }, $options: 'i' } },
-        { 'tfm.stage': { $text: { $search: searchString }, $options: 'i' } },
-        { 'tfm.product': { $text: { $search: searchString }, $options: 'i' } },
+        { 'dealSnapshot.details.ukefDealId': { $regex: searchStringRegex, $options: 'i' } }, // BSS
+        { 'dealSnapshot.ukefDealId': { $regex: searchStringRegex, $options: 'i' } }, // GEF
+        { 'dealSnapshot.bank.name': { $regex: searchStringRegex, $options: 'i' } },
+        { 'dealSnapshot.submissionDetails.supplier-name': { $regex: searchStringRegex, $options: 'i' } },
+        { 'dealSnapshot.exporter.companyName': { $regex: searchStringRegex, $options: 'i' } },
+        { 'dealSnapshot.submissionType': { $regex: searchStringRegex, $options: 'i' } },
+        { 'dealSnapshot.submissionDetails.buyer-name': { $regex: searchStringRegex, $options: 'i' } },
+        { 'tfm.stage': { $regex: searchStringRegex, $options: 'i' } },
+        { 'tfm.product': { $regex: searchStringRegex, $options: 'i' } },
       ],
     };
 
     if (dateString) {
+      const dateStringRegex = escapeRegExp(dateString);
       query.$or.push({
-        'tfm.dateReceived': { $regex: dateString, $options: 'i' },
+        'tfm.dateReceived': { $regex: dateStringRegex, $options: 'i' },
       });
     }
 

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
@@ -1,6 +1,6 @@
 const { ObjectId } = require('mongodb');
+const escapeStringRegexp = require('escape-string-regexp');
 const db = require('../../../../drivers/db-client');
-const { escapeRegExp } = require('../../../../helpers/escapeRegExp');
 
 exports.getFacilitiesByDealId = async (req, res) => {
   const { id: dealId } = req.params;
@@ -19,7 +19,7 @@ exports.getFacilitiesByDealId = async (req, res) => {
 
 exports.getAllFacilities = async (req, res) => {
   const collection = await db.getCollection('tfm-facilities');
-  const searchStringRegExp = escapeRegExp(req.body.searchString || '');
+  const searchStringEscaped = escapeStringRegexp(req.body?.searchString || '');
 
   /**
    * mongodb query that returns an array of objects with the following format:
@@ -102,13 +102,13 @@ exports.getAllFacilities = async (req, res) => {
         $or: [
           {
             ukefFacilityId: {
-              $regex: searchStringRegExp,
+              $regex: searchStringEscaped,
               $options: 'i'
             }
           },
           {
             companyName: {
-              $regex: searchStringRegExp,
+              $regex: searchStringEscaped,
               $options: 'i'
             }
           },

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
@@ -1,6 +1,6 @@
 const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
-const { escapeRegExp } = require('../../../../helpers/escapeRegExp.ts');
+const { escapeRegExp } = require('../../../../helpers/escapeRegExp');
 
 exports.getFacilitiesByDealId = async (req, res) => {
   const { id: dealId } = req.params;

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.js
@@ -1,5 +1,6 @@
 const { ObjectId } = require('mongodb');
 const db = require('../../../../drivers/db-client');
+const { escapeRegExp } = require('../../../../helpers/escapeRegExp.ts');
 
 exports.getFacilitiesByDealId = async (req, res) => {
   const { id: dealId } = req.params;
@@ -18,7 +19,7 @@ exports.getFacilitiesByDealId = async (req, res) => {
 
 exports.getAllFacilities = async (req, res) => {
   const collection = await db.getCollection('tfm-facilities');
-  const searchString = req.body.searchString || '';
+  const searchStringRegExp = escapeRegExp(req.body.searchString || '');
 
   /**
    * mongodb query that returns an array of objects with the following format:
@@ -101,13 +102,13 @@ exports.getAllFacilities = async (req, res) => {
         $or: [
           {
             ukefFacilityId: {
-              $regex: searchString,
+              $regex: searchStringRegExp,
               $options: 'i'
             }
           },
           {
             companyName: {
-              $regex: searchString,
+              $regex: searchStringRegExp,
               $options: 'i'
             }
           },


### PR DESCRIPTION
## Introduction :pencil2:
The search box in TFM shouldn't allow users to attack the database

## Resolution :heavy_check_mark:
In `dtfs-central-api` escape regex characters to prevent potential ReDOS attacks

## Miscellaneous :heavy_plus_sign:
[Attempted other ways attack the database, with no vulnerabilities found](https://ukef-dtfs.atlassian.net/browse/DTFS2-6700)

## Note ⚠️ 
This removes the ability to search the database with regex through the api. Whilst this shouldn't be used anywhere its potentially a breaking change