### PR TITLE
chore(DTFS2-6666): remove filter vulnerabilities

### DIFF
--- a/portal-api/api-tests/helpers/escapeOperators.api-test.js
+++ b/portal-api/api-tests/helpers/escapeOperators.api-test.js
@@ -44,7 +44,7 @@ describe('escapeOperators function', () => {
           'bank.id': '9',
         },
         {
-          OR: [{ age: 30 }, { city: 'London' }, { name: { REGEX: '.*ABC.*' } }],
+          OR: [{ age: 30 }, { city: 'London' }, { name: { KEYWORD: '.*ABC.*' } }],
         },
       ],
     };
@@ -54,7 +54,7 @@ describe('escapeOperators function', () => {
           'bank.id': { $eq: '9' },
         },
         {
-          $or: [{ age: { $eq: 30 } }, { city: { $eq: 'London' } }, { name: { $regex: '.*ABC.*' } }],
+          $or: [{ age: { $eq: 30 } }, { city: { $eq: 'London' } }, { name: { $regex: '\\.\\*ABC\\.\\*' } }],
         },
       ],
     };
@@ -62,15 +62,15 @@ describe('escapeOperators function', () => {
     expect(result).toEqual(expected);
   });
 
-  // Tests that the function handles mixed string REGEX
-  it('should handle mixed string regex', () => {
+  // Tests that the function handles mixed string KEYWORD
+  it('should handle mixed string keyword', () => {
     const filter = {
       AND: [
         {
           'bank.id': '9',
         },
         {
-          OR: [{ age: 30 }, { city: 'London' }, { name: { REGEX: 'ABC!"£123' } }],
+          OR: [{ age: 30 }, { city: 'London' }, { name: { KEYWORD: 'ABC!"£123' } }],
         },
       ],
     };
@@ -88,15 +88,15 @@ describe('escapeOperators function', () => {
     expect(result).toEqual(expected);
   });
 
-  // Tests that the function handles cases where the multiple regex exists
-  it('should multiple regex be transformed', () => {
+  // Tests that the function handles cases where the multiple keywords exist
+  it('should multiple keywords be transformed', () => {
     const filter = {
       AND: [
         {
           'bank.id': '9',
         },
         {
-          OR: [{ name: { REGEX: '.*ABC.*' } }, { exporter: { REGEX: 'Test' } }, { deal: { REGEX: 'AIN' } }],
+          OR: [{ name: { KEYWORD: '.*ABC.*' } }, { exporter: { KEYWORD: 'Test' } }, { deal: { KEYWORD: 'AIN' } }],
         },
       ],
     };
@@ -106,7 +106,7 @@ describe('escapeOperators function', () => {
           'bank.id': { $eq: '9' },
         },
         {
-          $or: [{ name: { $regex: '.*ABC.*' } }, { exporter: { $regex: 'Test' } }, { deal: { $regex: 'AIN' } }],
+          $or: [{ name: { $regex: '\\.\\*ABC\\.\\*' } }, { exporter: { $regex: 'Test' } }, { deal: { $regex: 'AIN' } }],
         },
       ],
     };

--- a/portal-api/package-lock.json
+++ b/portal-api/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "2.8.5",
         "date-fns": "^2.30.0",
         "dotenv": "16.0.3",
+        "escape-string-regexp": "^4.0.0",
         "express": "4.18.2",
         "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^6.11.2",

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -44,6 +44,7 @@
     "cors": "2.8.5",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "escape-string-regexp": "^4.0.0",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.11.2",

--- a/portal-api/src/v1/helpers/escapeOperators.js
+++ b/portal-api/src/v1/helpers/escapeOperators.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+const escapeStringRegexp = require('escape-string-regexp');
 
 /**
  * Objective:
@@ -30,8 +31,6 @@ Additional aspects:
   The function adds "$eq" to any criteria that is not an array.
   If the input "filter" is not an object or is null, it will be returned as is.
  */
-
-const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const getArrayKeyOperatorName = (key) => {
   if (key === 'AND') {
@@ -72,7 +71,7 @@ const recursivelyReplaceEscapeOperators = (filters, result = {}) => {
       recursivelyReplaceEscapeOperators(filters[key], result[key]);
       // These last two if statements handle the lowest level cases
     } else if (key === 'KEYWORD') {
-      result.$regex = escapeRegExp(filters[key]);
+      result.$regex = escapeStringRegexp(filters[key]);
     } else {
       result[key] = {
         $eq: filters[key],

--- a/portal-api/src/v1/helpers/escapeOperators.js
+++ b/portal-api/src/v1/helpers/escapeOperators.js
@@ -18,23 +18,20 @@ Flow:
   If the value of the key is an array, escape it by creating a new object with either "$and" or "$or" operator and map through its conditions.
   (If it is neither "AND" or "OR", we do not escape it, but continue processing the nested objects)
 
-  If a criteria contains the "REGEX" operator, escape it by creating a new object with the "$regex" operator.
-  If a criteria does not contain the "REGEX" operator, escape it by creating a new nested object with the "$eq" operator.
+  If a criteria contains the "KEYWORD" key, escape any regex characters and create a new object with the "$regex" operator
+  If a criteria does not contain the "KEYWORD" key, escape it by creating a new nested object with the "$eq" operator.
 
 Outputs:
   A new filter object with the escaped operators.
 
 Additional aspects:
-  The function only escapes the "AND", "OR", and "REGEX" operators.
-  The function adds "$eq" to any criteria that is not an array or has the key "REGEX"
+  The function only escapes the "AND" and "OR" operators.
+  The function converts any "KEYWORD" into an escaped $regex operator
+  The function adds "$eq" to any criteria that is not an array.
   If the input "filter" is not an object or is null, it will be returned as is.
  */
 
-/**
- * This function escapes MongoDB operators from the filter object
- * @param {Object} filter Object comprising of filters
- * @returns {Object} Escaped filter object
- */
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const getArrayKeyOperatorName = (key) => {
   if (key === 'AND') {
@@ -45,41 +42,47 @@ const getArrayKeyOperatorName = (key) => {
   } return key;
 };
 
-const recursivelyReplaceEscapeOperators = (filter, result = {}) => {
-  if (typeof filter !== 'object' || filter == null) {
-    return filter;
+/**
+ * This function escapes MongoDB operators from the filter object
+ * @param {Object} filters Object comprising of filters
+ * @returns {Object} Escaped filter object
+ */
+
+const recursivelyReplaceEscapeOperators = (filters, result = {}) => {
+  if (typeof filters !== 'object' || filters == null) {
+    return filters;
   }
 
-  const keys = Object.keys(filter);
+  const keys = Object.keys(filters);
 
   keys.forEach((key) => {
     // This handles when there is an array -- ie in the case of AND and OR
-    if (Array.isArray(filter[key])) {
+    if (Array.isArray(filters[key])) {
       const newKeyName = getArrayKeyOperatorName(key);
       if (!result[newKeyName]) {
         result[newKeyName] = [];
       }
-      filter[key].forEach((condition, i) => {
+      filters[key].forEach((condition, i) => {
         result[newKeyName][i] = {};
         recursivelyReplaceEscapeOperators(condition, result[newKeyName][i]);
       });
       // This handles nested objects ie {example: {REGEX: 'example'}}
-    } else if (typeof filter[key] === 'object' && filter[key] !== null) {
+    } else if (typeof filters[key] === 'object' && filters[key] !== null) {
       result[key] = {};
-      recursivelyReplaceEscapeOperators(filter[key], result[key]);
+      recursivelyReplaceEscapeOperators(filters[key], result[key]);
       // These last two if statements handle the lowest level cases
-    } else if (key === 'REGEX') {
-      result.$regex = filter[key];
+    } else if (key === 'KEYWORD') {
+      result.$regex = escapeRegExp(filters[key]);
     } else {
       result[key] = {
-        $eq: filter[key],
+        $eq: filters[key],
       };
     }
   });
   return result;
 };
 
-const escapeOperators = (filter) => recursivelyReplaceEscapeOperators(filter);
+const escapeOperators = (filters) => recursivelyReplaceEscapeOperators(filters);
 
 module.exports = {
   escapeOperators,

--- a/portal/server/controllers/dashboard/filters/generate-keyword-query.js
+++ b/portal/server/controllers/dashboard/filters/generate-keyword-query.js
@@ -1,16 +1,14 @@
-const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
 /**
  * Generates an object from given field name and keyword value
  *
  * @param {string} fieldName
  * @param {string} keyword value
  * @example ( 'submissionType', 'Automatic' )
- * @returns { dealType: { REGEX: 'Automatic', $options: 'i' } }
+ * @returns { dealType: { KEYWORD: 'Automatic', $options: 'i' } }
  */
 const generateObject = (fieldName, keywordValue) => ({
   [fieldName]: {
-    REGEX: escapeRegExp(keywordValue), $options: 'i',
+    KEYWORD: keywordValue, $options: 'i',
   },
 });
 
@@ -20,7 +18,7 @@ const generateObject = (fieldName, keywordValue) => ({
  * @param {array} fields
  * @param {string} keyword value
  * @example ( ['dealType', 'submissionType' ], 'Automatic' )
- * @returns [ { dealType: { REGEX: 'Automatic', $options: 'i' } }, { submissionType: { REGEX: 'Automatic', $options: 'i' } } ]
+ * @returns [ { dealType: { KEYWORD: 'Automatic', $options: 'i' } }, { submissionType: { KEYWORD: 'Automatic', $options: 'i' } } ]
  */
 const generateKeywordQuery = (fields, keywordValue) =>
   fields.map((fieldName) =>

--- a/portal/server/controllers/dashboard/filters/generate-keyword-query.js
+++ b/portal/server/controllers/dashboard/filters/generate-keyword-query.js
@@ -1,3 +1,5 @@
+const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /**
  * Generates an object from given field name and keyword value
  *
@@ -8,7 +10,7 @@
  */
 const generateObject = (fieldName, keywordValue) => ({
   [fieldName]: {
-    REGEX: keywordValue, $options: 'i',
+    REGEX: escapeRegExp(keywordValue), $options: 'i',
   },
 });
 

--- a/portal/server/controllers/dashboard/filters/generate-keyword-query.test.js
+++ b/portal/server/controllers/dashboard/filters/generate-keyword-query.test.js
@@ -17,7 +17,7 @@ describe('controllers/dashboard/filters - generate-keyword-query', () => {
 
       const expected = {
         [mockFieldName]: {
-          REGEX: mockKeywordValue, $options: 'i',
+          KEYWORD: mockKeywordValue, $options: 'i',
         },
       };
 


### PR DESCRIPTION
## Introduction :pencil2:
The keyword filter in portal shouldn't allow users to attack the database

## Resolution :heavy_check_mark:
- Use `KEYWORD` when sending a keyword filter to the api
- Convert `KEYWORD` into the `$regex` operator, escaping any regex special characters

## Note ⚠️ 
- This removes the ability to send a `REGEX` request to the api, this shouldn't be used anywhere but is potentially a breaking change