### PR TITLE
feat(FN-1261): reorder to authorise healthcheck

### DIFF
--- a/dtfs-central-api/src/generateApp.js
+++ b/dtfs-central-api/src/generateApp.js
@@ -15,8 +15,8 @@ const generateApp = () => {
 
   app.use(seo);
   app.use(security);
-  app.use(checkApiKey);
   app.use(healthcheck);
+  app.use(checkApiKey);
   // added limit for larger payloads - 500kb
   app.use(express.json({ limit: '500kb' }));
   app.use(compression());

--- a/external-api/src/generateApp.ts
+++ b/external-api/src/generateApp.ts
@@ -19,6 +19,7 @@ export const generateApp = () => {
   app.use(createRateLimit());
   app.use(seo);
   app.use(security);
+  app.use(healthcheck);
   app.use(express.json());
   app.use(compression());
   app.use(checkApiKey);
@@ -39,9 +40,6 @@ export const generateApp = () => {
 
   // API documentation route
   app.use('/api-docs', swaggerRoutes);
-
-  // healthcheck route
-  app.use(healthcheck);
 
   // all other API routes
   app.use(apiRoutes);


### PR DESCRIPTION
## Introduction :pencil2:
dtfs-central-api and external-api healthchecks were failing, I think this was because the `/healthcheck` endpoint was called after `checkApiKey`

## Resolution :heavy_check_mark:
Reorder the healthcheck

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

