### PR TITLE
fix: bicep refactor

### DIFF
--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -779,14 +779,11 @@ module tfmApi 'modules/webapps/trade-finance-manager-api-no-calculated-variables
     appServicePlanEgressSubnetId: vnet.outputs.appServicePlanEgressSubnetId
     appServicePlanId: appServicePlan.id
     containerRegistryName: containerRegistry.name
-    dtfsCentralApiHostname: dtfsCentralApi.outputs.defaultHostName
     environment: environment
-    externalApiHostname: externalApi.outputs.defaultHostName
     location: location
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
-    nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
   }
 }
 
@@ -951,6 +948,10 @@ module tfmApiCalculatedVariables 'modules/webapps/trade-finance-manager-api-calc
     cosmosDbAccountName: cosmosDb.outputs.cosmosDbAccountName
     cosmosDbDatabaseName: cosmosDb.outputs.cosmosDbDatabaseName
     environment: environment
+    containerRegistryName: containerRegistry.name
+    dtfsCentralApiHostname: dtfsCentralApi.outputs.defaultHostName
+    externalApiHostname: externalApi.outputs.defaultHostName
+    nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
     numberGeneratorFunctionDefaultHostName: functionNumberGenerator.outputs.defaultHostName
     secureConnectionStrings: tfmApiSecureConnectionStrings
     additionalSecureConnectionStrings: tfmApiAdditionalSecureConnectionStrings

--- a/infrastructure/resource_group_level/main.bicep
+++ b/infrastructure/resource_group_level/main.bicep
@@ -787,9 +787,6 @@ module tfmApi 'modules/webapps/trade-finance-manager-api-no-calculated-variables
     privateEndpointsSubnetId: vnet.outputs.privateEndpointsSubnetId
     azureWebsitesDnsZoneId: websitesDns.outputs.azureWebsitesDnsZoneId
     nodeDeveloperMode: parametersMap[environment].nodeDeveloperMode
-    settings: tmfApiSettings
-    secureSettings: tfmApiSecureSettings
-    additionalSecureSettings: tfmApiAdditionalSecureSettings
   }
 }
 
@@ -948,8 +945,8 @@ module frontDoorTfm 'modules/front-door-tfm.bicep' = {
 
 var tfmUiUrl = 'https://${frontDoorTfm.outputs.defaultHostName}'
 
-module tfmApiConnectionStrings 'modules/webapps/trade-finance-manager-api-calculated-variables.bicep' = {
-  name: 'tfmApiConnectionStrings'
+module tfmApiCalculatedVariables 'modules/webapps/trade-finance-manager-api-calculated-variables.bicep' = {
+  name: 'tfmApiCalculatedVariables'
   params: {
     cosmosDbAccountName: cosmosDb.outputs.cosmosDbAccountName
     cosmosDbDatabaseName: cosmosDb.outputs.cosmosDbDatabaseName
@@ -959,6 +956,8 @@ module tfmApiConnectionStrings 'modules/webapps/trade-finance-manager-api-calcul
     additionalSecureConnectionStrings: tfmApiAdditionalSecureConnectionStrings
     tfmUiUrl: tfmUiUrl
     storageAccountName: storage.outputs.storageAccountName
-    appSettings: tfmApi.outputs.tfmApiAppSettings
+    settings: tmfApiSettings
+    secureSettings: tfmApiSecureSettings
+    additionalSecureSettings: tfmApiAdditionalSecureSettings
   }
 }

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-calculated-variables.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-calculated-variables.bicep
@@ -1,4 +1,4 @@
-// We need to add the calculated variables separately beacause the value tfmUri comes from the TFM front-door, which would produce a circular dependency.
+// We need to add the calculated variables after beacause the value tfmUri comes from the TFM front-door, which would produce a circular dependency.
 // See the notes in trade-finance-manager-api-no-calculated-variables.bicep
 
 param environment string
@@ -7,19 +7,63 @@ param cosmosDbDatabaseName string
 param numberGeneratorFunctionDefaultHostName string
 param tfmUiUrl string
 param storageAccountName string
-param appSettings object
+param settings object
 
 var tfmApiNameFragment = 'trade-finance-manager-api'
 var tfmApiName = 'tfs-${environment}-${tfmApiNameFragment}'
 
+var deployApplicationInsights = false // TODO:DTFS2-6422 enable application insights
+var selfHostnameEnvironmentVariable = ''
+
 // These values are taken from GitHub secrets injected in the GHA Action
+@secure()
+param secureSettings object
 @secure()
 param secureConnectionStrings object
 
 // These values are taken from an export of Connection strings on Dev (& validating with staging).
 @secure()
+param additionalSecureSettings object
+@secure()
 param additionalSecureConnectionStrings object
 
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
+  name: containerRegistryName
+}
+var containerRegistryLoginServer = containerRegistry.properties.loginServer
+
+// https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+var azureDnsServerIp = '168.63.129.16'
+
+// These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
+var staticSettings = {
+  // hard coded
+  WEBSITE_DNS_SERVER: azureDnsServerIp
+  WEBSITE_VNET_ROUTE_ALL: '1'
+  PORT: '5000'
+  WEBSITES_PORT: '5000'
+}
+
+// These values are taken from an export of Configuration on Dev (& validating with staging).
+// TODO:FN-741 - access APIs over HTTPS.
+var dtfsCentralApiUrl = 'http://${dtfsCentralApiHostname}'
+// Note that in the CLI script, http was used, but the value in the exported config was https.
+var externalApiUrl = 'https://${externalApiHostname}'
+
+var additionalSettings = {
+  DOCKER_ENABLE_CI: 'true'
+  DOCKER_REGISTRY_SERVER_URL: containerRegistryLoginServer
+  DOCKER_REGISTRY_SERVER_USERNAME: containerRegistry.listCredentials().username
+  DOCKER_REGISTRY_SERVER_PASSWORD: containerRegistry.listCredentials().passwords[0].value
+  LOG4J_FORMAT_MSG_NO_LOOKUPS: 'true'
+  TZ: 'Europe/London'
+  WEBSITE_HTTPLOGGING_RETENTION_DAYS: '3'
+  WEBSITES_ENABLE_APP_SERVICE_STORAGE: 'false'
+  
+  DTFS_CENTRAL_API_URL: dtfsCentralApiUrl
+  EXTERNAL_API_URL: externalApiUrl
+}
 
 var connectionStringsList = [for item in items(union(secureConnectionStrings, additionalSecureConnectionStrings)): {
   name: item.key
@@ -43,6 +87,8 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing 
 }
 var storageAccountKey = storageAccount.listKeys().keys[0].value
 
+var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
+
 var calculatedAppSettings = {
   MONGO_INITDB_DATABASE: cosmosDbDatabaseName
   MONGODB_URI: mongoDbConnectionString
@@ -52,7 +98,21 @@ var calculatedAppSettings = {
   AZURE_PORTAL_STORAGE_ACCOUNT: storageAccountName
 }
 
-var appSettingsCombined = union(appSettings, calculatedAppSettings)
+var appSettings = union(
+  settings, 
+  staticSettings, 
+  secureSettings, 
+  additionalSettings, 
+  additionalSecureSettings, 
+  nodeEnv, 
+  calculatedAppSettings,
+  deployApplicationInsights ? {
+    APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
+    } : {},
+  selfHostnameEnvironmentVariable == '' ? {} : {
+      '${selfHostnameEnvironmentVariable}': site.properties.defaultHostName
+    }
+)
 
 resource site 'Microsoft.Web/sites@2022-09-01' existing = {
   name: tfmApiName
@@ -61,11 +121,15 @@ resource site 'Microsoft.Web/sites@2022-09-01' existing = {
 resource webappSetting 'Microsoft.Web/sites/config@2022-09-01' = {
   parent: site
   name: 'appsettings'
-  properties: appSettingsCombined
+  properties: appSettings
 }
 
 resource webappConnectionStrings 'Microsoft.Web/sites/config@2022-09-01' = if (!empty(connectionStringsList)) {
   parent: site
   name: 'connectionstrings'
   properties: connectionStringsProperties
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
+  name: applicationInsightsName
 }

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-calculated-variables.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-calculated-variables.bicep
@@ -4,6 +4,10 @@
 param environment string
 param cosmosDbAccountName string
 param cosmosDbDatabaseName string
+param containerRegistryName string
+param externalApiHostname string
+param dtfsCentralApiHostname string
+param nodeDeveloperMode bool
 param numberGeneratorFunctionDefaultHostName string
 param tfmUiUrl string
 param storageAccountName string
@@ -11,6 +15,7 @@ param settings object
 
 var tfmApiNameFragment = 'trade-finance-manager-api'
 var tfmApiName = 'tfs-${environment}-${tfmApiNameFragment}'
+var applicationInsightsName = 'tfs-${environment}-${tfmApiNameFragment}'
 
 var deployApplicationInsights = false // TODO:DTFS2-6422 enable application insights
 var selfHostnameEnvironmentVariable = ''

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-calculated-variables.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-calculated-variables.bicep
@@ -14,11 +14,8 @@ param appServicePlanEgressSubnetId string
 param appServicePlanId string
 param privateEndpointsSubnetId string
 param logAnalyticsWorkspaceId string
-param externalApiHostname string
-param dtfsCentralApiHostname string
 
 param azureWebsitesDnsZoneId string
-param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'trade-finance-manager-api'
 

--- a/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-calculated-variables.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/trade-finance-manager-api-no-calculated-variables.bicep
@@ -1,6 +1,6 @@
-// Note that we don't set the calculated variables & connection strings when creating the tfm-api webapp.
+// Note that we don't set the app settings & connection strings when creating the tfm-api webapp.
 // This is because we need to include the TFM front door hostname which would set
-// up a circular dependency. We avoid this by setting the calculated variables
+// up a circular dependency. We avoid this by calculating and setting the variables
 // separately later.
 // The alternative is to set them as normal and union the extra setting later.
 // See: https://stackoverflow.com/questions/72940236/is-there-a-workaround-to-keep-app-settings-which-not-defined-in-bicep-template
@@ -22,57 +22,11 @@ param nodeDeveloperMode bool
 
 param resourceNameFragment string = 'trade-finance-manager-api'
 
-param settings object
-
-// These values are taken from GitHub secrets injected in the GHA Action
-@secure()
-param secureSettings object
-
-// These values are taken from an export of Configuration on Dev (& validating with staging).
-@secure()
-param additionalSecureSettings object
-
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' existing = {
   name: containerRegistryName
 }
 var containerRegistryLoginServer = containerRegistry.properties.loginServer
 var dockerImageName = '${containerRegistryLoginServer}/${resourceNameFragment}:${environment}'
-
-// https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
-var azureDnsServerIp = '168.63.129.16'
-
-// These values are hardcoded in the CLI scripts, derived in the script or set from normal env variables or vars
-var staticSettings = {
-  // hard coded
-  WEBSITE_DNS_SERVER: azureDnsServerIp
-  WEBSITE_VNET_ROUTE_ALL: '1'
-  PORT: '5000'
-  WEBSITES_PORT: '5000'
-}
-
-// These values are taken from an export of Configuration on Dev (& validating with staging).
-// TODO:FN-741 - access APIs over HTTPS.
-var dtfsCentralApiUrl = 'http://${dtfsCentralApiHostname}'
-// Note that in the CLI script, http was used, but the value in the exported config was https.
-var externalApiUrl = 'https://${externalApiHostname}'
-
-var additionalSettings = {
-  DOCKER_ENABLE_CI: 'true'
-  DOCKER_REGISTRY_SERVER_URL: containerRegistryLoginServer
-  DOCKER_REGISTRY_SERVER_USERNAME: containerRegistry.listCredentials().username
-  DOCKER_REGISTRY_SERVER_PASSWORD: containerRegistry.listCredentials().passwords[0].value
-  LOG4J_FORMAT_MSG_NO_LOOKUPS: 'true'
-  TZ: 'Europe/London'
-  WEBSITE_HTTPLOGGING_RETENTION_DAYS: '3'
-  WEBSITES_ENABLE_APP_SERVICE_STORAGE: 'false'
-  
-  DTFS_CENTRAL_API_URL: dtfsCentralApiUrl
-  EXTERNAL_API_URL: externalApiUrl
-}
-
-var nodeEnv = nodeDeveloperMode ? { NODE_ENV: 'development' } : {}
-
-var appSettings = union(settings, staticSettings, secureSettings, additionalSettings, additionalSecureSettings, nodeEnv)
 
 
 module tfmApiWebapp 'webapp.bicep' = {
@@ -80,7 +34,7 @@ module tfmApiWebapp 'webapp.bicep' = {
   params: {
     appServicePlanEgressSubnetId: appServicePlanEgressSubnetId
     appServicePlanId: appServicePlanId
-    appSettings: appSettings
+    appSettings: {}
     azureWebsitesDnsZoneId: azureWebsitesDnsZoneId
     connectionStrings: {}
     deployApplicationInsights: false // TODO:DTFS2-6422 enable application insights
@@ -96,4 +50,3 @@ module tfmApiWebapp 'webapp.bicep' = {
 }
 
 output defaultHostName string = tfmApiWebapp.outputs.defaultHostName
-output tfmApiAppSettings object = appSettings

--- a/infrastructure/resource_group_level/modules/webapps/webapp.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/webapp.bicep
@@ -26,7 +26,7 @@ var appName = 'tfs-${environment}-${resourceNameFragment}'
 var privateEndpointName = 'tfs-${environment}-${resourceNameFragment}'
 var applicationInsightsName = 'tfs-${environment}-${resourceNameFragment}'
 
-var appSettingsWithAppInsights = if (!empty(appSettings)) {
+var appSettingsWithAppInsights = (!empty(appSettings)) ?
   union(
   appSettings, 
   deployApplicationInsights ? {
@@ -35,8 +35,7 @@ var appSettingsWithAppInsights = if (!empty(appSettings)) {
     selfHostnameEnvironmentVariable == '' ? {} : {
       '${selfHostnameEnvironmentVariable}': site.properties.defaultHostName
     }
-  )
-}
+  ) : {}
 
 resource site 'Microsoft.Web/sites@2022-09-01' = {
   name: appName

--- a/infrastructure/resource_group_level/modules/webapps/webapp.bicep
+++ b/infrastructure/resource_group_level/modules/webapps/webapp.bicep
@@ -26,8 +26,7 @@ var appName = 'tfs-${environment}-${resourceNameFragment}'
 var privateEndpointName = 'tfs-${environment}-${resourceNameFragment}'
 var applicationInsightsName = 'tfs-${environment}-${resourceNameFragment}'
 
-var appSettingsWithAppInsights = (!empty(appSettings)) ?
-  union(
+var appSettingsWithAppInsights = union(
   appSettings, 
   deployApplicationInsights ? {
     APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
@@ -35,7 +34,7 @@ var appSettingsWithAppInsights = (!empty(appSettings)) ?
     selfHostnameEnvironmentVariable == '' ? {} : {
       '${selfHostnameEnvironmentVariable}': site.properties.defaultHostName
     }
-  ) : {}
+  )
 
 resource site 'Microsoft.Web/sites@2022-09-01' = {
   name: appName


### PR DESCRIPTION
## Introduction :pencil2:
Refactoring the bicep I wrote when we changed connection strings to environment variables

## Resolution :heavy_check_mark:
- Set all tfm-api settings in `trade-finance-manager-api-calculated-variables`, instead of setting it twice
- Rename `tfmApiConnectionStrings` module to `tfmApiCalculatedVariables`
- Add condition to `webapp.bicep` to only set `appSettings` if not empty


