### PR TITLE
fix(dtfs2 6899): fix blocked user logging in with most recent sign in link

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
@@ -67,6 +67,7 @@ context('Resending sign in links', () => {
       checkYourEmail.visit();
       checkYourEmail.sendNewSignInLink();
 
+      // checkYourEmail.attemptsRemaining().should('contain', '1 attempt remaining');
       checkYourEmail.visit();
       checkYourEmail.sendNewSignInLink();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/resend-sign-in-link.spec.js
@@ -67,7 +67,7 @@ context('Resending sign in links', () => {
       checkYourEmail.visit();
       checkYourEmail.sendNewSignInLink();
 
-      // checkYourEmail.attemptsRemaining().should('contain', '1 attempt remaining');
+      checkYourEmail.attemptsRemaining().should('contain', '1 attempt remaining');
       checkYourEmail.visit();
       checkYourEmail.sendNewSignInLink();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/login/sign-in-link-session-edge-cases.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/login/sign-in-link-session-edge-cases.spec.js
@@ -1,4 +1,6 @@
-const { signInLink, header, userProfile } = require('../../pages');
+const {
+  signInLink, header, userProfile, checkYourEmail, signInLinkExpired, landingPage,
+} = require('../../pages');
 const relative = require('../../relativeURL');
 const { BANK1_MAKER1, BANK1_MAKER2 } = require('../../../../../e2e-fixtures');
 
@@ -39,5 +41,25 @@ context('Sign in link session edge cases', () => {
     cy.url().should('eq', relative('/dashboard/deals/0'));
     header.profile().click();
     userProfile.email().should('have.text', BANK1_MAKER1.username);
+  });
+
+  it('The user cannot use the last valid sign in token after they are blocked', () => {
+    checkYourEmail.attemptsRemaining().should('contain', '2 attempts remaining');
+    checkYourEmail.visit();
+    checkYourEmail.sendNewSignInLink();
+
+    checkYourEmail.attemptsRemaining().should('contain', '1 attempt remaining');
+    checkYourEmail.visit();
+    checkYourEmail.sendNewSignInLink();
+
+    cy.overridePortalUserSignInTokenByUsername({ username: BANK1_MAKER1.username, newSignInToken: SIGN_IN_TOKEN });
+
+    landingPage.visit();
+    cy.enterUsernameAndPassword(BANK1_MAKER1);
+    landingPage.accountSuspended().should('exist');
+
+    signInLink.visit({ token: SIGN_IN_TOKEN, userId: bank1Maker1Id });
+    cy.url().should('eq', relative('/login/sign-in-link-expired'));
+    signInLinkExpired.sendNewSignInLink();
   });
 });

--- a/e2e-tests/portal/cypress/e2e/pages/index.js
+++ b/e2e-tests/portal/cypress/e2e/pages/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   login: require('./login'),
   signInLink: require('./login/sign-in-link'),
+  signInLinkExpired: require('./login/sign-in-link-expired'),
   checkYourEmail: require('./login/check-your-email'),
   header: require('./header'),
   landingPage: require('./landingPage'),

--- a/e2e-tests/portal/cypress/e2e/pages/login/sign-in-link-expired.js
+++ b/e2e-tests/portal/cypress/e2e/pages/login/sign-in-link-expired.js
@@ -1,0 +1,6 @@
+const signInLinkExpired = {
+  sendNewSignInLinkButton: () => cy.get('[data-cy="request-new-sign-in-link"]'),
+  sendNewSignInLink: () => signInLinkExpired.sendNewSignInLinkButton().click(),
+};
+
+module.exports = signInLinkExpired;

--- a/portal-api/api-tests/api-test-users.js
+++ b/portal-api/api-tests/api-test-users.js
@@ -4,6 +4,7 @@ const { genPassword } = require('../src/crypto/utils');
 const databaseHelper = require('./database-helper');
 const { MAKER, CHECKER, ADMIN, READ_ONLY } = require('../src/v1/roles/roles');
 const { createLoggedInUserSession } = require('../test-helpers/api-test-helpers/database/user-repository');
+const { STATUS } = require('../src/constants/user');
 
 const banks = {
   Barclays: {
@@ -239,7 +240,7 @@ const setUpApiTestUser = async (as) => {
   const { salt, hash } = genPassword(apiTestUser.password);
 
   const userToCreate = {
-    'user-status': 'active',
+    'user-status': STATUS.ACTIVE,
     salt,
     hash,
     ...apiTestUser,

--- a/portal-api/api-tests/v1/deals/deals-status-submitted.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status-submitted.api-test.js
@@ -12,6 +12,7 @@ const { MAKER, CHECKER } = require('../../../src/v1/roles/roles');
 const { as } = require('../../api')(app);
 
 const CONSTANTS = require('../../../src/constants');
+const { STATUS } = require('../../../src/constants/user');
 
 describe('PUT /v1/deals/:id/status - status changes to `Submitted`', () => {
   let aBarclaysMaker;
@@ -225,7 +226,7 @@ describe('PUT /v1/deals/:id/status - status changes to `Submitted`', () => {
         surname: aBarclaysChecker.surname,
         timezone: aBarclaysChecker.timezone,
         lastLogin: expect.any(String),
-        'user-status': 'active',
+        'user-status': STATUS.ACTIVE,
       };
 
       expect(tfmDealSubmitSpy.mock.calls[0][0]).toEqual(dealId);

--- a/portal-api/api-tests/v1/deals/deals-status.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status.api-test.js
@@ -9,6 +9,7 @@ const sendStatusUpdateEmails = require('../../../src/v1/controllers/deal-status/
 const createFacilities = require('../../createFacilities');
 const api = require('../../../src/v1/api');
 const { MAKER, CHECKER, READ_ONLY, ADMIN } = require('../../../src/v1/roles/roles');
+const { STATUS } = require('../../../src/constants/user');
 
 const { as, get, put } = require('../../api')(app);
 
@@ -238,7 +239,7 @@ describe('/v1/deals/:id/status', () => {
           firstname: aBarclaysMaker.firstname,
           surname: aBarclaysMaker.surname,
           timezone: 'Europe/London',
-          'user-status': 'active',
+          'user-status': STATUS.ACTIVE,
         },
       });
     });

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -20,6 +20,7 @@ const mockFacilities = require('../../fixtures/gef/facilities');
 const referenceData = require('../../../src/external-api/api');
 
 const api = require('../../../src/v1/api');
+const { STATUS } = require('../../../src/constants/user');
 
 jest.mock('../../../src/external-api/api', () => ({
   sendEmail: jest.fn(() => Promise.resolve({})),
@@ -661,7 +662,7 @@ describe(baseUrl, () => {
           surname: aChecker.surname,
           timezone: aChecker.timezone,
           lastLogin: expect.any(String),
-          'user-status': 'active',
+          'user-status': STATUS.ACTIVE,
         };
 
         expect(tfmDealSubmitSpy.mock.calls[0][0]).toEqual(dealId);

--- a/portal-api/api-tests/v1/users/login-with-sign-in-link.api-test.js
+++ b/portal-api/api-tests/v1/users/login-with-sign-in-link.api-test.js
@@ -7,6 +7,7 @@ const { CryptographicallyStrongGenerator } = require('../../../src/crypto/crypto
 const { post } = require('../../api')(app);
 const { LOGIN_STATUSES } = require('../../../src/constants');
 const { withApiKeyAuthenticationTests } = require('../../common-tests/client-authentication-tests');
+const { STATUS } = require('../../../src/constants/user');
 
 describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
   const testUserId = '65626dc0bda51f77a78b86ae';
@@ -22,7 +23,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
 
   const testUser = {
     _id: new ObjectId(testUserId),
-    'user-status': 'active',
+    'user-status': STATUS.ACTIVE,
     salt: 'abc',
     hash: 'def',
     username: 'api-test-user',
@@ -32,12 +33,13 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
     timezone: 'Europe/London',
     roles: ['read-only'],
     bank: {
-      id: '*'
+      id: '*',
     },
     sessionIdentifier: 'a-session',
   };
 
-  const login = ({ userId, signInToken }, headers = { 'x-api-key': process.env.PORTAL_API_KEY }) => post(`/v1/users/${userId}/sign-in-link/${signInToken}/login`, undefined, { headers });
+  const login = ({ userId, signInToken }, headers = { 'x-api-key': process.env.PORTAL_API_KEY }) =>
+    post(`/v1/users/${userId}/sign-in-link/${signInToken}/login`, undefined, { headers });
 
   const usersCollection = () => getCollection('users');
 
@@ -52,13 +54,15 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
       expect(status).toBe(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
-        errors: [{
-          location: 'params',
-          msg: 'Value must be a valid MongoId',
-          path: 'userId',
-          type: 'field',
-          value: invalidUserId
-        }]
+        errors: [
+          {
+            location: 'params',
+            msg: 'Value must be a valid MongoId',
+            path: 'userId',
+            type: 'field',
+            value: invalidUserId,
+          },
+        ],
       });
     });
 
@@ -68,13 +72,15 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
       expect(status).toBe(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
-        errors: [{
-          location: 'params',
-          msg: 'Value must be a hexadecimal string',
-          path: 'signInToken',
-          type: 'field',
-          value: invalidSignInToken
-        }]
+        errors: [
+          {
+            location: 'params',
+            msg: 'Value must be a hexadecimal string',
+            path: 'signInToken',
+            type: 'field',
+            value: invalidSignInToken,
+          },
+        ],
       });
     });
   });
@@ -86,9 +92,11 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
       expect(status).toBe(404);
       expect(body).toStrictEqual({
         message: 'Not Found',
-        errors: [{
-          msg: `No user found with id ${testUserId}`
-        }]
+        errors: [
+          {
+            msg: `No user found with id ${testUserId}`,
+          },
+        ],
       });
     });
   });
@@ -99,7 +107,9 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
     });
 
     afterEach(async () => {
-      await (await usersCollection()).deleteOne({
+      await (
+        await usersCollection()
+      ).deleteOne({
         _id: { $eq: testUser._id },
       });
     });
@@ -111,9 +121,11 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         expect(status).toBe(403);
         expect(body).toStrictEqual({
           message: 'Forbidden',
-          errors: [{
-            msg: `Invalid sign in token for user ID: ${testUserId}`
-          }]
+          errors: [
+            {
+              msg: `Invalid sign in token for user ID: ${testUserId}`,
+            },
+          ],
         });
       });
     });
@@ -121,16 +133,18 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
     describe('when the user has a sign in token saved', () => {
       describe('when the signInToken does not match the saved sign in token', () => {
         beforeEach(async () => {
-          await (await usersCollection()).updateOne(
+          await (
+            await usersCollection()
+          ).updateOne(
             { _id: { $eq: testUser._id } },
             {
               $set: {
                 signInToken: {
                   saltHex: saltHexForValidSignInToken,
                   hashHex: nonMatchingHashHex,
-                  expiry: Date.now() + (30 * 60 * 1000),
-                }
-              }
+                  expiry: Date.now() + 30 * 60 * 1000,
+                },
+              },
             },
           );
         });
@@ -141,9 +155,11 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
           expect(status).toBe(403);
           expect(body).toStrictEqual({
             message: 'Forbidden',
-            errors: [{
-              msg: `Invalid sign in token for user ID: ${testUserId}`
-            }]
+            errors: [
+              {
+                msg: `Invalid sign in token for user ID: ${testUserId}`,
+              },
+            ],
           });
         });
       });
@@ -151,7 +167,9 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
       describe('when the signInToken does match the saved sign in token', () => {
         describe('when the saved sign in token has expired', () => {
           beforeEach(async () => {
-            await (await usersCollection()).updateOne(
+            await (
+              await usersCollection()
+            ).updateOne(
               { _id: { $eq: testUser._id } },
               {
                 $set: {
@@ -159,8 +177,8 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
                     saltHex: saltHexForValidSignInToken,
                     hashHex: hashHexForValidSignInToken,
                     expiry: Date.now() - 1,
-                  }
-                }
+                  },
+                },
               },
             );
           });
@@ -171,9 +189,11 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
             expect(status).toBe(403);
             expect(body).toStrictEqual({
               message: 'Forbidden',
-              errors: [{
-                msg: `Invalid sign in token for user ID: ${testUserId}`
-              }]
+              errors: [
+                {
+                  msg: `Invalid sign in token for user ID: ${testUserId}`,
+                },
+              ],
             });
           });
         });
@@ -182,9 +202,11 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
           beforeEach(async () => {
             // Not faking next tick is required for database interaction to work
             jest.useFakeTimers({
-              doNotFake: ['nextTick']
+              doNotFake: ['nextTick'],
             });
-            await (await usersCollection()).updateOne(
+            await (
+              await usersCollection()
+            ).updateOne(
               { _id: { $eq: testUser._id } },
               {
                 $set: {
@@ -192,8 +214,8 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
                     saltHex: saltHexForValidSignInToken,
                     hashHex: hashHexForValidSignInToken,
                     expiry: Date.now(),
-                  }
-                }
+                  },
+                },
               },
             );
           });

--- a/portal-api/api-tests/v1/users/login-with-sign-in-link.api-test.js
+++ b/portal-api/api-tests/v1/users/login-with-sign-in-link.api-test.js
@@ -14,6 +14,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
   const invalidUserId = '1';
   const validSignInToken = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
   const invalidSignInToken = 'x!y';
+  const thirtyMinutesInMilliseconds = 30 * 60 * 1000;
 
   const hasher = new Hasher(new Pbkdf2Sha512HashStrategy(new CryptographicallyStrongGenerator()));
   const hashedValidSignInToken = hasher.hash(validSignInToken);
@@ -142,7 +143,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
                 signInToken: {
                   saltHex: saltHexForValidSignInToken,
                   hashHex: nonMatchingHashHex,
-                  expiry: Date.now() + 30 * 60 * 1000,
+                  expiry: Date.now() + thirtyMinutesInMilliseconds,
                 },
               },
             },

--- a/portal-api/api-tests/v1/users/post-sign-in-link.api-test.js
+++ b/portal-api/api-tests/v1/users/post-sign-in-link.api-test.js
@@ -116,7 +116,14 @@ describe('POST /users/me/sign-in-link', () => {
 
   describe('when user has 3 sign in link send attempts ', () => {
     beforeEach(async () => {
-      databaseHelper.setUserProperties({ username, update: { signInLinkSendCount: 3, signInLinkSendDate: Date.now() } });
+      databaseHelper.setUserProperties({
+        username,
+        update: {
+          signInLinkSendCount: 3,
+          signInLinkSendDate: Date.now(),
+          signInToken: { hash, salt },
+        },
+      });
     });
 
     it('returns a 403 error response', async () => {
@@ -129,6 +136,13 @@ describe('POST /users/me/sign-in-link', () => {
 
       const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
       expect(userInDb.signInLinkSendCount).toBe(4);
+    });
+
+    it('deletes any existing sign in token data', async () => {
+      await sendSignInLink();
+
+      const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
+      expect(userInDb.signInToken).toBeUndefined();
     });
   });
 

--- a/portal-api/api-tests/v1/users/users.api-test.js
+++ b/portal-api/api-tests/v1/users/users.api-test.js
@@ -148,7 +148,7 @@ describe('a user', () => {
           firstname: MOCK_USER.firstname,
           surname: MOCK_USER.surname,
           timezone: 'Europe/London',
-          'user-status': 'active',
+          'user-status': STATUS.ACTIVE,
         }])
       }));
     });
@@ -414,7 +414,7 @@ describe('a user', () => {
         ...MOCK_USER,
         _id: expect.any(String),
         timezone: 'Europe/London',
-        'user-status': 'active',
+        'user-status': STATUS.ACTIVE,
       };
       delete expectedUserData.password;
 
@@ -515,7 +515,7 @@ describe('a user', () => {
         ...MOCK_USER,
         _id: expect.any(String),
         timezone: 'Europe/London',
-        'user-status': 'active',
+        'user-status': STATUS.ACTIVE,
       };
       delete expectedUserData.password;
 

--- a/portal-api/src/v1/users/login.controller.js
+++ b/portal-api/src/v1/users/login.controller.js
@@ -1,6 +1,7 @@
 const utils = require('../../crypto/utils');
 const { userIsBlocked, userIsDisabled, usernameOrPasswordIncorrect } = require('../../constants/login-results');
 const { findByUsername, incrementFailedLoginCount, updateSessionIdentifier } = require('./controller');
+const { STATUS } = require('src/constants/user');
 
 module.exports.login = (username, password) =>
   new Promise((resolve) => {
@@ -24,7 +25,7 @@ module.exports.login = (username, password) =>
         return resolve({ error: userIsDisabled });
       }
 
-      if (user['user-status'] === 'blocked') {
+      if (user['user-status'] === STATUS.BLOCKED) {
         return resolve({ error: userIsBlocked });
       }
 

--- a/portal-api/src/v1/users/login.controller.js
+++ b/portal-api/src/v1/users/login.controller.js
@@ -1,7 +1,7 @@
+const { STATUS } = require('src/constants/user');
 const utils = require('../../crypto/utils');
 const { userIsBlocked, userIsDisabled, usernameOrPasswordIncorrect } = require('../../constants/login-results');
 const { findByUsername, incrementFailedLoginCount, updateSessionIdentifier } = require('./controller');
-const { STATUS } = require('src/constants/user');
 
 module.exports.login = (username, password) =>
   new Promise((resolve) => {

--- a/portal-api/src/v1/users/login.controller.js
+++ b/portal-api/src/v1/users/login.controller.js
@@ -1,4 +1,4 @@
-const { STATUS } = require('src/constants/user');
+const { STATUS } = require('../../constants/user');
 const utils = require('../../crypto/utils');
 const { userIsBlocked, userIsDisabled, usernameOrPasswordIncorrect } = require('../../constants/login-results');
 const { findByUsername, incrementFailedLoginCount, updateSessionIdentifier } = require('./controller');

--- a/portal-api/src/v1/users/login.controller.test.js
+++ b/portal-api/src/v1/users/login.controller.test.js
@@ -3,6 +3,7 @@ const { login } = require('./login.controller');
 const { usernameOrPasswordIncorrect, userIsBlocked, userIsDisabled } = require('../../constants/login-results');
 const controller = require('./controller');
 const utils = require('../../crypto/utils');
+const { STATUS } = require('../../constants/user');
 
 jest.mock('./controller', () => ({
   findByUsername: jest.fn(),
@@ -106,7 +107,7 @@ describe('login', () => {
   });
 
   it("returns a 'userIsBlocked' error when the user is blocked", async () => {
-    const BLOCKED_USER = { ...USER, 'user-status': 'blocked' };
+    const BLOCKED_USER = { ...USER, 'user-status': STATUS.BLOCKED };
 
     mockFindByUsernameSuccess(BLOCKED_USER);
     mockValidPasswordSuccess();
@@ -132,7 +133,7 @@ describe('login', () => {
   });
 
   it("returns a 'usernameOrPasswordIncorrect' error when the password is incorrect and the user is blocked", async () => {
-    const BLOCKED_USER = { ...USER, 'user-status': 'blocked' };
+    const BLOCKED_USER = { ...USER, 'user-status': STATUS.BLOCKED };
 
     mockFindByUsernameSuccess(BLOCKED_USER);
     mockValidPasswordFailure();

--- a/portal-api/src/v1/users/repository.js
+++ b/portal-api/src/v1/users/repository.js
@@ -17,7 +17,10 @@ class UserRepository {
   }
 
   async deleteSignInTokenForUser(userId) {
+    this.#validateUserId(userId);
+
     const userCollection = await db.getCollection('users');
+
     return userCollection.updateOne({ _id: { $eq: ObjectId(userId) } }, { $unset: { signInToken: '' } });
   }
 

--- a/portal-api/src/v1/users/repository.test.js
+++ b/portal-api/src/v1/users/repository.test.js
@@ -59,6 +59,8 @@ describe('UserRepository', () => {
   describe('deleteSignInTokenForUser', () => {
     const userId = 'aaaa1234aaaabbbb5678bbbb';
 
+    withValidateUserIdTests({ methodCall: (invalidUserId) => repository.deleteSignInTokenForUser(invalidUserId) });
+
     it('deletes the signInToken field on the user document', async () => {
       await repository.deleteSignInTokenForUser(userId);
 

--- a/portal-api/src/v1/users/sanitizeUserData.test.js
+++ b/portal-api/src/v1/users/sanitizeUserData.test.js
@@ -1,6 +1,7 @@
 const { ObjectId } = require('mongodb');
 const { MAKER } = require('../../../../utils/mock-data-loader/portal/roles');
 const { sanitizeUser } = require('./sanitizeUserData');
+const { STATUS } = require('../../constants/user');
 
 describe('sanitizeUserData', () => {
   describe('sanitizeUser', () => {
@@ -18,7 +19,7 @@ describe('sanitizeUserData', () => {
         emails: ['maker1@ukexportfinance.gov.uk', 'maker2@ukexportfinance.gov.uk'],
       },
       lastLogin: new Date().getTime(),
-      'user-status': 'blocked',
+      'user-status': STATUS.BLOCKED,
       disabled: true,
       signInLinkSendDate: new Date().getTime(),
       signInLinkSendCount: 1,

--- a/portal-api/src/v1/users/sign-in-link.controller.js
+++ b/portal-api/src/v1/users/sign-in-link.controller.js
@@ -43,7 +43,7 @@ class SignInLinkController {
         });
       }
 
-      if (e instanceof InvalidSignInTokenError) {
+      if (e instanceof InvalidSignInTokenError || e instanceof UserBlockedError) {
         return res.status(403).send({
           message: 'Forbidden',
           errors: [{

--- a/portal-api/src/v1/users/sign-in-link.service.create-and-email-sign-in-link.test.js
+++ b/portal-api/src/v1/users/sign-in-link.service.create-and-email-sign-in-link.test.js
@@ -64,6 +64,7 @@ describe('SignInLinkService', () => {
       resetSignInLinkSendCountAndDate: jest.fn(),
       findById: jest.fn(),
       blockUser: jest.fn(),
+      deleteSignInTokenForUser: jest.fn(),
     };
     service = new SignInLinkService(randomGenerator, hasher, userRepository);
   });
@@ -88,9 +89,10 @@ describe('SignInLinkService', () => {
         userRepository.incrementSignInLinkSendCount.mockResolvedValueOnce(4); // MAX_SIGN_IN_LINK_SEND_COUNT + 1
       });
 
-      it('blocks the user and throws an error', async () => {
+      it('deletes the users sign in token, blocks the user and throws an error', async () => {
         await expect(service.createAndEmailSignInLink(user)).rejects.toThrowError(UserBlockedError);
         expect(userRepository.blockUser).toHaveBeenCalledWith({ userId: user._id, reason: USER.STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_LINKS });
+        expect(userRepository.deleteSignInTokenForUser).toHaveBeenCalledWith(user._id);
         expect(controller.sendBlockedEmail).toHaveBeenCalledWith(user.email);
       });
     });

--- a/portal-api/src/v1/users/sign-in-link.service.create-and-email-sign-in-link.test.js
+++ b/portal-api/src/v1/users/sign-in-link.service.create-and-email-sign-in-link.test.js
@@ -6,6 +6,7 @@ const { SIGN_IN_LINK_DURATION, EMAIL_TEMPLATE_IDS, USER } = require('../../const
 const { PORTAL_UI_URL } = require('../../config/sign-in-link.config');
 const UserBlockedError = require('../errors/user-blocked.error');
 const controller = require('./controller');
+const { STATUS } = require('../../constants/user');
 
 jest.mock('../email');
 jest.mock('./controller');
@@ -106,7 +107,7 @@ describe('SignInLinkService', () => {
       });
 
       describe('when the user is blocked', () => {
-        const blockedUser = { ...user, 'user-status': 'blocked' };
+        const blockedUser = { ...user, 'user-status': STATUS.BLOCKED };
 
         it('throws a UserBlockedError', async () => {
           await expect(service.createAndEmailSignInLink(blockedUser)).rejects.toThrowError(UserBlockedError);

--- a/portal-api/src/v1/users/sign-in-link.service.js
+++ b/portal-api/src/v1/users/sign-in-link.service.js
@@ -138,6 +138,7 @@ class SignInLinkService {
     const numberOfSendSignInLinkAttemptsRemaining = maxSignInLinkSendCount - signInLinkCount;
 
     if (numberOfSendSignInLinkAttemptsRemaining < 0) {
+      await this.deleteSignInToken(userId);
       await this.#blockUser({ userId, reason: STATUS_BLOCKED_REASON.EXCESSIVE_SIGN_IN_LINKS, userEmail });
       throw new UserBlockedError(userId);
     }

--- a/portal-api/src/v1/users/sign-in-link.service.js
+++ b/portal-api/src/v1/users/sign-in-link.service.js
@@ -67,6 +67,11 @@ class SignInLinkService {
 
   async loginUser(userId) {
     const user = await this.#userRepository.findById(userId);
+
+    if (user['user-status'] === STATUS.BLOCKED) {
+      throw new UserBlockedError(userId);
+    }
+
     const { sessionIdentifier, ...tokenObject } = utils.issueValid2faJWT(user);
     await this.#updateLastLogin({ userId: user._id, sessionIdentifier });
     return { user, tokenObject };

--- a/portal-api/src/v1/users/sign-in-link.service.login-user.test.js
+++ b/portal-api/src/v1/users/sign-in-link.service.login-user.test.js
@@ -40,28 +40,29 @@ describe('SignInLinkService', () => {
   });
 
   describe('loginUser', () => {
-    beforeEach(() => {
-      when(userRepository.findById)
-        .calledWith(TEST_USER._id)
-        .mockResolvedValueOnce(TEST_USER);
-      when(utils.issueValid2faJWT)
-        .calledWith(TEST_USER)
-        .mockReturnValueOnce(tokenObject);
-      when(userRepository.updateLastLogin)
-        .calledWith({ userId: TEST_USER._id, sessionIdentifier })
-        .mockResolvedValueOnce(undefined);
+    describe('when the user is blocked', () => {
+      it('throws a UserBlockedError if the user is blocked', async () => {});
     });
 
-    it('updates the last login of the user', async () => {
-      await service.loginUser(TEST_USER._id);
-      expect(userRepository.updateLastLogin)
-        .toHaveBeenCalledWith({ userId: TEST_USER._id, sessionIdentifier });
+    describe('when the user is not blocked', () => {
+      beforeEach(() => {
+        mockUserTestConfig(TEST_USER);
+      });
+
+      it('updates the last login of the user', async () => {
+        await service.loginUser(TEST_USER._id);
+        expect(userRepository.updateLastLogin).toHaveBeenCalledWith({ userId: TEST_USER._id, sessionIdentifier });
+      });
+
+      it('returns the user and a new 2FA JWT for the user', async () => {
+        await expect(service.loginUser(TEST_USER._id)).resolves.toStrictEqual({ user: TEST_USER, tokenObject: tokenObjectWithoutSessionIdentifier });
+      });
     });
 
-    it('returns the user and a new 2FA JWT for the user', async () => {
-      await expect(service.loginUser(TEST_USER._id))
-        .resolves
-        .toStrictEqual({ user: TEST_USER, tokenObject: tokenObjectWithoutSessionIdentifier });
-    });
+    function mockUserTestConfig(user) {
+      when(userRepository.findById).calledWith(user._id).mockResolvedValueOnce(user);
+      when(utils.issueValid2faJWT).calledWith(user).mockReturnValueOnce(tokenObject);
+      when(userRepository.updateLastLogin).calledWith({ userId: user._id, sessionIdentifier }).mockResolvedValueOnce(undefined);
+    }
   });
 });

--- a/portal-api/test-helpers/unit-test-mocks/mock-user.js
+++ b/portal-api/test-helpers/unit-test-mocks/mock-user.js
@@ -1,3 +1,4 @@
+const { STATUS } = require('../../src/constants/user');
 const { MAKER } = require('../../src/v1/roles/roles');
 
 const TEST_USER = {
@@ -19,7 +20,7 @@ const TEST_USER = {
 
 const TEST_DATABASE_USER = {
   _id: '075bcd157dcb851180e02a7c',
-  'user-status': 'active',
+  'user-status': STATUS.ACTIVE,
   timezone: 'Europe/London',
   username: 'HSBC-maker-1',
   firstname: 'Mister',


### PR DESCRIPTION
## Introduction :pencil2:
This change fixes an edge case where a user can access a recently issued sign in link, despite being blocked.

## Resolution :heavy_check_mark:
When a user is blocked, we wipe any past tokens from the database.
We also check the user is not blocked on login. While we realistically never get to this stage, due to the method being public, it has been included to avoid future issues

## Miscellaneous :heavy_plus_sign:
Moved some legacy hand written `user-status`s to enums

