### PR TITLE
feat(FN-1685): fix csv parsing for rows with empty data at end of row

### DIFF
--- a/portal/jest.config.js
+++ b/portal/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   testMatch: ['**/*.test.js', '**/*.component-test.js'],
   moduleNameMapper: {
     '^.+\\.(css|less|scss)$': 'babel-jest',
-    '^exceljs$': 'babel-jest',
+    'uuid': require.resolve('uuid'),
   },
   testEnvironment: 'jsdom',
 };

--- a/portal/server/constants/file-upload.js
+++ b/portal/server/constants/file-upload.js
@@ -9,7 +9,7 @@ const FILE_UPLOAD = {
   ],
   ALLOWED_FORMATS: ['bmp', 'doc', 'docx', 'gif', 'jpeg', 'jpg', 'pdf', 'png', 'ppt', 'pptx', 'tif', 'txt', 'xls', 'xlsx'],
   ALLOWED_FORMATS_UTILISATION_REPORT: ['xlsx', 'csv'],
-  ALLOWED_MIMETYPES_UTILISATION_REPORT: ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'text/csv'],
+  ALLOWED_MIMETYPES_UTILISATION_REPORT: ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel', 'text/csv'],
   MAX_FILE_SIZE: 12 * 1024 * 1024, // 12mb
   MAX_CELL_CHARACTER_COUNT: 15,
 };

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -201,7 +201,7 @@ const extractCsvData = async (file) => {
   let fileBuffer;
 
   try {
-    if (file.mimetype === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') {
+    if (file.mimetype === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' || file.mimetype === 'application/vnd.ms-excel') {
       // Read the .xlsx file using exceljs
       const workbook = new ExcelJS.Workbook();
       await workbook.xlsx.load(file.buffer, { sheetStubs: true }).then(async () => {

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -3,6 +3,11 @@ const csv = require('csv-parser');
 const { Readable } = require('stream');
 const { CELL_ADDRESS_REGEX } = require('../constants/regex');
 
+/**
+ * Converts a column index into an excel column (e.g. 0 -> A, 1 -> B)
+ * @param {number} index - number representing a column index e.g. 1.
+ * @returns {string} - string representing the excel column.
+ */
 const columnIndexToExcelColumn = (index) => {
   let result = '';
   let indexTracker = index;
@@ -13,10 +18,17 @@ const columnIndexToExcelColumn = (index) => {
   return result;
 };
 
+/**
+ * Converts the excel column into a column index (e.g. A -> 0, B -> 1)
+ * @param {string} column - string representing an excel column e.g. 'E'.
+ * @returns {number} - column index.
+ */
 const excelColumnToColumnIndex = (column) => {
   let result = 0;
   for (let i = 0; i < column.length; i += 1) {
+    // 26 represents the number of letters in the alphabet
     result *= 26;
+    // the unicode value of A is 65 so we minus 64 to get the index of A as 1
     result += column.charCodeAt(i) - 64;
   }
   return result - 1;
@@ -64,7 +76,7 @@ const parseXlsxToCsvArrays = (worksheet) => {
       }
     });
 
-    if (firstRow === false) {
+    if (!firstRow) {
       // If the row has no data in the final columns of the row, we need to fill in the empty cells with
       // empty strings and cell addresses so that the csv parser library can parse the data correctly
       while (columnCount < headerCount) {
@@ -73,7 +85,7 @@ const parseXlsxToCsvArrays = (worksheet) => {
         const lastAddressMatch = lastAddress.match(CELL_ADDRESS_REGEX);
         const [lastColumn, lastRow] = lastAddressMatch.slice(1);
         const lastColumnIndex = excelColumnToColumnIndex(lastColumn);
-        const newColumn = columnIndexToExcelColumn(parseInt(lastColumnIndex, 10) + 1);
+        const newColumn = columnIndexToExcelColumn(lastColumnIndex + 1);
         rowDataWithCellAddresses.push(`-${newColumn}${lastRow}`);
         columnCount += 1;
       }

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -5,9 +5,9 @@ const { CELL_ADDRESS_REGEX } = require('../constants/regex');
 
 /**
  * @typedef {import('exceljs').Worksheet} Worksheet
- * @typedef {Object} parsedXlsxDataResponse
- * @property {Object} csvData - The index of the object
- * @property {Object} csvDataWithCellAddresses - The error message of the object
+ * @typedef {Object} ParsedXlsxDataResponse
+ * @property {Object} csvData - array representing csv data from the worksheet
+ * @property {Object} csvDataWithCellAddresses - array representing csv data from the worksheet with cell addresses included
  */
 
 /**
@@ -62,7 +62,7 @@ const extractCellValue = (cell) => {
 /**
  * Takes in the worksheet from the exceljs package and parses it to an array of csv data.
  * @param {Worksheet} worksheet - worksheet representing the data.
- * @returns {parsedXlsxDataResponse} - object with a csvData array and csvData array of objects which also contain the cell address.
+ * @returns {ParsedXlsxDataResponse} - object with a csvData array and csvData array of objects which also contain the cell address.
  */
 const parseXlsxToCsvArrays = (worksheet) => {
   const csvData = [];

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -4,6 +4,13 @@ const { Readable } = require('stream');
 const { CELL_ADDRESS_REGEX } = require('../constants/regex');
 
 /**
+ * @typedef {import('exceljs').Worksheet} Worksheet
+ * @typedef {Object} parsedXlsxDataResponse
+ * @property {Object} csvData - The index of the object
+ * @property {Object} csvDataWithCellAddresses - The error message of the object
+ */
+
+/**
  * Converts a column index into an excel column (e.g. 0 -> A, 1 -> B)
  * @param {number} index - number representing a column index e.g. 1.
  * @returns {string} - string representing the excel column.
@@ -52,6 +59,11 @@ const extractCellValue = (cell) => {
   return cellValueWithoutNewLines;
 };
 
+/**
+ * Takes in the worksheet from the exceljs package and parses it to an array of csv data.
+ * @param {Worksheet} worksheet - worksheet representing the data.
+ * @returns {parsedXlsxDataResponse} - object with a csvData array and csvData array of objects which also contain the cell address.
+ */
 const parseXlsxToCsvArrays = (worksheet) => {
   const csvData = [];
   const csvDataWithCellAddresses = [];
@@ -231,6 +243,7 @@ module.exports = {
   extractCsvData,
   columnIndexToExcelColumn,
   excelColumnToColumnIndex,
+  parseXlsxToCsvArrays,
   xlsxBasedCsvToJsonPromise,
   csvBasedCsvToJsonPromise,
   removeCellAddressesFromArray,

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -1,5 +1,6 @@
 const {
   columnIndexToExcelColumn,
+  excelColumnToColumnIndex,
   xlsxBasedCsvToJsonPromise,
   csvBasedCsvToJsonPromise,
   removeCellAddressesFromArray,
@@ -18,6 +19,20 @@ describe('csv-utils', () => {
       const excelColumnIndex = columnIndexToExcelColumn(30);
 
       expect(excelColumnIndex).toBe('AE');
+    });
+  });
+
+  describe('excelColumnToColumnIndex', () => {
+    it('returns the correct index for a column below 26', async () => {
+      const columnIndex = excelColumnToColumnIndex('C');
+
+      expect(columnIndex).toBe(2);
+    });
+
+    it('returns the correct index for a column above 26', async () => {
+      const columnIndex = excelColumnToColumnIndex('AE');
+
+      expect(columnIndex).toBe(30);
     });
   });
 

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -1,3 +1,4 @@
+const ExcelJS = require('exceljs');
 const {
   columnIndexToExcelColumn,
   excelColumnToColumnIndex,
@@ -5,6 +6,7 @@ const {
   csvBasedCsvToJsonPromise,
   removeCellAddressesFromArray,
   extractCellValue,
+  parseXlsxToCsvArrays,
 } = require('./csv-utils');
 
 describe('csv-utils', () => {
@@ -33,6 +35,52 @@ describe('csv-utils', () => {
       const columnIndex = excelColumnToColumnIndex('AE');
 
       expect(columnIndex).toBe(30);
+    });
+  });
+
+  describe('parseXlsxToCsvArrays', () => {
+    it('Parses an excelJS workbook', async () => {
+      const workbook = new ExcelJS.Workbook();
+
+      const worksheet = workbook.addWorksheet('Sheet1');
+      worksheet.columns = [
+        { header: 'UKEF facility ID', key: 'A' },
+        { header: 'Exporter', key: 'B' },
+        { header: 'Base currency', key: 'C' },
+      ];
+      worksheet.addRow({ A: '20001371', B: 'Exporter 1', C: 'GBP' });
+      worksheet.addRow({ A: '20004872', B: 'Exporter 2', C: 'EUR' });
+
+      const parsedData = parseXlsxToCsvArrays(worksheet);
+
+      const expectedParsedData = {
+        csvData: 'UKEF facility ID,Exporter,Base currency\n20001371,Exporter 1,GBP\n20004872,Exporter 2,EUR',
+        csvDataWithCellAddresses: ['UKEF facility ID,Exporter,Base currency', '20001371-A2,Exporter 1-B2,GBP-C2', '20004872-A3,Exporter 2-B3,EUR-C3'],
+      };
+
+      expect(parsedData).toEqual(expectedParsedData);
+    });
+
+    it('Parses and excelJS workbook and adds in addresses for any missing cells in a row', async () => {
+      const workbook = new ExcelJS.Workbook();
+
+      const worksheet = workbook.addWorksheet('Sheet1');
+      worksheet.columns = [
+        { header: 'UKEF facility ID', key: 'A' },
+        { header: 'Exporter', key: 'B' },
+        { header: 'Base currency', key: 'C' },
+      ];
+      worksheet.addRow({ A: '20001371', B: 'Exporter 1', C: 'GBP' });
+      worksheet.addRow({ A: '20004872', B: 'Exporter 2' });
+
+      const parsedData = parseXlsxToCsvArrays(worksheet);
+
+      const expectedParsedData = {
+        csvData: 'UKEF facility ID,Exporter,Base currency\n20001371,Exporter 1,GBP\n20004872,Exporter 2,',
+        csvDataWithCellAddresses: ['UKEF facility ID,Exporter,Base currency', '20001371-A2,Exporter 1-B2,GBP-C2', '20004872-A3,Exporter 2-B3,-C3'],
+      };
+
+      expect(parsedData).toEqual(expectedParsedData);
     });
   });
 


### PR DESCRIPTION
## Introduction :pencil2:
Empty cells at the end of a row would not be processed by the excel library and so we would not get the cell addresses or empty values for these cells when processing

## Resolution :heavy_check_mark:
Keep count of how many header columns we have and add in any empty values with cell addresses so we can show descriptive error messages later on in the process.


