### PR TITLE
feat(FN-1992): update currency validation error message

### DIFF
--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-facility-utilisation-error.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-facility-utilisation-error.js
@@ -13,7 +13,7 @@ const generateFacilityUtilisationError = (facilityUtilisationObject, exporterNam
   }
   if (!CURRENCY_NUMBER_REGEX.test(facilityUtilisationObject?.value)) {
     return {
-      errorMessage: 'Facility utilisation must be a number',
+      errorMessage: 'Facility utilisation must be a number with a maximum of two decimal places',
       column: facilityUtilisationObject?.column,
       row: facilityUtilisationObject?.row,
       value: facilityUtilisationObject?.value,

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-facility-utilisation-error.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-facility-utilisation-error.test.js
@@ -29,10 +29,29 @@ describe('generateFacilityUtilisationError', () => {
       row: 1,
     };
     const expectedError = {
-      errorMessage: 'Facility utilisation must be a number',
+      errorMessage: 'Facility utilisation must be a number with a maximum of two decimal places',
       column: 1,
       row: 1,
       value: 'abc',
+      exporter: testExporterName,
+    };
+
+    const facilityUtilisationError = generateFacilityUtilisationError(invalidFacilityUtilisation, testExporterName);
+
+    expect(facilityUtilisationError).toEqual(expectedError);
+  });
+
+  it('returns an error when the value has more than 2 decimal places', async () => {
+    const invalidFacilityUtilisation = {
+      value: '0.123',
+      column: 1,
+      row: 1,
+    };
+    const expectedError = {
+      errorMessage: 'Facility utilisation must be a number with a maximum of two decimal places',
+      column: 1,
+      row: 1,
+      value: '0.123',
       exporter: testExporterName,
     };
 

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-monthly-fees-paid-error.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-monthly-fees-paid-error.js
@@ -13,7 +13,7 @@ const generateMonthlyFeesPaidError = (monthlyFeesPaidObject, exporterName) => {
   }
   if (!CURRENCY_NUMBER_REGEX.test(monthlyFeesPaidObject?.value)) {
     return {
-      errorMessage: 'Fees paid to UKEF for the period must be a number',
+      errorMessage: 'Fees paid to UKEF for the period must be a number with a maximum of two decimal places',
       column: monthlyFeesPaidObject?.column,
       row: monthlyFeesPaidObject?.row,
       value: monthlyFeesPaidObject?.value,

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-monthly-fees-paid-error.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-monthly-fees-paid-error.test.js
@@ -29,10 +29,29 @@ describe('generateMonthlyFeesPaidError', () => {
       row: 1,
     };
     const expectedError = {
-      errorMessage: 'Fees paid to UKEF for the period must be a number',
+      errorMessage: 'Fees paid to UKEF for the period must be a number with a maximum of two decimal places',
       column: 1,
       row: 1,
       value: 'abc',
+      exporter: testExporterName,
+    };
+
+    const monthlyFeesPaidError = generateMonthlyFeesPaidError(invalidMonthlyFeesPaid, testExporterName);
+
+    expect(monthlyFeesPaidError).toEqual(expectedError);
+  });
+
+  it('returns an error when the value has more than 2 decimal places', async () => {
+    const invalidMonthlyFeesPaid = {
+      value: '0.123',
+      column: 1,
+      row: 1,
+    };
+    const expectedError = {
+      errorMessage: 'Fees paid to UKEF for the period must be a number with a maximum of two decimal places',
+      column: 1,
+      row: 1,
+      value: '0.123',
       exporter: testExporterName,
     };
 

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-total-fees-accrued-error.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-total-fees-accrued-error.js
@@ -2,32 +2,25 @@ const { CURRENCY_NUMBER_REGEX } = require('../../../../constants/regex');
 const { FILE_UPLOAD } = require('../../../../constants/file-upload');
 
 const generateTotalFeesAccruedError = (totalFeesAccruedObject, exporterName) => {
-  if (!totalFeesAccruedObject?.value) {
+  if (!totalFeesAccruedObject) {
     return {
       errorMessage: 'Total fees accrued for the month must have an entry',
-      column: totalFeesAccruedObject?.column,
-      row: totalFeesAccruedObject?.row,
-      value: totalFeesAccruedObject?.value,
       exporter: exporterName,
     };
   }
-  if (!CURRENCY_NUMBER_REGEX.test(totalFeesAccruedObject?.value)) {
-    return {
-      errorMessage: 'Total fees accrued for the month must be a number',
-      column: totalFeesAccruedObject?.column,
-      row: totalFeesAccruedObject?.row,
-      value: totalFeesAccruedObject?.value,
-      exporter: exporterName,
-    };
+
+  const { value, column, row } = totalFeesAccruedObject;
+
+  const generateError = (errorMessage) => ({ errorMessage, column, row, value, exporter: exporterName });
+
+  if (!value) {
+    return generateError('Total fees accrued for the month must have an entry');
   }
-  if (totalFeesAccruedObject?.value?.length > FILE_UPLOAD.MAX_CELL_CHARACTER_COUNT) {
-    return {
-      errorMessage: `Total fees accrued for the month must be ${FILE_UPLOAD.MAX_CELL_CHARACTER_COUNT} characters or less`,
-      column: totalFeesAccruedObject?.column,
-      row: totalFeesAccruedObject?.row,
-      value: totalFeesAccruedObject?.value,
-      exporter: exporterName,
-    };
+  if (!CURRENCY_NUMBER_REGEX.test(value)) {
+    return generateError('Total fees accrued for the month must be a number with a maximum of two decimal places');
+  }
+  if (value.length > FILE_UPLOAD.MAX_CELL_CHARACTER_COUNT) {
+    return generateError(`Total fees accrued for the month must be ${FILE_UPLOAD.MAX_CELL_CHARACTER_COUNT} characters or less`);
   }
   return null;
 };

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-total-fees-accrued-error.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-cell-validators/generate-total-fees-accrued-error.test.js
@@ -29,10 +29,29 @@ describe('generateTotalFeesAccruedError', () => {
       row: 1,
     };
     const expectedError = {
-      errorMessage: 'Total fees accrued for the month must be a number',
+      errorMessage: 'Total fees accrued for the month must be a number with a maximum of two decimal places',
       column: 1,
       row: 1,
       value: 'abc',
+      exporter: testExporterName,
+    };
+
+    const totalFeesAccruedError = generateTotalFeesAccruedError(invalidTotalFeesAccrued, testExporterName);
+
+    expect(totalFeesAccruedError).toEqual(expectedError);
+  });
+
+  it('returns an error when the value has more than 2 decimal places', async () => {
+    const invalidTotalFeesAccrued = {
+      value: '0.123',
+      column: 1,
+      row: 1,
+    };
+    const expectedError = {
+      errorMessage: 'Total fees accrued for the month must be a number with a maximum of two decimal places',
+      column: 1,
+      row: 1,
+      value: '0.123',
       exporter: testExporterName,
     };
 


### PR DESCRIPTION
## Ticket
[FN-1992](https://ukef-dtfs.atlassian.net/browse/FN-1992)

## Introduction :pencil2:
Currently if a report field is a number, but has more than 2 decimal places, it still returns the generic
> <field_name> must be a number

error message. Instead the error message should be

> <field_name> must be a number with a maximum of two decimal places

## Resolution :heavy_check_mark:

Update error copy for any columns validating a currency amount
* Total fees accrued for the month
* Fees paid to UKEF for the period
* Facility utilisation
