### PR TITLE
fix(FN-1536): move payload parameters from query to body

### DIFF
--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.ts
@@ -70,7 +70,7 @@ export const getReportReconciliationSummariesViewModel = async (
   const bankHolidays = await getBankHolidayDates(userToken);
 
   return summariesApiResponse.map(({ items: apiItems, submissionMonth }) => {
-    const reportDueDate = getReportDueDate(userToken, bankHolidays, submissionMonth);
+    const reportDueDate = getReportDueDate(bankHolidays, submissionMonth);
     const reportPeriodStart = getReportPeriodStart(submissionMonth);
 
     return {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.ts
@@ -29,7 +29,7 @@ type UpdateUtilisationReportStatusRequestBody = {
   [key: string]: 'on'; // all checkboxes in payload have value 'on'
 };
 
-const getReportIdentifiersFromBody = (body: null | UpdateUtilisationReportStatusRequestBody): ReportIdentifier[] => {
+const getReportIdentifiersFromBody = (body: undefined | UpdateUtilisationReportStatusRequestBody): ReportIdentifier[] => {
   if (!body || typeof body !== 'object') {
     return [];
   }

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.ts
@@ -31,7 +31,7 @@ type UpdateUtilisationReportStatusRequestBody = {
 
 const getReportIdentifiersFromBody = (body: undefined | UpdateUtilisationReportStatusRequestBody): ReportIdentifier[] => {
   if (!body || typeof body !== 'object') {
-    return [];
+    throw new Error('Expected request body to be an object');  
   }
 
   const { 'submission-month': submissionMonth } = body;

--- a/trade-finance-manager-ui/server/helpers/date.js
+++ b/trade-finance-manager-ui/server/helpers/date.js
@@ -85,7 +85,7 @@ const getIsoMonth = (dateInMonth) => {
   return format(dateInMonth, 'yyyy-MM');
 };
 
-const ISO_MONTH_REGEX = /^\d{4}-\d{2}$/;
+const ISO_MONTH_REGEX = /^(?<year>\d{4})-(?<month>\d{2})$/;
 
 /**
  * Checks whether the provided value is an ISO month string in format 'yyyy-MM'

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
@@ -28,13 +28,12 @@ describe('utilisation-report-service', () => {
       'returns business day $businessDay as formatted due date $expectedDueDate based on bank holidays $bankHolidays',
       async ({ businessDay, bankHolidays, expectedDueDate }) => {
         // Arrange
-        const userToken = 'user-token';
         const submissionMonth = '2023-11';
 
         process.env.UTILISATION_REPORT_DUE_DATE_BUSINESS_DAYS_FROM_START_OF_MONTH = `${businessDay}`;
 
         // Act
-        const dueDate = await getReportDueDate(userToken, bankHolidays, submissionMonth);
+        const dueDate = await getReportDueDate(bankHolidays, submissionMonth);
 
         // Assert
         expect(dueDate).toEqual(expectedDueDate);

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.ts
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.ts
@@ -4,7 +4,7 @@ import { ReportPeriodStart } from '../types/utilisation-reports';
 import { getBusinessDayOfMonth, getOneIndexedMonth } from '../helpers/date';
 import { asString } from '../helpers/validation';
 
-export const getReportDueDate = (userToken: string, bankHolidays: Date[], submissionMonth: IsoMonthStamp): Date => {
+export const getReportDueDate = (bankHolidays: Date[], submissionMonth: IsoMonthStamp): Date => {
   const businessDaysFromStartOfMonth = asString(
     process.env.UTILISATION_REPORT_DUE_DATE_BUSINESS_DAYS_FROM_START_OF_MONTH,
     'UTILISATION_REPORT_DUE_DATE_BUSINESS_DAYS_FROM_START_OF_MONTH',

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
@@ -4,11 +4,11 @@
 {% macro render(params) %}
   {% set summaryItems = params.summaryItems %}
   {% set submissionMonth = params.submissionMonth %}
-  {% set reportPeriodStart = params.reportPeriodStart %}
   {% set csrfToken = params.csrfToken %}
 
   <form method="POST" data-cy="form">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <input type="hidden" name="submission-month" value="{{ submissionMonth }}"/>
     <table class="govuk-table bank-reports-reconciliation-table" data-module="moj-sortable-table" data-cy="utilisation-report-reconciliation-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
@@ -88,16 +88,18 @@
     <div class="govuk-button-group">
       {{ govukButton({
         text: "Mark report as completed",
+        name: "form-button",
+        value: "completed",
         attributes: {
-          formaction: ["?_csrf=", csrfToken, "&form-button=completed&reportPeriodStartMonth=", reportPeriodStart.month, "&reportPeriodYear=", reportPeriodStart.year] | join,
           "data-cy": "mark-report-as-completed-button"
         }
       }) }}
       {{ govukButton({
         text: "Mark as not completed",
+        name: "form-button",
+        value: "not-completed",
         classes: "govuk-button--secondary",
         attributes: {
-          formaction: ["?_csrf=", csrfToken, "&form-button=not-completed&reportPeriodStartMonth=", reportPeriodStart.month, "&reportPeriodYear=", reportPeriodStart.year] | join,
           "data-cy": "mark-as-not-completed-button"
         }
       }) }}

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-reports.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-reports.njk
@@ -36,7 +36,6 @@
         {{ reportReconciliationTable.render({
           summaryItems: reportPeriodSummary.items,
           submissionMonth: reportPeriodSummary.submissionMonth,
-          reportPeriodStart: reportPeriodSummary.reportPeriodStart,
           csrfToken: csrfToken
         }) }}
       {% endfor %}


### PR DESCRIPTION
## Introduction :pencil2:
Some of the parameters required to generate the `updateReportStatus` payload were stored in the request `url` as query parameters instead of being hidden in the request body. This meant that manually reloading the page after attempting to mark a report as done or not done would attempt to resubmit the form.

## Resolution :heavy_check_mark:
Moves the query parameters to the body and updates the controller to extract these values.

## Miscellaneous :heavy_plus_sign:
Updates a function which didn't need access to the `userToken`.

