### PR TITLE
chore(DTFS2-6952): update node and npm versions

### DIFF
--- a/azure-functions/acbs-function/package-lock.json
+++ b/azure-functions/acbs-function/package-lock.json
@@ -17,8 +17,8 @@
         "moment": "^2.29.4"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/azure-functions/acbs-function/package.json
+++ b/azure-functions/acbs-function/package.json
@@ -11,7 +11,6 @@
     "axios": "^0.27.2",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
-    "dtfs": "file:../..",
     "durable-functions": "^1.5.4",
     "eslint": "^8.55.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/azure-functions/acbs-function/package.json
+++ b/azure-functions/acbs-function/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.27.2",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
+    "dtfs": "file:../..",
     "durable-functions": "^1.5.4",
     "eslint": "^8.55.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -19,8 +20,8 @@
     "moment": "^2.29.4"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/azure-functions/number-generator-function/package-lock.json
+++ b/azure-functions/number-generator-function/package-lock.json
@@ -14,8 +14,8 @@
         "jest": "29.5.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/azure-functions/number-generator-function/package.json
+++ b/azure-functions/number-generator-function/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
-    "dtfs": "file:../..",
     "durable-functions": "^1.5.4",
     "jest": "29.5.0"
   },

--- a/azure-functions/number-generator-function/package.json
+++ b/azure-functions/number-generator-function/package.json
@@ -9,11 +9,12 @@
   "dependencies": {
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
+    "dtfs": "file:../..",
     "durable-functions": "^1.5.4",
     "jest": "29.5.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   }
 }

--- a/dtfs-central-api/package-lock.json
+++ b/dtfs-central-api/package-lock.json
@@ -6992,12 +6992,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "peer": true
-    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",

--- a/dtfs-central-api/package-lock.json
+++ b/dtfs-central-api/package-lock.json
@@ -37,8 +37,8 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -32,6 +32,7 @@
     "compression": "^1.7.4",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "dtfs": "file:..",
     "escape-string-regexp": "^4.0.0",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
@@ -56,8 +57,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -32,7 +32,6 @@
     "compression": "^1.7.4",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
-    "dtfs": "file:..",
     "escape-string-regexp": "^4.0.0",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",

--- a/external-api/package-lock.json
+++ b/external-api/package-lock.json
@@ -58,8 +58,8 @@
         "ts-jest": "^29.1.1"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/external-api/package.json
+++ b/external-api/package.json
@@ -43,7 +43,6 @@
     "cron-job-manager": "^2.3.1",
     "date-fns": "^2.30.0",
     "dotenv": "16.3.1",
-    "dtfs": "file:..",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.11.2",

--- a/external-api/package.json
+++ b/external-api/package.json
@@ -43,6 +43,7 @@
     "cron-job-manager": "^2.3.1",
     "date-fns": "^2.30.0",
     "dotenv": "16.3.1",
+    "dtfs": "file:..",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.11.2",
@@ -75,8 +76,8 @@
     "ts-jest": "^29.1.1"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/gef-ui/package-lock.json
+++ b/gef-ui/package-lock.json
@@ -78,8 +78,8 @@
         "webpack-merge": "^5.10.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/gef-ui/package.json
+++ b/gef-ui/package.json
@@ -47,7 +47,6 @@
     "csurf": "^1.11.0",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
-    "dtfs": "file:..",
     "express": "^4.18.2",
     "express-fileupload": "^1.4.3",
     "express-rate-limit": "^6.11.2",

--- a/gef-ui/package.json
+++ b/gef-ui/package.json
@@ -47,6 +47,7 @@
     "csurf": "^1.11.0",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "dtfs": "file:..",
     "express": "^4.18.2",
     "express-fileupload": "^1.4.3",
     "express-rate-limit": "^6.11.2",
@@ -101,8 +102,8 @@
     "webpack-merge": "^5.10.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "sort-package-json": "^2.6.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "sort-package-json": "^2.6.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/portal-api/package-lock.json
+++ b/portal-api/package-lock.json
@@ -54,8 +54,8 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -44,6 +44,7 @@
     "cors": "2.8.5",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "dtfs": "file:..",
     "escape-string-regexp": "^4.0.0",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
@@ -81,8 +82,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -44,7 +44,6 @@
     "cors": "2.8.5",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
-    "dtfs": "file:..",
     "escape-string-regexp": "^4.0.0",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -74,8 +74,8 @@
         "webpack-merge": "^5.10.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/portal/package.json
+++ b/portal/package.json
@@ -43,7 +43,6 @@
     "core-js": "^3.34.0",
     "csurf": "^1.11.0",
     "dotenv": "16.0.3",
-    "dtfs": "file:..",
     "express": "^4.18.2",
     "express-rate-limit": "^6.11.2",
     "express-session": "1.17.3",

--- a/portal/package.json
+++ b/portal/package.json
@@ -43,6 +43,7 @@
     "core-js": "^3.34.0",
     "csurf": "^1.11.0",
     "dotenv": "16.0.3",
+    "dtfs": "file:..",
     "express": "^4.18.2",
     "express-rate-limit": "^6.11.2",
     "express-session": "1.17.3",
@@ -98,8 +99,8 @@
     "webpack-merge": "^5.10.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/trade-finance-manager-api/package-lock.json
+++ b/trade-finance-manager-api/package-lock.json
@@ -55,8 +55,8 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -35,6 +35,7 @@
     "crypto": "^1.0.1",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "dtfs": "file:..",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.11.2",
@@ -73,8 +74,8 @@
     "typescript": "^5.3.3"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -35,7 +35,6 @@
     "crypto": "^1.0.1",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
-    "dtfs": "file:..",
     "express": "4.18.2",
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^6.11.2",

--- a/trade-finance-manager-ui/package-lock.json
+++ b/trade-finance-manager-ui/package-lock.json
@@ -74,8 +74,8 @@
         "webpack-merge": "^5.10.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/trade-finance-manager-ui/package.json
+++ b/trade-finance-manager-ui/package.json
@@ -47,6 +47,7 @@
     "csurf": "^1.11.0",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
+    "dtfs": "file:..",
     "express": "^4.18.2",
     "express-rate-limit": "^6.11.2",
     "express-session": "1.17.3",
@@ -97,8 +98,8 @@
     "webpack-merge": "^5.10.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/trade-finance-manager-ui/package.json
+++ b/trade-finance-manager-ui/package.json
@@ -47,7 +47,6 @@
     "csurf": "^1.11.0",
     "date-fns": "^2.30.0",
     "dotenv": "16.0.3",
-    "dtfs": "file:..",
     "express": "^4.18.2",
     "express-rate-limit": "^6.11.2",
     "express-session": "1.17.3",

--- a/utils/data-migration/package-lock.json
+++ b/utils/data-migration/package-lock.json
@@ -22,8 +22,8 @@
         "xml2js": "^0.5.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/utils/data-migration/package.json
+++ b/utils/data-migration/package.json
@@ -13,7 +13,6 @@
     "bson": "^6.2.0",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
-    "dtfs": "file:../..",
     "generate-password": "^1.7.1",
     "html-entities": "^2.4.0",
     "json2csv": "^5.0.7",

--- a/utils/data-migration/package.json
+++ b/utils/data-migration/package.json
@@ -13,6 +13,7 @@
     "bson": "^6.2.0",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
+    "dtfs": "file:../..",
     "generate-password": "^1.7.1",
     "html-entities": "^2.4.0",
     "json2csv": "^5.0.7",
@@ -22,8 +23,8 @@
     "xml2js": "^0.5.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/utils/mock-data-loader/package-lock.json
+++ b/utils/mock-data-loader/package-lock.json
@@ -20,8 +20,8 @@
         "mongodb": "^6.3.0"
       },
       "engines": {
-        "node": ">=21",
-        "npm": ">=9.8.0"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@babel/runtime": {

--- a/utils/mock-data-loader/package.json
+++ b/utils/mock-data-loader/package.json
@@ -10,6 +10,7 @@
     "chance": "^1.1.11",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
+    "dtfs": "file:../..",
     "generate-password": "^1.7.1",
     "json2csv": "^5.0.7",
     "jsonwebtoken": "^9.0.2",
@@ -17,8 +18,8 @@
     "mongodb": "^6.3.0"
   },
   "engines": {
-    "node": ">=21",
-    "npm": ">=9.8.0"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "engineStrict": true
 }

--- a/utils/mock-data-loader/package.json
+++ b/utils/mock-data-loader/package.json
@@ -10,7 +10,6 @@
     "chance": "^1.1.11",
     "date-fns": "^2.30.0",
     "dotenv": "^16.3.1",
-    "dtfs": "file:../..",
     "generate-password": "^1.7.1",
     "json2csv": "^5.0.7",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
## Introduction :pencil2:
All our docker files and the deployed versions of our code are using node 20 rather than node 21. We should match the package.json node versions to the deployed version of node.
Note the azure functions are actually at node 14 not 20 but these are already out of sync and need to be upgraded.
Npm should also be upgraded to the npm version that is coupled with node 20 (10+)

## Resolution :heavy_check_mark:
Update package.json files to have engines pointed at node 20 and npm 10


