### PR TITLE
fix(DTFS2-6200): update the database when deal being processed

### DIFF
--- a/portal/templates/contract/about/about-supplier.njk
+++ b/portal/templates/contract/about/about-supplier.njk
@@ -84,7 +84,7 @@
       }) }}
 
       {{ govukButton({
-        "text": "NextPage",
+        "text": "Next Page",
         "attributes" : { "data-cy" : "NextPage" }
       }) }}
 

--- a/portal/templates/contract/about/about-supply-buyer.njk
+++ b/portal/templates/contract/about/about-supply-buyer.njk
@@ -68,7 +68,7 @@
     }) }}
 
     {{ govukButton({
-      "text": "NextPage",
+      "text": "Next Page",
       "attributes" : { "data-cy" : "NextPage" }
     }) }}
 

--- a/trade-finance-manager-api/src/constants/durable-functions.js
+++ b/trade-finance-manager-api/src/constants/durable-functions.js
@@ -3,6 +3,12 @@ const TYPE = {
   NUMBER_GENERATOR: 'NUMBER_GENERATOR',
 };
 
+const STATUS = {
+  RUNNING: 'Running',
+  PENDING: 'Pending',
+};
+
 module.exports = {
   TYPE,
+  STATUS,
 };

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -110,7 +110,7 @@ const checkAzureAcbsFunction = async () => {
     const collection = await db.getCollection('durable-functions-log');
     const runningTasks = await collection.find({
       type: { $eq: 'ACBS' },
-      status: { $eq: 'CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING' },
+      status: { $eq: CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING },
     }).toArray();
     const tasks = await runningTasks.map(({ acbsTaskLinks = {} }) =>
       api.getFunctionsAPI(CONSTANTS.DURABLE_FUNCTIONS.TYPE.ACBS, acbsTaskLinks.statusQueryGetUri));

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -19,7 +19,7 @@ const addToACBSLog = async ({
       deal,
       facility,
       bank,
-      status: 'Running',
+      status: CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING,
       instanceId: acbsTaskLinks.id,
       acbsTaskLinks,
       submittedDate: moment().format(),
@@ -110,7 +110,7 @@ const checkAzureAcbsFunction = async () => {
     const collection = await db.getCollection('durable-functions-log');
     const runningTasks = await collection.find({
       type: { $eq: 'ACBS' },
-      status: { $eq: 'Running' },
+      status: { $eq: 'CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING' },
     }).toArray();
     const tasks = await runningTasks.map(({ acbsTaskLinks = {} }) =>
       api.getFunctionsAPI(CONSTANTS.DURABLE_FUNCTIONS.TYPE.ACBS, acbsTaskLinks.statusQueryGetUri));
@@ -119,7 +119,7 @@ const checkAzureAcbsFunction = async () => {
     taskList.forEach(async (task) => {
       if (task.runtimeStatus) {
       // Update
-        if (task.runtimeStatus !== 'Running') {
+        if (task.runtimeStatus !== CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING) {
           await collection.findOneAndUpdate(
             { instanceId: { $eq: task.instanceId } },
             $.flatten({

--- a/trade-finance-manager-api/src/v1/controllers/number-generator.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/number-generator.controller.js
@@ -51,7 +51,7 @@ const checkAzureNumberGeneratorFunction = async () => {
   const timenow = new Date().toUTCString();
   await collection.updateMany(
     {
-      status: { $eq: 'Running' },
+      status: { $eq: CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING },
       type: { $eq: CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR },
     },
     { $set: { status: `In progress at ${timenow}` } },
@@ -122,7 +122,7 @@ const checkAzureNumberGeneratorFunction = async () => {
         status: { $eq: `In progress at ${timenow}` },
         type: { $eq: CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR },
       },
-      { $set: { status: 'Running' } },
+      { $set: { status: CONSTANTS.STATUS.DURABLE_FUNCTIONS.RUNNING } },
     );
   }
 };

--- a/trade-finance-manager-api/src/v1/controllers/number-generator.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/number-generator.controller.js
@@ -48,83 +48,105 @@ const checkAzureNumberGeneratorFunction = async () => {
   // Fetch outstanding functions
 
   const collection = await db.getCollection('durable-functions-log');
-  const timenow = new Date().toUTCString();
-  await collection.updateMany(
-    {
-      status: { $eq: CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING },
-      type: { $eq: CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR },
-    },
-    { $set: { status: `In progress at ${timenow}` } },
-  );
+  const dateNow = new Date();
+  const STALENESS_TIME = 1 * 60 * 1000; // 1 minute
+  const dateWhenStale = new Date(dateNow - STALENESS_TIME);
+
+  // Query database for number generator functions that have either never been run
+  // or were ran STALENESS_TIME ago
+  const query = {
+    $and: [
+      {
+        status: { $eq: CONSTANTS.DURABLE_FUNCTIONS.STATUS.RUNNING },
+      },
+      {
+        type: { $eq: CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR },
+      },
+      {
+        $or: [
+          {
+            runningAt: {
+              $eq: null,
+            },
+          },
+          {
+            runningAt: {
+              $lt: dateWhenStale,
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  await collection
+    .updateMany(
+      query,
+      { $set: { runningAt: dateNow } }
+    );
   const runningTasks = await collection
     .find({
-      status: { $eq: `In progress at ${timenow}` },
+      runningAt: { $eq: dateNow },
       type: { $eq: CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR },
     })
     .toArray();
-  try {
-    const taskResults = runningTasks.map(({ numberGeneratorFunctionUrls = {} }) =>
+
+  const taskResults = runningTasks.map(
+    ({ numberGeneratorFunctionUrls = {} }) =>
       api.getFunctionsAPI(
         CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR,
         numberGeneratorFunctionUrls.statusQueryGetUri
-      ),);
+      ),
+  );
 
-    const taskResultsList = await Promise.all(taskResults);
+  const taskResultsList = await Promise.all(taskResults);
 
-    taskResultsList.forEach(async (task) => {
-      if (task?.runtimeStatus === 'Completed' && !task?.output?.ukefId?.error) {
-        // Only process if all tasks for that deals have finished
-        if (otherDealTasksStillRunning(task, taskResultsList)) {
-          return;
-        }
-
-        const { input, output, instanceId, runtimeStatus } = task;
-
-        // Update portalDeal
-        switch (input.dealType) {
-          case CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS:
-            await updatePortalDeal(input, output);
-            break;
-
-          case CONSTANTS.DEALS.DEAL_TYPE.GEF:
-            await updateGefApplication(input, output);
-            break;
-
-          default:
-            return;
-        }
-
-        // Submit to TFM.
-        // Only trigger this update if the Azure function task's ID, is the same as the deal ID.
-        // Without this conditional, every task (i.e multiple facilities) will trigger multiple deal submissions.
-        if (input.entityId === input.dealId) {
-          await dealSubmitController.submitDealAfterUkefIds(input.entityId, input.dealType, input.user);
-        }
-
-        // Update functionLog
-        // Keep any with errors for reference but remove successful ones
-        if (output && output.error) {
-          await collection.findOneAndUpdate(
-            { instanceId: { $eq: instanceId } },
-            $.flatten({
-              status: runtimeStatus,
-              taskResult: task,
-            }),
-          );
-        } else if (typeof instanceId === 'string') {
-          await collection.deleteOne({ instanceId: { $eq: instanceId } });
-        }
+  taskResultsList.forEach(async (task) => {
+    if (task?.runtimeStatus === 'Completed' && !task?.output?.ukefId?.error) {
+      // Only process if all tasks for that deals have finished
+      if (otherDealTasksStillRunning(task, taskResultsList)) {
+        return;
       }
-    });
-  } finally {
-    await collection.updateMany(
-      {
-        status: { $eq: `In progress at ${timenow}` },
-        type: { $eq: CONSTANTS.DURABLE_FUNCTIONS.TYPE.NUMBER_GENERATOR },
-      },
-      { $set: { status: CONSTANTS.STATUS.DURABLE_FUNCTIONS.RUNNING } },
-    );
-  }
+
+      const { input, output, instanceId, runtimeStatus } = task;
+
+      // Update portalDeal
+      switch (input.dealType) {
+        case CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS:
+          await updatePortalDeal(input, output);
+          break;
+
+        case CONSTANTS.DEALS.DEAL_TYPE.GEF:
+          await updateGefApplication(input, output);
+          break;
+
+        default:
+          return;
+      }
+
+      // Submit to TFM.
+      // Only trigger this update if the Azure function task's ID, is the same as the deal ID.
+      // Without this conditional, every task (i.e multiple facilities) will trigger multiple deal submissions.
+      if (input.entityId === input.dealId) {
+        await dealSubmitController.submitDealAfterUkefIds(input.entityId, input.dealType, input.user);
+      }
+
+      // Update functionLog
+      // Keep any with errors for reference but remove successful ones
+      if (output && output.error) {
+        await collection.findOneAndUpdate(
+          { instanceId: { $eq: instanceId } },
+          $.flatten({
+            status: runtimeStatus,
+            taskResult: task,
+            runningAt: null,
+          }),
+        );
+      } else if (typeof instanceId === 'string') {
+        await collection.deleteOne({ instanceId: { $eq: instanceId } });
+      }
+    }
+  });
 };
 
 module.exports = {


### PR DESCRIPTION
## Introduction :pencil2:
If timed badly, `trade-finanace-manager-api` can process a deal twice. This can result in duplicate emails being sent or the `tfm.stage` value not being added to the database.

## Resolution :heavy_check_mark:
* When a function is being processed, add/update `runningAt` field on the durable function document. 
* Only process documents that have either no `runningAt` field or, one sufficiently long ago to not cause any race conditions.


## Miscellaneous :heavy_plus_sign:
* Added the deal status to constants
* Fixed a typo on the Next Page buttons