### PR TITLE
chore: log sign-in link when in development

### DIFF
--- a/portal-api/src/v1/users/sign-in-link.service.js
+++ b/portal-api/src/v1/users/sign-in-link.service.js
@@ -113,6 +113,10 @@ class SignInLinkService {
   }
 
   async #sendSignInLinkEmail({ userEmail, userFirstName, userLastName, signInLink }) {
+    if (process.env.NODE_ENV === 'development') {
+      console.info('🔗 signInLink 🔗', signInLink);
+    }
+
     try {
       await sendEmail(EMAIL_TEMPLATE_IDS.SIGN_IN_LINK, userEmail, {
         firstName: userFirstName,


### PR DESCRIPTION
## Introduction :pencil2:
Automatically log the Portal sign-in link when in development to easily allow sign-in when emails are not actually sent.

