### PR TITLE
feat(FN-2050): handle non-ascii characters in csv files

### DIFF
--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -166,7 +166,12 @@ const csvBasedCsvToJsonPromise = async (csvBuffer) => {
       csvStream
         .pipe(
           csv({
-            mapHeaders: ({ header }) => header.toLowerCase().replace(/\s/g, ' ').trim(),
+            mapHeaders: ({ header }) =>
+              header
+                .toLowerCase()
+                .replace(/\s/g, ' ')
+                .replace(/[^ -~]+/g, ' ')
+                .trim(),
             mapValues: ({ index, value }) => ({ value, column: columnIndexToExcelColumn(index), row: null }),
           }),
         )

--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -163,6 +163,7 @@ const csvBasedCsvToJsonPromise = async (csvBuffer) => {
   return new Promise((resolve, reject) => {
     try {
       const csvData = [];
+      const nonPrintableAsciiCharacterRegex = /[^ -~]+/g;
       csvStream
         .pipe(
           csv({
@@ -170,7 +171,7 @@ const csvBasedCsvToJsonPromise = async (csvBuffer) => {
               header
                 .toLowerCase()
                 .replace(/\s/g, ' ')
-                .replace(/[^ -~]+/g, ' ')
+                .replace(nonPrintableAsciiCharacterRegex, ' ')
                 .trim(),
             mapValues: ({ index, value }) => ({ value, column: columnIndexToExcelColumn(index), row: null }),
           }),


### PR DESCRIPTION
## Introduction :pencil2:
We need to handle non-ascii characters in csv files in case during the download any of the characters are not ascii characters due to the different encoding used

## Resolution :heavy_check_mark:
Replace any non-ascii characters including the 65533 unicode question mark character with spaces. This works for the current mock reports we are using with the allowed headers

