### PR TITLE
feat(FN-2070): move bank reports primary navigation

### DIFF
--- a/trade-finance-manager-ui/templates/_partials/primary-navigation.njk
+++ b/trade-finance-manager-ui/templates/_partials/primary-navigation.njk
@@ -1,14 +1,5 @@
 {% from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
-{% set bankReportsNavItem = {
-  text: "Bank reports",
-  href: "/utilisation-reports",
-  active: (activePrimaryNavigation == "utilisation reports"),
-  attributes: {
-    "data-cy": "bank-reports-nav-link"
-  }
-} %}
-
 {% set allDealsNavItem = {
   text: "All deals",
   href: "/deals",
@@ -27,10 +18,19 @@
   }
 } %}
 
+{% set bankReportsNavItem = {
+  text: "Bank reports",
+  href: "/utilisation-reports",
+  active: (activePrimaryNavigation == "utilisation reports"),
+  attributes: {
+    "data-cy": "bank-reports-nav-link"
+  }
+} %}
+
 {% set navItems = [] %}
 
 {% if user and user | userIsInTeam(['PDC_READ', 'PDC_RECONCILE']) %}
-  {% set navItems = [bankReportsNavItem, allDealsNavItem, allFacilitiesNavItem] %}
+  {% set navItems = [allDealsNavItem, allFacilitiesNavItem, bankReportsNavItem] %}
 {% elif user %}
   {% set navItems = [allDealsNavItem, allFacilitiesNavItem] %}
 {% endif %}


### PR DESCRIPTION
## Introduction :pencil2:
We want the `TFM-UI` "Bank reports" primary navigation item to be on the far right.

## Resolution :heavy_check_mark:
Moves the primary navigation item.

## Screenshots 📷

![FN-2070-bank-reports-tab](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/872e802b-e5e1-497d-a578-c77765de14f5)


