### PR TITLE
fix(FN-2075): highlight 'Users' nav item on user admin pages in Portal

### DIFF
--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -1,5 +1,5 @@
 const pageRenderer = require('../pageRenderer');
-const { PAYMENT_REPORT_OFFICER } = require('../../server/constants/roles');
+const { ROLES, PRIMARY_NAV_KEY } = require('../../server/constants');
 
 const page = 'utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk';
 const render = pageRenderer(page);
@@ -8,7 +8,7 @@ describe(page, () => {
   const user = {
     firstname: 'John',
     surname: 'Smith',
-    roles: [PAYMENT_REPORT_OFFICER],
+    roles: [ROLES.PAYMENT_REPORT_OFFICER],
   };
   const dueReportDates = [{
     month: 12,
@@ -33,7 +33,7 @@ describe(page, () => {
     beforeEach(() => {
       wrapper = render({
         user,
-        primaryNav: 'utilisation_report_upload',
+        primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
         dueReportDates,
       });
     });
@@ -66,7 +66,7 @@ describe(page, () => {
     beforeEach(() => {
       wrapper = render({
         user,
-        primaryNav: 'utilisation_report_upload',
+        primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
         dueReportDates: dueReportDates.slice(1),
       });
     });
@@ -99,7 +99,7 @@ describe(page, () => {
     beforeEach(() => {
       wrapper = render({
         user,
-        primaryNav: 'utilisation_report_upload',
+        primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
         dueReportDates: dueReportDates.slice(2),
         nextDueReportDueDate,
       });
@@ -128,7 +128,7 @@ describe(page, () => {
     beforeEach(() => {
       wrapper = render({
         user,
-        primaryNav: 'utilisation_report_upload',
+        primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
         dueReportDates: [],
         nextReportPeriod,
         nextReportPeriodSubmissionStart,

--- a/portal/server/constants/dashboard.js
+++ b/portal/server/constants/dashboard.js
@@ -1,8 +1,9 @@
 const SORT_BY = require('./sort');
+const { PRIMARY_NAV_KEY } = require('./primary-nav-key');
 
 const DASHBOARD = {
   PAGE_SIZE: 20,
-  PRIMARY_NAV: 'home',
+  PRIMARY_NAV: PRIMARY_NAV_KEY.HOME,
   TABS: {
     DEALS: 'deals',
     FACILITIES: 'facilities',

--- a/portal/server/constants/index.js
+++ b/portal/server/constants/index.js
@@ -18,6 +18,7 @@ const ROLES = require('./roles');
 const { MONTH_NAMES } = require('./month-names');
 const ALL_BANKS_ID = require('./all-banks-id');
 const { LANDING_PAGES } = require('./landing-pages');
+const { PRIMARY_NAV_KEY } = require('./primary-nav-key');
 
 module.exports = {
   DASHBOARD,
@@ -40,4 +41,5 @@ module.exports = {
   ALL_BANKS_ID,
   LOGIN_STATUS,
   LANDING_PAGES,
+  PRIMARY_NAV_KEY,
 };

--- a/portal/server/constants/primary-nav-key.ts
+++ b/portal/server/constants/primary-nav-key.ts
@@ -1,0 +1,7 @@
+export const PRIMARY_NAV_KEY = {
+  HOME: 'home',
+  PREVIOUS_REPORTS: 'previous_reports',
+  REPORTS: 'reports',
+  USERS: 'users',
+  UTILISATION_REPORT_UPLOAD: 'utilisation_report_upload',
+} as const;

--- a/portal/server/controllers/dashboard/reports.controller.js
+++ b/portal/server/controllers/dashboard/reports.controller.js
@@ -21,7 +21,7 @@ exports.getPortalReports = async (req, res) => {
     dealWithConditionsCount: dealWithConditions.length,
     dealWithoutConditionsCount: dealWithoutConditions.length,
     user: req.session.user,
-    primaryNav: 'reports',
+    primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
   });
 };
 
@@ -32,7 +32,7 @@ exports.getUnissuedFacilitiesReport = async (req, res) => {
   return res.render('reports/unissued-facilities.njk', {
     facilities,
     user: req.session.user,
-    primaryNav: 'reports',
+    primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
     isChecker: isChecker(req?.session?.user?.roles),
   });
 };
@@ -44,7 +44,7 @@ exports.getUnconditionalDecisionReport = async (req, res) => {
   return res.render('reports/unconditional-decision.njk', {
     deals,
     user: req.session.user,
-    primaryNav: 'reports',
+    primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
     isChecker: isChecker(req?.session?.user?.roles),
   });
 };
@@ -56,7 +56,7 @@ exports.getConditionalDecisionReport = async (req, res) => {
   return res.render('reports/conditional-decision.njk', {
     deals,
     user: req.session.user,
-    primaryNav: 'reports',
+    primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
     isChecker: isChecker(req?.session?.user?.roles),
   });
 };

--- a/portal/server/controllers/dashboard/reports.test.js
+++ b/portal/server/controllers/dashboard/reports.test.js
@@ -84,7 +84,7 @@ describe('controllers/reports.controller', () => {
         totalUkefDecisions: 0,
         dealWithConditionsCount: 0,
         dealWithoutConditionsCount: 0,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
       });
     });
@@ -100,7 +100,7 @@ describe('controllers/reports.controller', () => {
         totalUkefDecisions: 0,
         dealWithConditionsCount: 0,
         dealWithoutConditionsCount: 0,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
       });
     });
@@ -115,7 +115,7 @@ describe('controllers/reports.controller', () => {
         totalUkefDecisions: 0,
         dealWithConditionsCount: 0,
         dealWithoutConditionsCount: 0,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
       });
     });
@@ -130,7 +130,7 @@ describe('controllers/reports.controller', () => {
         totalUkefDecisions: 0,
         dealWithConditionsCount: 0,
         dealWithoutConditionsCount: 0,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
       });
     });
@@ -147,7 +147,7 @@ describe('controllers/reports.controller', () => {
         totalUkefDecisions: 0,
         dealWithConditionsCount: 0,
         dealWithoutConditionsCount: 0,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
       });
     });
@@ -160,7 +160,7 @@ describe('controllers/reports.controller', () => {
 
       expect(res.render).toHaveBeenCalledWith('reports/unissued-facilities.njk', {
         facilities: [mockUnissuedFacilitiesReportResponse[1]],
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
         isChecker: false,
       });
@@ -173,7 +173,7 @@ describe('controllers/reports.controller', () => {
 
       expect(res.render).toHaveBeenCalledWith('reports/unissued-facilities.njk', {
         facilities: [mockUnissuedFacilitiesReportResponse[1]],
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
         isChecker: true,
       });
@@ -188,7 +188,7 @@ describe('controllers/reports.controller', () => {
 
       expect(res.render).toHaveBeenCalledWith('reports/unconditional-decision.njk', {
         deals: mockUkefUnconditionalDecisionReportResponse,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
         isChecker: false,
       });
@@ -201,7 +201,7 @@ describe('controllers/reports.controller', () => {
 
       expect(res.render).toHaveBeenCalledWith('reports/unconditional-decision.njk', {
         deals: mockUkefUnconditionalDecisionReportResponse,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
         isChecker: true,
       });
@@ -216,7 +216,7 @@ describe('controllers/reports.controller', () => {
 
       expect(res.render).toHaveBeenCalledWith('reports/conditional-decision.njk', {
         deals: mockUkefConditionalDecisionReportResponse,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
         isChecker: false,
       });
@@ -229,7 +229,7 @@ describe('controllers/reports.controller', () => {
 
       expect(res.render).toHaveBeenCalledWith('reports/conditional-decision.njk', {
         deals: mockUkefConditionalDecisionReportResponse,
-        primaryNav: 'reports',
+        primaryNav: CONSTANTS.PRIMARY_NAV_KEY.REPORTS,
         user: req.session.user,
         isChecker: true,
       });

--- a/portal/server/controllers/utilisation-report-service/previous-reports/index.js
+++ b/portal/server/controllers/utilisation-report-service/previous-reports/index.js
@@ -1,6 +1,7 @@
 const api = require('../../../api');
 const { getApiData } = require('../../../helpers');
 const { getMonthName } = require('../../../helpers/getMonthName');
+const { PRIMARY_NAV_KEY } = require('../../../constants');
 
 const getPreviousReports = async (req, res) => {
   const { user, userToken } = req.session;
@@ -37,7 +38,7 @@ const getPreviousReports = async (req, res) => {
 
     return res.render('utilisation-report-service/previous-reports/previous-reports.njk', {
       user: req.session.user,
-      primaryNav: 'previous_reports',
+      primaryNav: PRIMARY_NAV_KEY.PREVIOUS_REPORTS,
       navItems,
       reports,
       year,

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -4,6 +4,7 @@ const { validateCsvData, validateFilenameFormat } = require('./utilisation-repor
 const { getReportDueDate } = require('./utilisation-report-status');
 const api = require('../../../api');
 const { getReportAndUserDetails } = require('./utilisation-report-details');
+const { PRIMARY_NAV_KEY } = require('../../../constants');
 
 /**
  * Returns an array of due report dates including the one-indexed month,
@@ -70,7 +71,7 @@ const getUtilisationReportUpload = async (req, res) => {
       const nextDueReportDueDate = await getReportDueDate(userToken, reportPeriodDate);
       return res.render('utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk', {
         user,
-        primaryNav: 'utilisation_report_upload',
+        primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
         dueReportDates,
         nextDueReportDueDate,
       });
@@ -79,7 +80,7 @@ const getUtilisationReportUpload = async (req, res) => {
     const lastUploadedReportDetails = await getLastUploadedReportDetails(userToken, bankId);
     return res.render('utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk', {
       user,
-      primaryNav: 'utilisation_report_upload',
+      primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
       dueReportDates,
       ...lastUploadedReportDetails,
     });
@@ -134,14 +135,14 @@ const renderPageWithError = (req, res, errorSummary, validationError, dueReportD
       fileUploadError: validationError,
       errorSummary,
       user: req.session.user,
-      primaryNav: 'utilisation_report_upload',
+      primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
     });
   }
   return res.render('utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk', {
     validationError,
     errorSummary,
     user: req.session.user,
-    primaryNav: 'utilisation_report_upload',
+    primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
     dueReportDates,
   });
 };
@@ -183,7 +184,7 @@ const postUtilisationReportUpload = async (req, res) => {
         errorSummary,
         filename: req.file.originalname,
         user,
-        primaryNav: 'utilisation_report_upload',
+        primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
       });
     }
 
@@ -211,7 +212,7 @@ const getReportConfirmAndSend = async (req, res) => {
 
     return res.render('utilisation-report-service/utilisation-report-upload/confirm-and-send.njk', {
       user: req.session.user,
-      primaryNav: 'utilisation_report_upload',
+      primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
       filename: req.session.utilisationReport.filename,
     });
   } catch (error) {
@@ -253,7 +254,7 @@ const getReportConfirmation = async (req, res) => {
     delete req.session.utilisationReport;
     return res.render('utilisation-report-service/utilisation-report-upload/confirmation.njk', {
       user: req.session.user,
-      primaryNav: 'utilisation_report_upload',
+      primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
       reportPeriod,
       paymentOfficerEmail,
     });

--- a/portal/server/routes/admin/users.js
+++ b/portal/server/routes/admin/users.js
@@ -7,7 +7,7 @@ const {
   generateErrorSummary,
   constructPayload,
 } = require('../../helpers');
-const { ALL_BANKS_ID } = require('../../constants');
+const { ALL_BANKS_ID, PRIMARY_NAV_KEY } = require('../../constants');
 
 const router = express.Router();
 
@@ -19,6 +19,7 @@ const getOptionsForRenderingEditUser = async (req, res) => {
   const userToEdit = await getApiData(api.user(_id, userToken), res);
 
   return {
+    primaryNav: PRIMARY_NAV_KEY.USERS,
     _id,
     banks: banks.sort((bank1, bank2) => bank1.name < bank2.name),
     displayedUser: userToEdit,
@@ -34,6 +35,7 @@ router.get('/users', async (req, res) => {
   const banks = await getApiData(api.banks(userToken), res);
 
   return res.render('admin/dashboard.njk', {
+    primaryNav: PRIMARY_NAV_KEY.USERS,
     _id,
     users: userList.users,
     banks: banks.sort((bank1, bank2) => bank1.name < bank2.name),
@@ -48,6 +50,7 @@ router.get('/users/create', async (req, res) => {
   const banks = await getApiData(api.banks(userToken), res);
 
   return res.render('admin/user-edit.njk', {
+    primaryNav: PRIMARY_NAV_KEY.USERS,
     banks: banks.sort((bank1, bank2) => bank1.name < bank2.name),
     user: req.session.user,
     displayedUser: { roles: [] },
@@ -102,6 +105,7 @@ router.post('/users/create', async (req, res) => {
     const formattedValidationErrors = generateErrorSummary(data.errors, errorHref);
 
     return res.render('admin/user-edit.njk', {
+      primaryNav: PRIMARY_NAV_KEY.USERS,
       banks: banks.sort((bank1, bank2) => bank1.name < bank2.name),
       user: req.session.user,
       displayedUser: user,
@@ -174,6 +178,7 @@ router.get('/users/enable/:_id', async (req, res) => {
   const user = await getApiData(api.user(_id, userToken), res);
 
   return res.render('admin/user-enable.njk', {
+    primaryNav: PRIMARY_NAV_KEY.USERS,
     _id,
     user,
   });
@@ -186,6 +191,7 @@ router.get('/users/change-password/:_id', async (req, res) => {
   const user = await getApiData(api.user(_id, userToken), res);
 
   return res.render('admin/user-change-password.njk', {
+    primaryNav: PRIMARY_NAV_KEY.USERS,
     _id,
     user,
   });
@@ -213,6 +219,7 @@ router.post('/users/change-password/:_id', async (req, res) => {
   const formattedValidationErrors = generateErrorSummary(data.errors, errorHref);
   // Re-direct upon error(s)
   return res.render('admin/user-change-password.njk', {
+    primaryNav: PRIMARY_NAV_KEY.USERS,
     _id,
     user,
     validationErrors: formattedValidationErrors,


### PR DESCRIPTION
## Introduction :pencil2:
Currently when on any of the user admin pages in Portal the "Users" nav item is not highlighted:

![image](https://github.com/UK-Export-Finance/dtfs2/assets/16437079/831e00ea-b079-4c0c-ab3d-468f3df15230)

## Resolution :heavy_check_mark:
* add `primaryNav: 'users'` to all user admin pages so that the "Users" nav item is highlighted
* add a `PRIMARY_NAV_KEY` constant to use instead of hard-coded strings