### PR TITLE
feat(FN-2081): add "visible in TFM" flag to banks

### DIFF
--- a/dtfs-central-api/api-tests/mocks/banks.ts
+++ b/dtfs-central-api/api-tests/mocks/banks.ts
@@ -33,7 +33,7 @@ export const MOCK_BANKS: Record<BankName, Bank> = {
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
   HSBC: {
     _id: new ObjectId('6597e018fe34214bc0dac161'),
@@ -49,6 +49,6 @@ export const MOCK_BANKS: Record<BankName, Bank> = {
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
 };

--- a/dtfs-central-api/api-tests/mocks/banks.ts
+++ b/dtfs-central-api/api-tests/mocks/banks.ts
@@ -33,6 +33,7 @@ export const MOCK_BANKS: Record<BankName, Bank> = {
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: true,
   },
   HSBC: {
     _id: new ObjectId('6597e018fe34214bc0dac161'),
@@ -48,5 +49,6 @@ export const MOCK_BANKS: Record<BankName, Bank> = {
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: true,
   },
 };

--- a/dtfs-central-api/src/constants/payloads.js
+++ b/dtfs-central-api/src/constants/payloads.js
@@ -8,7 +8,7 @@ const BANK = {
   hasGefAccessOnly: Boolean,
   paymentOfficerTeam: Object,
   utilisationReportPeriodSchedule: Object,
-  isUtilisationReportVisibleInTfm: Boolean,
+  isVisibleInTfmUtilisationReports: Boolean,
 };
 
 const PORTAL = {

--- a/dtfs-central-api/src/constants/payloads.js
+++ b/dtfs-central-api/src/constants/payloads.js
@@ -8,6 +8,7 @@ const BANK = {
   hasGefAccessOnly: Boolean,
   paymentOfficerTeam: Object,
   utilisationReportPeriodSchedule: Object,
+  isUtilisationReportVisibleInTfm: Boolean,
 };
 
 const PORTAL = {

--- a/dtfs-central-api/src/types/db-models/banks.ts
+++ b/dtfs-central-api/src/types/db-models/banks.ts
@@ -18,4 +18,5 @@ export type Bank = WithId<{
     email: string;
   };
   utilisationReportPeriodSchedule: ReportPeriodSchedule[];
+  isUtilisationReportVisibleInTfm: boolean;
 }>;

--- a/dtfs-central-api/src/types/db-models/banks.ts
+++ b/dtfs-central-api/src/types/db-models/banks.ts
@@ -18,5 +18,5 @@ export type Bank = WithId<{
     email: string;
   };
   utilisationReportPeriodSchedule: ReportPeriodSchedule[];
-  isUtilisationReportVisibleInTfm: boolean;
+  isVisibleInTfmUtilisationReports: boolean;
 }>;

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
@@ -159,9 +159,10 @@ export const generateReconciliationSummaries = async (currentSubmissionMonth: Is
   // TODO FN-1949 - when banks' reporting schedules are added to the `bank` collection, add new repo method to only
   //  fetch banks that are due to submit this month
   const banks = await getAllBanks();
+  const banksVisibleInTfm = banks.filter((bank) => bank.isUtilisationReportVisibleInTfm);
 
-  const allReportsForCurrentSubmissionMonth = await getAllReportsForSubmissionMonth(banks, currentSubmissionMonth);
-  const openReportsForPreviousSubmissionMonths = await getPreviousOpenReportsBySubmissionMonth(banks, currentSubmissionMonth);
+  const allReportsForCurrentSubmissionMonth = await getAllReportsForSubmissionMonth(banksVisibleInTfm , currentSubmissionMonth);
+  const openReportsForPreviousSubmissionMonths = await getPreviousOpenReportsBySubmissionMonth(banksVisibleInTfm , currentSubmissionMonth);
 
   return [allReportsForCurrentSubmissionMonth, ...openReportsForPreviousSubmissionMonths];
 };

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
@@ -159,7 +159,7 @@ export const generateReconciliationSummaries = async (currentSubmissionMonth: Is
   // TODO FN-1949 - when banks' reporting schedules are added to the `bank` collection, add new repo method to only
   //  fetch banks that are due to submit this month
   const banks = await getAllBanks();
-  const banksVisibleInTfm = banks.filter((bank) => bank.isUtilisationReportVisibleInTfm);
+  const banksVisibleInTfm = banks.filter((bank) => bank.isVisibleInTfmUtilisationReports);
 
   const allReportsForCurrentSubmissionMonth = await getAllReportsForSubmissionMonth(banksVisibleInTfm , currentSubmissionMonth);
   const openReportsForPreviousSubmissionMonths = await getPreviousOpenReportsBySubmissionMonth(banksVisibleInTfm , currentSubmissionMonth);

--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -100,8 +100,6 @@ utilisationReportsRouter.route('/:_id').get(mongoIdValidation, handleExpressVali
  *               type: array
  *               items:
  *                 $ref: '#/definitions/UtilisationReportReportPeriodReconciliationSummary'
- *       200:
- *         description: OK
  *       400:
  *         description: Bad request
  *       500:

--- a/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/utilisation-reports-reconciliation-summary.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/utilisation-reports-reconciliation-summary.js
@@ -38,12 +38,12 @@
  *     required:
  *       - submissionMonth
  *       - items
- *     properties
+ *     properties:
  *       submissionMonth:
  *         type: string
  *         description: ISO 8601 format month (i.e. 'yyyy-MM')
  *         example: 2021-01
- *       items
+ *       items:
  *         type: array
  *         items:
  *           $ref: '#/definitions/UtilisationReportReconciliationSummaryItem'

--- a/portal-api/src/constants/payloads.js
+++ b/portal-api/src/constants/payloads.js
@@ -8,7 +8,7 @@ const BANK = {
   hasGefAccessOnly: Boolean,
   paymentOfficerTeam: Object,
   utilisationReportPeriodSchedule: Object,
-  isUtilisationReportVisibleInTfm: Boolean,
+  isVisibleInTfmUtilisationReports: Boolean,
 };
 
 const PORTAL = {

--- a/portal-api/src/constants/payloads.js
+++ b/portal-api/src/constants/payloads.js
@@ -8,6 +8,7 @@ const BANK = {
   hasGefAccessOnly: Boolean,
   paymentOfficerTeam: Object,
   utilisationReportPeriodSchedule: Object,
+  isUtilisationReportVisibleInTfm: Boolean,
 };
 
 const PORTAL = {

--- a/trade-finance-manager-ui/server/types/custom-express-request.ts
+++ b/trade-finance-manager-ui/server/types/custom-express-request.ts
@@ -22,10 +22,10 @@ type CustomExpressRequestOptions = {
 };
 
 export type CustomExpressRequest<Options extends CustomExpressRequestOptions> = Request<
-  keyof Options extends 'params' ? Options['params'] : RequestParams,
+  'params' extends keyof Options ? Options['params'] : RequestParams,
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  keyof Options extends 'resBody' ? Options['resBody'] : any,
-  keyof Options extends 'reqBody' ? Options['reqBody'] : any,
+  'resBody' extends keyof Options  ? Options['resBody'] : any,
+  'reqBody' extends keyof Options  ? Options['reqBody'] : any,
   /* eslint-enable @typescript-eslint/no-explicit-any */
-  keyof Options extends 'query' ? Options['query'] : RequestQuery
+  'query' extends keyof Options ? Options['query'] : RequestQuery
 >;

--- a/utils/mock-data-loader/banks/index.js
+++ b/utils/mock-data-loader/banks/index.js
@@ -27,7 +27,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
   {
     id: '961',
@@ -42,7 +42,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
   {
     id: '999',
@@ -57,7 +57,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: false,
+    isVisibleInTfmUtilisationReports: false,
   },
   {
     id: '5213',
@@ -72,7 +72,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: false,
+    isVisibleInTfmUtilisationReports: false,
   },
   {
     id: '964',
@@ -92,7 +92,7 @@ const BANKS = [
       { startMonth: 9, endMonth: 11 },
       { startMonth: 12, endMonth: 2 },
     ],
-    isUtilisationReportVisibleInTfm: false,
+    isVisibleInTfmUtilisationReports: false,
   },
   {
     id: '1004',
@@ -107,7 +107,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: false,
+    isVisibleInTfmUtilisationReports: false,
   },
   {
     id: '953',
@@ -122,7 +122,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
   {
     id: '9',
@@ -137,7 +137,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
   {
     id: '10',
@@ -157,7 +157,7 @@ const BANKS = [
       { startMonth: 9, endMonth: 11 },
       { startMonth: 12, endMonth: 2 },
     ],
-    isUtilisationReportVisibleInTfm: true,
+    isVisibleInTfmUtilisationReports: true,
   },
 ];
 

--- a/utils/mock-data-loader/banks/index.js
+++ b/utils/mock-data-loader/banks/index.js
@@ -27,6 +27,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: true,
   },
   {
     id: '961',
@@ -41,6 +42,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: true,
   },
   {
     id: '999',
@@ -55,6 +57,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: false,
   },
   {
     id: '5213',
@@ -69,6 +72,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: false,
   },
   {
     id: '964',
@@ -88,6 +92,7 @@ const BANKS = [
       { startMonth: 9, endMonth: 11 },
       { startMonth: 12, endMonth: 2 },
     ],
+    isUtilisationReportVisibleInTfm: false,
   },
   {
     id: '1004',
@@ -102,6 +107,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: false,
   },
   {
     id: '953',
@@ -116,6 +122,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: true,
   },
   {
     id: '9',
@@ -130,6 +137,7 @@ const BANKS = [
       email: 'payment-officer4@ukexportfinance.gov.uk',
     },
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isUtilisationReportVisibleInTfm: true,
   },
   {
     id: '10',
@@ -149,6 +157,7 @@ const BANKS = [
       { startMonth: 9, endMonth: 11 },
       { startMonth: 12, endMonth: 2 },
     ],
+    isUtilisationReportVisibleInTfm: true,
   },
 ];
 


### PR DESCRIPTION
## Introduction :pencil2:
We want to add a flag to banks which signals whether or not they are viewable in `TFM` (ie. whether or not they submit utilisation reports via `portal`).

## Resolution :heavy_check_mark:
Adds the `isUtilisationReportVisibleInTfm` flag to `Banks` in `dtfs-central-api` and `mock-data-loader`. This flag is not optional as we want every banks "opt-in" status to be explicit. We also add this flag to the `portal-api` payload validation as `mock-data-loader` sends the bank payload through this api.

## Miscellaneous :heavy_plus_sign:
Corrects the `CustomExpressRequest` type helper and fixes some swagger docs issues.

