### PR TITLE
fix(gha): checkout with ref

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -105,6 +105,8 @@ jobs:
     steps:
       - name: Repository 🗃️
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Defaults ✨
         uses: Azure/cli@v1.0.9
@@ -207,6 +209,8 @@ jobs:
     steps:
       - name: Repository 🗃️
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Defaults ✨
         uses: Azure/cli@v1.0.9


### PR DESCRIPTION
## Introduction :pencil2:
Ensure deployment checkout is on the workflow run head branch.

## Resolution :heavy_check_mark:
* GHA checkout with `ref`

