### PR TITLE
chore(DTFS2-6994): remove moment js from portal-api

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/submit-a-deal-for-review-with-issued-and-unissued-facilities-and-resubmit-after-checker-returns/dealReadyToSubmitToChecker.js
@@ -1,6 +1,6 @@
 const dateConstants = require('../../../../../../e2e-fixtures/dateConstants');
 
-const now = new Date().valueOf;
+const now = new Date().valueOf();
 const nowFormatted = new Date();
 const nowDay = (dateConstants.todayDay).toString();
 const nowMonth = (dateConstants.todayMonth).toString();

--- a/portal-api/src/constants/date-formats.ts
+++ b/portal-api/src/constants/date-formats.ts
@@ -1,10 +1,10 @@
 /**
  * For use with date-fns format method.
- * 
+ *
  * e.g. 1st February 2024
- * 
+ *
  * Equivalent to 'Do MMMM YYYY' in moment().format()
- * 
+ *
  * https://date-fns.org/v3.3.1/docs/format
  */
-export const LONG_FORM_DATE = 'do MMMM yyyy'
+export const LONG_FORM_DATE = 'do MMMM yyyy';

--- a/portal-api/src/now.js
+++ b/portal-api/src/now.js
@@ -1,6 +1,0 @@
-const moment = require('moment');
-
-// one place that defines how we store timestamps..
-//  at least if we decide we don't like current implentation
-//  we just change it here + fix the results..
-module.exports = () => moment().utc().valueOf().toString();

--- a/portal-api/src/v1/controllers/deal-status/create-approval-date.js
+++ b/portal-api/src/v1/controllers/deal-status/create-approval-date.js
@@ -1,10 +1,10 @@
 const { updateDeal } = require('../deal.controller');
-const now = require('../../../now');
+const { getNowAsEpochMillisecondString } = require('../../helpers/date');
 
 const createApprovalDate = async (dealId) => {
   const modifiedDeal = {
     details: {
-      approvalDate: now(),
+      approvalDate: getNowAsEpochMillisecondString(),
     },
   };
 

--- a/portal-api/src/v1/controllers/deal-status/create-mia-submission-date.js
+++ b/portal-api/src/v1/controllers/deal-status/create-mia-submission-date.js
@@ -1,10 +1,10 @@
 const { updateDeal } = require('../deal.controller');
-const now = require('../../../now');
+const { getNowAsEpochMillisecondString } = require('../../helpers/date');
 
 const createMiaSubmissionDate = async (dealId) => {
   const modifiedDeal = {
     details: {
-      manualInclusionApplicationSubmissionDate: now(),
+      manualInclusionApplicationSubmissionDate: getNowAsEpochMillisecondString(),
     },
   };
 

--- a/portal-api/src/v1/controllers/deal-status/create-submission-date.js
+++ b/portal-api/src/v1/controllers/deal-status/create-submission-date.js
@@ -1,10 +1,10 @@
 const { updateDeal } = require('../deal.controller');
-const now = require('../../../now');
+const { getNowAsEpochMillisecondString } = require('../../helpers/date');
 
 const createSubmissionDate = async (dealId, user) => {
   const modifiedDeal = {
     details: {
-      submissionDate: now(),
+      submissionDate: getNowAsEpochMillisecondString(),
       checker: user,
     },
   };

--- a/portal-api/src/v1/gef/controllers/application-submit.js
+++ b/portal-api/src/v1/gef/controllers/application-submit.js
@@ -1,4 +1,4 @@
-const now = require('../../../now');
+const { getNowAsEpochMillisecondString } = require('../../helpers/date');
 const externalApi = require('../../../external-api/api');
 const {
   getAllFacilitiesByDealId,
@@ -19,7 +19,7 @@ const generateSubmissionData = async (existingApplication) => {
   result.count = existingApplication.submissionCount + 1;
 
   if (!existingApplication.submissionDate) {
-    result.date = now();
+    result.date = getNowAsEpochMillisecondString();
   }
 
   return result;
@@ -61,7 +61,7 @@ const addSubmissionDateToIssuedFacilities = async (dealId) => {
      */
     if (hasBeenIssued && !hasBeenIssuedAndAcknowledged) {
       const update = {
-        submittedAsIssuedDate: now(),
+        submittedAsIssuedDate: getNowAsEpochMillisecondString(),
       };
       /**
        * if canResubmitIssuedFacilities and shouldCoverStartOnSubmission is true

--- a/portal-api/src/v1/users/controller.js
+++ b/portal-api/src/v1/users/controller.js
@@ -1,5 +1,5 @@
 const { ObjectId } = require('mongodb');
-const now = require('../../now');
+const { getNowAsEpochMillisecondString } = require('../helpers/date');
 const db = require('../../drivers/db-client');
 const sendEmail = require('../email');
 const businessRules = require('../../config/businessRules');
@@ -261,7 +261,7 @@ exports.updateLastLoginAndResetSignInData = async (user, sessionIdentifier, call
 
   const collection = await db.getCollection('users');
   const update = {
-    lastLogin: now(),
+    lastLogin: getNowAsEpochMillisecondString(),
     loginFailureCount: 0,
     sessionIdentifier,
   };
@@ -286,7 +286,7 @@ exports.incrementFailedLoginCount = async (user) => {
       }
     : {
         loginFailureCount: failureCount,
-        lastLoginFailure: now(),
+        lastLoginFailure: getNowAsEpochMillisecondString(),
       };
 
   await collection.updateOne({ _id: { $eq: ObjectId(user._id) } }, { $set: update }, {});


### PR DESCRIPTION
## Introduction :pencil2:
Moment js is deprecated, it should be replaced. This PR wont convert any tests - see #2706 
Validation changes are covered by #2797, facility-dates changes are covered by #2799

## Resolution :heavy_check_mark:
* Replace moment() with vanilla Dates where possible and date-fns where necessary
* replace `now()` method with `getNowAsEpochMillisecondString()` date helper

## Miscellaneous :heavy_plus_sign:
* Cleaned up some obsolete functions handling dates

## Note ⚠️ 
*  `updateCoverEndDate` doesn't return `NaN` when the date or year is invalid. I believe this wasn't intended but the test coverage doesn't verify this
* Need to remove `formattedTimestamp` function and package dependency on `moment` once both PRs are merged