### PR TITLE
fix(DTFS2-7003): refer to email property as opposed to username

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -46,9 +46,6 @@ on:
     branches:
       - main
 
-    paths:
-      - "*"
-
 env:
   environment: dev
   timezone: ${{ vars.TIMEZONE }}

--- a/portal-api/src/v1/users/controller.js
+++ b/portal-api/src/v1/users/controller.js
@@ -180,7 +180,7 @@ exports.update = async (_id, update, callback) => {
   collection.findOne({ _id: { $eq: ObjectId(_id) } }, async (error, existingUser) => {
     if (existingUser['user-status'] !== USER.STATUS.BLOCKED && userSetUpdate['user-status'] === USER.STATUS.BLOCKED) {
       // User is being blocked.
-      await sendBlockedEmail(existingUser.username);
+      await sendBlockedEmail(existingUser.email);
     }
 
     if (existingUser['user-status'] === USER.STATUS.BLOCKED && userSetUpdate['user-status'] === USER.STATUS.ACTIVE) {
@@ -192,7 +192,7 @@ exports.update = async (_id, update, callback) => {
         blockedStatusReason: '',
       };
 
-      await sendUnblockedEmail(existingUser.username);
+      await sendUnblockedEmail(existingUser.email);
     }
 
     // Password update


### PR DESCRIPTION
## Introduction :pencil2:
Portal user block and active status emails are not being delivered on `non-production` environment.

## Resolution :heavy_check_mark:
* `username` property has been replaced with `email`.

## Miscellaneous ➕ 
* `sca.yml` execution on all PRs

