### PR TITLE
fix(deployment)!: changed branch name to prod

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -32,7 +32,7 @@ if [ -n "$selection" ]; then
         elif [ "$destination" = "staging" ]; then
             branch=dev
         ############### PRODUCTION ###############
-        elif [ "$destination" = "production" ]; then
+        elif [ "$destination" = "prod" ]; then
             branch=staging
         fi
     ############### ACR PURGE ###############

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -27,7 +27,7 @@
 # Key Points
 # **********
 # Triggers on Completed QAT Workflow: The workflow only runs if the preceding QAT workflow completes successfully.
-# Environment-Specific: Uses environment variables to tailor deployments for different environments (dev, feature, staging, production).
+# Environment-Specific: Uses environment variables to tailor deployments for different environments (dev, feature, staging, prod).
 # Matrix Strategies: Employs matrices to iterate through lists of web apps and functions for sequential deployment.
 # Concurrency Control: Uses concurrency groups to prevent multiple deployments of the same web app or function from running concurrently.
 # Fail-Fast Disabled: Allows all matrix jobs to complete even if some fail.
@@ -47,7 +47,7 @@ on:
       - dev
       - feature
       - staging
-      - production
+      - prod
 
 env:
   PRODUCT: dtfs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ on:
       - dev
       - feature
       - staging
-      - production
+      - prod
 
     paths:
       - ".github/workflows/deployment.yml"


### PR DESCRIPTION
## Introduction :pencil2:
Production deployments on GitHub Event hook are not being trigged.

## Resolution :heavy_check_mark:
* Updated branch name to `prod` from `production`.

