### PR TITLE
fix(dTFS2-7007): Ensure EC wording is correct

### DIFF
--- a/utils/mock-data-loader/bss/eligibilityCriteria.js
+++ b/utils/mock-data-loader/bss/eligibilityCriteria.js
@@ -346,7 +346,7 @@ module.exports = [
       {
         id: 16,
         description:
-          'The Supplier has confirmed in its Supplier Declaration that the Supply Contract does not involve any of the following Controlled Sectors: sharp arms defence, nuclear, radiological, biological, human cloning, pornography, tobacco or gambling, and the Bank is not aware that any of the information contained within it is inaccurate.',
+          'The Supplier has confirmed in its Supplier Declaration that the Supply Contract does not involve any of the following Controlled Sectors: sharp arms defence, nuclear, radiological, biological, human cloning, pornography, tobacco, gambling, coal, oil, gas or fossil fuel energy and the Bank is not aware that any of the information contained within it is inaccurate.',
       },
       {
         id: 17,


### PR DESCRIPTION
## Introduction :pencil2:
`BSS/EWCS` EC 16 does not include fossil fuel wording.

## Resolution :heavy_check_mark:
* Updated `BSS/EWCS` `v7` EC `16`.

