### PR TITLE
refactor(FN-2226): remove suppression of eslint 'default-param-last' rule

### DIFF
--- a/dtfs-central-api/src/v1/validation/create-facility-rules/associated-deal-id.js
+++ b/dtfs-central-api/src/v1/validation/create-facility-rules/associated-deal-id.js
@@ -1,10 +1,9 @@
 const { orderNumber } = require('../../../utils/error-list-order-number');
 const { hasValue } = require('../../../utils/string');
 
-// eslint-disable-next-line default-param-last
-module.exports = (facility = {}, errorList) => {
+module.exports = (facility, errorList) => {
   const newErrorList = { ...errorList };
-  const { dealId } = facility;
+  const dealId = facility?.dealId;
 
   if (!hasValue(dealId)) {
     newErrorList.dealId = {

--- a/dtfs-central-api/src/v1/validation/create-facility-rules/type.js
+++ b/dtfs-central-api/src/v1/validation/create-facility-rules/type.js
@@ -2,10 +2,9 @@ const { orderNumber } = require('../../../utils/error-list-order-number');
 const { hasValue } = require('../../../utils/string');
 const { FACILITY_TYPE } = require('../../../constants/facilities');
 
-// eslint-disable-next-line default-param-last
-module.exports = (facility = {}, errorList) => {
+module.exports = (facility, errorList) => {
   const newErrorList = { ...errorList };
-  const { type } = facility;
+  const type = facility?.type;
 
   if (!hasValue(type)) {
     newErrorList.type = {


### PR DESCRIPTION
## Introduction :pencil2:
Remove inline suppression of eslint `default-param-last` rule as requested in a [separate PR](https://github.com/UK-Export-Finance/dtfs2/pull/2596#discussion_r1487381621).

