### PR TITLE
chore(DTFS2-4533): remove moment from gef-ui, tfm-api and tfm-ui tests

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -32,7 +32,6 @@
     "date-fns": "^2.30.0",
     "eslint": "^8.56.0",
     "eslint-plugin-cypress": "^2.15.1",
-    "moment": "^2.30.1",
     "mongodb": "^6.3.0"
   },
   "engines": {

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import moment from 'moment';
+import { format } from 'date-fns';
 import {
   userToken,
   isObject,
@@ -504,7 +504,7 @@ describe('mapSummaryList()', () => {
     const reverseFunction = (val) => val.split('').reverse().join('');
 
     mockedDisplayItems[0].id = 'reverse';
-    mockedDisplayItems[0].method = (callback) => reverseFunction(callback);
+    mockedDisplayItems[0].method = (value) => reverseFunction(value);
 
     mockedData.details.reverse = 'com';
     const { text } = mapSummaryList(mockedData, mockedDisplayItems, mapSummaryParams)[0].value;
@@ -521,8 +521,11 @@ describe('mapSummaryList()', () => {
     };
 
     mockedDisplayItems[0].id = 'coverStartDate';
-    mockedDisplayItems[0].method = (callback) => moment(callback)
-      .format('D MMMM YYYY');
+    mockedDisplayItems[0].method = (value) => {
+      // value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
+      const date = new Date(value);
+      return format(date, 'd MMMM yyyy');
+    };
 
     mockedData.details.coverStartDate = '2021-12-20T00:00:00.000+00:00';
     const { text } = mapSummaryList(mockedData, mockedDisplayItems, mapSummaryParams)[0].value;
@@ -539,8 +542,12 @@ describe('mapSummaryList()', () => {
     };
 
     mockedDisplayItems[0].id = 'coverStartDate';
-    mockedDisplayItems[0].method = (callback) => moment(callback)
-      .format('D MMMM YYYY');
+    mockedDisplayItems[0].method = (value) => {
+      // value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
+      const date = new Date(value);
+      return format(date, 'd MMMM yyyy');
+    };
+
     mockedDisplayItems[0].shouldCoverStartOnSubmission = true;
     mockedDisplayItems[0].issueDate = null;
 
@@ -559,8 +566,12 @@ describe('mapSummaryList()', () => {
     };
 
     mockedDisplayItems[0].id = 'coverStartDate';
-    mockedDisplayItems[0].method = (callback) => moment(callback)
-      .format('D MMMM YYYY');
+    mockedDisplayItems[0].method = (value) => {
+      // value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
+      const date = new Date(value);
+      return format(date, 'd MMMM yyyy');
+    };
+
     mockedDisplayItems[0].shouldCoverStartOnSubmission = true;
     mockedDisplayItems[0].issueDate = '2021-12-25T00:00:00.000+00:00';
 

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -522,7 +522,7 @@ describe('mapSummaryList()', () => {
 
     mockedDisplayItems[0].id = 'coverStartDate';
     mockedDisplayItems[0].method = (value) => {
-      // value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
+      // input value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
       const date = new Date(value);
       return format(date, 'd MMMM yyyy');
     };
@@ -543,7 +543,7 @@ describe('mapSummaryList()', () => {
 
     mockedDisplayItems[0].id = 'coverStartDate';
     mockedDisplayItems[0].method = (value) => {
-      // value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
+      // input value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
       const date = new Date(value);
       return format(date, 'd MMMM yyyy');
     };
@@ -567,7 +567,7 @@ describe('mapSummaryList()', () => {
 
     mockedDisplayItems[0].id = 'coverStartDate';
     mockedDisplayItems[0].method = (value) => {
-      // value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
+      // input value is an ISO-8601 string with milliseconds (e.g '2024-02-14T00:00:00.000+00:00')
       const date = new Date(value);
       return format(date, 'd MMMM yyyy');
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21483,6 +21483,7 @@
         "is-port-reachable": "^3.1.0",
         "joi": "^17.12.1",
         "jsonwebtoken": "^9.0.2",
+        "lodash": "^4.17.21",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.44",
         "mongo-dot-notation": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,7 +235,6 @@
         "date-fns": "^2.30.0",
         "eslint": "^8.56.0",
         "eslint-plugin-cypress": "^2.15.1",
-        "moment": "^2.30.1",
         "mongodb": "^6.3.0"
       },
       "engines": {

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -7,7 +7,8 @@ jest.mock('../../../src/v1/controllers/deal.controller', () => ({
   submitACBSIfAllPartiesHaveUrn: jest.fn(),
 }));
 
-const moment = require('moment');
+const { set } = require('date-fns');
+const { cloneDeep } = require('lodash');
 const api = require('../../../src/v1/api');
 const acbsController = require('../../../src/v1/controllers/acbs.controller');
 const dealController = require('../../../src/v1/controllers/deal.controller');
@@ -59,7 +60,7 @@ const createSubmitBody = (mockDeal) => ({
 });
 
 const createFacilityCoverEndDate = (facility) =>
-  moment().set({
+  set(new Date(), {
     date: Number(facility['coverEndDate-day']),
     month: Number(facility['coverEndDate-month']) - 1, // months are zero indexed
     year: Number(facility['coverEndDate-year']),
@@ -149,7 +150,7 @@ describe('/v1/deals', () => {
         });
 
         it('should add bond.facilityGuaranteeDates', async () => {
-          const initialBond = MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED.bondTransactions.items[0];
+          const initialBond = cloneDeep(MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED.bondTransactions.items[0]);
           const dealSubmissionDate = MOCK_DEAL_AIN_SECOND_SUBMIT_FACILITIES_UNISSUED_TO_ISSUED.details.submissionDate;
 
           // add fields that are mapped in deal.submit

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.tasks.api-test.js
@@ -7,11 +7,10 @@ jest.mock('../../../src/v1/controllers/deal.controller', () => ({
   submitACBSIfAllPartiesHaveUrn: jest.fn(),
 }));
 
-const moment = require('moment');
+const { format } = require('date-fns');
 const api = require('../../../src/v1/api');
 const acbsController = require('../../../src/v1/controllers/acbs.controller');
 const CONSTANTS = require('../../../src/constants');
-const formattedTimestamp = require('../../../src/v1/formattedTimestamp');
 const { createDealTasks } = require('../../../src/v1/controllers/deal.tasks');
 const { generateTaskEmailVariables } = require('../../../src/v1/helpers/generate-task-email-variables');
 const submitDeal = require('../utils/submitDeal');
@@ -123,6 +122,8 @@ describe('/v1/deals', () => {
 
           const { email: expectedTeamEmailAddress } = MOCK_TEAMS.find((t) => t.id === firstTask.team.id);
 
+          const submissionDate = new Date(Number(body.dealSnapshot.details.submissionDate));
+
           const expected = {
             templateId: CONSTANTS.EMAIL_TEMPLATE_IDS.TASK_READY_TO_START,
             sendToEmailAddress: expectedTeamEmailAddress,
@@ -131,7 +132,7 @@ describe('/v1/deals', () => {
               firstTask,
               body.dealSnapshot.exporter.companyName,
               body.dealSnapshot.details.submissionType,
-              moment(formattedTimestamp(body.dealSnapshot.details.submissionDate)).format('Do MMMM YYYY'),
+              format(submissionDate, 'do MMMM yyyy'),
               body.dealSnapshot.bank.name,
             ),
           };

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -46,6 +46,7 @@
     "is-port-reachable": "^3.1.0",
     "joi": "^17.12.1",
     "jsonwebtoken": "^9.0.2",
+    "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.44",
     "mongo-dot-notation": "^3.1.0",

--- a/trade-finance-manager-api/src/utils/date.test.js
+++ b/trade-finance-manager-api/src/utils/date.test.js
@@ -1,5 +1,3 @@
-const moment = require('moment');
-
 const { formatYear, formatDate, formatTimestamp, convertDateToTimestamp, isValidIsoMonth } = require('./date');
 
 describe('utils - date', () => {
@@ -24,7 +22,7 @@ describe('utils - date', () => {
       const mockDate = '20210419';
       const result = formatDate(mockDate);
 
-      const expected = moment(mockDate).format('YYYY-MM-DD');
+      const expected = '2021-04-19';
       expect(result).toEqual(expected);
     });
   });

--- a/trade-finance-manager-api/src/v1/helpers/get-guarantee-dates.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/get-guarantee-dates.api-test.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const { set } = require('date-fns');
 const getGuaranteeDates = require('./get-guarantee-dates');
 
 const submissionDate = '2023-01-01';
@@ -6,7 +6,7 @@ const dealSubmissionDate = new Date(submissionDate).valueOf();
 const issuedFacility = {
   hasBeenIssued: true,
   coverStartDate: new Date(submissionDate).valueOf(),
-  coverEndDate: moment().set({
+  coverEndDate: set(new Date(), {
     date: Number('01'),
     month: Number('01') - 1, // months are zero indexed
     year: Number('2024'),

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.api-test.js
@@ -14,7 +14,7 @@ describe('mapCoverEndDate', () => {
 
     const result = mapCoverEndDate(day, month, year, {});
 
-    const coverEndDate =  set(new Date(), {
+    const coverEndDate = set(new Date(), {
       date: Number(day),
       month: Number(month) - 1, // months are zero indexed
       year: Number(year),

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.api-test.js
@@ -1,5 +1,4 @@
-const moment = require('moment');
-const { format, fromUnixTime } = require('date-fns');
+const { format, fromUnixTime, set } = require('date-fns');
 const mapCoverEndDate = require('./mapCoverEndDate');
 const { formatYear } = require('../../../../utils/date');
 
@@ -15,13 +14,13 @@ describe('mapCoverEndDate', () => {
 
     const result = mapCoverEndDate(day, month, year, {});
 
-    const coverEndDate = moment().set({
+    const coverEndDate =  set(new Date(), {
       date: Number(day),
       month: Number(month) - 1, // months are zero indexed
       year: Number(year),
     });
 
-    const expected = moment(coverEndDate).format('D MMMM YYYY');
+    const expected = format(coverEndDate, 'd MMMM yyyy');
 
     expect(result).toEqual(expected);
   });
@@ -38,16 +37,16 @@ describe('mapCoverEndDate', () => {
 
       const result = mapCoverEndDate(day, month, year, {});
 
-      const coverEndDate = moment().set({
+      const coverEndDate = set(new Date(), {
         date: Number(day),
         month: Number(month) - 1, // months are zero indexed
         year: formatYear(Number(year)),
       });
 
-      const expected = moment(coverEndDate).format('D MMMM YYYY');
+      const expected = format(coverEndDate, 'd MMMM yyyy');
       expect(result).toEqual(expected);
 
-      const yearResult = moment(coverEndDate).format('YYYY');
+      const yearResult = format(coverEndDate, 'yyyy');
       expect(yearResult).toEqual('2021');
     });
   });
@@ -73,16 +72,16 @@ describe('mapCoverEndDate', () => {
 
       const result = mapCoverEndDate(day, month, year, facility);
 
-      const coverEndDate = moment().set({
+      const coverEndDate = set(new Date(), {
         date: Number(day),
         month: Number(month) - 1, // months are zero indexed
         year: formatYear(Number(year)),
       });
 
-      const expected = moment(coverEndDate).format('D MMMM YYYY');
+      const expected = format(coverEndDate, 'd MMMM yyyy');
       expect(result).toEqual(expected);
 
-      const yearResult = moment(coverEndDate).format('YYYY');
+      const yearResult = format(coverEndDate, 'yyyy');
       expect(yearResult).toEqual('2021');
     });
   });

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/gef-facilities/mapGefFacilityDates.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/gef-facilities/mapGefFacilityDates.api-test.js
@@ -53,10 +53,12 @@ describe('mapGefFacilityDates', () => {
   it('should return mapped coverEndDate', () => {
     const result = mapGefFacilityDates(mockFacility, mockFacilityTfm, MOCK_GEF_DEAL);
 
+    const mockCoverEndDate = new Date(mockFacility.facilitySnapshot.coverEndDate);
+
     const expected = mapCoverEndDate(
-      format(mockFacility.facilitySnapshot.coverEndDate, 'dd'),
-      format(mockFacility.facilitySnapshot.coverEndDate, 'MM'),
-      format(mockFacility.facilitySnapshot.coverEndDate, 'yyyy'),
+      format(mockCoverEndDate, 'dd'),
+      format(mockCoverEndDate, 'MM'),
+      format(mockCoverEndDate, 'yyyy'),
       mockFacility,
     );
 

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/gef-facilities/mapGefFacilityDates.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/gef-facilities/mapGefFacilityDates.api-test.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const { format } = require('date-fns');
 const mapGefFacilityDates = require('./mapGefFacilityDates');
 const mapCoverEndDate = require('../facilities/mapCoverEndDate');
 const mapTenorDate = require('../facilities/mapTenorDate');
@@ -54,9 +54,9 @@ describe('mapGefFacilityDates', () => {
     const result = mapGefFacilityDates(mockFacility, mockFacilityTfm, MOCK_GEF_DEAL);
 
     const expected = mapCoverEndDate(
-      moment(mockFacility.facilitySnapshot.coverEndDate).format('DD'),
-      moment(mockFacility.facilitySnapshot.coverEndDate).format('MM'),
-      moment(mockFacility.facilitySnapshot.coverEndDate).format('YYYY'),
+      format(mockFacility.facilitySnapshot.coverEndDate, 'dd'),
+      format(mockFacility.facilitySnapshot.coverEndDate, 'MM'),
+      format(mockFacility.facilitySnapshot.coverEndDate, 'yyyy'),
       mockFacility,
     );
 

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-formatDateString.test.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-formatDateString.test.js
@@ -1,16 +1,23 @@
-import moment from 'moment';
+import { format } from 'date-fns';
 import formatDateString from './filter-formatDateString';
 
 describe('nunjuck filters - formatDateString', () => {
   it('should return formatted date from existing formatted date', () => {
-    const fromFormat = 'DD-MM-YYYY';
-    const mockDate = moment().format(fromFormat);
+    const fromFormat = {
+      moment: 'DD-MM-YYYY',
+      'date-fns': 'dd-MM-yyyy',
+    };
+    const date = new Date();
+    const mockDate = format(date, fromFormat['date-fns']);
 
-    const toFormat = 'DD/MM/YYYY';
+    const toFormat = {
+      moment: 'DD/MM/YYYY',
+      'date-fns': 'dd/MM/yyyy',
+    };
 
-    const result = formatDateString(mockDate, fromFormat, toFormat);
+    const result = formatDateString(mockDate, fromFormat.moment, toFormat.moment);
 
-    const expected = moment(mockDate, fromFormat).format(toFormat);
+    const expected = format(date, toFormat['date-fns']);
     expect(result).toEqual(expected);
   });
 });

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-formatDateString.test.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-formatDateString.test.js
@@ -3,6 +3,8 @@ import formatDateString from './filter-formatDateString';
 
 describe('nunjuck filters - formatDateString', () => {
   it('should return formatted date from existing formatted date', () => {
+    // TODO: DTFS2-6999 update these tests to only use date-fns formatting tokens
+    // https://date-fns.org/v3.3.1/docs/format
     const fromFormat = {
       moment: 'DD-MM-YYYY',
       'date-fns': 'dd-MM-yyyy',


### PR DESCRIPTION
## Introduction :pencil2:
Moment js is deprecated, it should be replaced. The functional code is changed in #2758 .

## Resolution :heavy_check_mark:
* Replace moment() with vanilla Dates where possible and date-fns where necessary in
  * gef-ui 
  * trade-finance-manager-api
  * trade-finance-manager-ui