### PR TITLE
refactor: change 'isEqualReportPeriodStart' to 'isEqualMonthAndYear'

### DIFF
--- a/dtfs-central-api/src/utils/date.test.ts
+++ b/dtfs-central-api/src/utils/date.test.ts
@@ -1,4 +1,5 @@
-import { eachIsoMonthOfInterval, getOneIndexedMonth, isValidIsoMonth, toIsoMonthStamp } from './date';
+import { eachIsoMonthOfInterval, getOneIndexedMonth, isEqualMonthAndYear, isValidIsoMonth, toIsoMonthStamp } from './date';
+import { MonthAndYear } from '../types/date';
 
 describe('date utils', () => {
   describe('getOneIndexedMonth', () => {
@@ -66,6 +67,36 @@ describe('date utils', () => {
       ])('returns $expected when $testCase (start: $start, end: $end)', ({ start, end, expected }) => {
         expect(eachIsoMonthOfInterval(start, end, { exclusive: true })).toEqual(expected);
       });
+    });
+  });
+
+  describe('isEqualMonthAndYear', () => {
+    it.each([
+      {
+        testCase: 'months are the same but years are different',
+        values: [
+          { month: 1, year: 2023 },
+          { month: 1, year: 2024 },
+        ],
+      },
+      {
+        testCase: 'years are the same but months are different',
+        values: [
+          { month: 1, year: 2024 },
+          { month: 2, year: 2024 },
+        ],
+      },
+    ])('returns false when $testCase', ({ values }) => {
+      expect(isEqualMonthAndYear(values[0], values[1])).toBe(false);
+    });
+
+    it('returns true when values are equal', () => {
+      // Arrange
+      const value1: MonthAndYear = { month: 2, year: 2024 };
+      const value2: MonthAndYear = { month: 2, year: 2024 };
+
+      // Act / Assert
+      expect(isEqualMonthAndYear(value1, value2)).toBe(true);
     });
   });
 });

--- a/dtfs-central-api/src/utils/date.ts
+++ b/dtfs-central-api/src/utils/date.ts
@@ -1,6 +1,6 @@
 import { eachMonthOfInterval, format, isValid, parseISO } from 'date-fns';
 import { isString } from '@ukef/dtfs2-common';
-import { IsoMonthStamp, OneIndexedMonth } from '../types/date';
+import { IsoMonthStamp, MonthAndYear, OneIndexedMonth } from '../types/date';
 
 /**
  * Converts date with index-0 month value to numeric index-1 month
@@ -22,3 +22,9 @@ export const eachIsoMonthOfInterval = (start: IsoMonthStamp, end: IsoMonthStamp,
   const resultDates = options?.exclusive ? monthsBetweenDatesInclusive.slice(1, -1) : monthsBetweenDatesInclusive;
   return resultDates.map(toIsoMonthStamp);
 };
+
+/**
+ * Checks if the {@link MonthAndYear} objects are equal
+ */
+export const isEqualMonthAndYear = (monthAndYear1: MonthAndYear, monthAndYear2: MonthAndYear): boolean =>
+  monthAndYear1.year === monthAndYear2.year && monthAndYear1.month === monthAndYear2.month;

--- a/dtfs-central-api/src/utils/report-period.test.ts
+++ b/dtfs-central-api/src/utils/report-period.test.ts
@@ -4,10 +4,9 @@ import {
   getPreviousReportPeriodStart,
   getReportPeriodStartForSubmissionMonth,
   getSubmissionMonthForReportPeriodStart,
-  isEqualReportPeriodStart,
   parseReportPeriod,
 } from './report-period';
-import { MonthAndYear, OneIndexedMonth } from '../types/date';
+import { OneIndexedMonth } from '../types/date';
 import { BankReportPeriodSchedule } from '../types/db-models/banks';
 import { ReportPeriod } from '../types/utilisation-reports';
 
@@ -36,36 +35,6 @@ describe('report-period utils', () => {
       { current: { month: 1, year: 2024 }, previous: { month: 12, year: 2023 } },
     ])('returns $previous when the current ReportPeriodStart is $current', ({ current, previous }) => {
       expect(getPreviousReportPeriodStart(current)).toEqual(previous);
-    });
-  });
-
-  describe('isEqualReportPeriodStart', () => {
-    it.each([
-      {
-        testCase: 'months are the same but years are different',
-        values: [
-          { month: 1, year: 2023 },
-          { month: 1, year: 2024 },
-        ],
-      },
-      {
-        testCase: 'years are the same but months are different',
-        values: [
-          { month: 1, year: 2024 },
-          { month: 2, year: 2024 },
-        ],
-      },
-    ])('returns false when $testCase', ({ values }) => {
-      expect(isEqualReportPeriodStart(values[0], values[1])).toBe(false);
-    });
-
-    it('returns true when values are equal', () => {
-      // Arrange
-      const value1: MonthAndYear = { month: 2, year: 2024 };
-      const value2: MonthAndYear = { month: 2, year: 2024 };
-
-      // Act / Assert
-      expect(isEqualReportPeriodStart(value1, value2)).toBe(true);
     });
   });
 

--- a/dtfs-central-api/src/utils/report-period.ts
+++ b/dtfs-central-api/src/utils/report-period.ts
@@ -46,15 +46,6 @@ export const getPreviousReportPeriodStart = (monthAndYear: MonthAndYear): MonthA
 };
 
 /**
- * Checks if the two report period starts are equal
- * @param reportPeriodStart1 - A report period start
- * @param reportPeriodStart2 - The report period start to check against
- * @returns Whether or not the report period starts are equal
- */
-export const isEqualReportPeriodStart = (reportPeriodStart1: MonthAndYear, reportPeriodStart2: MonthAndYear): boolean =>
-  reportPeriodStart1.year === reportPeriodStart2.year && reportPeriodStart1.month === reportPeriodStart2.month;
-
-/**
  * Get the report period for the inputted bank schedule by the target date
  * @param bankReportPeriodSchedule - The bank report period schedule
  * @param dateInTargetReportPeriod - A date in the target report period

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
@@ -12,8 +12,8 @@ import {
   getReportPeriodForBankScheduleBySubmissionMonth,
   getReportPeriodStartForSubmissionMonth,
   getSubmissionMonthForReportPeriodStart,
-  isEqualReportPeriodStart,
 } from '../../../../utils/report-period';
+import { isEqualMonthAndYear } from '../../../../utils/date';
 
 type UtilisationReportForSubmissionMonth = {
   submissionMonth: IsoMonthStamp;
@@ -109,7 +109,7 @@ const isBankDueToSubmitReport =
   (currentSubmissionMonth: IsoMonthStamp) =>
   (bank: Bank): boolean => {
     const currentReportPeriodForBank = getCurrentReportPeriodForBankSchedule(bank.utilisationReportPeriodSchedule);
-    return isEqualReportPeriodStart(currentReportPeriodForBank.start, getReportPeriodStartForSubmissionMonth(currentSubmissionMonth));
+    return isEqualMonthAndYear(currentReportPeriodForBank.start, getReportPeriodStartForSubmissionMonth(currentSubmissionMonth));
   };
 
 export const generateReconciliationSummaries = async (currentSubmissionMonth: IsoMonthStamp): Promise<UtilisationReportReconciliationSummary[]> => {


### PR DESCRIPTION
Change `isEqualReportPeriodStart` function in `report-period` utils to more general `isEqualMonthAndYear` in `date` utils.