### PR TITLE
chore: add 'npm run dev' script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This documentation provides a comprehensive overview of the UKEF Digital TradeFi
    - `JWT_VALIDATING_KEY=5678`
 6. Set UKEF TFM environment variables in your terminal: `UKEF_TFM_API_SYSTEM_KEY` and `UKEF_TFM_API_REPORTS_KEY`.
 7. run `npm install` in the root folder of the repository. (note: this will install dependencies for the entire project, including those specified in sub-packages. More details on this in the [npm workspaces](./doc/npm-workspaces.md) doc directory)
-8. Start your local environment with `docker-compose -f docker-compose.dev.yml up --build`.
+8. Start your local environment with `npm run dev`.
 9. Create mock data by running `npm run load` from the root folder of the repository. This should generate mocks in your database.
 
 Recommended: Install a MongoDB client such as Compass or Robo 3T.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "audit:all": "npm audit --if-present",
     "audit:fix:all": "npm audit --fix --if-present",
     "ci:all": "npm ci --if-present",
+    "dev": "docker-compose -f docker-compose.dev.yml up --build",
     "housekeeping": "npm run update:all && npm run install:all && npm run lint:fix:all && npm run audit:fix:all && npm run spellcheck",
     "postinstall": "husky install",
     "install:all": "npm install --if-present",


### PR DESCRIPTION
## Introduction :pencil2:
Add `dev` script to root package.json so you don't need to remember the docker command.

