### PR TITLE
chore(DTFS2-NONE): bump axios version

### DIFF
--- a/azure-functions/acbs-function/package.json
+++ b/azure-functions/acbs-function/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint ./"
   },
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.6.7",
     "date-fns": "^2.30.0",
     "dotenv": "^16.4.1",
     "durable-functions": "^1.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     },
     "azure-functions/acbs-function": {
       "dependencies": {
-        "axios": "^0.27.2",
+        "axios": "^1.6.7",
         "date-fns": "^2.30.0",
         "dotenv": "^16.4.1",
         "durable-functions": "^1.5.4",
@@ -61,28 +61,6 @@
       "engines": {
         "node": ">=20",
         "npm": ">=10"
-      }
-    },
-    "azure-functions/acbs-function/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "azure-functions/acbs-function/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "azure-functions/number-generator-function": {


### PR DESCRIPTION
We should only merge this once we have validated we have ways of detecting if this fails.

## Introduction :pencil2:
We need to bump the version of axios. This is problematic as there is a major version release (`0.26`->`1.6`) and our testing in this area is not adequate to pick up issues

## Resolution :heavy_check_mark:
Bumped version
Checked a community migration guide to 1.0.0 -- identified no issues


