### PR TITLE
feat(FN-1865): add script to display all sql tables in terminal

### DIFF
--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -28,6 +28,7 @@
     "db:migrate": "npm run typeorm -- migration:run -d src/sql-db-connection/data-source.ts",
     "db:migrate:down": "npm run typeorm -- migration:revert -d src/sql-db-connection/data-source.ts",
     "db:reset": "npm run db:drop-all && npm run db:migrate",
+    "db:view-tables": "npx ts-node src/__helpers__/view-all-tables.ts",
     "lint": "eslint \"src/**/*.{ts,js}\" && npm run type-check",
     "lint:fix": "eslint \"src/**/*.{ts,js}\"",
     "prettier": "prettier --check \"src/**/*.{ts,js}\"",

--- a/libs/common/src/__helpers__/view-all-tables.ts
+++ b/libs/common/src/__helpers__/view-all-tables.ts
@@ -1,0 +1,61 @@
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { SqlDbDataSource } from '../sql-db-connection';
+import { UtilisationReportEntity, UtilisationDataEntity, AzureFileInfoEntity } from '../sql-db-entities';
+
+const tempDataSourceOptions: DataSourceOptions = {
+  ...SqlDbDataSource.options,
+  logging: false,
+};
+
+const tempDataSource = new DataSource(tempDataSourceOptions);
+
+const mapToObjectWithColumnIdAsKey = <T extends UtilisationReportEntity | UtilisationDataEntity | AzureFileInfoEntity, R extends { id: number } = T>(
+  input: T[],
+  formatter?: (original: T) => R,
+): { [key: number]: Omit<R, 'id'> } =>
+  input.reduce((output, current) => {
+    const formatted = formatter ? formatter(current) : current;
+    const { id, ...rest } = formatted;
+    return {
+      ...output,
+      [id]: rest,
+    };
+  }, {});
+
+const displayAllUtilisationReports = async (dataSource: DataSource): Promise<void> => {
+  console.info('-- UTILISATION REPORTS --');
+  const utilisationReports = await dataSource.manager.find(UtilisationReportEntity);
+  const mappedUtilisationReports = mapToObjectWithColumnIdAsKey(utilisationReports, ({ reportPeriod, ...rest }) => ({
+    ...rest,
+    reportPeriod: JSON.stringify(reportPeriod),
+  }));
+  // eslint-disable-next-line no-console
+  console.table(mappedUtilisationReports);
+};
+
+const displayAllUtilisationData = async (dataSource: DataSource): Promise<void> => {
+  console.info('-- UTILISATION DATA --');
+  const utilisationData = await dataSource.manager.find(UtilisationDataEntity);
+  const mappedUtilisationData = mapToObjectWithColumnIdAsKey(utilisationData);
+  // eslint-disable-next-line no-console
+  console.table(mappedUtilisationData);
+};
+
+const displayAllAzureFileInfo = async (dataSource: DataSource): Promise<void> => {
+  console.info('-- AZURE FILE INFO --');
+  const azureFileInfo = await dataSource.manager.find(AzureFileInfoEntity);
+  const mappedAzureFileInfo = mapToObjectWithColumnIdAsKey(azureFileInfo);
+  // eslint-disable-next-line no-console
+  console.table(mappedAzureFileInfo);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+tempDataSource.initialize().then(async (dataSource) => {
+  console.info('-- DISPLAYING ALL TABLES (index column = column id) --');
+
+  await displayAllUtilisationReports(dataSource);
+  await displayAllUtilisationData(dataSource);
+  await displayAllAzureFileInfo(dataSource);
+
+  await dataSource.destroy();
+});


### PR DESCRIPTION
## Introduction :pencil2:
Whilst waiting for the AVDs to have SSMS installed, it would be nice to be able to view the data inside the SQL tables.

## Resolution :heavy_check_mark:
- Adds a hidden helper to `libs/common` which displays all tables
- Provides functionality for custom formatting to the data in the tables
- Adds a command to `libs/common/package.json` to run the commands

A screenshot of the output you get from running this command (after seeding some data) is shown below.
![FN-1865-display-tables](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/a137a978-eb0d-49b1-8b7d-c3b9bcc8f377)

