### PR TITLE
feat(FN-1853): fix portal e2e test mock reports

### DIFF
--- a/dtfs-central-api/src/helpers/fee-record.helper.ts
+++ b/dtfs-central-api/src/helpers/fee-record.helper.ts
@@ -27,11 +27,11 @@ export const feeRecordCsvRowToSqlEntity = ({ dataEntry, requestSource }: FeeReco
     baseCurrency: dataEntry[UTILISATION_REPORT_HEADERS.BASE_CURRENCY],
     facilityUtilisation: Number(dataEntry[UTILISATION_REPORT_HEADERS.FACILITY_UTILISATION]),
     totalFeesAccruedForThePeriod: Number(dataEntry[UTILISATION_REPORT_HEADERS.TOTAL_FEES_ACCRUED]),
-    totalFeesAccruedForThePeriodCurrency: dataEntry[UTILISATION_REPORT_HEADERS.TOTAL_FEES_ACCRUED_CURRENCY],
+    totalFeesAccruedForThePeriodCurrency: dataEntry[UTILISATION_REPORT_HEADERS.TOTAL_FEES_ACCRUED_CURRENCY] ?? dataEntry[UTILISATION_REPORT_HEADERS.BASE_CURRENCY],
     totalFeesAccruedForThePeriodExchangeRate: asNumberOrDefault(dataEntry[UTILISATION_REPORT_HEADERS.TOTAL_FEES_ACCRUED_EXCHANGE_RATE], 1),
     feesPaidToUkefForThePeriod: Number(dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD]),
     feesPaidToUkefForThePeriodCurrency: dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD_CURRENCY],
-    paymentCurrency: dataEntry[UTILISATION_REPORT_HEADERS.PAYMENT_CURRENCY],
+    paymentCurrency: dataEntry[UTILISATION_REPORT_HEADERS.PAYMENT_CURRENCY] ?? dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD_CURRENCY],
     paymentExchangeRate: asNumberOrDefault(dataEntry[UTILISATION_REPORT_HEADERS.PAYMENT_EXCHANGE_RATE], 1),
     requestSource,
   });

--- a/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
+++ b/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
@@ -1,15 +1,7 @@
 // TODO FN-1853 - rename this to `utilisation-report.repo.ts` when all repo
 //  methods have been migrated from MongoDB to SQL
 import { SqlDbDataSource } from '@ukef/dtfs2-common/sql-db-connection';
-import {
-  AzureFileInfoEntity,
-  DbRequestSource,
-  UtilisationReportEntity,
-  ReportPeriod,
-  AzureFileInfo,
-  FeeRecordEntity,
-  UTILISATION_REPORT_RECONCILIATION_STATUS,
-} from '@ukef/dtfs2-common';
+import { AzureFileInfoEntity, DbRequestSource, FeeRecordEntity, UtilisationReportEntity, ReportPeriod, AzureFileInfo } from '@ukef/dtfs2-common';
 import { Not, Equal, FindOptionsWhere, LessThan } from 'typeorm';
 import { UtilisationReportRawCsvData } from '../../types/utilisation-reports';
 import { feeRecordCsvRowToSqlEntity } from '../../helpers';
@@ -40,15 +32,21 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
   /**
    * Finds all reports with bankId and matching options
    * @param bankId - The id of the bank to fetch reports for
-   * @param otpions - The options determining which reports are retrieved for the given bank
+   * @param options - The options determining which reports are retrieved for the given bank
    * @returns The found reports
    */
   async findAllByBankId(bankId: string, options?: GetUtilisationReportDetailsOptions): Promise<UtilisationReportEntity[]> {
-    return await this.findBy({
-      bankId,
-      ...(options?.reportPeriod && { reportPeriod: options.reportPeriod }),
-      ...(options?.excludeNotReceived && { status: Not(UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED) }),
-    });
+    const findByOptionsWhere: FindOptionsWhere<UtilisationReportEntity> = { bankId };
+
+    if (options?.reportPeriod) {
+      findByOptionsWhere.reportPeriod = options.reportPeriod;
+    }
+
+    if (options?.excludeNotReceived) {
+      findByOptionsWhere.status = Not('REPORT_NOT_RECEIVED');
+    }
+
+    return await this.findBy(findByOptionsWhere);
   },
 
   /**

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/previous-reports/list-previous-reports.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/previous-reports/list-previous-reports.spec.js
@@ -7,6 +7,7 @@ const { BANK1_PAYMENT_REPORT_OFFICER1 } = MOCK_USERS;
 
 context('List previous utilisation reports', () => {
   before(() => {
+    cy.removeAllUtilisationReports();
     cy.insertUtilisationReports(previousReportDetails);
   });
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirm-and-send.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirm-and-send.spec.js
@@ -23,6 +23,7 @@ context('Confirm and send', () => {
 
       confirmAndSend.mainHeading().should('not.exist');
       confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+      confirmAndSend.currentUrl().should('not.contain', '/confirm-and-send');
     });
 
     it('Should route to the Upload Report page when the change button is selected', () => {
@@ -30,6 +31,7 @@ context('Confirm and send', () => {
 
       confirmAndSend.mainHeading().should('not.exist');
       confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+      confirmAndSend.currentUrl().should('not.contain', '/confirm-and-send');
     });
 
     it('Should route to the Confirmation page when the Confirm and Send button is selected', () => {
@@ -46,6 +48,7 @@ context('Confirm and send', () => {
       cy.visit(relativeURL('/utilisation-report-upload/confirm-and-send'));
 
       confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+      confirmAndSend.currentUrl().should('not.contain', '/confirm-and-send');
     });
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirmation.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/confirmation.spec.js
@@ -41,6 +41,7 @@ context('Confirmation', () => {
       cy.visit(relativeURL('/utilisation-report-upload/confirm-and-send'));
 
       confirmAndSend.currentUrl().should('contain', '/utilisation-report-upload');
+      confirmAndSend.currentUrl().should('not.contain', '/confirm-and-send');
     });
   });
 });

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -1,39 +1,32 @@
-const {
-  eachMonthOfInterval,
-  getYear,
-  getMonth,
-  subMonths,
-} = require('date-fns');
+const { eachMonthOfInterval, getYear, getMonth, subMonths } = require('date-fns');
 const { BANK1_PAYMENT_REPORT_OFFICER1 } = require('../../../e2e-fixtures');
+const { UtilisationReportEntityMockBuilder, AzureFileInfoEntity, MOCK_AZURE_FILE_INFO } = require('@ukef/dtfs2-common');
 
-const BANK1 = {
-  id: BANK1_PAYMENT_REPORT_OFFICER1.bank.id,
-  name: BANK1_PAYMENT_REPORT_OFFICER1.bank.name,
-};
+const bankId = BANK1_PAYMENT_REPORT_OFFICER1.bank.id;
 
-const generateReportDetails = (year, month) => {
-  const bank = BANK1;
-  const uploadedBy = BANK1_PAYMENT_REPORT_OFFICER1;
-  const dateUploaded = new Date(year, month - 1);
-  return {
-    bank,
-    reportPeriod: {
-      start: {
-        month,
-        year,
-      },
-      end: {
-        month,
-        year,
-      },
-    },
-    dateUploaded,
-    uploadedBy,
-    // Azure file info must be non-null if in 'PENDING_RECONCILIATION' state
-    azureFileInfo: {},
-    status: 'PENDING_RECONCILIATION',
-  };
-};
+const createAzureFileInfo = () => AzureFileInfoEntity.create({ ...MOCK_AZURE_FILE_INFO, requestSource: { platform: 'SYSTEM' } });
+
+function* idGenerator() {
+  let id = 0;
+  while (true) {
+    id += 1;
+    yield id;
+  }
+}
+const reportIdGenerator = idGenerator();
+
+const generateReportDetails = (year, month) =>
+  UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION')
+    .withBankId(bankId)
+    .withId(reportIdGenerator.next().value)
+    .withReportPeriod({
+      start: { month, year },
+      end: { month, year },
+    })
+    .withDateUploaded(new Date(year, month - 1))
+    // .withUploadedByUserId() // we don't have access to the user id without querying the mongo database
+    .withAzureFileInfo(createAzureFileInfo())
+    .build();
 
 const generateReports = (startMonthDate, endMonthDate) =>
   eachMonthOfInterval({
@@ -49,21 +42,14 @@ const generateReports = (startMonthDate, endMonthDate) =>
 const previousReportDetails = generateReports(new Date('2020-01-01'), new Date('2023-01-01')).filter(({ reportPeriod }) => reportPeriod.start.year !== 2021);
 
 const february2023ReportDetails = [
-  {
-    bankId: BANK1.id,
-    reportPeriod: {
-      start: {
-        month: 2,
-        year: 2023,
-      },
-      end: {
-        month: 2,
-        year: 2023,
-      },
-    },
-    status: 'REPORT_NOT_RECEIVED',
-    updatedByUserId: `SYSTEM`
-  },
+  UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED')
+    .withId(reportIdGenerator.next().value)
+    .withBankId(bankId)
+    .withReportPeriod({
+      start: { month: 2, year: 2023 },
+      end: { month: 2, year: 2023 },
+    })
+    .build(),
 ];
 
 const generateUpToDateReportDetails = () => {

--- a/e2e-tests/support/tasks.js
+++ b/e2e-tests/support/tasks.js
@@ -1,7 +1,7 @@
 const crypto = require('node:crypto');
 const { MongoDbClient } = require('@ukef/dtfs2-common/mongo-db-client');
 const { SqlDbDataSource } = require('@ukef/dtfs2-common/sql-db-connection');
-const { UtilisationReportEntity, UtilisationDataEntity } = require('@ukef/dtfs2-common');
+const { UtilisationReportEntity, FeeRecordEntity } = require('@ukef/dtfs2-common');
 const { DB_COLLECTIONS } = require('../e2e-fixtures/dbCollections');
 
 SqlDbDataSource.initialize()
@@ -102,7 +102,7 @@ module.exports = {
        * Deletes all the rows from the utilisation report and azure file info tables
        */
       async removeAllUtilisationReportsFromDb() {
-        await SqlDbDataSource.manager.getRepository(UtilisationDataEntity).delete({});
+        await SqlDbDataSource.manager.getRepository(FeeRecordEntity).delete({});
         return await SqlDbDataSource.manager.getRepository(UtilisationReportEntity).delete({});
       },
 

--- a/e2e-tests/support/tasks.js
+++ b/e2e-tests/support/tasks.js
@@ -1,7 +1,7 @@
 const crypto = require('node:crypto');
 const { MongoDbClient } = require('@ukef/dtfs2-common/mongo-db-client');
 const { SqlDbDataSource } = require('@ukef/dtfs2-common/sql-db-connection');
-const { UtilisationReportEntity } = require('@ukef/dtfs2-common');
+const { UtilisationReportEntity, UtilisationDataEntity } = require('@ukef/dtfs2-common');
 const { DB_COLLECTIONS } = require('../e2e-fixtures/dbCollections');
 
 SqlDbDataSource.initialize()
@@ -102,6 +102,7 @@ module.exports = {
        * Deletes all the rows from the utilisation report and azure file info tables
        */
       async removeAllUtilisationReportsFromDb() {
+        await SqlDbDataSource.manager.getRepository(UtilisationDataEntity).delete({});
         return await SqlDbDataSource.manager.getRepository(UtilisationReportEntity).delete({});
       },
 

--- a/portal-api/src/v1/controllers/utilisation-report-service/utilisation-report-upload.controller.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/utilisation-report-upload.controller.js
@@ -1,3 +1,4 @@
+const { UTILISATION_REPORT_RECONCILIATION_STATUS } = require('@ukef/dtfs2-common');
 const api = require('../../api');
 const sendEmail = require('../../email');
 const { EMAIL_TEMPLATE_IDS, FILESHARES } = require('../../../constants');
@@ -112,7 +113,6 @@ const uploadReportAndSendNotification = async (req, res) => {
 
     const existingReports = await api.getUtilisationReports(bankId, {
       reportPeriod: parsedReportPeriod,
-      excludeNotReceived: true,
     });
 
     if (existingReports.length !== 1) {
@@ -120,6 +120,14 @@ const uploadReportAndSendNotification = async (req, res) => {
     }
 
     const existingReport = existingReports[0];
+
+    if (existingReport.status !== UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED) {
+      return res
+        .status(500)
+        .send(
+          `Expected report to be in '${UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED}' state (was actually in '${existingReport.status}' state)`,
+        );
+    }
 
     const fileInfo = await saveFileToAzure(file, bankId);
 


### PR DESCRIPTION
## Introduction :pencil2:
Portal e2e tests are currently failing due to the reports that are being inserted having the wrong schema.

## Resolution :heavy_check_mark:
- Updates the generated mocks in `e2e-tests/portal` to use the `UtilisationReportEntityMockBuilder`
- Improves test coverage for some e2e tests

## Miscellaneous :heavy_plus_sign:

