### PR TITLE
feat(FN-1862): remove mark not received as completed

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports.api-test.ts
@@ -76,7 +76,6 @@ describe('GET /v1/bank/:bankId/utilisation-reports', () => {
     const nonUploadedReport = UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED')
       .withId(2)
       .withBankId(bankId)
-      .withUploadedByUserId(portalUserId)
       .build();
 
     await saveReportsToDatabase(uploadedReport, nonUploadedReport);
@@ -101,15 +100,13 @@ describe('GET /v1/bank/:bankId/utilisation-reports', () => {
 
     const notReceivedReport = UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED').withId(2).withBankId(bankId).build();
 
-    const nonUploadedMarkedReconciledReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED')
+    const reconciliationCompletedReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED')
       .withId(3)
       .withBankId(bankId)
-      .withUploadedByUserId(null)
-      .withDateUploaded(null)
-      .withAzureFileInfo(undefined)
+      .withUploadedByUserId(portalUserId)
       .build();
 
-    await saveReportsToDatabase(uploadedReport, notReceivedReport, nonUploadedMarkedReconciledReport);
+    await saveReportsToDatabase(uploadedReport, notReceivedReport, reconciliationCompletedReport);
 
     // Act
     const response: CustomSuccessResponse = await api.get(`${getUrl(bankId)}?excludeNotReceived=true`);
@@ -119,7 +116,7 @@ describe('GET /v1/bank/:bankId/utilisation-reports', () => {
     expect(response.body.length).toEqual(2);
     const ids = response.body.map((report) => report.id);
     expect(ids).toContain(uploadedReport.id);
-    expect(ids).toContain(nonUploadedMarkedReconciledReport.id);
+    expect(ids).toContain(reconciliationCompletedReport.id);
   });
 
   it('gets utilisation reports for specified period', async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/put-utilisation-report-status.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/put-utilisation-report-status.api-test.ts
@@ -12,7 +12,7 @@ describe('/v1/utilisation-reports/set-status', () => {
   const setStatusUrl = '/v1/utilisation-reports/set-status';
 
   const reportId = 1;
-  const mockReport = UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED').withId(reportId).build();
+  const mockReport = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').withId(reportId).build();
 
   beforeAll(async () => {
     await SqlDbHelper.initialize();
@@ -21,7 +21,7 @@ describe('/v1/utilisation-reports/set-status', () => {
     await SqlDbHelper.saveNewEntry('UtilisationReport', mockReport);
   });
 
-  it(`should return a 500 error when trying to set a non-existent report to '${UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED}'`, async () => {
+  it(`should return a 500 error when trying to set a non-existent report to '${UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED}'`, async () => {
     // Arrange
     const invalidReportId = reportId + 1;
     const requestBody = {
@@ -29,7 +29,7 @@ describe('/v1/utilisation-reports/set-status', () => {
       reportsWithStatus: [
         {
           reportId: invalidReportId,
-          status: UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED,
+          status: UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED,
         },
       ],
     };

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.test.ts
@@ -1,8 +1,6 @@
 import { EntityManager } from 'typeorm';
 import {
-  AzureFileInfoEntity,
   DbRequestSource,
-  MOCK_AZURE_FILE_INFO,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntity,
   UtilisationReportEntityMockBuilder,
@@ -23,45 +21,19 @@ describe('handleUtilisationReportManuallySetIncompleteEvent', () => {
     save: mockSave,
   } as unknown as EntityManager;
 
-  describe('when a report has been uploaded', () => {
-    const azureFileInfo = AzureFileInfoEntity.create({ ...MOCK_AZURE_FILE_INFO, requestSource });
-    const expectedNewStatus = UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION;
+  it("sets the report status to 'PENDING_RECONCILIATION' and saves the report using the transaction entity manager", async () => {
+    // Arrange
+    const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').build();
 
-    it(`sets the report status to '${expectedNewStatus}' and saves the report using the transaction entity manager`, async () => {
-      // Arrange
-      const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withAzureFileInfo(azureFileInfo).build();
-
-      // Act
-      await handleUtilisationReportManuallySetIncompleteEvent(report, {
-        requestSource,
-        transactionEntityManager: mockEntityManager,
-      });
-
-      // Assert
-      expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, report);
-      expect(report.status).toEqual(expectedNewStatus);
-      expect(report.updatedByUserId).toEqual(updatedByUserId);
+    // Act
+    await handleUtilisationReportManuallySetIncompleteEvent(report, {
+      requestSource,
+      transactionEntityManager: mockEntityManager,
     });
-  });
 
-  describe('when a report has not been uploaded', () => {
-    const azureFileInfo = undefined;
-    const expectedNewStatus = UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED;
-
-    it(`sets the report status to '${expectedNewStatus}' and saves the report using the transaction entity manager`, async () => {
-      // Arrange
-      const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withAzureFileInfo(azureFileInfo).build();
-
-      // Act
-      await handleUtilisationReportManuallySetIncompleteEvent(report, {
-        requestSource,
-        transactionEntityManager: mockEntityManager,
-      });
-
-      // Assert
-      expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, report);
-      expect(report.status).toEqual(expectedNewStatus);
-      expect(report.updatedByUserId).toEqual(updatedByUserId);
-    });
+    // Assert
+    expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, report);
+    expect(report.status).toEqual(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION);
+    expect(report.updatedByUserId).toEqual(updatedByUserId);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, UtilisationReportEntity, UtilisationReportReconciliationStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, UtilisationReportEntity } from '@ukef/dtfs2-common';
 import { BaseUtilisationReportEvent } from '../../event/base-utilisation-report.event';
 
 type ManuallySetIncompleteEventPayload = {
@@ -13,7 +13,6 @@ export const handleUtilisationReportManuallySetIncompleteEvent = async (
   report: UtilisationReportEntity,
   { requestSource, transactionEntityManager }: ManuallySetIncompleteEventPayload,
 ): Promise<UtilisationReportEntity> => {
-  const incompleteStatusForReport: UtilisationReportReconciliationStatus = report.azureFileInfo ? 'PENDING_RECONCILIATION' : 'REPORT_NOT_RECEIVED';
-  report.updateWithStatus({ status: incompleteStatusForReport, requestSource });
+  report.updateWithStatus({ status: 'PENDING_RECONCILIATION', requestSource });
   return await transactionEntityManager.save(UtilisationReportEntity, report);
 };

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
@@ -91,29 +91,7 @@ describe('UtilisationReportStateMachine', () => {
       expect(handleUtilisationReportReportUploadedEvent).toHaveBeenCalledTimes(1);
     });
 
-    it(`handles the '${UTILISATION_REPORT_EVENT_TYPE.MANUALLY_SET_COMPLETED}' event`, async () => {
-      // Arrange
-      const requestSource: DbRequestSource = {
-        platform: 'TFM',
-        userId: 'abc123',
-      };
-      const transactionEntityManager = {} as unknown as EntityManager;
-      const stateMachine = UtilisationReportStateMachine.forReport(REPORT_NOT_RECEIVED_REPORT);
-
-      // Act
-      await stateMachine.handleEvent({
-        type: 'MANUALLY_SET_COMPLETED',
-        payload: {
-          requestSource,
-          transactionEntityManager,
-        },
-      });
-
-      // Assert
-      expect(handleUtilisationReportManuallySetCompletedEvent).toHaveBeenCalledTimes(1);
-    });
-
-    const VALID_REPORT_NOT_RECEIVED_EVENT_TYPES = [UTILISATION_REPORT_EVENT_TYPE.REPORT_UPLOADED, UTILISATION_REPORT_EVENT_TYPE.MANUALLY_SET_COMPLETED];
+    const VALID_REPORT_NOT_RECEIVED_EVENT_TYPES = [UTILISATION_REPORT_EVENT_TYPE.REPORT_UPLOADED];
 
     it.each(difference(UTILISATION_REPORT_EVENT_TYPES, VALID_REPORT_NOT_RECEIVED_EVENT_TYPES))(
       "throws an 'InvalidStateMachineTransitionError' for event type %p",

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.ts
@@ -67,8 +67,6 @@ export class UtilisationReportStateMachine {
         switch (event.type) {
           case 'REPORT_UPLOADED':
             return handleUtilisationReportReportUploadedEvent(this.report, event.payload);
-          case 'MANUALLY_SET_COMPLETED':
-            return handleUtilisationReportManuallySetCompletedEvent(this.report, event.payload);
           default:
             return this.handleInvalidTransition(event);
         }

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-utilisation-report-status.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-utilisation-report-status.controller/index.test.ts
@@ -130,10 +130,9 @@ describe('put-utilisation-report-status.controller', () => {
       const { req, res } = getHttpMocks();
       req.body.reportsWithStatus = reportsWithStatusForMarkingAsCompleted;
 
-      const existingReports = [
-        UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED').withId(reportsWithStatusForMarkingAsCompleted[0].reportId).build(),
-        UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').withId(reportsWithStatusForMarkingAsCompleted[1].reportId).build(),
-      ];
+      const existingReports = reportsWithStatusForMarkingAsCompleted.map(({ reportId }) =>
+        UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').withId(reportId).build(),
+      );
 
       utilisationReportRepoFindOneByOrFailSpy.mockImplementation(mockFindOneByOrFail(existingReports));
 
@@ -157,34 +156,37 @@ describe('put-utilisation-report-status.controller', () => {
       });
     });
 
-    it('responds with an error if trying to mark an already completed report as completed', async () => {
-      // Arrange
-      const reportWithStatus: ReportWithStatus = {
-        reportId: 1,
-        status: 'RECONCILIATION_COMPLETED',
-      };
+    it.each([UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED, UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED])(
+      "responds with an error if trying to mark a report with status '%s' as completed",
+      async (reportStatus) => {
+        // Arrange
+        const reportWithStatus: ReportWithStatus = {
+          reportId: 1,
+          status: 'RECONCILIATION_COMPLETED',
+        };
 
-      const { req, res } = getHttpMocks();
-      req.body.reportsWithStatus = [reportWithStatus];
+        const { req, res } = getHttpMocks();
+        req.body.reportsWithStatus = [reportWithStatus];
 
-      const existingReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withId(reportWithStatus.reportId).build();
+        const existingReport = UtilisationReportEntityMockBuilder.forStatus(reportStatus).withId(reportWithStatus.reportId).build();
 
-      utilisationReportRepoFindOneByOrFailSpy.mockResolvedValue(existingReport);
+        utilisationReportRepoFindOneByOrFailSpy.mockResolvedValue(existingReport);
 
-      // Act
-      await putUtilisationReportStatus(req, res);
+        // Act
+        await putUtilisationReportStatus(req, res);
 
-      // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._getData()).toEqual('Failed to update utilisation report statuses: Transaction failed');
-      expect(createQueryRunnerSpy).toHaveBeenCalledTimes(1);
-      expect(mockConnect).toHaveBeenCalledTimes(1);
-      expect(mockStartTransaction).toHaveBeenCalledTimes(1);
-      expect(mockCommitTransaction).not.toHaveBeenCalled();
-      expect(mockRollbackTransaction).toHaveBeenCalledTimes(1);
-      expect(mockRelease).toHaveBeenCalled();
-      expect(mockTransactionManager.save).not.toHaveBeenCalled();
-    });
+        // Assert
+        expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+        expect(res._getData()).toEqual('Failed to update utilisation report statuses: Transaction failed');
+        expect(createQueryRunnerSpy).toHaveBeenCalledTimes(1);
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+        expect(mockStartTransaction).toHaveBeenCalledTimes(1);
+        expect(mockCommitTransaction).not.toHaveBeenCalled();
+        expect(mockRollbackTransaction).toHaveBeenCalledTimes(1);
+        expect(mockRelease).toHaveBeenCalled();
+        expect(mockTransactionManager.save).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe('when trying to only mark reports as not completed', () => {
@@ -197,11 +199,7 @@ describe('put-utilisation-report-status.controller', () => {
         },
         {
           reportId: 2,
-          status: 'REPORT_NOT_RECEIVED',
-        },
-        {
-          reportId: 3,
-          status: 'REPORT_NOT_RECEIVED',
+          status: 'PENDING_RECONCILIATION',
         },
       ];
 
@@ -216,15 +214,9 @@ describe('put-utilisation-report-status.controller', () => {
         },
       });
 
-      const existingReports = reportsWithStatusForMarkingAsNotCompleted.map((reportWithStatus) => {
-        if (reportWithStatus.status === 'PENDING_RECONCILIATION') {
-          return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED')
-            .withId(reportWithStatus.reportId)
-            .withAzureFileInfo(azureFileInfo)
-            .build();
-        }
-        return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withId(reportWithStatus.reportId).withAzureFileInfo(undefined).build();
-      });
+      const existingReports = reportsWithStatusForMarkingAsNotCompleted.map((reportWithStatus) =>
+        UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withId(reportWithStatus.reportId).withAzureFileInfo(azureFileInfo).build(),
+      );
 
       utilisationReportRepoFindOneByOrFailSpy.mockImplementation(mockFindOneByOrFail(existingReports));
 
@@ -255,7 +247,7 @@ describe('put-utilisation-report-status.controller', () => {
         // Arrange
         const reportWithStatus: ReportWithStatus = {
           reportId: 1,
-          status: 'REPORT_NOT_RECEIVED',
+          status: 'PENDING_RECONCILIATION',
         };
 
         const { req, res } = getHttpMocks();

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
@@ -21,6 +21,7 @@ context('PDC_READ users can route to the payments page for a bank', () => {
 
       getAllBanksResult
         .filter((bank) => bank.isVisibleInTfmUtilisationReports)
+        .filter((bank) => bank.id !== '10') // TODO FN-1601 remove after TFM is working for quarterly banks
         .forEach((visibleBank) => {
           visibleBanks.push(visibleBank);
         });
@@ -30,12 +31,7 @@ context('PDC_READ users can route to the payments page for a bank', () => {
     cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
 
     cy.wrap(visibleBanks).each((bank) => {
-      // TODO FN-1601 update after TFM is working for quarterly banks
-      if (bank.id === '10') {
-        return;
-      }
-
-      const reportPeriod = getReportPeriodForBankScheduleBySubmissionMonth(bank.utilisationReportPeriodSchedule);
+      const reportPeriod = getReportPeriodForBankScheduleBySubmissionMonth(bank.utilisationReportPeriodSchedule, submissionMonth);
 
       const mockUtilisationReport = UtilisationReportEntityMockBuilder.forStatus(status)
         .withId(bank.id)

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
@@ -21,7 +21,6 @@ context('PDC_READ users can route to the payments page for a bank', () => {
 
       getAllBanksResult
         .filter((bank) => bank.isVisibleInTfmUtilisationReports)
-        .filter((bank) => bank.id !== '10') // TODO FN-1601 remove after TFM is working for quarterly banks
         .forEach((visibleBank) => {
           visibleBanks.push(visibleBank);
         });
@@ -52,6 +51,11 @@ context('PDC_READ users can route to the payments page for a bank', () => {
 
     cy.get(aliasSelector(allBanksAlias)).each((bank) => {
       const { id, isVisibleInTfmUtilisationReports } = bank;
+
+      // TODO FN-1601 remove after TFM is working for quarterly banks
+      if (id === '10') {
+        return;
+      }
 
       if (isVisibleInTfmUtilisationReports) {
         pages.utilisationReportsPage.tableRowSelector(id, submissionMonth).should('exist');

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
@@ -18,7 +18,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
   const utilisationReportsAlias = 'utilisationReportsAlias';
 
   const displayStatusSelector = 'td > strong[data-cy="utilisation-report-reconciliation-status"]';
-  const tableCellCheckboxSelector = (reportId) => `th > div > div > input[data-cy="table-cell-checkbox--set-status--reportId-${reportId}"]`;
+  const tableCellCheckboxSelector = (reportId, status) =>
+    `th > div > div > input[data-cy="table-cell-checkbox--set-status--reportId-${reportId}-currentStatus-${status}"]`;
 
   const getDisplayStatus = (utilisationReportReconciliationStatus) => {
     switch (utilisationReportReconciliationStatus) {
@@ -88,13 +89,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
      */
     const notReceivedUtilisationReports = [];
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
-      const { bankId, id, reportPeriod } = utilisationReport;
+      const { bankId, id, reportPeriod, status } = utilisationReport;
 
       pages.utilisationReportsPage
         .tableRowSelector(bankId, submissionMonth)
         .should('exist')
         .within(($tableRow) => {
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).should('exist');
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).should('exist');
         });
 
       const notReceivedUtilisationReport = UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED')
@@ -107,13 +108,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
 
     cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
     cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, notReceivedUtilisationReports).each((notReceivedReport) => {
-      const { bankId, id } = notReceivedReport;
+      const { bankId, id, status } = notReceivedReport;
 
       pages.utilisationReportsPage
         .tableRowSelector(bankId, submissionMonth)
         .should('exist')
         .within(($tableRow) => {
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).should('not.exist');
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).should('not.exist');
         });
     });
   });
@@ -128,7 +129,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         .should('exist')
         .within(($tableRow) => {
           cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).click();
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).click();
         });
     });
 
@@ -136,8 +137,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
-
       const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
+
       pages.utilisationReportsPage
         .tableRowSelector(bankId, submissionMonth)
         .should('exist')
@@ -157,7 +158,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         .should('exist')
         .within(($tableRow) => {
           cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).click();
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).click();
         });
     });
 
@@ -166,13 +167,15 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId, id } = utilisationReport;
 
-      const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
+      const completedStatus = UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED;
+      const displayStatus = getDisplayStatus(completedStatus);
+
       pages.utilisationReportsPage
         .tableRowSelector(bankId, submissionMonth)
         .should('exist')
         .within(($tableRow) => {
           cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).click();
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, completedStatus)).click();
         });
     });
 
@@ -180,12 +183,12 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
+      const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION);
 
       pages.utilisationReportsPage
         .tableRowSelector(bankId, submissionMonth)
         .should('exist')
         .within(($tableRow) => {
-          const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION);
           cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
         });
     });
@@ -252,7 +255,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         .should('exist')
         .within(($tableRow) => {
           cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).click();
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).click();
         });
     });
 
@@ -293,13 +296,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     cy.reload();
 
     cy.get(aliasSelector(previousUtilisationReportAlias)).then((utilisationReport) => {
-      const { id, bankId } = utilisationReport;
+      const { id, bankId, status } = utilisationReport;
 
       pages.utilisationReportsPage
         .tableRowSelector(bankId, previousSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).click();
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).click();
         });
     });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
@@ -18,8 +18,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
   const utilisationReportsAlias = 'utilisationReportsAlias';
 
   const displayStatusSelector = 'td > strong[data-cy="utilisation-report-reconciliation-status"]';
-  const tableCellCheckboxSelector = (reportId, status) =>
-    `th > div > div > input[data-cy="table-cell-checkbox--set-status--reportId-${reportId}-currentStatus-${status}"]`;
+  const tableCellCheckboxSelector = (reportId, status) => `input[data-cy="table-cell-checkbox--set-status--reportId-${reportId}-currentStatus-${status}"]`;
 
   const getDisplayStatus = (utilisationReportReconciliationStatus) => {
     switch (utilisationReportReconciliationStatus) {

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
@@ -88,6 +88,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         .withUploadedByUserId(uploadedByUserId)
         .build();
       mockUtilisationReports.push(mockUtilisationReport);
+      statusWithBankId[index].bankId = bankId;
     });
 
     cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
@@ -251,5 +251,23 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
 
       pages.utilisationReportsPage.tableRowSelector(bankId, previousSubmissionMonth).should('not.exist');
     });
+
+    // Make sure original reports are still present
+    cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
+      const { bankId } = utilisationReport;
+      const statusWithSpecificBankId = statusWithBankId.find(({ bankId: bankIdToMatch }) => bankId === bankIdToMatch);
+      if (!statusWithSpecificBankId) {
+        return;
+      }
+      const { status } = statusWithSpecificBankId;
+      const displayStatus = getDisplayStatus(status);
+
+      pages.utilisationReportsPage
+        .tableRowSelector(bankId, submissionMonth)
+        .should('exist')
+        .within(($tableRow) => {
+          cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
+        });
+    });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
@@ -204,11 +204,11 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         .should('exist')
         .within(($tableRow) => {
           cy.wrap($tableRow).get(displayStatusSelector).should('exist').contains(displayStatus);
-          cy.wrap($tableRow).get(tableCellCheckboxSelector(id)).click();
+          cy.wrap($tableRow).get(tableCellCheckboxSelector(id, status)).click();
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsNotCompletedButton();
+    pages.utilisationReportsPage.clickMarkReportAsNotCompletedButton(submissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
@@ -259,7 +259,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsCompletedButton();
+    pages.utilisationReportsPage.clickMarkReportAsCompletedButton(submissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;

--- a/libs/common/src/test-helpers/mock-data/utilisation-report.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/utilisation-report.entity.mock-builder.ts
@@ -4,14 +4,14 @@ import { getDbAuditUpdatedByUserId } from '../../sql-db-entities/helpers';
 import { ReportPeriodPartialEntity } from '../../sql-db-entities/partial-entities';
 import { MOCK_AZURE_FILE_INFO } from './azure-file-info.mock';
 
-export class UtilisationReportEntityMockBuilder {
+export class UtilisationReportEntityMockBuilder<ReportStatus extends UtilisationReportReconciliationStatus> {
   private readonly report: UtilisationReportEntity;
 
   private constructor(report: UtilisationReportEntity) {
     this.report = report;
   }
 
-  public static forStatus(status: UtilisationReportReconciliationStatus): UtilisationReportEntityMockBuilder {
+  public static forStatus<Status extends UtilisationReportReconciliationStatus>(status: Status): UtilisationReportEntityMockBuilder<Status> {
     const bankId = '123';
     const reportPeriod = {
       start: { month: 11, year: 2023 },
@@ -19,7 +19,7 @@ export class UtilisationReportEntityMockBuilder {
     };
 
     if (status === 'REPORT_NOT_RECEIVED') {
-      return new UtilisationReportEntityMockBuilder(
+      return new UtilisationReportEntityMockBuilder<typeof status>(
         UtilisationReportEntity.createNotReceived({
           bankId,
           reportPeriod,
@@ -46,37 +46,39 @@ export class UtilisationReportEntityMockBuilder {
     return new UtilisationReportEntityMockBuilder(report);
   }
 
-  public withId(id: number): UtilisationReportEntityMockBuilder {
+  public withId(id: number): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.id = id;
     return this;
   }
 
-  public withBankId(bankId: string): UtilisationReportEntityMockBuilder {
+  public withBankId(bankId: string): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.bankId = bankId;
     return this;
   }
 
-  public withReportPeriod(reportPeriod: ReportPeriodPartialEntity): UtilisationReportEntityMockBuilder {
+  public withReportPeriod(reportPeriod: ReportPeriodPartialEntity): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.reportPeriod = reportPeriod;
     return this;
   }
 
-  public withDateUploaded(dateUploaded: Date | null): UtilisationReportEntityMockBuilder {
+  public withDateUploaded(dateUploaded: ReportStatus extends 'REPORT_NOT_RECEIVED' ? null : Date): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.dateUploaded = dateUploaded;
     return this;
   }
 
-  public withAzureFileInfo(azureFileInfo: AzureFileInfoEntity | undefined): UtilisationReportEntityMockBuilder {
+  public withAzureFileInfo(
+    azureFileInfo: ReportStatus extends 'REPORT_NOT_RECEIVED' ? undefined : AzureFileInfoEntity,
+  ): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.azureFileInfo = azureFileInfo;
     return this;
   }
 
-  public withUploadedByUserId(uploadedByUserId: string | null): UtilisationReportEntityMockBuilder {
+  public withUploadedByUserId(uploadedByUserId: ReportStatus extends 'REPORT_NOT_RECEIVED' ? null : string): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.uploadedByUserId = uploadedByUserId;
     return this;
   }
 
-  public withFeeRecords(feeRecords: FeeRecordEntity[]): UtilisationReportEntityMockBuilder {
+  public withFeeRecords(feeRecords: FeeRecordEntity[]): UtilisationReportEntityMockBuilder<ReportStatus> {
     this.report.feeRecords = feeRecords;
     return this;
   }

--- a/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.js
+++ b/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.js
@@ -78,12 +78,10 @@ const getFormattedReportPeriod = () => {
  */
 const getIsReportSubmitted = async (bank) => {
   const reportPeriod = getReportPeriod();
-  const uploadedReportsInReportPeriod = (
-    await api.getUtilisationReports(bank.id, {
-      reportPeriod,
-      excludeNotReceived: true,
-    })
-  ).filter((report) => !!report.azureFileInfo);
+  const uploadedReportsInReportPeriod = await api.getUtilisationReports(bank.id, {
+    reportPeriod,
+    excludeNotReceived: true,
+  });
   return uploadedReportsInReportPeriod.length > 0;
 };
 

--- a/portal-api/src/v1/controllers/utilisation-report-service/last-uploaded.controller.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/last-uploaded.controller.js
@@ -4,11 +4,9 @@ const getLastUploadedReportByBankId = async (req, res) => {
   try {
     const { bankId } = req.params;
 
-    const uploadedReports = (
-      await api.getUtilisationReports(bankId, {
-        excludeNotReceived: true,
-      })
-    ).filter((report) => !!report.azureFileInfo);
+    const uploadedReports = await api.getUtilisationReports(bankId, {
+      excludeNotReceived: true,
+    });
 
     const lastUploadedReport = uploadedReports.at(-1);
     if (!lastUploadedReport) {

--- a/portal-api/src/v1/controllers/utilisation-report-service/previous-reports.controller.ts
+++ b/portal-api/src/v1/controllers/utilisation-report-service/previous-reports.controller.ts
@@ -72,11 +72,9 @@ export const getPreviousReportsByBankId = async (req: GetPreviousReportsByBankId
   try {
     const { bankId } = req.params;
 
-    const uploadedReports = (
-      await api.getUtilisationReports(bankId, {
-        excludeNotReceived: true,
-      })
-    ).filter((report) => !!report.azureFileInfo);
+    const uploadedReports = await api.getUtilisationReports(bankId, {
+      excludeNotReceived: true,
+    });
 
     const sortedReports = groupAndSortReports(uploadedReports);
 

--- a/trade-finance-manager-api/api-tests/v1/utilisation-reports/update-utilisation-report-service.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/utilisation-reports/update-utilisation-report-service.api-test.ts
@@ -1,4 +1,3 @@
-import { ObjectId } from 'bson';
 import app from '../../../src/createApp';
 import createApi from '../../api';
 import testUserCache from '../../api-test-users';
@@ -91,7 +90,7 @@ describe('/v1/utilisation-reports/set-status', () => {
       reportsWithStatus: [
         {
           status: UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION,
-          reportId: (new ObjectId()).toString(),
+          reportId: '1',
         },
       ],
     };

--- a/trade-finance-manager-api/src/v1/validation/route-validators/update-report-status-payload-validation/index.test.ts
+++ b/trade-finance-manager-api/src/v1/validation/route-validators/update-report-status-payload-validation/index.test.ts
@@ -1,7 +1,6 @@
 import { Request } from 'express';
 import { validationResult } from 'express-validator';
 import { createRequest } from 'node-mocks-http';
-import { ObjectId } from 'bson';
 import { updateReportStatusPayloadValidation } from '.';
 import { UTILISATION_REPORT_RECONCILIATION_STATUS } from '../../../../constants';
 import { TfmSessionUser } from '../../../../types/tfm-session-user';
@@ -21,8 +20,8 @@ describe('updateReportStatusPayloadValidation', () => {
     user: opts.user ?? MOCK_TFM_SESSION_USER,
     reportsWithStatus: opts.reportsWithStatus ?? [
       {
-        status: opts.status ?? UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION,
-        reportId: opts.reportId ?? new ObjectId().toString(),
+        status: opts.status ?? 'PENDING_RECONCILIATION',
+        reportId: opts.reportId ?? '123',
       },
     ],
   });
@@ -50,9 +49,9 @@ describe('updateReportStatusPayloadValidation', () => {
     expect(errors.length).not.toEqual(0);
   });
 
-  it('returns a single error when the report id is not a valid mongo id', async () => {
+  it('returns a single error when the report id is not a valid sql id', async () => {
     // Arrange
-    const reportId = '123';
+    const reportId = 'abc123';
     const body = getValidPayloadBody({ reportId });
     const req = createRequest({ body });
 
@@ -61,7 +60,7 @@ describe('updateReportStatusPayloadValidation', () => {
 
     // Assert
     expect(errors.length).toEqual(1);
-    expect(errors.at(0)?.msg).toEqual('Report id must be a valid mongo id string');
+    expect(errors.at(0)?.msg).toEqual('Report id must be an integer string');
   });
 
   it('returns a single error when the user is not an object', async () => {

--- a/trade-finance-manager-api/src/v1/validation/route-validators/update-report-status-payload-validation/index.ts
+++ b/trade-finance-manager-api/src/v1/validation/route-validators/update-report-status-payload-validation/index.ts
@@ -1,6 +1,5 @@
 import { body, checkSchema } from 'express-validator';
 import { UTILISATION_REPORT_RECONCILIATION_STATUS } from '../../../../constants';
-import { isValidMongoId } from '../../validateIds';
 
 const VALID_UPDATE_PAYLOAD_STATUSES = [
   UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED,
@@ -18,13 +17,5 @@ export const updateReportStatusPayloadValidation = [
       },
     },
   }),
-  body('reportsWithStatus.*.reportId', "'reportsWithStatus' array does not match any expected format")
-    .exists()
-    .isString()
-    .custom((value: string) => {
-      if (!isValidMongoId(value)) {
-        throw new Error('Report id must be a valid mongo id string');
-      }
-      return true;
-    }),
+  body('reportsWithStatus.*.reportId', "'reportsWithStatus' array does not match any expected format").exists().isInt({ gt: 0 }),
 ];

--- a/trade-finance-manager-api/src/v1/validation/route-validators/update-report-status-payload-validation/index.ts
+++ b/trade-finance-manager-api/src/v1/validation/route-validators/update-report-status-payload-validation/index.ts
@@ -17,5 +17,5 @@ export const updateReportStatusPayloadValidation = [
       },
     },
   }),
-  body('reportsWithStatus.*.reportId', "'reportsWithStatus' array does not match any expected format").exists().isInt({ gt: 0 }),
+  body('reportsWithStatus.*.reportId', 'Report id must be an integer string').exists().isInt({ gt: 0 }),
 ];

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../api';
 import * as getUtilisationReportsController from '..';
 import { UpdateUtilisationReportStatusRequest, UpdateUtilisationReportStatusRequestBody, updateUtilisationReportStatus } from '.';
 import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user';
-import { TEAM_IDS, UTILISATION_REPORT_RECONCILIATION_STATUS } from '../../../constants';
+import { TEAM_IDS } from '../../../constants';
 import { ReportWithStatus } from '../../../types/utilisation-reports';
 
 console.error = jest.fn();
@@ -25,12 +25,11 @@ describe('controllers/utilisation-reports/update-utilisation-report-status', () 
     };
 
     const validSqlId = '1';
-    // TODO FN-1862 Fix type assertion below
     const validBody: UpdateUtilisationReportStatusRequestBody = {
       _csrf: 'csrf',
       'form-button': 'completed',
-      [`set-status--reportId-${validSqlId}-currentStatus-${UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION}`]: 'on',
-    } as UpdateUtilisationReportStatusRequestBody;
+      'set-status--reportId-1-currentStatus-PENDING_RECONCILIATION': 'on',
+    };
 
     const getPostRequestMocks = ({ body }: { body: undefined | Partial<UpdateUtilisationReportStatusRequestBody> }) =>
       httpMocks.createMocks<UpdateUtilisationReportStatusRequest>({ session, body });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.test.ts
@@ -3,7 +3,7 @@ import api from '../../../api';
 import * as getUtilisationReportsController from '..';
 import { UpdateUtilisationReportStatusRequest, UpdateUtilisationReportStatusRequestBody, updateUtilisationReportStatus } from '.';
 import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user';
-import { TEAM_IDS } from '../../../constants';
+import { TEAM_IDS, UTILISATION_REPORT_RECONCILIATION_STATUS } from '../../../constants';
 import { ReportWithStatus } from '../../../types/utilisation-reports';
 
 console.error = jest.fn();
@@ -24,12 +24,13 @@ describe('controllers/utilisation-reports/update-utilisation-report-status', () 
       user: { ...MOCK_TFM_SESSION_USER, teams: [TEAM_IDS.PDC_RECONCILE] },
     };
 
-    const validMongoObjectId = '5ce819935e539c343f141ece';
+    const validSqlId = '1';
+    // TODO FN-1862 Fix type assertion below
     const validBody: UpdateUtilisationReportStatusRequestBody = {
       _csrf: 'csrf',
       'form-button': 'completed',
-      [`set-status--reportId-${validMongoObjectId}`]: 'on',
-    };
+      [`set-status--reportId-${validSqlId}-currentStatus-${UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION}`]: 'on',
+    } as UpdateUtilisationReportStatusRequestBody;
 
     const getPostRequestMocks = ({ body }: { body: undefined | Partial<UpdateUtilisationReportStatusRequestBody> }) =>
       httpMocks.createMocks<UpdateUtilisationReportStatusRequest>({ session, body });
@@ -85,7 +86,7 @@ describe('controllers/utilisation-reports/update-utilisation-report-status', () 
       const expectedReportsWithStatus: ReportWithStatus[] = [
         {
           status: 'RECONCILIATION_COMPLETED',
-          reportId: validMongoObjectId,
+          reportId: validSqlId,
         },
       ];
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/update-utilisation-report-status/index.ts
@@ -1,17 +1,20 @@
 import { Response } from 'express';
 import api from '../../../api';
 import { asString } from '../../../helpers/validation';
-import { ReportWithStatus } from '../../../types/utilisation-reports';
+import { ReportWithStatus, UtilisationReportReconciliationStatus } from '../../../types/utilisation-reports';
 import { CustomExpressRequest } from '../../../types/custom-express-request';
 import { UTILISATION_REPORT_RECONCILIATION_STATUS } from '../../../constants';
 import { getUtilisationReports } from '..';
 import { asUserSession } from '../../../helpers/express-session';
 
 const CHECKBOX_PREFIX_REGEX = 'set-status--';
-const MONGO_ID_REGEX = '[a-f\\d]+';
+const SQL_ID_REGEX = '\\d+';
+const UTILISATION_REPORT_RECONCILIATION_STATUS_REGEX = Object.values(UTILISATION_REPORT_RECONCILIATION_STATUS).join('|');
 const CHECKBOX_PATTERN = {
   WITHOUT_GROUPS: new RegExp(CHECKBOX_PREFIX_REGEX),
-  WITH_GROUPS: new RegExp(`${CHECKBOX_PREFIX_REGEX}reportId-(?<id>${MONGO_ID_REGEX})`),
+  WITH_GROUPS: new RegExp(
+    `${CHECKBOX_PREFIX_REGEX}reportId-(?<id>${SQL_ID_REGEX})-currentStatus-(?<currentStatus>${UTILISATION_REPORT_RECONCILIATION_STATUS_REGEX})`,
+  ),
 } as const;
 
 const FORM_BUTTON_VALUES = {
@@ -22,24 +25,26 @@ const FORM_BUTTON_VALUES = {
 export type UpdateUtilisationReportStatusRequestBody = {
   _csrf: string;
   'form-button': string;
-  [key: `set-status--reportId-${string}`]: 'on';
+  [key: `set-status--reportId-${string}-currentStatus-${UtilisationReportReconciliationStatus}`]: 'on';
 };
 
-const getReportIdsFromBody = (body: undefined | UpdateUtilisationReportStatusRequestBody): string[] => {
+const getReportIdsAndStatusesFromBody = (
+  body: undefined | UpdateUtilisationReportStatusRequestBody,
+): { id: string; status: UtilisationReportReconciliationStatus }[] => {
   if (!body || typeof body !== 'object') {
-    throw new Error('Expected request body to be an object');  
+    throw new Error('Expected request body to be an object');
   }
 
   return Object.keys(body)
     .filter((key) => key.match(CHECKBOX_PATTERN.WITHOUT_GROUPS))
-    .map((setStatusKey): string => {
+    .map((setStatusKey) => {
       const match = setStatusKey.match(CHECKBOX_PATTERN.WITH_GROUPS);
       if (!match?.groups) {
         throw new Error(`Failed to parse reportIds from request body key '${setStatusKey}'`);
       }
 
-      const { id } = match.groups;
-      return id;
+      const { id, currentStatus } = match.groups;
+      return { id, status: currentStatus as UtilisationReportReconciliationStatus };
     });
 };
 
@@ -70,11 +75,16 @@ export const updateUtilisationReportStatus = async (req: UpdateUtilisationReport
   const { user, userToken } = asUserSession(req.session);
 
   try {
-    const reportIds = getReportIdsFromBody(req.body);
+    const reportIdsAndStatuses = getReportIdsAndStatusesFromBody(req.body);
 
     const { 'form-button': formButton } = req.body;
-    const reportsWithStatus = reportIds
-      .map((reportId) => getReportWithStatus(reportId, asString(formButton, 'formButton')));
+    const reportsWithStatus = reportIdsAndStatuses.reduce((acc, { id, status }) => {
+      const reportWithStatus = getReportWithStatus(id, asString(formButton, 'formButton'));
+      if (reportWithStatus.status === status) {
+        return acc;
+      }
+      return [...acc, reportWithStatus];
+    }, [] as ReportWithStatus[]);
 
     if (reportsWithStatus.length === 0) {
       return await getUtilisationReports(req, res);

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
@@ -43,7 +43,7 @@
             class="govuk-table__header govuk-!-font-weight-regular"
             data-sort-value="{{ summaryItem.bank.name }}"
           >
-            {% if user | userIsInTeam(["PDC_RECONCILE"]) %}
+            {% if user | userIsInTeam(["PDC_RECONCILE"]) and summaryItem.status !== 'REPORT_NOT_RECEIVED' %}
               {{ tableCellCheckbox.render({
                 checkboxId: checkboxId,
                 label: checkboxLabel

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
@@ -24,7 +24,7 @@
 
       <tbody class="govuk-table__body">
       {% for summaryItem in summaryItems %}
-        {% set checkboxId = ['set-status--reportId-', summaryItem.reportId] | join %}
+        {% set checkboxId = ['set-status--reportId-', summaryItem.reportId, '-currentStatus-', summaryItem.status] | join %}
         {% set checkboxLabel %}
           {# TODO FN-1603 - link to individual bank report page (replace `div` with `a`) #}
           {# <a class="govuk-link govuk-link--no-visited-state table-cell-checkbox-text" href="#">#}


### PR DESCRIPTION
## Introduction :pencil2:
We want to remove the ability of `PDC_RECONCILE` users to mark reports in the `REPORT_NOT_RECEIVED` state as completed. This change will now mean that any report not in the `REPORT_NOT_RECEIVED` state has been uploaded.

## Resolution :heavy_check_mark:
- Updates the state machine to no longer allow reports in the `REPORT_NOT_RECEIVED` state to be marked as completed
- Updates TFM-UI to not display the checkbox for reports in the `REPORT_NOT_RECEIVED` state
- Updates unit, api and e2e* tests to reflect these changes
- Update the `UtilisationReportEntityMockBuilder` to use a generic (see [this comment](https://github.com/UK-Export-Finance/dtfs2/pull/2926#discussion_r1537473223))
- Updates `tfm-ui` so that you can mark `'PENDING_RECONCILIATION'` and `'RECONCILIATION_COMPLETED'` reports as not completed and completed respectively (see [this comment](https://github.com/UK-Export-Finance/dtfs2/pull/2926#discussion_r1537463613))

*some of the TFM e2e tests rely on testing quarterly banks which has not been implemented yet. The mock bank with a quarterly schedule has `id` `'10'`, so these have been filtered for and a `TODO FN-1601` comment has been left in the places where this filtering is performed

## Miscellaneous :heavy_plus_sign:

