### PR TITLE
feat(DTFS2-7083): add audit logs to update facility endpoint

### DIFF
--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
@@ -64,10 +64,10 @@ describe('/v1/tfm/facilities', () => {
       const createdFacility = postResult.body;
 
       const updatedFacility = {
-        facilityUpdate: {
+        tfmUpdate: {
           bondIssuerPartyUrn: 'testUrn',
         },
-        user: { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb' }
+        user: { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb' },
       };
 
       await api
@@ -81,7 +81,7 @@ describe('/v1/tfm/facilities', () => {
       const { body, status } = await api.put(updatedFacility).to(`/v1/tfm/facilities/${createdFacility._id}`);
 
       expect(status).toEqual(200);
-      expect(body.tfm).toEqual(updatedFacility.facilityUpdate);
+      expect(body.tfm).toEqual(updatedFacility.tfmUpdate);
       expect(body.auditDetails).toEqual({
         lastUpdatedAt: expect.any(String),
         lastUpdatedByTfmUserId: 'bbbbbbbbbbbbbbbbbbbbbbbb',

--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
@@ -1,10 +1,12 @@
-const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details');
+const { generatePortalAuditDetails, generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details');
 const wipeDB = require('../../../wipeDB');
 const app = require('../../../../src/createApp');
 const api = require('../../../api')(app);
 const aDeal = require('../../deal-builder');
 const CONSTANTS = require('../../../../src/constants');
 const { MOCK_PORTAL_USER } = require('../../../mocks/test-users/mock-portal-user');
+const { MOCK_TFM_USER } = require('../../../mocks/test-users/mock-tfm-user');
+
 
 const newFacility = {
   type: 'Bond',
@@ -67,7 +69,7 @@ describe('/v1/tfm/facilities', () => {
         tfmUpdate: {
           bondIssuerPartyUrn: 'testUrn',
         },
-        sessionTfmUser: { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb' },
+        auditDetails: generateTfmAuditDetails(MOCK_TFM_USER._id),
       };
 
       await api
@@ -84,7 +86,7 @@ describe('/v1/tfm/facilities', () => {
       expect(body.tfm).toEqual(updatedFacility.tfmUpdate);
       expect(body.auditDetails).toEqual({
         lastUpdatedAt: expect.any(String),
-        lastUpdatedByTfmUserId: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+        lastUpdatedByTfmUserId: MOCK_TFM_USER._id,
         lastUpdatedByIsSystem: null,
         lastUpdatedByPortalUserId: null,
         noUserLoggedIn: null,

--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
@@ -67,7 +67,7 @@ describe('/v1/tfm/facilities', () => {
         facilityUpdate: {
           bondIssuerPartyUrn: 'testUrn',
         },
-        user: { _id: 'tfm-user-id'}
+        user: { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb' }
       };
 
       await api
@@ -84,7 +84,10 @@ describe('/v1/tfm/facilities', () => {
       expect(body.tfm).toEqual(updatedFacility.facilityUpdate);
       expect(body.auditDetails).toEqual({
         lastUpdatedAt: expect.any(String),
-        lastUpdatedByTfmUserId: 'tfm-user-id',
+        lastUpdatedByTfmUserId: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+        lastUpdatedByIsSystem: null,
+        lastUpdatedByPortalUserId: null,
+        noUserLoggedIn: null,
       });
     });
   });

--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
@@ -67,7 +67,7 @@ describe('/v1/tfm/facilities', () => {
         tfmUpdate: {
           bondIssuerPartyUrn: 'testUrn',
         },
-        user: { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb' },
+        sessionTfmUser: { _id: 'bbbbbbbbbbbbbbbbbbbbbbbb' },
       };
 
       await api

--- a/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
+++ b/dtfs-central-api/api-tests/v1/tfm/facilities/tfm-facility-put.api-test.js
@@ -67,6 +67,7 @@ describe('/v1/tfm/facilities', () => {
         facilityUpdate: {
           bondIssuerPartyUrn: 'testUrn',
         },
+        user: { _id: 'tfm-user-id'}
       };
 
       await api
@@ -81,6 +82,10 @@ describe('/v1/tfm/facilities', () => {
 
       expect(status).toEqual(200);
       expect(body.tfm).toEqual(updatedFacility.facilityUpdate);
+      expect(body.auditDetails).toEqual({
+        lastUpdatedAt: expect.any(String),
+        lastUpdatedByTfmUserId: 'tfm-user-id',
+      });
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
@@ -1,5 +1,6 @@
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
+const { generateTfmUserAuditDetails, generateSystemAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/generateAuditDetails');
 const { findOneFacility } = require('./tfm-get-facility.controller');
 const db = require('../../../../drivers/db-client');
 const { DB_COLLECTIONS } = require('../../../../constants');
@@ -10,7 +11,7 @@ const withoutId = (obj) => {
   return cleanedObject;
 };
 
-const updateFacility = async (facilityId, tfmUpdate) => {
+const updateFacility = async (facilityId, tfmUpdate, sessionUser, options = {}) => {
   const collection = await db.getCollection(DB_COLLECTIONS.TFM_FACILITIES);
 
   const update = {
@@ -19,9 +20,18 @@ const updateFacility = async (facilityId, tfmUpdate) => {
     },
   };
 
+  const queryWithoutAuditDetails = $.flatten(withoutId(update));
+  const query = {
+    ...queryWithoutAuditDetails,
+    $set: {
+      ...queryWithoutAuditDetails.$set,
+      auditDetails: options.isSystemUpdate ? generateSystemAuditDetails() : generateTfmUserAuditDetails(sessionUser._id),
+    },
+  }
+
   const findAndUpdateResponse = await collection.findOneAndUpdate(
     { _id: { $eq: ObjectId(facilityId) } },
-    $.flatten(withoutId(update)),
+    query,
     { returnNewDocument: true, returnDocument: 'after', upsert: true },
   );
 
@@ -32,18 +42,18 @@ const updateFacility = async (facilityId, tfmUpdate) => {
 
 exports.updateFacilityPut = async (req, res) => {
   const facilityId = req.params.id;
-  if (ObjectId.isValid(facilityId)) {
-    const { facilityUpdate } = req.body;
+  if(!ObjectId.isValid(facilityId)) {
+    return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
+  }
+  const { facilityUpdate, user, options } = req.body;
 
-    const facility = await findOneFacility(facilityId);
+  const facility = await findOneFacility(facilityId);
 
-    if (facility) {
-      const updatedFacility = await updateFacility(facilityId, facilityUpdate);
-
-      return res.status(200).json(updatedFacility);
-    }
-
+  if (!facility) {
     return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
-  return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
+
+  const updatedFacility = await updateFacility(facilityId, facilityUpdate, user, options);
+
+  return res.status(200).json(updatedFacility);
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
@@ -1,7 +1,7 @@
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
-const { validateAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/validateAuditDetails');
-const { generateAuditDatabaseRecordFromAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/generateAuditDatabaseRecord');
+const { validateAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/validate-audit-details');
+const { generateAuditDatabaseRecordFromAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
 const { findOneFacility } = require('./tfm-get-facility.controller');
 const db = require('../../../../drivers/db-client');
 const { DB_COLLECTIONS } = require('../../../../constants');

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
@@ -47,6 +47,10 @@ exports.updateFacilityPut = async (req, res) => {
   }
   const { facilityUpdate, user, options } = req.body;
 
+  if (!user?._id) {
+    return res.status(400).send({ status: 400, message: 'Invalid user' })
+  }
+
   const facility = await findOneFacility(facilityId);
 
   if (!facility) {

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
@@ -11,14 +11,14 @@ const withoutId = (obj) => {
   return cleanedObject;
 };
 
-const updateFacility = async (facilityId, tfmUpdate, sessionUser, options = {}) => {
+const updateFacility = async ({ facilityId, tfmUpdate, sessionUser, isSystemUpdate }) => {
   const collection = await db.getCollection(DB_COLLECTIONS.TFM_FACILITIES);
 
   const update = {
     tfm: {
       ...tfmUpdate,
     },
-    auditDetails: options.isSystemUpdate ? generateSystemAuditDetails() : generateTfmUserAuditDetails(sessionUser._id),
+    auditDetails: isSystemUpdate ? generateSystemAuditDetails() : generateTfmUserAuditDetails(sessionUser._id),
   };
 
   const findAndUpdateResponse = await collection.findOneAndUpdate(
@@ -44,13 +44,14 @@ exports.updateFacilityPut = async (req, res) => {
     return res.status(404).send({ status: 404, message: 'Deal not found' });
   }
 
-  const { facilityUpdate, user, options } = req.body;
+  const { tfmUpdate, user, isSystemUpdate } = req.body;
 
   if (!user?._id) {
     return res.status(400).send({ status: 400, message: 'Invalid user' })
   }
 
-  const updatedFacility = await updateFacility(facilityId, facilityUpdate, user, options);
+  const updatedFacility = await updateFacility({ 
+    facilityId, tfmUpdate, sessionUser: user, isSystemUpdate});
 
   return res.status(200).json(updatedFacility);
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.js
@@ -59,7 +59,7 @@ exports.updateFacilityPut = async (req, res) => {
 
   const { tfmUpdate, sessionPortalUser, sessionTfmUser, isSystemUpdate } = req.body;
 
-  if (!sessionPortalUser?._id && !sessionTfmUser?._id && !isSystemUpdate) {
+  if (!isSystemUpdate && !ObjectId.isValid(sessionPortalUser?._id) && !ObjectId.isValid(sessionTfmUser?._id)) {
     return res.status(400).send({ status: 400, message: 'Invalid user' });
   }
 

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -427,22 +427,15 @@ tfmRouter.route('/facilities/:id')
  *                       properties:
  *                         aNewField:
  *                           example: true
- *                     sessionTfmUser:
+ *                     auditDetails:
  *                       type: object
- *                       required: false
  *                       properties:
- *                         _id:
+ *                         userType:
+ *                           type: string
+ *                           enum: [system, portal, tfm]
+ *                         id:
  *                           type: string
  *                           example: '1234567890abcdef12345678'
- *                     sessionPortalUser:
- *                       type: object
- *                       required: false
- *                       properties:
- *                         _id:
- *                           example: '1234567890abcdef12345678'
- *                     isSystemUpdate:
-  *                     required: false
-*                       type: boolean
  *       404:
  *         description: Not found
  */

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -427,13 +427,21 @@ tfmRouter.route('/facilities/:id')
  *                       properties:
  *                         aNewField:
  *                           example: true
- *                     user:
+ *                     sessionTfmUser:
  *                       type: object
+ *                       required: false
+ *                       properties:
+ *                         _id:
+ *                           example: '1234567890abcdef12345678'
+ *                     sessionPortalUser:
+ *                       type: object
+ *                       required: false
  *                       properties:
  *                         _id:
  *                           example: '1234567890abcdef12345678'
  *                     isSystemUpdate:
- *                       type: boolean
+  *                     required: false
+*                       type: boolean
  *       404:
  *         description: Not found
  */

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -427,6 +427,11 @@ tfmRouter.route('/facilities/:id')
  *                       properties:
  *                         aNewField:
  *                           example: true
+ *                      user
+ *                        type: object
+ *                        properties:
+ *                          _id:
+ *                            example: '1234567890abcdef12345678'
  *       404:
  *         description: Not found
  */

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -432,6 +432,7 @@ tfmRouter.route('/facilities/:id')
  *                       required: false
  *                       properties:
  *                         _id:
+ *                           type: string
  *                           example: '1234567890abcdef12345678'
  *                     sessionPortalUser:
  *                       type: object

--- a/dtfs-central-api/src/v1/routes/tfm-routes.js
+++ b/dtfs-central-api/src/v1/routes/tfm-routes.js
@@ -422,16 +422,18 @@ tfmRouter.route('/facilities/:id')
  *                 - $ref: '#/definitions/TFMFacilityGEF'
  *                 - type: object
  *                   properties:
- *                     facilitySnapshot:
+ *                     tfmUpdate:
  *                       type: object
  *                       properties:
  *                         aNewField:
  *                           example: true
- *                      user
- *                        type: object
- *                        properties:
- *                          _id:
- *                            example: '1234567890abcdef12345678'
+ *                     user:
+ *                       type: object
+ *                       properties:
+ *                         _id:
+ *                           example: '1234567890abcdef12345678'
+ *                     isSystemUpdate:
+ *                       type: boolean
  *       404:
  *         description: Not found
  */

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
+const { MOCK_TFM_SESSION_USER } = require('../src/v1/__mocks__/mock-tfm-session-user');
 
 const api = jest.requireActual('../src/v1/api');
 
@@ -367,7 +368,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility(urlTraversal, 'mock update', { _id: 'tfm-user-id'});
+      const response = await api.updateFacility(urlTraversal, 'mock update', MOCK_TFM_SESSION_USER);
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -376,7 +377,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility(localIp, 'mock update', { _id: 'tfm-user-id'});
+      const response = await api.updateFacility(localIp, 'mock update', MOCK_TFM_SESSION_USER);
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -384,7 +385,7 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.updateFacility(validFacilityId, 'mock update', { _id: 'tfm-user-id'});
+      const response = await api.updateFacility(validFacilityId, 'mock update', MOCK_TFM_SESSION_USER);
 
       expect(response).toEqual(mockResponse);
     });

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
+const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/generateAuditDetails')
 const { MOCK_TFM_SESSION_USER } = require('../src/v1/__mocks__/mock-tfm-session-user');
 
 const api = jest.requireActual('../src/v1/api');
@@ -368,7 +369,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility({ facilityId: urlTraversal, tfmUpdate: 'mock update', sessionTfmUser: MOCK_TFM_SESSION_USER });
+      const response = await api.updateFacility({ facilityId: urlTraversal, tfmUpdate: 'mock update', auditDetails: generateTfmAuditDetails(MOCK_TFM_SESSION_USER._id) });
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -377,7 +378,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility({ facilityId: localIp, tfmUpdate: 'mock update', sessionTfmUser: MOCK_TFM_SESSION_USER });
+      const response = await api.updateFacility({ facilityId: localIp, tfmUpdate: 'mock update', auditDetails: generateTfmAuditDetails(MOCK_TFM_SESSION_USER._id) });
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -385,7 +386,7 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.updateFacility({ facilityId: validFacilityId, tfmUpdate: 'mock update', sessionTfmUser: MOCK_TFM_SESSION_USER });
+      const response = await api.updateFacility({ facilityId: validFacilityId, tfmUpdate: 'mock update', auditDetails: generateTfmAuditDetails(MOCK_TFM_SESSION_USER._id) });
 
       expect(response).toEqual(mockResponse);
     });

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
-const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/generateAuditDetails')
+const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details')
 const { MOCK_TFM_SESSION_USER } = require('../src/v1/__mocks__/mock-tfm-session-user');
 
 const api = jest.requireActual('../src/v1/api');

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -368,7 +368,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility(urlTraversal, 'mock update', MOCK_TFM_SESSION_USER);
+      const response = await api.updateFacility({ facilityId: urlTraversal, tfmUpdate: 'mock update', sessionUser: MOCK_TFM_SESSION_USER });
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -377,7 +377,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility(localIp, 'mock update', MOCK_TFM_SESSION_USER);
+      const response = await api.updateFacility({ facilityId: localIp, tfmUpdate: 'mock update', sessionUser: MOCK_TFM_SESSION_USER });
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -385,7 +385,7 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.updateFacility(validFacilityId, 'mock update', MOCK_TFM_SESSION_USER);
+      const response = await api.updateFacility({ facilityId: validFacilityId, tfmUpdate: 'mock update', sessionUser: MOCK_TFM_SESSION_USER });
 
       expect(response).toEqual(mockResponse);
     });

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -368,7 +368,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility({ facilityId: urlTraversal, tfmUpdate: 'mock update', sessionUser: MOCK_TFM_SESSION_USER });
+      const response = await api.updateFacility({ facilityId: urlTraversal, tfmUpdate: 'mock update', sessionTfmUser: MOCK_TFM_SESSION_USER });
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -377,7 +377,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility({ facilityId: localIp, tfmUpdate: 'mock update', sessionUser: MOCK_TFM_SESSION_USER });
+      const response = await api.updateFacility({ facilityId: localIp, tfmUpdate: 'mock update', sessionTfmUser: MOCK_TFM_SESSION_USER });
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -385,7 +385,7 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.updateFacility({ facilityId: validFacilityId, tfmUpdate: 'mock update', sessionUser: MOCK_TFM_SESSION_USER });
+      const response = await api.updateFacility({ facilityId: validFacilityId, tfmUpdate: 'mock update', sessionTfmUser: MOCK_TFM_SESSION_USER });
 
       expect(response).toEqual(mockResponse);
     });

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -367,7 +367,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility(urlTraversal, 'mock update');
+      const response = await api.updateFacility(urlTraversal, 'mock update', { _id: 'tfm-user-id'});
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -376,7 +376,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.updateFacility(localIp, 'mock update');
+      const response = await api.updateFacility(localIp, 'mock update', { _id: 'tfm-user-id'});
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -384,7 +384,7 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.updateFacility(validFacilityId, 'mock update');
+      const response = await api.updateFacility(validFacilityId, 'mock update', { _id: 'tfm-user-id'});
 
       expect(response).toEqual(mockResponse);
     });

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-submit.second-submission.api-test.js
@@ -54,7 +54,6 @@ const findOneTeamSpy = jest.fn(() => Promise.resolve({ email: [] }));
 const getGefMandatoryCriteriaByVersion = jest.fn(() => Promise.resolve([]));
 api.getGefMandatoryCriteriaByVersion = getGefMandatoryCriteriaByVersion;
 
-
 const createFacilityCoverEndDate = (facility) =>
   set(new Date(), {
     date: Number(facility['coverEndDate-day']),

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -159,7 +159,7 @@ module.exports = {
 
     return mapped;
   },
-  updateFacility: (facilityId, tfmUpdate) => {
+  updateFacility: ({ facilityId, tfmUpdate }) => {
     const facility = ALL_MOCK_FACILITIES.find((f) => f._id === facilityId);
 
     // for some reason 2 api tests act differently if tfmUpdate is *not* included in both

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -316,7 +316,7 @@ const findFacilitiesByDealId = async (dealId) => {
   }
 };
 
-const updateFacility = async ({ facilityId, tfmUpdate, sessionTfmUser, sessionPortalUser, isSystemUpdate }) => {
+const updateFacility = async ({ facilityId, tfmUpdate, auditDetails }) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
 
@@ -331,9 +331,7 @@ const updateFacility = async ({ facilityId, tfmUpdate, sessionTfmUser, sessionPo
       headers: headers.central,
       data: {
         tfmUpdate,
-        sessionTfmUser,
-        sessionPortalUser,
-        isSystemUpdate,
+        auditDetails,
       },
     });
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -316,7 +316,7 @@ const findFacilitiesByDealId = async (dealId) => {
   }
 };
 
-const updateFacility = async (facilityId, facilityUpdate) => {
+const updateFacility = async (facilityId, facilityUpdate, sessionUser, options = {}) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
 
@@ -331,6 +331,8 @@ const updateFacility = async (facilityId, facilityUpdate) => {
       headers: headers.central,
       data: {
         facilityUpdate,
+        user: sessionUser,
+        options,
       },
     });
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -316,7 +316,7 @@ const findFacilitiesByDealId = async (dealId) => {
   }
 };
 
-const updateFacility = async ({ facilityId, tfmUpdate, sessionUser, isSystemUpdate }) => {
+const updateFacility = async ({ facilityId, tfmUpdate, sessionTfmUser, sessionPortalUser, isSystemUpdate }) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
 
@@ -331,7 +331,8 @@ const updateFacility = async ({ facilityId, tfmUpdate, sessionUser, isSystemUpda
       headers: headers.central,
       data: {
         tfmUpdate,
-        user: sessionUser,
+        sessionTfmUser,
+        sessionPortalUser,
         isSystemUpdate,
       },
     });

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -316,7 +316,7 @@ const findFacilitiesByDealId = async (dealId) => {
   }
 };
 
-const updateFacility = async (facilityId, facilityUpdate, sessionUser, options = {}) => {
+const updateFacility = async ({ facilityId, tfmUpdate, sessionUser, isSystemUpdate }) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
 
@@ -330,9 +330,9 @@ const updateFacility = async (facilityId, facilityUpdate, sessionUser, options =
       url: `${DTFS_CENTRAL_API_URL}/v1/tfm/facilities/${facilityId}`,
       headers: headers.central,
       data: {
-        facilityUpdate,
+        tfmUpdate,
         user: sessionUser,
-        options,
+        isSystemUpdate,
       },
     });
 

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -63,7 +63,7 @@ const updateDealAcbs = async (taskOutput) => {
     .map((facility) => {
       const { facilityId, ...acbsFacility } = facility;
       // Add `acbs` object to tfm-facilities
-      return tfmController.updateFacilityAcbs(facilityId, acbsFacility, undefined, { isSystemUpdate: true });
+      return tfmController.updateFacilityAcbs(facilityId, acbsFacility);
     });
   await Promise.all(facilitiesUpdates);
 };
@@ -83,7 +83,7 @@ const updateIssuedFacilityAcbs = ({ facilityId, issuedFacilityMaster, facilityLo
     issuedFacilityMaster,
     facilityLoan,
     facilityFee,
-  }, undefined, { isSystemUpdate: true });
+  });
 
 const updateAmendedFacilityAcbs = (taskResult) => {
   if (taskResult.instanceId && taskResult.output) {
@@ -98,7 +98,7 @@ const updateAmendedFacilityAcbs = (taskResult) => {
     };
 
     // Update tfm-facilities `acbs` object with ACBS amendments response
-    tfmController.updateFacilityAcbs(_id, acbsUpdate, undefined, { isSystemUpdate: true });
+    tfmController.updateFacilityAcbs(_id, acbsUpdate);
   }
 };
 

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -63,7 +63,7 @@ const updateDealAcbs = async (taskOutput) => {
     .map((facility) => {
       const { facilityId, ...acbsFacility } = facility;
       // Add `acbs` object to tfm-facilities
-      return tfmController.updateFacilityAcbs(facilityId, acbsFacility);
+      return tfmController.updateFacilityAcbs(facilityId, acbsFacility, undefined, { isSystemUpdate: true });
     });
   await Promise.all(facilitiesUpdates);
 };
@@ -83,7 +83,7 @@ const updateIssuedFacilityAcbs = ({ facilityId, issuedFacilityMaster, facilityLo
     issuedFacilityMaster,
     facilityLoan,
     facilityFee,
-  });
+  }, undefined, { isSystemUpdate: true });
 
 const updateAmendedFacilityAcbs = (taskResult) => {
   if (taskResult.instanceId && taskResult.output) {
@@ -98,7 +98,7 @@ const updateAmendedFacilityAcbs = (taskResult) => {
     };
 
     // Update tfm-facilities `acbs` object with ACBS amendments response
-    tfmController.updateFacilityAcbs(_id, acbsUpdate);
+    tfmController.updateFacilityAcbs(_id, acbsUpdate, undefined, { isSystemUpdate: true });
   }
 };
 

--- a/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
+++ b/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
@@ -15,7 +15,7 @@ const { mapBssEwcsFacility } = require('../mappings/map-submitted-deal/map-bss-e
  * @param {Object} deal TFM deal object
  * @returns {Boolean} Boolean upon execution
  */
-const amendIssuedFacility = async (amendment, facility, deal) => {
+const amendIssuedFacility = async (amendment, facility, deal, sessionUser) => {
   try {
     if (amendment && facility && deal) {
       const {
@@ -130,7 +130,7 @@ const amendIssuedFacility = async (amendment, facility, deal) => {
         };
 
         // Updated `facility.tfm` property
-        await api.updateFacility(facility._id, facilityTfmUpdate);
+        await api.updateFacility(facility._id, facilityTfmUpdate, sessionUser);
       }
 
       return true;

--- a/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
+++ b/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
@@ -15,7 +15,7 @@ const { mapBssEwcsFacility } = require('../mappings/map-submitted-deal/map-bss-e
  * @param {Object} deal TFM deal object
  * @returns {Boolean} Boolean upon execution
  */
-const amendIssuedFacility = async (amendment, facility, deal, sessionUser) => {
+const amendIssuedFacility = async (amendment, facility, deal, sessionTfmUser) => {
   try {
     if (amendment && facility && deal) {
       const {
@@ -130,7 +130,7 @@ const amendIssuedFacility = async (amendment, facility, deal, sessionUser) => {
         };
 
         // Updated `facility.tfm` property
-        await api.updateFacility({ facilityId: facility._id, tfmUpdate: facilityTfmUpdate, sessionUser });
+        await api.updateFacility({ facilityId: facility._id, tfmUpdate: facilityTfmUpdate, sessionTfmUser });
       }
 
       return true;

--- a/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
+++ b/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
@@ -13,7 +13,7 @@ const { mapBssEwcsFacility } = require('../mappings/map-submitted-deal/map-bss-e
  * @param {Object} amendment Amendment object
  * @param {Object} facility Facility object
  * @param {Object} deal TFM deal object
- * @param {import("@ukef/dtfs2-common/src/types/auditDetails").UserInformation} auditDetails - details of the user making the request
+ * @param {import("@ukef/dtfs2-common/src/types/audit-details").AuditDetails} auditDetails - details of the user making the request
  * @returns {Boolean} Boolean upon execution
  */
 const amendIssuedFacility = async (amendment, facility, deal, auditDetails) => {

--- a/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
+++ b/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
@@ -13,9 +13,10 @@ const { mapBssEwcsFacility } = require('../mappings/map-submitted-deal/map-bss-e
  * @param {Object} amendment Amendment object
  * @param {Object} facility Facility object
  * @param {Object} deal TFM deal object
+ * @param {import("@ukef/dtfs2-common/src/types/auditDetails").UserInformation} auditDetails - details of the user making the request
  * @returns {Boolean} Boolean upon execution
  */
-const amendIssuedFacility = async (amendment, facility, deal, sessionTfmUser) => {
+const amendIssuedFacility = async (amendment, facility, deal, auditDetails) => {
   try {
     if (amendment && facility && deal) {
       const {
@@ -130,7 +131,7 @@ const amendIssuedFacility = async (amendment, facility, deal, sessionTfmUser) =>
         };
 
         // Updated `facility.tfm` property
-        await api.updateFacility({ facilityId: facility._id, tfmUpdate: facilityTfmUpdate, sessionTfmUser });
+        await api.updateFacility({ facilityId: facility._id, tfmUpdate: facilityTfmUpdate, auditDetails });
       }
 
       return true;

--- a/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
+++ b/trade-finance-manager-api/src/v1/controllers/amend-issued-facility.js
@@ -130,7 +130,7 @@ const amendIssuedFacility = async (amendment, facility, deal, sessionUser) => {
         };
 
         // Updated `facility.tfm` property
-        await api.updateFacility(facility._id, facilityTfmUpdate, sessionUser);
+        await api.updateFacility({ facilityId: facility._id, tfmUpdate: facilityTfmUpdate, sessionUser });
       }
 
       return true;

--- a/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
@@ -257,7 +257,7 @@ const updateFacilityAmendment = async (req, res) => {
         // TFM Facility update + ACBS Interaction
         if (canSendToAcbs(amendment)) {
           // Amend facility TFM properties
-          await amendIssuedFacility(amendment, facility, tfmDeal, req.user);
+          await amendIssuedFacility(amendment, facility, tfmDeal, generateTfmAuditDetails(req.user._id));
           // Amendment email notification to PDC
           await internalAmendmentEmail(ukefFacilityId);
           // Amend facility ACBS records

--- a/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
@@ -257,7 +257,7 @@ const updateFacilityAmendment = async (req, res) => {
         // TFM Facility update + ACBS Interaction
         if (canSendToAcbs(amendment)) {
           // Amend facility TFM properties
-          await amendIssuedFacility(amendment, facility, tfmDeal);
+          await amendIssuedFacility(amendment, facility, tfmDeal, req.user);
           // Amendment email notification to PDC
           await internalAmendmentEmail(ukefFacilityId);
           // Amend facility ACBS records

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -250,7 +250,7 @@ const submitDealAfterUkefIdsPUT = async (req, res) => {
 
     const deal = await submitDealAfterUkefIds(dealId, dealType, checker, generatePortalAuditDetails(checker._id));
 
-    if (!deal) {
+    if (!deal) { // this occuring
       console.error('Deal does not exist in TFM %s', dealId);
       return res.status(404).send();
     }

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -150,7 +150,7 @@ const submitDealAfterUkefIds = async (dealId, dealType, checker, auditDetails) =
     mappedDeal.status = status;
 
     // Update issued facilities
-    const updatedDeal = await updatedIssuedFacilities(mappedDeal);
+    const updatedDeal = await updatedIssuedFacilities(mappedDeal, checker);
     /**
      * Current requirement only allows AIN & MIN deals to be send to ACBS
      * This call UPDATES facility record by updating their stage from
@@ -250,7 +250,7 @@ const submitDealAfterUkefIdsPUT = async (req, res) => {
 
     const deal = await submitDealAfterUkefIds(dealId, dealType, checker, generatePortalAuditDetails(checker._id));
 
-    if (!deal) { // this occuring
+    if (!deal) {
       console.error('Deal does not exist in TFM %s', dealId);
       return res.status(404).send();
     }

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -86,7 +86,7 @@ const submitDealAfterUkefIds = async (dealId, dealType, checker, auditDetails) =
     const dealWithTfmData = await addTfmDealData(updatedMappedDeal, auditDetails);
     const updatedDealWithPartyUrn = await addPartyUrns(dealWithTfmData, auditDetails);
     const updatedDealWithDealCurrencyConversions = await convertDealCurrencies(updatedDealWithPartyUrn, auditDetails);
-    const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithDealCurrencyConversions, checker);
+    const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithDealCurrencyConversions, auditDetails);
     const updatedDealWithCreateEstore = await createEstoreSite(updatedDealWithUpdatedFacilities);
 
     if (updatedMappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN || updatedMappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {
@@ -150,7 +150,7 @@ const submitDealAfterUkefIds = async (dealId, dealType, checker, auditDetails) =
     mappedDeal.status = status;
 
     // Update issued facilities
-    const updatedDeal = await updatedIssuedFacilities(mappedDeal, checker);
+    const updatedDeal = await updatedIssuedFacilities(mappedDeal, auditDetails);
     /**
      * Current requirement only allows AIN & MIN deals to be send to ACBS
      * This call UPDATES facility record by updating their stage from

--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -86,7 +86,7 @@ const submitDealAfterUkefIds = async (dealId, dealType, checker, auditDetails) =
     const dealWithTfmData = await addTfmDealData(updatedMappedDeal, auditDetails);
     const updatedDealWithPartyUrn = await addPartyUrns(dealWithTfmData, auditDetails);
     const updatedDealWithDealCurrencyConversions = await convertDealCurrencies(updatedDealWithPartyUrn, auditDetails);
-    const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithDealCurrencyConversions);
+    const updatedDealWithUpdatedFacilities = await updateFacilities(updatedDealWithDealCurrencyConversions, checker);
     const updatedDealWithCreateEstore = await createEstoreSite(updatedDealWithUpdatedFacilities);
 
     if (updatedMappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.AIN || updatedMappedDeal.submissionType === CONSTANTS.DEALS.SUBMISSION_TYPE.MIA) {

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -91,7 +91,7 @@ const updateFacility = async (req, res) => {
   const { facilityId } = req.params;
   const facilityUpdate = req.body;
   try {
-    const updatedFacility = await api.updateFacility(facilityId, facilityUpdate, req.user);
+    const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionUser: req.user});
     return res.status(200).send({
       updateFacility: updatedFacility.tfm
     });

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -91,7 +91,7 @@ const updateFacility = async (req, res) => {
   const { facilityId } = req.params;
   const facilityUpdate = req.body;
   try {
-    const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionUser: req.user});
+    const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionTfmUser: req.user});
     return res.status(200).send({
       updateFacility: updatedFacility.tfm
     });

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -91,7 +91,7 @@ const updateFacility = async (req, res) => {
   const { facilityId } = req.params;
   const facilityUpdate = req.body;
   try {
-    const updatedFacility = await api.updateFacility(facilityId, facilityUpdate);
+    const updatedFacility = await api.updateFacility(facilityId, facilityUpdate, req.user);
     return res.status(200).send({
       updateFacility: updatedFacility.tfm
     });
@@ -111,15 +111,7 @@ const getAllFacilities = async (searchString) => {
   return allFacilities;
 };
 
-const updateTfmFacility = async (facilityId, tfmUpdate) => {
-  const updatedFacility = await api.updateFacility(facilityId, tfmUpdate);
-  return updatedFacility.tfm;
-};
 
-const updateTfmFacilityRiskProfile = async (facilityId, tfmUpdate) => {
-  const updatedFacility = await api.updateFacility(facilityId, tfmUpdate);
-  return updatedFacility.tfm;
-};
 
 module.exports = {
   getFacility,
@@ -127,6 +119,4 @@ module.exports = {
   updateFacility,
   getAllFacilities,
   findOneFacility,
-  updateTfmFacility,
-  updateTfmFacilityRiskProfile,
 };

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -1,5 +1,6 @@
 const { format, getUnixTime } = require('date-fns');
 const commaNumber = require('comma-number');
+const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/generateAuditDetails')
 const api = require('../api');
 const { findOneTfmDeal } = require('./deal.controller');
 const facilityMapper = require('../rest-mappings/facility');
@@ -91,7 +92,7 @@ const updateFacility = async (req, res) => {
   const { facilityId } = req.params;
   const facilityUpdate = req.body;
   try {
-    const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionTfmUser: req.user});
+    const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, auditDetails: generateTfmAuditDetails(req.user._id)});
     return res.status(200).send({
       updateFacility: updatedFacility.tfm
     });

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -1,6 +1,6 @@
 const { format, getUnixTime } = require('date-fns');
 const commaNumber = require('comma-number');
-const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/changeStream/generateAuditDetails')
+const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details')
 const api = require('../api');
 const { findOneTfmDeal } = require('./deal.controller');
 const facilityMapper = require('../rest-mappings/facility');

--- a/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
@@ -18,7 +18,7 @@ const updateAcbs = async (taskOutput) => {
 exports.updateAcbs = updateAcbs;
 
 const updateFacilityAcbs = async (facilityId, acbs) => {
-  const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: { acbs }, isSystemUpdate: true });
+  const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: { acbs }, auditDetails: generateSystemAuditDetails() });
   // TFM - Update Facility Activity : MVP2
   return updatedFacility.tfm;
 };

--- a/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
@@ -18,7 +18,7 @@ const updateAcbs = async (taskOutput) => {
 exports.updateAcbs = updateAcbs;
 
 const updateFacilityAcbs = async (facilityId, acbs) => {
-  const updatedFacility = await api.updateFacility(facilityId, { acbs }, undefined, { isSystemUpdate: true });
+  const updatedFacility = await api.updateFacility({ facilityId, tfmUpdate: { acbs }, isSystemUpdate: true });
   // TFM - Update Facility Activity : MVP2
   return updatedFacility.tfm;
 };

--- a/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
@@ -17,8 +17,8 @@ const updateAcbs = async (taskOutput) => {
 };
 exports.updateAcbs = updateAcbs;
 
-const updateFacilityAcbs = async (facilityId, acbs, sessionUser) => {
-  const updatedFacility = await api.updateFacility(facilityId, { acbs }, sessionUser);
+const updateFacilityAcbs = async (facilityId, acbs) => {
+  const updatedFacility = await api.updateFacility(facilityId, { acbs }, undefined, { isSystemUpdate: true });
   // TFM - Update Facility Activity : MVP2
   return updatedFacility.tfm;
 };

--- a/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/tfm.controller.js
@@ -17,8 +17,8 @@ const updateAcbs = async (taskOutput) => {
 };
 exports.updateAcbs = updateAcbs;
 
-const updateFacilityAcbs = async (facilityId, acbs) => {
-  const updatedFacility = await api.updateFacility(facilityId, { acbs });
+const updateFacilityAcbs = async (facilityId, acbs, sessionUser) => {
+  const updatedFacility = await api.updateFacility(facilityId, { acbs }, sessionUser);
   // TFM - Update Facility Activity : MVP2
   return updatedFacility.tfm;
 };

--- a/trade-finance-manager-api/src/v1/controllers/update-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-facilities.js
@@ -7,7 +7,7 @@ const getFacilityPremiumSchedule = require('./get-facility-premium-schedule');
 const { calculateGefFacilityFeeRecord } = require('../helpers/calculate-gef-facility-fee-record');
 const CONSTANTS = require('../../constants');
 
-const updateFacilities = async (deal, sessionPortalUser) => {
+const updateFacilities = async (deal, auditDetails) => {
   // Create deep clone
   // Note this has the side effect of converting dates to strings
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
@@ -105,7 +105,7 @@ const updateFacilities = async (deal, sessionPortalUser) => {
         riskProfile: DEFAULTS.FACILITY_RISK_PROFILE,
       };
 
-      const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionPortalUser });
+      const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, auditDetails });
 
       // add the updated tfm object to returned facility.
       // if we return updateFacilityResponse, we'll get facilitySnapshot

--- a/trade-finance-manager-api/src/v1/controllers/update-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-facilities.js
@@ -7,8 +7,9 @@ const getFacilityPremiumSchedule = require('./get-facility-premium-schedule');
 const { calculateGefFacilityFeeRecord } = require('../helpers/calculate-gef-facility-fee-record');
 const CONSTANTS = require('../../constants');
 
-const updateFacilities = async (deal) => {
+const updateFacilities = async (deal, sessionUser) => {
   // Create deep clone
+  // Note this has the side effect of converting dates to strings
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
 
   const {
@@ -104,7 +105,7 @@ const updateFacilities = async (deal) => {
         riskProfile: DEFAULTS.FACILITY_RISK_PROFILE,
       };
 
-      const updateFacilityResponse = await api.updateFacility(facilityId, facilityUpdate);
+      const updateFacilityResponse = await api.updateFacility(facilityId, facilityUpdate, sessionUser);
 
       // add the updated tfm object to returned facility.
       // if we return updateFacilityResponse, we'll get facilitySnapshot

--- a/trade-finance-manager-api/src/v1/controllers/update-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-facilities.js
@@ -7,7 +7,7 @@ const getFacilityPremiumSchedule = require('./get-facility-premium-schedule');
 const { calculateGefFacilityFeeRecord } = require('../helpers/calculate-gef-facility-fee-record');
 const CONSTANTS = require('../../constants');
 
-const updateFacilities = async (deal, sessionUser) => {
+const updateFacilities = async (deal, sessionPortalUser) => {
   // Create deep clone
   // Note this has the side effect of converting dates to strings
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
@@ -105,7 +105,7 @@ const updateFacilities = async (deal, sessionUser) => {
         riskProfile: DEFAULTS.FACILITY_RISK_PROFILE,
       };
 
-      const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionUser });
+      const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionPortalUser });
 
       // add the updated tfm object to returned facility.
       // if we return updateFacilityResponse, we'll get facilitySnapshot

--- a/trade-finance-manager-api/src/v1/controllers/update-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-facilities.js
@@ -105,7 +105,7 @@ const updateFacilities = async (deal, sessionUser) => {
         riskProfile: DEFAULTS.FACILITY_RISK_PROFILE,
       };
 
-      const updateFacilityResponse = await api.updateFacility(facilityId, facilityUpdate, sessionUser);
+      const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionUser });
 
       // add the updated tfm object to returned facility.
       // if we return updateFacilityResponse, we'll get facilitySnapshot

--- a/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
@@ -6,7 +6,7 @@ const getFacilityPremiumSchedule = require('./get-facility-premium-schedule');
 const { calculateGefFacilityFeeRecord } = require('../helpers/calculate-gef-facility-fee-record');
 const { sendIssuedFacilitiesReceivedEmail } = require('./send-issued-facilities-received-email');
 
-const updatedIssuedFacilities = async (deal) => {
+const updatedIssuedFacilities = async (deal, sessionUser) => {
   // Create deep clone
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
 
@@ -111,7 +111,7 @@ const updatedIssuedFacilities = async (deal) => {
        * Add the updated properties to the returned facility
        * to retain flat, generic facility mapping used in deal submission calls.
        * */
-        const updateFacilityResponse = await api.updateFacility(facilityId, facilityUpdate);
+        const updateFacilityResponse = await api.updateFacility(facilityId, facilityUpdate, sessionUser);
         facility.tfm = updateFacilityResponse.tfm;
         updatedFacilities.push(facility);
       }

--- a/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
@@ -111,7 +111,7 @@ const updatedIssuedFacilities = async (deal, sessionUser) => {
        * Add the updated properties to the returned facility
        * to retain flat, generic facility mapping used in deal submission calls.
        * */
-        const updateFacilityResponse = await api.updateFacility(facilityId, facilityUpdate, sessionUser);
+        const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionUser });
         facility.tfm = updateFacilityResponse.tfm;
         updatedFacilities.push(facility);
       }

--- a/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
@@ -6,7 +6,7 @@ const getFacilityPremiumSchedule = require('./get-facility-premium-schedule');
 const { calculateGefFacilityFeeRecord } = require('../helpers/calculate-gef-facility-fee-record');
 const { sendIssuedFacilitiesReceivedEmail } = require('./send-issued-facilities-received-email');
 
-const updatedIssuedFacilities = async (deal, sessionUser) => {
+const updatedIssuedFacilities = async (deal, sessionPortalUser) => {
   // Create deep clone
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
 
@@ -111,7 +111,7 @@ const updatedIssuedFacilities = async (deal, sessionUser) => {
        * Add the updated properties to the returned facility
        * to retain flat, generic facility mapping used in deal submission calls.
        * */
-        const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionUser });
+        const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionPortalUser });
         facility.tfm = updateFacilityResponse.tfm;
         updatedFacilities.push(facility);
       }

--- a/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
+++ b/trade-finance-manager-api/src/v1/controllers/update-issued-facilities.js
@@ -6,7 +6,7 @@ const getFacilityPremiumSchedule = require('./get-facility-premium-schedule');
 const { calculateGefFacilityFeeRecord } = require('../helpers/calculate-gef-facility-fee-record');
 const { sendIssuedFacilitiesReceivedEmail } = require('./send-issued-facilities-received-email');
 
-const updatedIssuedFacilities = async (deal, sessionPortalUser) => {
+const updatedIssuedFacilities = async (deal, auditDetails) => {
   // Create deep clone
   const modifiedDeal = JSON.parse(JSON.stringify(deal));
 
@@ -111,7 +111,7 @@ const updatedIssuedFacilities = async (deal, sessionPortalUser) => {
        * Add the updated properties to the returned facility
        * to retain flat, generic facility mapping used in deal submission calls.
        * */
-        const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, sessionPortalUser });
+        const updateFacilityResponse = await api.updateFacility({ facilityId, tfmUpdate: facilityUpdate, auditDetails });
         facility.tfm = updateFacilityResponse.tfm;
         updatedFacilities.push(facility);
       }


### PR DESCRIPTION
## Introduction :pencil2:
All endpoints in dtfs-central-api should add `auditDetails` when inserting/updating data. This PR covers the update facility endpoint

## Resolution :heavy_check_mark:
- Add audit details to database changes for update facility endpoint


