### PR TITLE
feat(FN-2335): accessibility fix for utilisation report upload buttons

### DIFF
--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -81,7 +81,8 @@ describe(page, () => {
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
-      wrapper.expectText('[data-cy="upload-report-text"]').toRead('Upload December 2022 report');
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[Upload December 2022 report]/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[The file must be an XLSX or CSV]/);
     });
   });
 
@@ -113,7 +114,8 @@ describe(page, () => {
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
-      wrapper.expectText('[data-cy="upload-report-text"]').toRead('Upload January 2023 report');
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[Upload January 2023 report]/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[The file must be an XLSX or CSV]/);
     });
   });
 

--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -64,7 +64,7 @@ describe(page, () => {
 
     it('should display a generic warning message about reports being overdue', () => {
       wrapper.expectElement('[data-cy="warning-text"]').toExist();
-      wrapper.expectText('.govuk-warning-text__text').toMatch(/[There are overdue reports, please send them as soon as possible.]/);
+      wrapper.expectText('.govuk-warning-text__text').toMatch(/(There are overdue reports, please send them as soon as possible.)/);
     });
 
     it('should display the two overdue reports with a specific message', () => {
@@ -81,8 +81,8 @@ describe(page, () => {
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[Upload December 2022 report]/);
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[The file must be an XLSX or CSV]/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(Upload December 2022 report)/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(The file must be an XLSX or CSV)/);
     });
   });
 
@@ -98,7 +98,7 @@ describe(page, () => {
 
     it('should display a specific warning message about which reports to upload', () => {
       wrapper.expectElement('[data-cy="warning-text"]').toExist();
-      wrapper.expectText('.govuk-warning-text__text').toMatch(/[January 2023 report is overdue, please send it as soon as possible.]/);
+      wrapper.expectText('.govuk-warning-text__text').toMatch(/(January 2023 report is overdue, please send it as soon as possible.)/);
     });
 
     it('should display the one overdue report as being overdue', () => {
@@ -114,8 +114,8 @@ describe(page, () => {
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[Upload January 2023 report]/);
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/[The file must be an XLSX or CSV]/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(Upload January 2023 report)/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(The file must be an XLSX or CSV)/);
     });
   });
 

--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -64,7 +64,7 @@ describe(page, () => {
 
     it('should display a generic warning message about reports being overdue', () => {
       wrapper.expectElement('[data-cy="warning-text"]').toExist();
-      wrapper.expectText('.govuk-warning-text__text').toMatch(/(There are overdue reports, please send them as soon as possible.)/);
+      wrapper.expectText('.govuk-warning-text__text').toMatch(/There are overdue reports, please send them as soon as possible./);
     });
 
     it('should display the two overdue reports with a specific message', () => {
@@ -81,8 +81,8 @@ describe(page, () => {
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(Upload December 2022 report)/);
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(The file must be an XLSX or CSV)/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/Upload December 2022 report/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/The file must be an XLSX or CSV/);
     });
   });
 
@@ -98,7 +98,7 @@ describe(page, () => {
 
     it('should display a specific warning message about which reports to upload', () => {
       wrapper.expectElement('[data-cy="warning-text"]').toExist();
-      wrapper.expectText('.govuk-warning-text__text').toMatch(/(January 2023 report is overdue, please send it as soon as possible.)/);
+      wrapper.expectText('.govuk-warning-text__text').toMatch(/January 2023 report is overdue, please send it as soon as possible./);
     });
 
     it('should display the one overdue report as being overdue', () => {
@@ -114,8 +114,8 @@ describe(page, () => {
     });
 
     it('should state which report the page is expecting to be uploaded', () => {
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(Upload January 2023 report)/);
-      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/(The file must be an XLSX or CSV)/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/Upload January 2023 report/);
+      wrapper.expectText('[data-cy="upload-report-text"]').toMatch(/The file must be an XLSX or CSV/);
     });
   });
 

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/check-the-report.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/check-the-report.njk
@@ -72,6 +72,9 @@
         <div class="govuk-form-group {% if fileUploadError %}govuk-form-group--error{% endif %}">
             <label class="govuk-label govuk-label--m" for="utilisation-report-file-upload">
                 Upload the report again
+                <div id="utilisation-report-file-upload-hint" class="govuk-hint">
+                    The file must be an XLSX or CSV
+                </div>
             </label>
             <div id="utilisation-report-file-upload-hint" class="govuk-hint">
                 You can upload the corrected report now or come back later and upload it

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
@@ -77,10 +77,10 @@
             <div class="govuk-form-group {% if validationError %}govuk-form-group--error{% endif %}">
                 <label class="govuk-label govuk-label--m" for="utilisation-report-file-upload" data-cy="upload-report-text">
                     Upload {{ nextDueReport.formattedReportPeriod }} report
+                    <div id="utilisation-report-file-upload-hint" class="govuk-hint">
+                        The file must be an XLSX or CSV
+                    </div>
                 </label>
-                <div id="utilisation-report-file-upload-hint" class="govuk-hint">
-                    The file must be an XLSX or CSV
-                </div>
                 {% if validationError %}
                     <span class="govuk-error-message" data-cy="utilisation-report-file-upload-error-message">
                         <span class="govuk-visually-hidden">Error:</span>


### PR DESCRIPTION
## Introduction :pencil2:
The utilisation report upload button labels did not include information about the expected file type, meaning users who use a screen reader would not be provided that information when focusing on the button.

## Resolution :heavy_check_mark:
Moves the `div.govuk-hint` element inside of the `label`.

## Screenshots 📷 

Below are screenshots from using the google chrome accessibility dev tools to show that the label for the button now include the file type information.

"Utilisation report upload"

![FN-2335-upload-report-page](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/ebf2efd2-8cc5-49f8-baa0-eef5ee744729)

"Check the report"

![FN-2335-check-the-report-1](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/a316e055-5014-4224-bccb-c8a9dc20e121)

![FN-2335-check-the-report-2](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/530b4fa7-708a-4632-97e2-6fcd9b06d7d5)

