### PR TITLE
feat(FN-1853): add cascade delete to fee record table

### DIFF
--- a/dtfs-central-api/api-tests/sql-db-helper.ts
+++ b/dtfs-central-api/api-tests/sql-db-helper.ts
@@ -8,8 +8,6 @@ type SqlTableName = 'UtilisationReport' | 'FeeRecord' | 'AzureFileInfo';
 const deleteAllEntries = async (tableName: SqlTableName): Promise<void> => {
   switch (tableName) {
     case 'UtilisationReport':
-      // Cascade deletes are not enabled for the 'FeeRecord' table
-      await SqlDbDataSource.manager.delete(FeeRecordEntity, {});
       await SqlDbDataSource.manager.delete(UtilisationReportEntity, {});
       return;
     case 'FeeRecord':

--- a/e2e-tests/support/tasks.js
+++ b/e2e-tests/support/tasks.js
@@ -1,7 +1,7 @@
 const crypto = require('node:crypto');
 const { MongoDbClient } = require('@ukef/dtfs2-common/mongo-db-client');
 const { SqlDbDataSource } = require('@ukef/dtfs2-common/sql-db-connection');
-const { UtilisationReportEntity, FeeRecordEntity } = require('@ukef/dtfs2-common');
+const { UtilisationReportEntity } = require('@ukef/dtfs2-common');
 const { DB_COLLECTIONS } = require('../e2e-fixtures/dbCollections');
 
 SqlDbDataSource.initialize()
@@ -102,7 +102,6 @@ module.exports = {
        * Deletes all the rows from the utilisation report and azure file info tables
        */
       async removeAllUtilisationReportsFromDb() {
-        await SqlDbDataSource.manager.getRepository(FeeRecordEntity).delete({});
         return await SqlDbDataSource.manager.getRepository(UtilisationReportEntity).delete({});
       },
 

--- a/libs/common/src/sql-db-connection/migrations/1711652127585-AddFeeRecordCascadeDelete.ts
+++ b/libs/common/src/sql-db-connection/migrations/1711652127585-AddFeeRecordCascadeDelete.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFeeRecordCascadeDelete1711652127585 implements MigrationInterface {
+  name = 'AddFeeRecordCascadeDelete1711652127585';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord" DROP CONSTRAINT "FK_f90d2441e5bee2fa7de081fdb21"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord"
+            ADD CONSTRAINT "FK_f90d2441e5bee2fa7de081fdb21" FOREIGN KEY ("reportId") REFERENCES "UtilisationReport"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord" DROP CONSTRAINT "FK_f90d2441e5bee2fa7de081fdb21"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord"
+            ADD CONSTRAINT "FK_f90d2441e5bee2fa7de081fdb21" FOREIGN KEY ("reportId") REFERENCES "UtilisationReport"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+  }
+}

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -21,6 +21,7 @@ export class FeeRecordEntity extends AuditableBaseEntity {
    */
   @ManyToOne(() => UtilisationReportEntity, (report) => report.feeRecords, {
     nullable: false,
+    onDelete: 'CASCADE',
   })
   report!: UtilisationReportEntity;
 

--- a/portal-api/api-tests/sql-db-helper.ts
+++ b/portal-api/api-tests/sql-db-helper.ts
@@ -8,8 +8,6 @@ type SqlTableName = 'UtilisationReport' | 'FeeRecord' | 'AzureFileInfo';
 const deleteAllEntries = async (tableName: SqlTableName): Promise<void> => {
   switch (tableName) {
     case 'UtilisationReport':
-      // Cascade deletes are not enabled for the 'FeeRecord' table
-      await SqlDbDataSource.manager.delete(FeeRecordEntity, {});
       await SqlDbDataSource.manager.delete(UtilisationReportEntity, {});
       return;
     case 'FeeRecord':


### PR DESCRIPTION
## Introduction :pencil2:
We want to add cascade deletes to the `FeeRecord` table.

A `FeeRecord` has a many-to-one relation with the `UtilisationReport` table, so making this change means that deleting a row in the `UtilisationReport` table will delete all linked rows in the `FeeRecord` table.

## Resolution :heavy_check_mark:
- Adds the cascade delete option to the `FeeRecord` entity
- Generates the required migration
- Updates existing implementations where `FeeRecord` rows are manually deleted before `UtilisationReport` rows are deleted

## Miscellaneous :heavy_plus_sign:

