### PR TITLE
fix(DTFS2-6119): fix duplicate emails being sent

### DIFF
--- a/gef-ui/templates/application-abandon.njk
+++ b/gef-ui/templates/application-abandon.njk
@@ -30,6 +30,7 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <div class="govuk-button-group govuk-!-margin-top-7">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Yes, abandon",
             attributes: {
               'data-cy': 'submit-button'
@@ -37,6 +38,7 @@
             classes: "govuk-!-margin-right-6"
           }) }}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "No, keep",
             attributes: {
               'data-cy': 'cancel-button'

--- a/gef-ui/templates/application-details-comments.njk
+++ b/gef-ui/templates/application-details-comments.njk
@@ -58,6 +58,7 @@
         }) }}
         <p class="govuk-button-group govuk-!-margin-top-7" id="application-details-comments-submit">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Submit",
             attributes: {
               'data-cy': 'submit-button'

--- a/gef-ui/templates/includes/application-details/applicationReferenceAndActions.njk
+++ b/gef-ui/templates/includes/application-details/applicationReferenceAndActions.njk
@@ -7,6 +7,7 @@
     <div class="govuk-grid-column-full" id="application-reference-and-actions-actions">
       {% if status and isMaker %}
          {{ govukButton({
+            preventDoubleClick: true,
             text: "Clone",
             attributes: {
               "data-cy": "clone-gef-deal-link",
@@ -18,6 +19,7 @@
       {% endif %}
       {% if abandon and not hasChangedFacilities and not MIAReturnToMaker and not returnToMakerNoFacilitiesChanged %}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Abandon",
           attributes: {
             "data-cy": "abandon-link",

--- a/gef-ui/templates/includes/application-details/facilities.njk
+++ b/gef-ui/templates/includes/application-details/facilities.njk
@@ -25,6 +25,7 @@
 {% if not previewMode and not hasChangedFacilities and not MIAReturnToMaker and not returnToMakerNoFacilitiesChanged%}
   <div class="govuk-button-group">
     {{ govukButton({
+      preventDoubleClick: true,
       text: "Add a cash facility",
       classes: "govuk-button--secondary",
       href: dealId + "/facilities",
@@ -33,6 +34,7 @@
       }
     }) }}
     {{ govukButton({
+      preventDoubleClick: true,
       text: "Add a contingent facility",
       classes: "govuk-button--secondary",
       href: dealId + "/facilities?facilityType=Contingent",

--- a/gef-ui/templates/includes/exporters-address/separate-correspondence.njk
+++ b/gef-ui/templates/includes/exporters-address/separate-correspondence.njk
@@ -72,6 +72,7 @@
         </div>
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'

--- a/gef-ui/templates/includes/submit/submit-to-checker-post-ukef-approval.njk
+++ b/gef-ui/templates/includes/submit/submit-to-checker-post-ukef-approval.njk
@@ -5,6 +5,7 @@
 </p>
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Submit to be checked at your bank",
   attributes: {
     'data-cy': 'submit-ukef-approved-application-to-checker'

--- a/gef-ui/templates/includes/submit/submit-to-checker.njk
+++ b/gef-ui/templates/includes/submit/submit-to-checker.njk
@@ -6,6 +6,7 @@
 
 {% if submit %}
   {{ govukButton({
+    preventDoubleClick: true,
     text: "Submit to be checked at your bank",
     attributes: {
       'data-cy': 'submit-button'

--- a/gef-ui/templates/includes/submit/submit-to-ukef.njk
+++ b/gef-ui/templates/includes/submit/submit-to-ukef.njk
@@ -6,6 +6,7 @@
 <p class="govuk-body">If this is ready, you can submit it to UKEF. Or you can return it to the maker to make changes.</p>
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Submit to UKEF",
   href: dealId + "/submit-to-ukef",
   attributes: {
@@ -14,6 +15,7 @@
 }) }}
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Return to maker",
   classes: "govuk-button--secondary",
   href: dealId + "/return-to-maker",

--- a/gef-ui/templates/partials/about-exporter.njk
+++ b/gef-ui/templates/partials/about-exporter.njk
@@ -192,6 +192,7 @@
 
           <div class="govuk-button-group">
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Done",
               attributes: {
                 'data-cy': 'done-button'
@@ -199,6 +200,7 @@
             }) }}
 
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Save and return",
               classes: "govuk-button--secondary",
               attributes: {

--- a/gef-ui/templates/partials/about-facility.njk
+++ b/gef-ui/templates/partials/about-facility.njk
@@ -130,6 +130,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'
@@ -137,6 +138,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save and return",
             classes: "govuk-button--secondary",
             attributes: {

--- a/gef-ui/templates/partials/automatic-cover.njk
+++ b/gef-ui/templates/partials/automatic-cover.njk
@@ -81,6 +81,7 @@
     {% endfor %}
     <div class="govuk-button-group">
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Continue",
         attributes: {
           'data-cy': 'continue-button'
@@ -88,6 +89,7 @@
       }) }}
 
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Save and return",
         classes: "govuk-button--secondary",
         attributes: {

--- a/gef-ui/templates/partials/companies-house.njk
+++ b/gef-ui/templates/partials/companies-house.njk
@@ -63,6 +63,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/confirm-cover-start-date.njk
+++ b/gef-ui/templates/partials/confirm-cover-start-date.njk
@@ -137,6 +137,7 @@
 
                     <div class="govuk-button-group">
                         {{ govukButton({
+                            preventDoubleClick: true,
                             text: "Save",
                             attributes: {
                                 "data-cy": "continue-button"

--- a/gef-ui/templates/partials/eligible-automatic-cover.njk
+++ b/gef-ui/templates/partials/eligible-automatic-cover.njk
@@ -11,6 +11,7 @@
   </h1>
 
   {{ govukButton({
+    preventDoubleClick: true,
     text: "Continue",
     href: "/gef/application-details/" + dealId,
     attributes: {

--- a/gef-ui/templates/partials/enter-exporters-correspondence-address.njk
+++ b/gef-ui/templates/partials/enter-exporters-correspondence-address.njk
@@ -116,6 +116,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'
@@ -123,6 +124,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save and return",
             classes: "govuk-button--secondary",
             attributes: {

--- a/gef-ui/templates/partials/facilities.njk
+++ b/gef-ui/templates/partials/facilities.njk
@@ -80,6 +80,7 @@
 
     <div class="govuk-button-group">
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Continue",
         attributes: {
           'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/facility-confirm-deletion.njk
+++ b/gef-ui/templates/partials/facility-confirm-deletion.njk
@@ -18,6 +18,7 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     <div class="govuk-button-group">
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Yes, delete",
         attributes: {
           'data-cy': 'delete-button'
@@ -25,6 +26,7 @@
       }) }}
 
       {{ govukButton({
+        preventDoubleClick: true,
         text: "No, keep",
         classes: "govuk-button--secondary",
         href: "/gef/application-details/" + dealId,

--- a/gef-ui/templates/partials/facility-currency.njk
+++ b/gef-ui/templates/partials/facility-currency.njk
@@ -104,6 +104,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'
@@ -111,6 +112,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save and return",
             classes: "govuk-button--secondary",
             attributes: {

--- a/gef-ui/templates/partials/facility-guarantee.njk
+++ b/gef-ui/templates/partials/facility-guarantee.njk
@@ -221,6 +221,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Done",
             attributes: {
               'data-cy': 'done-button'

--- a/gef-ui/templates/partials/facility-value.njk
+++ b/gef-ui/templates/partials/facility-value.njk
@@ -143,12 +143,14 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'
             }
           }) }}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save and return",
             classes: "govuk-button--secondary",
             attributes: {

--- a/gef-ui/templates/partials/ineligible-automatic-cover.njk
+++ b/gef-ui/templates/partials/ineligible-automatic-cover.njk
@@ -16,6 +16,7 @@
   </div>
 
   {{ govukButton({
+    preventDoubleClick: true,
     text: "Continue",
     href: "/gef/application-details/" + dealId + "/supporting-information/document/manual-inclusion-questionnaire",
     attributes: {

--- a/gef-ui/templates/partials/ineligible-gef.njk
+++ b/gef-ui/templates/partials/ineligible-gef.njk
@@ -16,6 +16,7 @@
 
 
   {{ govukButton({
+    preventDoubleClick: true,
     text: "Back to applications and notices",
     href: "/dashboard",
     attributes: {

--- a/gef-ui/templates/partials/issued-facility-to-unissued.njk
+++ b/gef-ui/templates/partials/issued-facility-to-unissued.njk
@@ -74,6 +74,7 @@
 
     <div class="govuk-button-group">
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Continue",
         attributes: {
           'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/mandatory-criteria.njk
+++ b/gef-ui/templates/partials/mandatory-criteria.njk
@@ -87,6 +87,7 @@
 
     <div class="govuk-button-group">
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Continue",
         attributes: {
             'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/name-application.njk
+++ b/gef-ui/templates/partials/name-application.njk
@@ -69,6 +69,7 @@
 
       <div class="govuk-button-group">
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Continue",
           attributes: {
           'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/provided-facility.njk
+++ b/gef-ui/templates/partials/provided-facility.njk
@@ -138,6 +138,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'
@@ -145,6 +146,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save and return",
             classes: "govuk-button--secondary",
             attributes: {

--- a/gef-ui/templates/partials/return-to-maker.njk
+++ b/gef-ui/templates/partials/return-to-maker.njk
@@ -60,6 +60,7 @@
 
         <p class="govuk-button-group govuk-!-margin-top-7" id="return-to-maker-submit">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Return to maker",
             attributes: {
               'data-cy': 'submit-button'

--- a/gef-ui/templates/partials/review-decision.njk
+++ b/gef-ui/templates/partials/review-decision.njk
@@ -103,6 +103,7 @@
 
                     <div class="govuk-button-group">
                         {{ govukButton({
+                            preventDoubleClick: true,
                             text: "Continue",
                             attributes: {
                                 "data-cy": "continue-button"

--- a/gef-ui/templates/partials/security-details.njk
+++ b/gef-ui/templates/partials/security-details.njk
@@ -78,6 +78,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'submit-button'

--- a/gef-ui/templates/partials/select-exporters-correspondence-address.njk
+++ b/gef-ui/templates/partials/select-exporters-correspondence-address.njk
@@ -82,6 +82,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: {
               'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/submit-to-ukef.njk
+++ b/gef-ui/templates/partials/submit-to-ukef.njk
@@ -56,6 +56,7 @@
 
         <p class="govuk-button-group govuk-!-margin-top-7" id="submit-to-ukef-submit">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Submit to UKEF",
             attributes: {
               'data-cy': 'submit-button'

--- a/gef-ui/templates/partials/unissued-change-about-facility.njk
+++ b/gef-ui/templates/partials/unissued-change-about-facility.njk
@@ -97,6 +97,7 @@
             <div class="govuk-button-group">
 
               {{ govukButton({
+                preventDoubleClick: true,
                 text: "Continue",
                 attributes: {
                   'data-cy': 'continue-button'

--- a/gef-ui/templates/partials/unissued-facilities.njk
+++ b/gef-ui/templates/partials/unissued-facilities.njk
@@ -94,6 +94,7 @@
         }) }}
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             href: "/gef/application-details/" + dealId,
               attributes: {

--- a/gef-ui/templates/partials/upload-supporting-documents.njk
+++ b/gef-ui/templates/partials/upload-supporting-documents.njk
@@ -91,6 +91,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+            preventDoubleClick: true,
             text: 'Continue',
             classes: 'govuk-button--primary moj-multi-file-upload__button',
             name: 'submit',

--- a/portal/templates/admin/dashboard.njk
+++ b/portal/templates/admin/dashboard.njk
@@ -109,6 +109,7 @@
   </table>
 
   {{ govukButton({
+      preventDoubleClick: true,
       text: "Add user",
       href: "/admin/users/create",
       classes: "govuk-!-margin-right-1",
@@ -118,6 +119,7 @@
   }) }}
 
   {{ govukButton({
+        preventDoubleClick: true,
         text: "Cancel",
         classes: "govuk-button--secondary govuk-!-margin-right-1",
         href: "/dashboard",

--- a/portal/templates/admin/user-change-password.njk
+++ b/portal/templates/admin/user-change-password.njk
@@ -16,11 +16,13 @@
     {% include "_partials/password-create.njk" %}
 
     {{ govukButton({
+      preventDoubleClick: true,
       text: "Submit",
       classes: "govuk-!-margin-right-1"
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
       text: "Cancel",
       classes: "govuk-button--secondary",
       href: "/admin/users/edit/" + user._id

--- a/portal/templates/admin/user-disable.njk
+++ b/portal/templates/admin/user-disable.njk
@@ -13,12 +13,14 @@
   </h1>
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Confirm",
   classes: "govuk-!-margin-right-1",
   href: "/admin/users/"
 }) }}
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Cancel and go back",
   classes: "govuk-button--secondary",
   href: "/admin/users/"

--- a/portal/templates/admin/user-edit.njk
+++ b/portal/templates/admin/user-edit.njk
@@ -215,12 +215,14 @@
 
   {% if _id %}
     {{ govukButton({
+      preventDoubleClick: true,
       attributes: {"data-cy": "Save"},
       classes: "govuk-!-margin-right-1",
       text: "Save"
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
         text: "Change password",
         href: "/admin/users/change-password/" + _id,
         classes: "govuk-!-margin-right-1",
@@ -231,6 +233,7 @@
     }}
   {% else %}
     {{ govukButton({
+      preventDoubleClick: true,
       attributes: {
         "data-cy": "create-user-add"
         },
@@ -240,6 +243,7 @@
   {% endif %}
 
   {{ govukButton({
+        preventDoubleClick: true,
         text: "Cancel",
         classes: "govuk-button--secondary govuk-!-margin-right-1",
         href: "/admin/users/",

--- a/portal/templates/admin/user-enable.njk
+++ b/portal/templates/admin/user-enable.njk
@@ -13,12 +13,14 @@
   </h1>
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Confirm",
   classes: "govuk-!-margin-right-1",
   href: "/admin/users/"
 }) }}
 
 {{ govukButton({
+  preventDoubleClick: true,
   text: "Cancel and go back",
   classes: "govuk-button--secondary",
   href: "/admin/users/"

--- a/portal/templates/contract/about/about-supplier.njk
+++ b/portal/templates/contract/about/about-supplier.njk
@@ -84,11 +84,13 @@
       }) }}
 
       {{ govukButton({
+        preventDoubleClick: true,
         "text": "Next Page",
         "attributes" : { "data-cy" : "NextPage" }
       }) }}
 
       {{ govukButton({
+        preventDoubleClick: true,
         "text": "Save and go back to deal",
         "classes" : "govuk-button govuk-button--secondary",
         "attributes" : {

--- a/portal/templates/contract/about/about-supply-buyer.njk
+++ b/portal/templates/contract/about/about-supply-buyer.njk
@@ -68,11 +68,13 @@
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
       "text": "Next Page",
       "attributes" : { "data-cy" : "NextPage" }
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
       "text": "Save and go back to deal",
       "classes" : "govuk-button govuk-button--secondary",
       "attributes" : {

--- a/portal/templates/contract/about/about-supply-financial.njk
+++ b/portal/templates/contract/about/about-supply-financial.njk
@@ -128,11 +128,13 @@
     </div>
 
     {{ govukButton({
+      preventDoubleClick: true,
       "text": "Preview",
       "attributes" : { "data-cy" : "Preview" }
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
       "text": "Save and go back to deal",
       "classes" : "govuk-button govuk-button--secondary",
       "attributes" : {

--- a/portal/templates/contract/about/components/input-companies-house-reg-number.njk
+++ b/portal/templates/contract/about/components/input-companies-house-reg-number.njk
@@ -22,6 +22,7 @@
   }) }}
 
   {{ govukButton({
+    preventDoubleClick: true,
     "text": "Search",
     "attributes" : {
       "data-cy" : "DoSearch-" + prefix+'-companies-house-registration-number',

--- a/portal/templates/contract/components/contract-actions/abandon-deal-button.njk
+++ b/portal/templates/contract/components/contract-actions/abandon-deal-button.njk
@@ -8,6 +8,7 @@
       {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) %}
 
         {{ govukButton({
+          preventDoubleClick: true,
           "disabled": false,
           "text": "Abandon",
           "classes": "govuk-button--secondary",
@@ -20,6 +21,7 @@
       {% elseif  ["Abandoned", "Acknowledged", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "Ready for Checker's approval"].includes(params.deal.status) %}
 
         {{ govukButton({
+          preventDoubleClick: true,
           "disabled": true,
           "text": "Abandon",
           "classes": "govuk-button--secondary",

--- a/portal/templates/contract/components/contract-actions/proceed-to-review-button.njk
+++ b/portal/templates/contract/components/contract-actions/proceed-to-review-button.njk
@@ -7,6 +7,7 @@
     {% if ["Draft", "Further Maker's input required"].includes(params.deal.status) and params.isEveryDealFormComplete %}
 
       {{ govukButton({
+        preventDoubleClick: true,
         "disabled": false,
         "text": "Proceed to review",
         "attributes" : {
@@ -18,6 +19,7 @@
     {% elseif ["Ready for Checker's approval"].includes(params.deal.status) and not params.user.roles.includes('checker')%}
 
       {{ govukButton({
+        preventDoubleClick: true,
         "disabled": true,
         "text": "Proceed to review",
         "attributes" : {
@@ -29,6 +31,7 @@
     {% elseif  ["Draft", "Further Maker's input required", "Abandoned", "Acknowledged"].includes(params.deal.status) and not params.dealHasIssuedFacilitiesToSubmit %}
 
       {{ govukButton({
+        preventDoubleClick: true,
         "disabled": true,
         "text": "Proceed to review",
         "attributes" : {
@@ -41,7 +44,8 @@
 
       {% if params.dealHasIssuedFacilitiesToSubmit or params.allRequestedCoverStartDatesConfirmed %}
         {{ govukButton({
-          "disabled": false,
+          preventDoubleClick: true,
+        "disabled": false,
           "text": "Proceed to review",
           "attributes" : {
             "data-cy" : "ProceedToReview"
@@ -50,7 +54,8 @@
         }) }}
       {% else %}
         {{ govukButton({
-          "disabled": true,
+          preventDoubleClick: true,
+        "disabled": true,
           "text": "Proceed to review",
           "attributes" : {
             "data-cy" : "ProceedToReview"
@@ -61,6 +66,7 @@
 
     {% elseif ["Acknowledged", "Ready for Checker's approval", "Further Maker's input required"].includes(params.deal.status) and params.dealHasIssuedFacilitiesToSubmit %}
       {{ govukButton({
+        preventDoubleClick: true,
         "disabled": false,
         "text": "Proceed to review",
         "attributes" : {

--- a/portal/templates/contract/components/contract-actions/proceed-to-submit-button.njk
+++ b/portal/templates/contract/components/contract-actions/proceed-to-submit-button.njk
@@ -20,6 +20,7 @@
         {% if ["Ready for Checker's approval"].includes(params.deal.status) %}
 
           {{ govukButton({
+            preventDoubleClick: true,
             "disabled": false,
             "text": "Proceed to submit",
             "attributes" : {
@@ -31,6 +32,7 @@
         {% elseif  ["Draft", "Abandoned", "Acknowledged", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "In progress by UKEF"].includes(params.deal.status) %}
 
           {{ govukButton({
+            preventDoubleClick: true,
             "disabled": true,
             "text": "Proceed to submit",
             "attributes" : {

--- a/portal/templates/contract/components/contract-actions/return-to-maker-button.njk
+++ b/portal/templates/contract/components/contract-actions/return-to-maker-button.njk
@@ -20,6 +20,7 @@
         {% if ["Ready for Checker's approval"].includes(params.deal.status) %}
 
           {{ govukButton({
+            preventDoubleClick: true,
             "disabled": false,
             "text": "Return to Maker",
             "classes": "govuk-button--secondary",
@@ -32,6 +33,7 @@
         {% elseif  ["Draft", "Abandoned", "Acknowledged", "Accepted by UKEF (without conditions)", "Accepted by UKEF (with conditions)", "In progress by UKEF"].includes(params.deal.status) %}
 
           {{ govukButton({
+            preventDoubleClick: true,
             "disabled": true,
             "text": "Return to Maker",
             "classes": "govuk-button--secondary",

--- a/portal/templates/login/index.njk
+++ b/portal/templates/login/index.njk
@@ -76,6 +76,7 @@
             }
           }) }}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Sign in",
             attributes: {
               "data-cy": "LogIn"

--- a/portal/templates/reports/conditional-decision.njk
+++ b/portal/templates/reports/conditional-decision.njk
@@ -34,6 +34,7 @@
     </div>
     <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
       {{ govukButton({
+          preventDoubleClick: true,
           text: "Download",
           classes: "govuk-button--secondary",
           href: "/reports/download-conditional-decision-report",

--- a/portal/templates/reports/unconditional-decision.njk
+++ b/portal/templates/reports/unconditional-decision.njk
@@ -34,6 +34,7 @@
     </div>
     <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
       {{ govukButton({
+          preventDoubleClick: true,
           text: "Download",
           classes: "govuk-button--secondary",
           href: "/reports/download-unconditional-decision-report",

--- a/portal/templates/reports/unissued-facilities.njk
+++ b/portal/templates/reports/unissued-facilities.njk
@@ -34,6 +34,7 @@
     </div>
     <div class="govuk-grid-column-one-quarter govuk-!-text-align-right">
       {{ govukButton({
+          preventDoubleClick: true,
           text: "Download",
           classes: "govuk-button--secondary",
           href: "/reports/download-unissued-facilities-report",

--- a/portal/templates/reset-password.njk
+++ b/portal/templates/reset-password.njk
@@ -50,6 +50,7 @@
         </p>
 
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Submit",
           attributes: {
             "data-cy": "reset-password-submit"
@@ -58,6 +59,7 @@
         }) }}
 
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Cancel",
           attributes: {
             "data-cy": "reset-password-cancel"

--- a/portal/templates/select-scheme.njk
+++ b/portal/templates/select-scheme.njk
@@ -64,6 +64,7 @@
 
           <div class="govuk-button-group">
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Continue",
               attributes: {
                 'data-cy': 'continue-button'

--- a/portal/templates/user/change-password.njk
+++ b/portal/templates/user/change-password.njk
@@ -42,6 +42,7 @@
         {% endif %}
 
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Submit",
           attributes: {
             "data-cy": "profile-change-password-submit"
@@ -50,6 +51,7 @@
         }) }}
 
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Cancel",
           attributes: {
             "data-cy": "profile-change-password-cancel"

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/confirm-and-send.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/confirm-and-send.njk
@@ -21,6 +21,7 @@
             <form method="POST" data-cy="form">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
                 {{ govukButton({
+                    preventDoubleClick: true,
                     text: "Confirm and send",
                     attributes: {
                         'data-cy': 'confirm-and-send-button'

--- a/trade-finance-manager-ui/templates/case/_macros/save-close-buttons.njk
+++ b/trade-finance-manager-ui/templates/case/_macros/save-close-buttons.njk
@@ -4,6 +4,7 @@
   
   <div class="govuk-!-margin-top-4">
     {{ govukButton({
+      preventDoubleClick: true,
       text: "Save and continue",
       attributes: {
         'data-cy': 'save-button'

--- a/trade-finance-manager-ui/templates/case/activity/_macros/activity-comment-filter.njk
+++ b/trade-finance-manager-ui/templates/case/activity/_macros/activity-comment-filter.njk
@@ -40,6 +40,7 @@
         }) }}
 
         {{ govukButton({
+        preventDoubleClick: true,
         text: "Filter results",
         attributes: {
           "data-cy": "submit-button"

--- a/trade-finance-manager-ui/templates/case/activity/activity-comment.njk
+++ b/trade-finance-manager-ui/templates/case/activity/activity-comment.njk
@@ -54,6 +54,7 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
+              preventDoubleClick: true,
               html: 'Add <span class="govuk-visually-hidden">this comment</span>',
               attributes: {
               'data-cy': 'add-comment-button'

--- a/trade-finance-manager-ui/templates/case/activity/activity.njk
+++ b/trade-finance-manager-ui/templates/case/activity/activity.njk
@@ -31,6 +31,7 @@
       {{ activityCommentFilter.render(filterCommentData) }}
 
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Add a comment",
         classes: "govuk-button--secondary",
         href: "/case/" + dealId + "/activity" + "/post-comment",

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-check-answers.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-check-answers.njk
@@ -89,6 +89,7 @@
         <div class="govuk-button-group govuk-!-margin-top-4">
           {% if isEditable %}
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Submit",
               attributes: { "data-cy": "amendment--continue-button" }
               })

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-effective-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-effective-date.njk
@@ -81,6 +81,7 @@
         <div class="govuk-button-group">
           {% if isEditable %}
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Continue",
               attributes: {
                   "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-receive-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision-receive-date.njk
@@ -81,6 +81,7 @@
           <div class="govuk-button-group">
             {% if isEditable %}
               {{ govukButton({
+                preventDoubleClick: true,
                 text: "Continue",
                 attributes: {
                     "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-banks-decision.njk
@@ -58,6 +58,7 @@
           <div class="govuk-button-group">
             {% if isEditable %}
               {{ govukButton({
+                preventDoubleClick: true,
                 text: "Continue",
                 attributes: {
                     "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-managers-decision-cover-end-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-managers-decision-cover-end-date.njk
@@ -98,6 +98,7 @@
           <div class="govuk-button-group">
             {% if isEditable %}
               {{ govukButton({
+                preventDoubleClick: true,
                 text: "Continue",
                 attributes: {
                     "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-add-managers-decision-facility-value.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-add-managers-decision-facility-value.njk
@@ -98,6 +98,7 @@
           <div class="govuk-button-group">
             {% if isEditable %}
               {{ govukButton({
+                preventDoubleClick: true,
                 text: "Continue",
                 attributes: {
                     "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-answers.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-answers.njk
@@ -112,6 +112,7 @@
         <div class="govuk-button-group govuk-!-margin-top-4">
           {% if isEditable %}
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Submit",
               attributes: { "data-cy": "amendment--continue-button" }
               })

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-assign-lead-underwriter.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-assign-lead-underwriter.njk
@@ -35,6 +35,7 @@
           {% if isEditable %}
 
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Save",
               attributes: {
                 'data-cy': 'amendment--continue-button'

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-banks-decision.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-banks-decision.njk
@@ -32,6 +32,7 @@
             {% elif isEditable %}
               <div class="govuk-!-padding-top-0">
                 {{ govukButton({
+                    preventDoubleClick: true,
                     text: "Add decision",
                     href: "/case/" + amendment.dealId + "/facility/" + amendment.facilityId + "/amendment/" + amendment.amendmentId + "/banks-decision",
                     attributes: {

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-cover-end-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-cover-end-date.njk
@@ -85,6 +85,7 @@
     <div class="govuk-button-group">
       {% if isEditable %}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Continue",
           attributes: {
               "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-effective-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-effective-date.njk
@@ -80,6 +80,7 @@
     <div class="govuk-button-group">
       {% if isEditable %}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Continue",
           attributes: {
               "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-facility-value.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-facility-value.njk
@@ -56,6 +56,7 @@
     <div class="govuk-button-group">
       {% if isEditable %}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Continue",
           attributes: {
               "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-lead-underwriter.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-lead-underwriter.njk
@@ -47,6 +47,7 @@
 
         {% if leadUnderwriter.isEditable %}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Add underwriter",
             href: "/case/" + dealId + "/facility/" + facilityId + "/amendment/" + amendmentId + "/lead-underwriter",
             attributes: {

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-managers-conditions-and-comments-summary.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-managers-conditions-and-comments-summary.njk
@@ -139,6 +139,7 @@
         <div class="govuk-button-group">
           {% if isEditable %}
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Send to bank",
               attributes: { "data-cy": "amendment--send-to-bank-button" }
               })

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-managers-conditions-and-comments.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-managers-conditions-and-comments.njk
@@ -110,6 +110,7 @@
         <div class="govuk-button-group">
           {% if isEditable %}
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Continue",
               attributes: { "data-cy": "amendment--continue-button" }
               })

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-managers-decision.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-managers-decision.njk
@@ -17,6 +17,7 @@
             {% if amendment.changeCoverEndDate %}
               <div class="govuk-!-padding-top-0">
                 {{ govukButton({
+                    preventDoubleClick: true,
                     text: "Add decision",
                     href: "/case/" + dealId + "/facility/" + facilityId + "/amendment/" + amendmentId + "/cover-end-date/managers-decision",
                     attributes: { "data-cy":"amendment-manager-add-decision-link" }
@@ -25,6 +26,7 @@
             {% elif amendment.changeFacilityValue %}
               <div class="govuk-!-padding-top-0">
                 {{ govukButton({
+                    preventDoubleClick: true,
                     text: "Add decision",
                     href: "/case/" + dealId + "/facility/" + facilityId + "/amendment/" + amendmentId + "/facility-value/managers-decision",
                     attributes: { "data-cy":"amendment-manager-add-decision-link" }

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-options.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-options.njk
@@ -63,6 +63,7 @@
       <div class="govuk-button-group govuk-!-margin-top-4">
         {% if isEditable %}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: { "data-cy": "amendment--continue-button" }
             })

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-request-approval.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-request-approval.njk
@@ -54,6 +54,7 @@
       <div class="govuk-button-group">
         {% if isEditable %}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Continue",
             attributes: { "data-cy": "amendment--continue-button" }
             })

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-request-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-request-date.njk
@@ -80,6 +80,7 @@
     <div class="govuk-button-group">
       {% if isEditable %}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Continue",
           attributes: {
               "data-cy": "amendment--continue-button"

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-task.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-task.njk
@@ -86,6 +86,7 @@
           }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save and close",
             attributes: {
               'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/facility/_macros/add-amendment.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/add-amendment.njk
@@ -14,6 +14,7 @@
         <form method="post" data-cy="form">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}">
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Add an amendment request",
             attributes: {
               'data-cy': 'amendment--add-amendment-button'
@@ -22,6 +23,7 @@
         </form>
       {% elif showContinueAmendmentButton === true %}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Continue with amendment request " + amendmentVersion,
           attributes: {
             'data-cy': 'amendment--continue-amendment-button'

--- a/trade-finance-manager-ui/templates/case/parties/non-existent.njk
+++ b/trade-finance-manager-ui/templates/case/parties/non-existent.njk
@@ -34,6 +34,7 @@
     <div class="govuk-grid-column-full">
       <div class="govuk-!-margin-top-4">
         {{ govukButton({
+                preventDoubleClick: true,
                 text: "Back to parties",
                 href: "/case/" + dealId + "/parties",
                 attributes: {

--- a/trade-finance-manager-ui/templates/case/parties/summary/bond.njk
+++ b/trade-finance-manager-ui/templates/case/parties/summary/bond.njk
@@ -95,6 +95,7 @@
         <div class="govuk-grid-column-one-half">
           <div class="govuk-!-margin-top-4">
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Save and close",
               attributes: {
                 'data-cy': 'save-button'

--- a/trade-finance-manager-ui/templates/case/parties/summary/party.njk
+++ b/trade-finance-manager-ui/templates/case/parties/summary/party.njk
@@ -83,6 +83,7 @@
         <div class="govuk-grid-column-one-half">
           <div class="govuk-!-margin-top-4">
             {{ govukButton({
+              preventDoubleClick: true,
               text: "Save and close",
               attributes: {
                 'data-cy': 'save-button'

--- a/trade-finance-manager-ui/templates/case/tasks/_macros/task-filters.njk
+++ b/trade-finance-manager-ui/templates/case/tasks/_macros/task-filters.njk
@@ -48,6 +48,7 @@
       })}}
 
       {{ govukButton({
+        preventDoubleClick: true,
         text: "Filter results",
         attributes: {
           "data-cy": "submit-button"

--- a/trade-finance-manager-ui/templates/case/tasks/task.njk
+++ b/trade-finance-manager-ui/templates/case/tasks/task.njk
@@ -90,6 +90,7 @@
         }}
 
         {{ govukButton({
+          preventDoubleClick: true,,
           text: "Save and close",
           attributes: {
             'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/underwriting/lead-underwriter/assign-lead-underwriter.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/lead-underwriter/assign-lead-underwriter.njk
@@ -36,6 +36,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save",
             attributes: {
               'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/underwriting/lead-underwriter/lead-underwriter.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/lead-underwriter/lead-underwriter.njk
@@ -47,6 +47,7 @@
       {% else %}
         {% if leadUnderwriter.userCanEdit %}
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Add underwriter",
             href: "/case/" + leadUnderwriter.dealId  + "/underwriting/lead-underwriter/assign",
             attributes: {

--- a/trade-finance-manager-ui/templates/case/underwriting/managers-decision/edit-managers-decision.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/managers-decision/edit-managers-decision.njk
@@ -120,6 +120,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save",
             attributes: {
               'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/underwriting/managers-decision/managers-decision.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/managers-decision/managers-decision.njk
@@ -21,6 +21,7 @@
           {% if underWriterDecision.userCanEdit %}
             <div class="govuk-!-padding-top-0">
               {{ govukButton({
+                  preventDoubleClick: true,
                   text: "Add decision",
                   href: "/case/" + underWriterDecision.dealId  + "/underwriting/managers-decision/edit",
                   attributes: {

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/edit-facility-risk-profile/edit-facility-risk-profile.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/edit-facility-risk-profile/edit-facility-risk-profile.njk
@@ -73,6 +73,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save",
             attributes: {
               'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/edit-pricing-and-risk.njk
@@ -91,6 +91,7 @@
               }}
 
               {{ govukButton({
+                preventDoubleClick: true,
                 text: "Save",
                 attributes: {
                   'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/loss-given-default.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/loss-given-default.njk
@@ -55,6 +55,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save",
             attributes: {
               'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/probability-of-default.njk
+++ b/trade-finance-manager-ui/templates/case/underwriting/pricing-and-risk/probability-of-default.njk
@@ -61,6 +61,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Save",
             attributes: {
               'data-cy': 'submit-button'

--- a/trade-finance-manager-ui/templates/deals/_macros/deals-table-search-form.njk
+++ b/trade-finance-manager-ui/templates/deals/_macros/deals-table-search-form.njk
@@ -13,6 +13,7 @@
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
       text: 'Search deals',
       classes: 'ukef-search-form__button',
       attributes: {

--- a/trade-finance-manager-ui/templates/facilities/_macros/facilities-table-search-form.njk
+++ b/trade-finance-manager-ui/templates/facilities/_macros/facilities-table-search-form.njk
@@ -13,6 +13,7 @@
     }) }}
 
     {{ govukButton({
+      preventDoubleClick: true,
       text: 'Search facilities',
       classes: 'ukef-search-form__button',
       attributes: {

--- a/trade-finance-manager-ui/templates/login.njk
+++ b/trade-finance-manager-ui/templates/login.njk
@@ -82,6 +82,7 @@
           }) }}
 
           {{ govukButton({
+            preventDoubleClick: true,
             text: "Sign in",
             attributes: {
               "data-cy": "submit-button"

--- a/trade-finance-manager-ui/templates/user/change-password.njk
+++ b/trade-finance-manager-ui/templates/user/change-password.njk
@@ -61,6 +61,7 @@
 
 
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Submit",
           attributes: {
             "data-cy": "submit"
@@ -70,6 +71,7 @@
         }) }}
 
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Cancel",
           attributes: {
             "data-cy": "cancel"

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/report-reconciliation-table.njk
@@ -89,6 +89,7 @@
 
       <div class="govuk-button-group">
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Mark report as completed",
           name: "form-button",
           value: "completed",
@@ -97,6 +98,7 @@
           }
         }) }}
         {{ govukButton({
+          preventDoubleClick: true,
           text: "Mark as not completed",
           name: "form-button",
           value: "not-completed",


### PR DESCRIPTION
## Introduction :pencil2:
This is half a front end fix for ensuring that we do not resubmit forms.

This PR tackles buttons that currently use `govukButton`.

## Resolution :heavy_check_mark:
Added the built in method `preventDoubleClick: true` to all `govukButton`.

## Miscellaneous :heavy_plus_sign:
There is additional work to extract other buttons into `govukButton`s but this will be a different PR
