### PR TITLE
feat(FN-1456): quarterly reports on TFM bank reports page

### DIFF
--- a/dtfs-central-api/api-tests/mocks/utilisation-reports/utilisation-report-reconciliation-summary.ts
+++ b/dtfs-central-api/api-tests/mocks/utilisation-reports/utilisation-report-reconciliation-summary.ts
@@ -4,6 +4,7 @@ import { MOCK_BANKS } from '../banks';
 
 const MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEM: UtilisationReportReconciliationSummaryItem = {
   reportId: 12,
+  reportPeriod: { start: { month: 1, year: 2023 }, end: { month: 1, year: 2023 } },
   bank: {
     id: MOCK_BANKS.BARCLAYS.id,
     name: MOCK_BANKS.BARCLAYS.name,

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
@@ -4,7 +4,7 @@ import {
   MONGO_DB_COLLECTIONS,
   UtilisationReportEntityMockBuilder,
   getCurrentReportPeriodForBankSchedule,
-  getSubmissionMonthForReportPeriodStart,
+  getSubmissionMonthForReportPeriodEnd,
 } from '@ukef/dtfs2-common';
 import wipeDB from '../../wipeDB';
 import app from '../../../src/createApp';
@@ -57,7 +57,7 @@ describe('/v1/utilisation-reports/reconciliation-summary/:submissionMonth', () =
     it('returns a 200 response with the correct number of associated fee records', async () => {
       // Arrange
       const reportPeriod = getCurrentReportPeriodForBankSchedule(MOCK_BANKS.BARCLAYS.utilisationReportPeriodSchedule);
-      const submissionMonth = getSubmissionMonthForReportPeriodStart(reportPeriod.start);
+      const submissionMonth = getSubmissionMonthForReportPeriodEnd(reportPeriod.end);
 
       await SqlDbHelper.deleteAllEntries('UtilisationReport');
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
@@ -4,7 +4,7 @@ import {
   MONGO_DB_COLLECTIONS,
   UtilisationReportEntityMockBuilder,
   getCurrentReportPeriodForBankSchedule,
-  getSubmissionMonthForReportPeriodEnd,
+  getSubmissionMonthForReportPeriod,
 } from '@ukef/dtfs2-common';
 import wipeDB from '../../wipeDB';
 import app from '../../../src/createApp';
@@ -57,7 +57,7 @@ describe('/v1/utilisation-reports/reconciliation-summary/:submissionMonth', () =
     it('returns a 200 response with the correct number of associated fee records', async () => {
       // Arrange
       const reportPeriod = getCurrentReportPeriodForBankSchedule(MOCK_BANKS.BARCLAYS.utilisationReportPeriodSchedule);
-      const submissionMonth = getSubmissionMonthForReportPeriodEnd(reportPeriod.end);
+      const submissionMonth = getSubmissionMonthForReportPeriod(reportPeriod);
 
       await SqlDbHelper.deleteAllEntries('UtilisationReport');
 

--- a/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
+++ b/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
@@ -87,15 +87,15 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
   },
 
   /**
-   * Finds open reports by bank id which have report periods before
-   * the supplied report period start
+   * Finds open reports by bank id which have report periods which ended before
+   * the supplied report period end
    * @param bankId - The bank id
-   * @param reportPeriodStart - The report period start
+   * @param reportPeriodEnd - The report period end
    * @returns The found report
    */
-  async findOpenReportsBeforeReportPeriodStartForBankId(
+  async findOpenReportsForBankIdWithReportPeriodEndBefore(
     bankId: string,
-    reportPeriodStart: ReportPeriod['start'],
+    reportPeriodEnd: ReportPeriod['end'],
     includeFeeRecords = false,
   ): Promise<UtilisationReportEntity[]> {
     const bankIdAndStatusFindOptions: FindOptionsWhere<UtilisationReportEntity> = {
@@ -105,17 +105,17 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
 
     const previousYearFindOptions: FindOptionsWhere<UtilisationReportEntity> = {
       reportPeriod: {
-        start: {
-          year: LessThan(reportPeriodStart.year),
+        end: {
+          year: LessThan(reportPeriodEnd.year),
         },
       },
     };
 
     const sameYearPreviousMonthsFindOptions: FindOptionsWhere<UtilisationReportEntity> = {
       reportPeriod: {
-        start: {
-          year: Equal(reportPeriodStart.year),
-          month: LessThan(reportPeriodStart.month),
+        end: {
+          year: Equal(reportPeriodEnd.year),
+          month: LessThan(reportPeriodEnd.month),
         },
       },
     };

--- a/dtfs-central-api/src/types/utilisation-reports.ts
+++ b/dtfs-central-api/src/types/utilisation-reports.ts
@@ -32,6 +32,7 @@ export type GetUtilisationReportResponse = {
 
 export type UtilisationReportReconciliationSummaryItem = {
   reportId: number;
+  reportPeriod: ReportPeriod;
   bank: {
     id: string;
     name: string;

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.test.ts
@@ -8,11 +8,12 @@ import {
 } from '@ukef/dtfs2-common';
 
 import { UtilisationReportRepo } from '../../../../repositories/utilisation-reports-repo';
-import { getAllReportsForSubmissionMonth, getPreviousOpenReportsBySubmissionMonth } from './helpers';
+import { generateReconciliationSummaries, getAllReportsForSubmissionMonth, getPreviousOpenReportsBySubmissionMonth } from './helpers';
 import { IsoMonthStamp } from '../../../../types/date';
 import { UtilisationReportReconciliationSummary, UtilisationReportReconciliationSummaryItem } from '../../../../types/utilisation-reports';
 import { aBank } from '../../../../../test-helpers/test-data/bank';
 import { aMonthlyBankReportPeriodSchedule } from '../../../../../test-helpers/test-data/bank-report-period-schedule';
+import { getAllBanks } from '../../../../repositories/banks-repo';
 
 jest.mock('../../../../repositories/banks-repo');
 jest.mock('../../../../repositories/utilisation-reports-repo');
@@ -20,6 +21,24 @@ jest.mock('../../../../repositories/utilisation-data-repo');
 
 describe('get-utilisation-reports-reconciliation-summary.controller helper', () => {
   const getMockFeeRecordForReport = (report: UtilisationReportEntity): FeeRecordEntity => FeeRecordEntityMockBuilder.forReport(report).build();
+
+  const getOpenReportWithReportPeriod = (bank: Bank, reportPeriod: ReportPeriod): UtilisationReportEntity => {
+    const openReport = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').withBankId(bank.id).withReportPeriod(reportPeriod).build();
+    openReport.feeRecords = [getMockFeeRecordForReport(openReport)];
+    return openReport;
+  };
+
+  const getOpenMonthlyReport = ({ bank, month }: { bank: Bank; month: number }): UtilisationReportEntity =>
+    getOpenReportWithReportPeriod(bank, {
+      start: {
+        month,
+        year: 2023,
+      },
+      end: {
+        month,
+        year: 2023,
+      },
+    });
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -32,7 +51,7 @@ describe('get-utilisation-reports-reconciliation-summary.controller helper', () 
       // Arrange
       const banks: Bank[] = [aBank()];
 
-      jest.spyOn(UtilisationReportRepo, 'findOpenReportsForBankIdWithReportPeriodEndBefore').mockResolvedValue([]);
+      jest.spyOn(UtilisationReportRepo, 'findOneByBankIdAndReportPeriod').mockResolvedValue(null);
 
       const expectedError = new Error(`Failed to get report for bank with id ${banks[0].id} for submission month ${submissionMonth}`);
 
@@ -84,20 +103,26 @@ describe('get-utilisation-reports-reconciliation-summary.controller helper', () 
         }
       });
 
-      jest.spyOn(UtilisationReportRepo, 'findOpenReportsForBankIdWithReportPeriodEndBefore').mockResolvedValue([]);
-
       // Act
       const result = await getAllReportsForSubmissionMonth(banks, submissionMonth);
 
       // Assert
-      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledWith(bankIdOne, {
-        start: { month: 12, year: 2023 },
-        end: { month: 12, year: 2023 },
-      });
-      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledWith(bankIdTwo, {
-        start: { month: 10, year: 2023 },
-        end: { month: 12, year: 2023 },
-      });
+      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledWith(
+        bankIdOne,
+        {
+          start: { month: 12, year: 2023 },
+          end: { month: 12, year: 2023 },
+        },
+        true,
+      );
+      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledWith(
+        bankIdTwo,
+        {
+          start: { month: 10, year: 2023 },
+          end: { month: 12, year: 2023 },
+        },
+        true,
+      );
       expect(result).toEqual<UtilisationReportReconciliationSummary>({
         submissionMonth,
         items: [
@@ -212,24 +237,6 @@ describe('get-utilisation-reports-reconciliation-summary.controller helper', () 
       ]);
     });
 
-    const getOpenReportWithReportPeriod = (bank: Bank, reportPeriod: ReportPeriod): UtilisationReportEntity => {
-      const openReport = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').withBankId(bank.id).withReportPeriod(reportPeriod).build();
-      openReport.feeRecords = [getMockFeeRecordForReport(openReport)];
-      return openReport;
-    };
-
-    const getOpenMonthlyReport = ({ bank, month }: { bank: Bank; month: number }): UtilisationReportEntity =>
-      getOpenReportWithReportPeriod(bank, {
-        start: {
-          month,
-          year: 2023,
-        },
-        end: {
-          month,
-          year: 2023,
-        },
-      });
-
     it('orders results by submissionMonth then bank name', async () => {
       const bankA: Bank = { ...aBank(), id: 'A', name: 'Bank A', utilisationReportPeriodSchedule: aMonthlyBankReportPeriodSchedule() };
       const bankB: Bank = { ...aBank(), id: 'B', name: 'Bank B', utilisationReportPeriodSchedule: aMonthlyBankReportPeriodSchedule() };
@@ -340,8 +347,8 @@ describe('get-utilisation-reports-reconciliation-summary.controller helper', () 
       const result = await getPreviousOpenReportsBySubmissionMonth(banks, currentSubmissionMonth);
 
       // Assert
-      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankA.id, { month: 11, year: 2023 });
-      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankB.id, { month: 11, year: 2023 });
+      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankA.id, { month: 11, year: 2023 }, true);
+      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankB.id, { month: 11, year: 2023 }, true);
       expect(result).toEqual([
         // submissionMonth: '2023-12' (2023-11 report period) is the current submission month, so should not appear
         {
@@ -386,5 +393,187 @@ describe('get-utilisation-reports-reconciliation-summary.controller helper', () 
         },
       ]);
     });
+  });
+
+  describe('generateReconciliationSummaries', () => {
+    const submissionMonth: IsoMonthStamp = '2023-12';
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(submissionMonth));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("doesn't fetch reports for banks which are not visible in tfm utilisation reports", async () => {
+      // Arrange
+      const invisibleBank: Bank = { ...aBank(), isVisibleInTfmUtilisationReports: false };
+      jest.mocked(getAllBanks).mockResolvedValue([invisibleBank]);
+      const findOneReportSpy = jest.spyOn(UtilisationReportRepo, 'findOneByBankIdAndReportPeriod');
+      const findOpenReportsSpy = jest.spyOn(UtilisationReportRepo, 'findOpenReportsForBankIdWithReportPeriodEndBefore');
+
+      // Act
+      const response = await generateReconciliationSummaries(submissionMonth);
+
+      // Assert
+      expect(response).toEqual([{
+        submissionMonth,
+        items: [],
+      }]);
+      expect(findOneReportSpy).not.toHaveBeenCalled();
+      expect(findOpenReportsSpy).not.toHaveBeenCalled();
+    });
+
+    it('fetches current and open reports for all banks visible in tfm utilisation reports', async () => {
+      // Arrange
+      const bankA = aMonthlyReportingBank('1');
+      const bankB = aQuarterlyReportingBankWithDecemberEndingReportPeriod('2');
+      const bankC = aQuarterlyReportingBankWithNovemberEndingReportPeriod('3');
+
+      const banks: Bank[] = [bankB, bankA, bankC];
+      jest.mocked(getAllBanks).mockResolvedValue(banks);
+
+      const findOpenReportsForBankIdWithReportPeriodEndBeforeSpy = jest
+        .spyOn(UtilisationReportRepo, 'findOpenReportsForBankIdWithReportPeriodEndBefore')
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .mockImplementation((bankId, _) => {
+          switch (bankId) {
+            case bankA.id:
+              return Promise.resolve([
+                getOpenMonthlyReport({ bank: bankA, month: 10 }),
+                getOpenMonthlyReport({ bank: bankA, month: 9 }),
+                getOpenMonthlyReport({ bank: bankA, month: 8 }),
+              ]);
+            case bankB.id:
+              return Promise.resolve([
+                getOpenReportWithReportPeriod(bankB, { start: { month: 7, year: 2023 }, end: { month: 9, year: 2023 } }),
+                getOpenReportWithReportPeriod(bankB, { start: { month: 4, year: 2023 }, end: { month: 6, year: 2023 } }),
+              ]);
+            case bankC.id:
+              return Promise.resolve([]);
+            default:
+              throw new Error(`unexpected bankId ${bankId}`);
+          }
+        });
+
+      // eslint-disable-next-line @typescript-eslint/require-await
+      const findOneByBankIdAndReportPeriodSpy = jest.spyOn(UtilisationReportRepo, 'findOneByBankIdAndReportPeriod').mockImplementation(async (bankId) => {
+        switch (bankId) {
+          case bankA.id:
+            return getOpenMonthlyReport({ bank: bankA, month: 11 });
+          case bankC.id:
+            return getOpenReportWithReportPeriod(bankA, { start: { month: 9, year: 2023 }, end: { month: 11, year: 2023 } });
+          default:
+            return null;
+        }
+      });
+
+      // Act
+      const result = await generateReconciliationSummaries(submissionMonth);
+
+      // Assert
+      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledTimes(2);
+      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledWith(bankA.id, { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } }, true);
+      expect(findOneByBankIdAndReportPeriodSpy).toHaveBeenCalledWith(bankC.id, { start: { month: 9, year: 2023 }, end: { month: 11, year: 2023 } }, true);
+      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankA.id, { month: 11, year: 2023 }, true);
+      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankB.id, { month: 11, year: 2023 }, true);
+      expect(findOpenReportsForBankIdWithReportPeriodEndBeforeSpy).toHaveBeenCalledWith(bankC.id, { month: 11, year: 2023 }, true);
+      expect(result).toEqual([
+        {
+          submissionMonth: '2023-12', // 2023-11 ending report period
+          items: [
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
+              bank: { id: bankA.id, name: bankA.name },
+            }),
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 9, year: 2023 }, end: { month: 11, year: 2023 } },
+              bank: { id: bankC.id, name: bankC.name },
+            }),
+          ],
+        },
+        {
+          submissionMonth: '2023-11', // 2023-10 ending report period
+          items: [
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 10, year: 2023 }, end: { month: 10, year: 2023 } },
+              bank: { id: bankA.id, name: bankA.name },
+            }),
+          ],
+        },
+        {
+          submissionMonth: '2023-10', // 2023-09 ending report period
+          items: [
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 9, year: 2023 }, end: { month: 9, year: 2023 } },
+              bank: { id: bankA.id, name: bankA.name },
+            }),
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 7, year: 2023 }, end: { month: 9, year: 2023 } },
+              bank: { id: bankB.id, name: bankB.name },
+            }),
+          ],
+        },
+        {
+          submissionMonth: '2023-09', // 2023-08 ending report period
+          items: [
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 8, year: 2023 }, end: { month: 8, year: 2023 } },
+              bank: { id: bankA.id, name: bankA.name },
+            }),
+          ],
+        },
+        {
+          submissionMonth: '2023-07', // 2023-06 ending report period
+          items: [
+            expect.objectContaining<Partial<UtilisationReportReconciliationSummaryItem>>({
+              reportPeriod: { start: { month: 4, year: 2023 }, end: { month: 6, year: 2023 } },
+              bank: { id: bankB.id, name: bankB.name },
+            }),
+          ],
+        },
+      ]);
+    });
+
+    function aMonthlyReportingBank(id: string): Bank {
+      return {
+        ...aBank(),
+        id,
+        name: `Bank ${id}`,
+        isVisibleInTfmUtilisationReports: true,
+        utilisationReportPeriodSchedule: aMonthlyBankReportPeriodSchedule(),
+      };
+    }
+
+    function aQuarterlyReportingBankWithDecemberEndingReportPeriod(id: string): Bank {
+      return {
+        ...aBank(),
+        id,
+        name: `Bank ${id}`,
+        isVisibleInTfmUtilisationReports: true,
+        utilisationReportPeriodSchedule: [
+          { startMonth: 1, endMonth: 3 },
+          { startMonth: 4, endMonth: 6 },
+          { startMonth: 7, endMonth: 9 },
+          { startMonth: 10, endMonth: 12 },
+        ],
+      };
+    }
+
+    function aQuarterlyReportingBankWithNovemberEndingReportPeriod(id: string): Bank {
+      return {
+        ...aBank(),
+        id,
+        name: `Bank ${id}`,
+        isVisibleInTfmUtilisationReports: true,
+        utilisationReportPeriodSchedule: [
+          { startMonth: 12, endMonth: 2 },
+          { startMonth: 3, endMonth: 5 },
+          { startMonth: 6, endMonth: 8 },
+          { startMonth: 9, endMonth: 11 },
+        ],
+      };
+    }
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
@@ -2,9 +2,9 @@ import groupBy from 'lodash/groupBy';
 import orderBy from 'lodash/orderBy';
 import {
   getCurrentReportPeriodForBankSchedule,
-  getReportPeriodForBankScheduleBySubmissionMonth,
+  getPreviousReportPeriodForBankScheduleByMonth,
   getReportPeriodEndForSubmissionMonth,
-  getSubmissionMonthForReportPeriodEnd,
+  getSubmissionMonthForReportPeriod,
   isEqualMonthAndYear,
   Bank,
   UtilisationReportEntity,
@@ -54,7 +54,7 @@ const mapToSubmissionMonth = (reports: UtilisationReportEntity[]): UtilisationRe
   const reportsOrderedByReportPeriodEndAscending = orderBy(reports, ['reportPeriod.end.year', 'reportPeriod.end.month'], ['asc', 'asc']);
 
   return reportsOrderedByReportPeriodEndAscending.map((report) => {
-    const submissionMonth = getSubmissionMonthForReportPeriodEnd(report.reportPeriod.end);
+    const submissionMonth = getSubmissionMonthForReportPeriod(report.reportPeriod);
     return { submissionMonth, report };
   });
 };
@@ -93,7 +93,7 @@ export const getPreviousOpenReportsBySubmissionMonth = async (
 };
 
 const getCurrentReconciliationSummaryItem = async (bank: Bank, submissionMonth: IsoMonthStamp): Promise<UtilisationReportReconciliationSummaryItem> => {
-  const reportPeriod = getReportPeriodForBankScheduleBySubmissionMonth(bank.utilisationReportPeriodSchedule, submissionMonth);
+  const reportPeriod = getPreviousReportPeriodForBankScheduleByMonth(bank.utilisationReportPeriodSchedule, submissionMonth);
   const report = await UtilisationReportRepo.findOneByBankIdAndReportPeriod(bank.id, reportPeriod, true);
   if (!report) {
     throw new Error(`Failed to get report for bank with id ${bank.id} for submission month ${submissionMonth}`);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers.ts
@@ -3,8 +3,8 @@ import orderBy from 'lodash/orderBy';
 import {
   getCurrentReportPeriodForBankSchedule,
   getReportPeriodForBankScheduleBySubmissionMonth,
-  getReportPeriodStartForSubmissionMonth,
-  getSubmissionMonthForReportPeriodStart,
+  getReportPeriodEndForSubmissionMonth,
+  getSubmissionMonthForReportPeriodEnd,
   isEqualMonthAndYear,
   Bank,
   UtilisationReportEntity,
@@ -33,6 +33,7 @@ const mapReportToSummaryItem = (bank: Bank, report: UtilisationReportEntity): Ut
 
   return {
     reportId: report.id,
+    reportPeriod: report.reportPeriod,
     bank: {
       id: bank.id,
       name: bank.name,
@@ -50,20 +51,20 @@ const mapToSummaryItemForSubmissionMonth = (bank: Bank, { submissionMonth, repor
 });
 
 const mapToSubmissionMonth = (reports: UtilisationReportEntity[]): UtilisationReportForSubmissionMonth[] => {
-  const reportsOrderedByReportPeriodStartAscending = orderBy(reports, ['reportPeriod.start.year', 'reportPeriod.start.month'], ['asc', 'asc']);
+  const reportsOrderedByReportPeriodEndAscending = orderBy(reports, ['reportPeriod.end.year', 'reportPeriod.end.month'], ['asc', 'asc']);
 
-  return reportsOrderedByReportPeriodStartAscending.map((report) => {
-    const submissionMonth = getSubmissionMonthForReportPeriodStart(report.reportPeriod.start);
+  return reportsOrderedByReportPeriodEndAscending.map((report) => {
+    const submissionMonth = getSubmissionMonthForReportPeriodEnd(report.reportPeriod.end);
     return { submissionMonth, report };
   });
 };
 
 const getPreviousOpenReportsForBank = async (bank: Bank, currentSubmissionMonth: IsoMonthStamp): Promise<SummaryItemForSubmissionMonth[]> => {
-  const currentReportPeriodStart = getReportPeriodStartForSubmissionMonth(currentSubmissionMonth);
+  const currentReportPeriodEnd = getReportPeriodEndForSubmissionMonth(currentSubmissionMonth);
 
-  const openReportsBeforeCurrentReportPeriod = await UtilisationReportRepo.findOpenReportsBeforeReportPeriodStartForBankId(
+  const openReportsBeforeCurrentReportPeriod = await UtilisationReportRepo.findOpenReportsForBankIdWithReportPeriodEndBefore(
     bank.id,
-    currentReportPeriodStart,
+    currentReportPeriodEnd,
     true,
   );
 
@@ -109,7 +110,7 @@ const isBankDueToSubmitReport =
   (currentSubmissionMonth: IsoMonthStamp) =>
   (bank: Bank): boolean => {
     const currentReportPeriodForBank = getCurrentReportPeriodForBankSchedule(bank.utilisationReportPeriodSchedule);
-    return isEqualMonthAndYear(currentReportPeriodForBank.start, getReportPeriodStartForSubmissionMonth(currentSubmissionMonth));
+    return isEqualMonthAndYear(currentReportPeriodForBank.end, getReportPeriodEndForSubmissionMonth(currentSubmissionMonth));
   };
 
 export const generateReconciliationSummaries = async (currentSubmissionMonth: IsoMonthStamp): Promise<UtilisationReportReconciliationSummary[]> => {

--- a/dtfs-central-api/test-helpers/test-data/bank-report-period-schedule.ts
+++ b/dtfs-central-api/test-helpers/test-data/bank-report-period-schedule.ts
@@ -1,0 +1,16 @@
+import { BankReportPeriodSchedule } from '@ukef/dtfs2-common';
+
+export const aMonthlyBankReportPeriodSchedule = (): BankReportPeriodSchedule => [
+  { startMonth: 1, endMonth: 1 },
+  { startMonth: 2, endMonth: 2 },
+  { startMonth: 3, endMonth: 3 },
+  { startMonth: 4, endMonth: 4 },
+  { startMonth: 5, endMonth: 5 },
+  { startMonth: 6, endMonth: 6 },
+  { startMonth: 7, endMonth: 7 },
+  { startMonth: 8, endMonth: 8 },
+  { startMonth: 9, endMonth: 9 },
+  { startMonth: 10, endMonth: 10 },
+  { startMonth: 11, endMonth: 11 },
+  { startMonth: 12, endMonth: 12 },
+];

--- a/dtfs-central-api/test-helpers/test-data/bank.ts
+++ b/dtfs-central-api/test-helpers/test-data/bank.ts
@@ -1,0 +1,20 @@
+import { Bank } from '@ukef/dtfs2-common';
+import { ObjectId } from 'mongodb';
+import { aMonthlyBankReportPeriodSchedule } from './bank-report-period-schedule';
+
+export const aBank = (): Bank => ({
+  _id: new ObjectId('6597dffeb5ef5ff4267e5044'),
+  id: '956',
+  name: 'Barclays Bank',
+  mga: ['Test.pdf'],
+  emails: ['maker4@ukexportfinance.gov.uk', 'checker4@ukexportfinance.gov.uk'],
+  companiesHouseNo: '01026167',
+  partyUrn: '00300130',
+  hasGefAccessOnly: false,
+  paymentOfficerTeam: {
+    teamName: 'Barclays Payment Reporting Team',
+    emails: ['payment-officer4@ukexportfinance.gov.uk'],
+  },
+  utilisationReportPeriodSchedule: aMonthlyBankReportPeriodSchedule(),
+  isVisibleInTfmUtilisationReports: true,
+});

--- a/dtfs-central-api/tsconfig.eslint.json
+++ b/dtfs-central-api/tsconfig.eslint.json
@@ -4,7 +4,8 @@
         "src",
         "api-tests",
         "./*.jest.config.js/",
-        ".eslintrc.js"
+        ".eslintrc.js",
+        "test-helpers",
     ],
     "exclude": []
  }

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
@@ -52,11 +52,6 @@ context('PDC_READ users can route to the payments page for a bank', () => {
     cy.get(aliasSelector(allBanksAlias)).each((bank) => {
       const { id, isVisibleInTfmUtilisationReports } = bank;
 
-      // TODO FN-1601 remove after TFM is working for quarterly banks
-      if (id === '10') {
-        return;
-      }
-
       if (isVisibleInTfmUtilisationReports) {
         pages.utilisationReportsPage.tableRowSelector(id, submissionMonth).should('exist');
       } else {

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/mark-report-as-done.spec.js
@@ -44,7 +44,6 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     cy.task(NODE_TASKS.GET_ALL_BANKS).then((getAllBanksResult) => {
       getAllBanksResult
         .filter((bank) => bank.isVisibleInTfmUtilisationReports)
-        .filter((bank) => bank.id !== '10') // TODO FN-1601 remove after TFM is working for quarterly banks
         .forEach((bank) => {
           visibleBanks.push(bank);
         });

--- a/libs/common/src/utils/report-period.test.ts
+++ b/libs/common/src/utils/report-period.test.ts
@@ -4,8 +4,9 @@ import {
   getNextReportPeriodForBankSchedule,
   getFormattedReportPeriodWithLongMonth,
   getReportPeriodEndForSubmissionMonth,
-  getSubmissionMonthForReportPeriodEnd,
+  getSubmissionMonthForReportPeriod,
   getFormattedReportPeriodWithShortMonth,
+  getPreviousReportPeriodForBankScheduleByMonth,
 } from './report-period';
 import { OneIndexedMonth, BankReportPeriodSchedule, ReportPeriod } from '../types';
 
@@ -19,12 +20,42 @@ describe('report-period utils', () => {
     });
   });
 
-  describe('getSubmissionMonthForReportPeriodStart', () => {
+  describe('getSubmissionMonthForReportPeriod', () => {
     it.each([
-      { reportPeriodEnd: { month: 1, year: 2024 }, submissionMonth: '2024-02' },
-      { reportPeriodEnd: { month: 12, year: 2023 }, submissionMonth: '2024-01' },
-    ])('returns $submissionMonth when reportPeriodStart is $reportPeriodStart', ({ reportPeriodEnd, submissionMonth }) => {
-      expect(getSubmissionMonthForReportPeriodEnd(reportPeriodEnd)).toEqual(submissionMonth);
+      { reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 1, year: 2024 } }, submissionMonth: '2024-02', description: 'quarterly' },
+      { reportPeriod: { start: { month: 12, year: 2023 }, end: { month: 12, year: 2023 } }, submissionMonth: '2024-01', description: 'monthly' },
+    ])('returns month after report period end when reportPeriod is a $description period', ({ reportPeriod, submissionMonth }) => {
+      expect(getSubmissionMonthForReportPeriod(reportPeriod)).toEqual(submissionMonth);
+    });
+  });
+
+  describe('getPreviousReportPeriodForBankScheduleByMonth', () => {
+    it('gets report period for bank schedule by submission month for monthly schedule', () => {
+      // Arrange
+      const oneIndexedMonths = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+      const schedule: BankReportPeriodSchedule = oneIndexedMonths.map((month) => ({ startMonth: month, endMonth: month }));
+
+      // Act
+      const result = getPreviousReportPeriodForBankScheduleByMonth(schedule, '2024-04');
+
+      // Assert
+      expect(result).toEqual({ start: { month: 3, year: 2024 }, end: { month: 3, year: 2024 } });
+    });
+
+    it('gets report period for bank schedule by submission month for quarterly schedule', () => {
+      // Arrange
+      const schedule: BankReportPeriodSchedule = [
+        { startMonth: 12, endMonth: 2 },
+        { startMonth: 3, endMonth: 5 },
+        { startMonth: 6, endMonth: 8 },
+        { startMonth: 9, endMonth: 11 },
+      ];
+
+      // Act
+      const result = getPreviousReportPeriodForBankScheduleByMonth(schedule, '2024-03');
+
+      // Assert
+      expect(result).toEqual({ start: { month: 12, year: 2023 }, end: { month: 2, year: 2024 } });
     });
   });
 

--- a/libs/common/src/utils/report-period.test.ts
+++ b/libs/common/src/utils/report-period.test.ts
@@ -2,69 +2,28 @@ import { addMonths } from 'date-fns';
 import {
   getCurrentReportPeriodForBankSchedule,
   getNextReportPeriodForBankSchedule,
-  getPreviousReportPeriodStart,
-  getReportPeriodStartForSubmissionMonth,
-  getSubmissionMonthForReportPeriodStart,
-  isEqualReportPeriodStart,
   getFormattedReportPeriod,
+  getReportPeriodEndForSubmissionMonth,
+  getSubmissionMonthForReportPeriodEnd,
 } from './report-period';
-import { MonthAndYear, OneIndexedMonth, BankReportPeriodSchedule, ReportPeriod } from '../types';
+import { OneIndexedMonth, BankReportPeriodSchedule, ReportPeriod } from '../types';
 
 describe('report-period utils', () => {
-  describe('getReportPeriodStartForSubmissionMonth', () => {
+  describe('getReportPeriodEndForSubmissionMonth', () => {
     it.each([
-      { submissionMonth: '2024-02', reportPeriodStart: { month: 1, year: 2024 } },
-      { submissionMonth: '2024-01', reportPeriodStart: { month: 12, year: 2023 } },
-    ])('returns $reportPeriodStart when submissionMonth is $submissionMonth', ({ submissionMonth, reportPeriodStart }) => {
-      expect(getReportPeriodStartForSubmissionMonth(submissionMonth)).toEqual(reportPeriodStart);
+      { submissionMonth: '2024-02', reportPeriodEnd: { month: 1, year: 2024 } },
+      { submissionMonth: '2024-01', reportPeriodEnd: { month: 12, year: 2023 } },
+    ])('returns $reportPeriodStart when submissionMonth is $submissionMonth', ({ submissionMonth, reportPeriodEnd }) => {
+      expect(getReportPeriodEndForSubmissionMonth(submissionMonth)).toEqual(reportPeriodEnd);
     });
   });
 
   describe('getSubmissionMonthForReportPeriodStart', () => {
     it.each([
-      { reportPeriodStart: { month: 1, year: 2024 }, submissionMonth: '2024-02' },
-      { reportPeriodStart: { month: 12, year: 2023 }, submissionMonth: '2024-01' },
-    ])('returns $submissionMonth when reportPeriodStart is $reportPeriodStart', ({ reportPeriodStart, submissionMonth }) => {
-      expect(getSubmissionMonthForReportPeriodStart(reportPeriodStart)).toEqual(submissionMonth);
-    });
-  });
-
-  describe('getPreviousReportPeriodStart', () => {
-    it.each([
-      { current: { month: 2, year: 2024 }, previous: { month: 1, year: 2024 } },
-      { current: { month: 1, year: 2024 }, previous: { month: 12, year: 2023 } },
-    ])('returns $previous when the current ReportPeriodStart is $current', ({ current, previous }) => {
-      expect(getPreviousReportPeriodStart(current)).toEqual(previous);
-    });
-  });
-
-  describe('isEqualReportPeriodStart', () => {
-    it.each([
-      {
-        testCase: 'months are the same but years are different',
-        values: [
-          { month: 1, year: 2023 },
-          { month: 1, year: 2024 },
-        ],
-      },
-      {
-        testCase: 'years are the same but months are different',
-        values: [
-          { month: 1, year: 2024 },
-          { month: 2, year: 2024 },
-        ],
-      },
-    ])('returns false when $testCase', ({ values }) => {
-      expect(isEqualReportPeriodStart(values[0]!, values[1]!)).toBe(false);
-    });
-
-    it('returns true when values are equal', () => {
-      // Arrange
-      const value1: MonthAndYear = { month: 2, year: 2024 };
-      const value2: MonthAndYear = { month: 2, year: 2024 };
-
-      // Act / Assert
-      expect(isEqualReportPeriodStart(value1, value2)).toBe(true);
+      { reportPeriodEnd: { month: 1, year: 2024 }, submissionMonth: '2024-02' },
+      { reportPeriodEnd: { month: 12, year: 2023 }, submissionMonth: '2024-01' },
+    ])('returns $submissionMonth when reportPeriodStart is $reportPeriodStart', ({ reportPeriodEnd, submissionMonth }) => {
+      expect(getSubmissionMonthForReportPeriodEnd(reportPeriodEnd)).toEqual(submissionMonth);
     });
   });
 

--- a/libs/common/src/utils/report-period.ts
+++ b/libs/common/src/utils/report-period.ts
@@ -3,11 +3,11 @@ import { getOneIndexedMonth, toIsoMonthStamp, getDateFromMonthAndYear, isEqualMo
 import { IsoMonthStamp, MonthAndYear, BankReportPeriodSchedule, ReportPeriod } from '../types';
 
 /**
- * Gets the report period start for the inputted submission month
+ * Gets the report period end for the inputted submission month
  * @param submissionMonth - The submission month
- * @returns The report period start
+ * @returns The report period end
  */
-export const getReportPeriodStartForSubmissionMonth = (submissionMonth: IsoMonthStamp): MonthAndYear => {
+export const getReportPeriodEndForSubmissionMonth = (submissionMonth: IsoMonthStamp): MonthAndYear => {
   // TODO FN-1456 - calculate report period start month based on bank's report period schedule
   const reportPeriodDate = subMonths(new Date(submissionMonth), 1);
   return {
@@ -17,39 +17,15 @@ export const getReportPeriodStartForSubmissionMonth = (submissionMonth: IsoMonth
 };
 
 /**
- * Gets the submission month for the report period starting at the inputted month and year
+ * Gets the submission month for the report period ending at the inputted month and year
  * @param monthAndYear - The month and year
  * @returns The submission month
  */
-export const getSubmissionMonthForReportPeriodStart = (monthAndYear: MonthAndYear): IsoMonthStamp => {
+export const getSubmissionMonthForReportPeriodEnd = (monthAndYear: MonthAndYear): IsoMonthStamp => {
   const { month, year } = monthAndYear;
   const submissionMonthDate = addMonths(new Date(year, month - 1), 1);
   return toIsoMonthStamp(submissionMonthDate);
 };
-
-/**
- * Gets the previous report period start relative to the inputted month and year
- * @param monthAndYear - The month and year
- * @returns The previous report period start
- */
-export const getPreviousReportPeriodStart = (monthAndYear: MonthAndYear): MonthAndYear => {
-  const { month, year } = monthAndYear;
-  // TODO FN-1456 - calculate report period start month based on bank's report period schedule
-  const previousReportPeriodDate = subMonths(new Date(year, month - 1), 1);
-  return {
-    month: getOneIndexedMonth(previousReportPeriodDate),
-    year: previousReportPeriodDate.getFullYear(),
-  };
-};
-
-/**
- * Checks if the two report period starts are equal
- * @param reportPeriodStart1 - A report period start
- * @param reportPeriodStart2 - The report period start to check against
- * @returns Whether or not the report period starts are equal
- */
-export const isEqualReportPeriodStart = (reportPeriodStart1: MonthAndYear, reportPeriodStart2: MonthAndYear): boolean =>
-  reportPeriodStart1.year === reportPeriodStart2.year && reportPeriodStart1.month === reportPeriodStart2.month;
 
 /**
  * Get the current report period for the inputted bank schedule by the target date

--- a/libs/common/src/utils/report-period.ts
+++ b/libs/common/src/utils/report-period.ts
@@ -8,7 +8,6 @@ import { IsoMonthStamp, MonthAndYear, BankReportPeriodSchedule, ReportPeriod } f
  * @returns The report period end
  */
 export const getReportPeriodEndForSubmissionMonth = (submissionMonth: IsoMonthStamp): MonthAndYear => {
-  // TODO FN-1456 - calculate report period start month based on bank's report period schedule
   const reportPeriodDate = subMonths(new Date(submissionMonth), 1);
   return {
     month: getOneIndexedMonth(reportPeriodDate),

--- a/libs/common/src/utils/report-period.ts
+++ b/libs/common/src/utils/report-period.ts
@@ -20,8 +20,8 @@ export const getReportPeriodEndForSubmissionMonth = (submissionMonth: IsoMonthSt
  * @param monthAndYear - The month and year
  * @returns The submission month
  */
-export const getSubmissionMonthForReportPeriodEnd = (monthAndYear: MonthAndYear): IsoMonthStamp => {
-  const { month, year } = monthAndYear;
+export const getSubmissionMonthForReportPeriod = (reportPeriod: ReportPeriod): IsoMonthStamp => {
+  const { month, year } = reportPeriod.end;
   const submissionMonthDate = addMonths(new Date(year, month - 1), 1);
   return toIsoMonthStamp(submissionMonthDate);
 };
@@ -126,15 +126,14 @@ export const getCurrentReportPeriodForBankSchedule = (bankReportPeriodSchedule: 
 };
 
 /**
- * Gets the current report period for the inputted bank schedule for the inputted submission month
+ * Gets the most recent report period for the inputted bank schedule for the inputted submission month
  * @param bankReportPeriodSchedule - The bank report period schedule
- * @param submissionMonth - The submission month
+ * @param month - The submission month
  * @returns The report period for the submission month
  */
-export const getReportPeriodForBankScheduleBySubmissionMonth = (bankReportPeriodSchedule: BankReportPeriodSchedule, submissionMonth: IsoMonthStamp) => {
-  const submissionMonthDate = new Date(submissionMonth);
-  const previousMonthDate = subMonths(submissionMonthDate, 1);
-  return getReportPeriodForBankScheduleByTargetDate(bankReportPeriodSchedule, previousMonthDate);
+export const getPreviousReportPeriodForBankScheduleByMonth = (bankReportPeriodSchedule: BankReportPeriodSchedule, month: IsoMonthStamp) => {
+  const monthDate = new Date(month);
+  return getPreviousReportPeriodForBankScheduleByTargetDate(bankReportPeriodSchedule, monthDate);
 };
 
 const getFormattedReportPeriod = (reportPeriod: ReportPeriod, monthFormat: string, includePeriodicity: boolean): string => {

--- a/libs/common/src/utils/report-period.ts
+++ b/libs/common/src/utils/report-period.ts
@@ -138,8 +138,22 @@ export const getReportPeriodForBankScheduleBySubmissionMonth = (bankReportPeriod
   return getReportPeriodForBankScheduleByTargetDate(bankReportPeriodSchedule, previousMonthDate);
 };
 
+const getFormattedReportPeriod = (reportPeriod: ReportPeriod, monthFormat: string, includePeriodicity: boolean): string => {
+  const startOfReportPeriod = getDateFromMonthAndYear(reportPeriod.start);
+  const endOfReportPeriod = getDateFromMonthAndYear(reportPeriod.end);
+
+  const formattedEndOfPeriod = format(endOfReportPeriod, `${monthFormat} yyyy`);
+  if (isEqualMonthAndYear(reportPeriod.start, reportPeriod.end)) {
+    return includePeriodicity ? `${formattedEndOfPeriod} (monthly)` : formattedEndOfPeriod;
+  }
+
+  const formattedStartOfPeriod =
+    reportPeriod.start.year === reportPeriod.end.year ? format(startOfReportPeriod, monthFormat) : format(startOfReportPeriod, `${monthFormat} yyyy`);
+  return includePeriodicity ? `${formattedStartOfPeriod} to ${formattedEndOfPeriod} (quarterly)` : `${formattedStartOfPeriod} to ${formattedEndOfPeriod}`;
+};
+
 /**
- * Gets the formatted report period
+ * Gets the formatted report period with the month name in the long format
  * @param reportPeriod - The report period
  * @returns The formatted report period
  * @example
@@ -167,16 +181,40 @@ export const getReportPeriodForBankScheduleBySubmissionMonth = (bankReportPeriod
  * const formattedReportPeriod = getFormattedReportPeriod(reportPeriod);
  * console.log(formattedReportPeriod); // December 2023 to January 2024
  */
-export const getFormattedReportPeriod = (reportPeriod: ReportPeriod): string => {
-  const startOfReportPeriod = getDateFromMonthAndYear(reportPeriod.start);
-  const endOfReportPeriod = getDateFromMonthAndYear(reportPeriod.end);
+export const getFormattedReportPeriodWithLongMonth = (reportPeriod: ReportPeriod): string => {
+  return getFormattedReportPeriod(reportPeriod, 'MMMM', false);
+};
 
-  const formattedEndOfPeriod = format(endOfReportPeriod, 'MMMM yyyy');
-  if (isEqualMonthAndYear(reportPeriod.start, reportPeriod.end)) {
-    return formattedEndOfPeriod;
-  }
-
-  const formattedStartOfPeriod =
-    reportPeriod.start.year === reportPeriod.end.year ? format(startOfReportPeriod, 'MMMM') : format(startOfReportPeriod, 'MMMM yyyy');
-  return `${formattedStartOfPeriod} to ${formattedEndOfPeriod}`;
+/**
+ * Gets the formatted report period with the month in short format
+ * @param reportPeriod - The report period
+ * @param includePeriodicity - Whether to suffix the formatted period with the periodicity
+ * @returns The formatted report period
+ * @example
+ * const reportPeriod = {
+ *   start: { month: 1, year: 2024 },
+ *   end: { month: 1, year: 2024 },
+ * };
+ *
+ * const formattedReportPeriod = getFormattedReportPeriod(reportPeriod, true);
+ * console.log(formattedReportPeriod); // Jan 2024 (monthly)
+ * @example
+ * const reportPeriod = {
+ *   start: { month: 1, year: 2024 },
+ *   end: { month: 2, year: 2024 },
+ * };
+ *
+ * const formattedReportPeriod = getFormattedReportPeriod(reportPeriod, true);
+ * console.log(formattedReportPeriod); // Jan to Feb 2024 (quarterly)
+ * @example
+ * const reportPeriod = {
+ *   start: { month: 12, year: 2023 },
+ *   end: { month: 1, year: 2024 },
+ * };
+ *
+ * const formattedReportPeriod = getFormattedReportPeriod(reportPeriod, false);
+ * console.log(formattedReportPeriod); // Dec 2023 to Jan 2024
+ */
+export const getFormattedReportPeriodWithShortMonth = (reportPeriod: ReportPeriod, includePeriodicity: boolean): string => {
+  return getFormattedReportPeriod(reportPeriod, 'MMM', includePeriodicity);
 };

--- a/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.ts
+++ b/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.ts
@@ -5,7 +5,7 @@ import {
   ReportPeriod,
   getCurrentReportPeriodForBankSchedule,
   getOneIndexedMonth,
-  getFormattedReportPeriod,
+  getFormattedReportPeriodWithLongMonth,
 } from '@ukef/dtfs2-common';
 import externalApi from '../../external-api/api';
 import api from '../../v1/api';
@@ -57,7 +57,7 @@ export const getIsReportDue = async (bankId: string, reportPeriod: ReportPeriod)
 
   if (reportsInReportPeriod.length !== 1) {
     throw new Error(
-      `Expected to find one report for bank (id: ${bankId}) for report period ${getFormattedReportPeriod(reportPeriod)} but found ${
+      `Expected to find one report for bank (id: ${bankId}) for report period ${getFormattedReportPeriodWithLongMonth(reportPeriod)} but found ${
         reportsInReportPeriod.length
       }`,
     );
@@ -126,7 +126,7 @@ const sendEmailForBank = async (
 const sendEmailToBankIfReportNotReceived = async (bank: BankResponse, emailDescription: string, sendEmailCallback: SendEmailCallback): Promise<void> => {
   const { name: bankName, id: bankId, utilisationReportPeriodSchedule: schedule } = bank;
   const currentReportingPeriodForBank = getCurrentReportPeriodForBankSchedule(schedule);
-  const formattedReportPeriod = getFormattedReportPeriod(currentReportingPeriodForBank);
+  const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(currentReportingPeriodForBank);
 
   if (!isPreviousCalendarMonth(currentReportingPeriodForBank.end.month)) {
     console.info(

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/index.js
@@ -1,5 +1,5 @@
 const { format, startOfMonth, addMonths } = require('date-fns');
-const { getFormattedReportPeriod } = require('@ukef/dtfs2-common');
+const { getFormattedReportPeriodWithLongMonth } = require('@ukef/dtfs2-common');
 const { extractCsvData, removeCellAddressesFromArray } = require('../../../utils/csv-utils');
 const { validateCsvData } = require('./utilisation-report-validator');
 const { getUploadErrors } = require('./utilisation-report-upload-errors');
@@ -46,7 +46,7 @@ const getLastUploadedReportDetails = async (userToken, bankId) => {
   const reportAndUserDetails = getReportAndUserDetails(lastUploadedReport);
 
   const nextReportPeriod = await api.getNextReportPeriodByBankId(userToken, bankId);
-  const formattedNextReportPeriod = getFormattedReportPeriod(nextReportPeriod);
+  const formattedNextReportPeriod = getFormattedReportPeriodWithLongMonth(nextReportPeriod);
 
   const nextReportPeriodSubmissionEndDate = addMonths(new Date(nextReportPeriod.end.year, nextReportPeriod.end.month - 1), 1);
   const nextReportPeriodSubmissionStart = format(startOfMonth(nextReportPeriodSubmissionEndDate), 'd MMMM yyyy');

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.js
@@ -1,11 +1,11 @@
 const { format, parseISO } = require('date-fns');
-const { getFormattedReportPeriod } = require('@ukef/dtfs2-common');
+const { getFormattedReportPeriodWithLongMonth } = require('@ukef/dtfs2-common');
 
 /**
  * @typedef {Object} ReportAndUserDetails
  * @property {string} uploadedByFullName - The uploaded by users full name with format '{firstname} {surname}'
  * @property {string} formattedDateAndTimeUploaded - The date uploaded formatted as 'd MMMM yyyy at h:mmaaa'
- * @property {string} lastUploadedReportPeriod - The report period of the report formatted as described in {@link getFormattedReportPeriod}
+ * @property {string} lastUploadedReportPeriod - The report period of the report formatted as described in {@link getFormattedReportPeriodWithLongMonth}
  */
 
 /**
@@ -30,7 +30,7 @@ const getReportAndUserDetails = (report) => {
   const formattedTime = format(date, 'h:mmaaa');
   const formattedDateAndTimeUploaded = `${formattedDate} at ${formattedTime}`;
 
-  const lastUploadedReportPeriod = getFormattedReportPeriod(reportPeriod);
+  const lastUploadedReportPeriod = getFormattedReportPeriodWithLongMonth(reportPeriod);
 
   return {
     uploadedByFullName,

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-status.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-status.js
@@ -1,5 +1,5 @@
 const { subMonths, format, addMonths } = require('date-fns');
-const { getFormattedReportPeriod } = require('@ukef/dtfs2-common');
+const { getFormattedReportPeriodWithLongMonth } = require('@ukef/dtfs2-common');
 const { getBusinessDayOfMonth } = require('../../../helpers');
 const api = require('../../../api');
 
@@ -36,7 +36,7 @@ const getReportDueDate = async (userToken, reportPeriodEndDate = subMonths(new D
 const getDueReportPeriodsByBankId = async (userToken, bankId) => {
   const dueReportPeriods = await api.getDueReportPeriodsByBankId(userToken, bankId);
   return dueReportPeriods.map((dueReportPeriod) => {
-    const formattedReportPeriod = getFormattedReportPeriod(dueReportPeriod);
+    const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(dueReportPeriod);
     return { ...dueReportPeriod, formattedReportPeriod };
   });
 };

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-reports.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-reports.component-test.js
@@ -37,7 +37,7 @@ describe(page, () => {
   });
 
   it('should render the report period heading', async () => {
-    (await getWrapper()).expectText('[data-cy="2023-12-submission-month-report-period-heading"]').toRead(`Open reports: Nov 2023`);
+    (await getWrapper()).expectText('[data-cy="2023-12-submission-month-report-period-heading"]').toRead(`Open reports: Nov 2023 (monthly)`);
   });
 
   it('should render the report due date for the current period', async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.test.ts
@@ -1,5 +1,5 @@
 import { addDays } from 'date-fns';
-import { IsoMonthStamp, MonthAndYear } from '@ukef/dtfs2-common';
+import { IsoMonthStamp, ReportPeriod } from '@ukef/dtfs2-common';
 import { getDueDateText, getReportPeriodHeading, getReportReconciliationSummariesViewModel } from './reconciliation-summary-helper';
 import { MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS } from '../../../test-mocks/mock-utilisation-report-reconciliation-summary';
 import { UtilisationReportReconciliationSummary } from '../../../types/utilisation-reports';
@@ -50,26 +50,54 @@ describe('reconciliation-summary-helper', () => {
       // Arrange
       jest.useFakeTimers().setSystemTime(new Date('2024-01-05'));
       const submissionMonth: IsoMonthStamp = '2024-01';
-      const reportPeriodStart: MonthAndYear = { month: 12, year: 2023 };
+      const reportPeriod: ReportPeriod = { start: { month: 12, year: 2023 }, end: { month: 12, year: 2023 } };
 
       // Act
-      const result = getReportPeriodHeading(submissionMonth, reportPeriodStart);
+      const result = getReportPeriodHeading(submissionMonth, [reportPeriod]);
 
       // Assert
-      expect(result).toEqual('Current reporting period: Dec 2023');
+      expect(result).toEqual('Current reporting period: Dec 2023 (monthly)');
+    });
+
+    it('includes all report periods when submission month is this month', () => {
+      // Arrange
+      jest.useFakeTimers().setSystemTime(new Date('2024-01-05'));
+      const submissionMonth: IsoMonthStamp = '2024-01';
+      const monthlyReportPeriod: ReportPeriod = { start: { month: 12, year: 2023 }, end: { month: 12, year: 2023 } };
+      const quarterlyReportPeriod: ReportPeriod = { start: { month: 10, year: 2023 }, end: { month: 12, year: 2023 } };
+
+      // Act
+      const result = getReportPeriodHeading(submissionMonth, [monthlyReportPeriod, quarterlyReportPeriod]);
+
+      // Assert
+      expect(result).toEqual('Current reporting period: Dec 2023 (monthly) and Oct to Dec 2023 (quarterly)');
     });
 
     it("refers to 'Open reports' if the submission month is before this month", () => {
       // Arrange
       jest.useFakeTimers().setSystemTime(new Date('2024-01-05'));
       const submissionMonth: IsoMonthStamp = '2023-12';
-      const reportPeriodStart: MonthAndYear = { month: 11, year: 2023 };
+      const reportPeriod: ReportPeriod = { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } };
 
       // Act
-      const result = getReportPeriodHeading(submissionMonth, reportPeriodStart);
+      const result = getReportPeriodHeading(submissionMonth, [reportPeriod]);
 
       // Assert
-      expect(result).toEqual('Open reports: Nov 2023');
+      expect(result).toEqual('Open reports: Nov 2023 (monthly)');
+    });
+
+    it('includes all report periods when submission month is before this month', () => {
+      // Arrange
+      jest.useFakeTimers().setSystemTime(new Date('2024-01-05'));
+      const submissionMonth: IsoMonthStamp = '2024-02';
+      const monthlyReportPeriod: ReportPeriod = { start: { month: 1, year: 2024 }, end: { month: 1, year: 2024 } };
+      const quarterlyReportPeriod: ReportPeriod = { start: { month: 11, year: 2023 }, end: { month: 1, year: 2024 } };
+
+      // Act
+      const result = getReportPeriodHeading(submissionMonth, [monthlyReportPeriod, quarterlyReportPeriod]);
+
+      // Assert
+      expect(result).toEqual('Open reports: Jan 2024 (monthly) and Nov 2023 to Jan 2024 (quarterly)');
     });
   });
 
@@ -78,9 +106,13 @@ describe('reconciliation-summary-helper', () => {
       // Arrange
       const submissionMonth = '2023-12';
 
-      const reportNotReceivedSummaryItem = MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS.REPORT_NOT_RECEIVED;
+      const reportNotReceivedSummaryItem = {
+        ...MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS.REPORT_NOT_RECEIVED,
+        reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
+      };
       const pendingReconciliationSummaryItem = {
         ...MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS.PENDING_RECONCILIATION,
+        reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
         dateUploaded: '2023-12-03T15:45:00Z',
       };
       const summariesApiResponse: UtilisationReportReconciliationSummary[] = [
@@ -112,7 +144,7 @@ describe('reconciliation-summary-helper', () => {
           ],
           submissionMonth,
           reportPeriodStart: { month: 11, year: 2023 },
-          reportPeriodHeading: 'Open reports: Nov 2023',
+          reportPeriodHeading: 'Open reports: Nov 2023 (monthly)',
           dueDateText: 'Reports were due to be received by 14 December 2023.',
         },
       ];

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.test.ts
@@ -143,7 +143,6 @@ describe('reconciliation-summary-helper', () => {
             },
           ],
           submissionMonth,
-          reportPeriodStart: { month: 11, year: 2023 },
           reportPeriodHeading: 'Open reports: Nov 2023 (monthly)',
           dueDateText: 'Reports were due to be received by 14 December 2023.',
         },

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.ts
@@ -1,7 +1,7 @@
 import { endOfDay, format, isPast, isSameMonth, parseISO } from 'date-fns';
-import { IsoMonthStamp, MonthAndYear, ReportPeriod, UtilisationReportReconciliationStatus, getFormattedReportPeriodWithShortMonth } from '@ukef/dtfs2-common';
+import { IsoMonthStamp, ReportPeriod, UtilisationReportReconciliationStatus, getFormattedReportPeriodWithShortMonth } from '@ukef/dtfs2-common';
 import { UtilisationReportReconciliationSummary, UtilisationReportReconciliationSummaryItem } from '../../../types/utilisation-reports';
-import { getReportDueDate, getReportPeriodStart } from '../../../services/utilisation-report-service';
+import { getReportDueDate } from '../../../services/utilisation-report-service';
 import api from '../../../api';
 
 type SummaryItemViewModel = UtilisationReportReconciliationSummaryItem & {
@@ -13,7 +13,6 @@ type SummaryItemViewModel = UtilisationReportReconciliationSummaryItem & {
 type ReportPeriodSummaryViewModel = {
   items: SummaryItemViewModel[];
   submissionMonth: IsoMonthStamp;
-  reportPeriodStart: MonthAndYear;
   reportPeriodHeading: string;
   dueDateText: string;
 };
@@ -78,13 +77,11 @@ export const getReportReconciliationSummariesViewModel = async (
 
   return summariesApiResponse.map(({ items: apiItems, submissionMonth }) => {
     const reportDueDate = getReportDueDate(bankHolidays, submissionMonth);
-    const reportPeriodStart = getReportPeriodStart(submissionMonth);
     const distinctReportPeriods = getDistinctReportPeriodsByStartMonth(apiItems.map((item) => item.reportPeriod));
 
     return {
       items: apiItems.map(getSummaryItemViewModel),
       submissionMonth,
-      reportPeriodStart,
       reportPeriodHeading: getReportPeriodHeading(submissionMonth, distinctReportPeriods),
       dueDateText: getDueDateText(reportDueDate),
     };

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
@@ -1,4 +1,4 @@
-const { getReportDueDate, getReportPeriodStart } = require('./utilisation-report-service');
+const { getReportDueDate } = require('./utilisation-report-service');
 
 const originalProcessEnv = process.env;
 
@@ -39,15 +39,5 @@ describe('utilisation-report-service', () => {
         expect(dueDate).toEqual(expectedDueDate);
       },
     );
-  });
-
-  describe('getReportPeriodStart', () => {
-    it.each([
-      { submissionMonth: '2023-11', expectedReportPeriodStart: { month: 10, year: 2023 } },
-      { submissionMonth: '2023-03', expectedReportPeriodStart: { month: 2, year: 2023 } },
-      { submissionMonth: '2023-01', expectedReportPeriodStart: { month: 12, year: 2022 } },
-    ])("returns '$expectedReportPeriodStart' when submissionMonth is '$submissionMonth'", ({ submissionMonth, expectedReportPeriodStart }) => {
-      expect(getReportPeriodStart(submissionMonth)).toEqual(expectedReportPeriodStart);
-    });
   });
 });

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.ts
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.ts
@@ -1,6 +1,5 @@
-import { subMonths } from 'date-fns';
-import { IsoMonthStamp, MonthAndYear } from '@ukef/dtfs2-common';
-import { getBusinessDayOfMonth, getOneIndexedMonth } from '../helpers/date';
+import { IsoMonthStamp } from '@ukef/dtfs2-common';
+import { getBusinessDayOfMonth } from '../helpers/date';
 import { asString } from '../helpers/validation';
 
 export const getReportDueDate = (bankHolidays: Date[], submissionMonth: IsoMonthStamp): Date => {
@@ -11,12 +10,4 @@ export const getReportDueDate = (bankHolidays: Date[], submissionMonth: IsoMonth
   const businessDay = parseInt(businessDaysFromStartOfMonth, 10);
   const dateInReportMonth = new Date(submissionMonth);
   return getBusinessDayOfMonth(dateInReportMonth, bankHolidays, businessDay);
-};
-
-export const getReportPeriodStart = (submissionMonth: IsoMonthStamp): MonthAndYear => {
-  const reportPeriodDate = subMonths(new Date(submissionMonth), 1);
-  return {
-    month: getOneIndexedMonth(reportPeriodDate),
-    year: reportPeriodDate.getFullYear(),
-  };
 };

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.ts
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.ts
@@ -14,7 +14,6 @@ export const getReportDueDate = (bankHolidays: Date[], submissionMonth: IsoMonth
 };
 
 export const getReportPeriodStart = (submissionMonth: IsoMonthStamp): MonthAndYear => {
-  // TODO FN-1456 - calculate report period start month based on bank's report period schedule
   const reportPeriodDate = subMonths(new Date(submissionMonth), 1);
   return {
     month: getOneIndexedMonth(reportPeriodDate),

--- a/trade-finance-manager-ui/server/test-mocks/mock-utilisation-report-reconciliation-summary.ts
+++ b/trade-finance-manager-ui/server/test-mocks/mock-utilisation-report-reconciliation-summary.ts
@@ -4,6 +4,7 @@ import { UtilisationReportReconciliationSummary, UtilisationReportReconciliation
 
 export const MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS: Record<UtilisationReportReconciliationStatus, UtilisationReportReconciliationSummaryItem> = {
   REPORT_NOT_RECEIVED: {
+    reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
     reportId: '65784d376fe2fe26168990e8',
     bank: {
       id: MOCK_BANKS.BARCLAYS.id,
@@ -13,6 +14,7 @@ export const MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS: Record<Utilis
   },
   PENDING_RECONCILIATION: {
     reportId: '65784d376fe2fe26168990e7',
+    reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
     bank: {
       id: MOCK_BANKS.HSBC.id,
       name: MOCK_BANKS.HSBC.name,
@@ -24,6 +26,7 @@ export const MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS: Record<Utilis
   },
   RECONCILIATION_IN_PROGRESS: {
     reportId: '65784d402e1ea1fbb8414c0b',
+    reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
     bank: {
       id: MOCK_BANKS.NEWABLE.id,
       name: MOCK_BANKS.NEWABLE.name,
@@ -35,6 +38,7 @@ export const MOCK_UTILISATION_REPORT_RECONCILIATION_SUMMARY_ITEMS: Record<Utilis
   },
   RECONCILIATION_COMPLETED: {
     reportId: '65784d4953165930828976ae',
+    reportPeriod: { start: { month: 11, year: 2023 }, end: { month: 11, year: 2023 } },
     bank: {
       id: MOCK_BANKS.LLOYDS.id,
       name: MOCK_BANKS.LLOYDS.name,

--- a/trade-finance-manager-ui/server/types/utilisation-reports.ts
+++ b/trade-finance-manager-ui/server/types/utilisation-reports.ts
@@ -1,7 +1,8 @@
-import { UtilisationReportReconciliationStatus, IsoDateTimeStamp, IsoMonthStamp } from '@ukef/dtfs2-common';
+import { UtilisationReportReconciliationStatus, IsoDateTimeStamp, IsoMonthStamp, ReportPeriod } from '@ukef/dtfs2-common';
 
 export type UtilisationReportReconciliationSummaryItem = {
   reportId: string;
+  reportPeriod: ReportPeriod;
   bank: {
     id: string;
     name: string;


### PR DESCRIPTION
## Introduction :pencil2:
Include quarterly reports on the TFM reports page

## Resolution :heavy_check_mark:
- FN-1456: Current reporting period section contains current quarterly reports and if there are any include the quarterly report period in the heading
- FN-1412: Open reports sections contain open quarterly reports, grouped by their submission month with monthly reports, and the header details the quarterly report period if there is one

## Miscellaneous :heavy_plus_sign:
- Also closes off FN-1799, using shortened months for report period headers, this was pre-existing behaviour for the monthly report periods included in headers and has been continued to be used for the quarterly report periods in headers.