### PR TITLE
feat(FN-2559): quarterly previous reports

### DIFF
--- a/libs/common/src/utils/report-period.test.ts
+++ b/libs/common/src/utils/report-period.test.ts
@@ -273,5 +273,16 @@ describe('report-period utils', () => {
         expect(response).toEqual(expectedResponse);
       },
     );
+
+    it('should include year for start of report period contained in a single year when "alwaysStateYear" is true', () => {
+      // Arrange
+      const reportPeriod = { start: { month: 3, year: 2023 }, end: { month: 5, year: 2023 } };
+
+      // Act
+      const response = getFormattedReportPeriodWithShortMonth(reportPeriod, false, true);
+
+      // Assert
+      expect(response).toEqual('Mar 2023 to May 2023');
+    });
   });
 });

--- a/libs/common/src/utils/report-period.ts
+++ b/libs/common/src/utils/report-period.ts
@@ -136,7 +136,7 @@ export const getPreviousReportPeriodForBankScheduleByMonth = (bankReportPeriodSc
   return getPreviousReportPeriodForBankScheduleByTargetDate(bankReportPeriodSchedule, monthDate);
 };
 
-const getFormattedReportPeriod = (reportPeriod: ReportPeriod, monthFormat: string, includePeriodicity: boolean): string => {
+const getFormattedReportPeriod = (reportPeriod: ReportPeriod, monthFormat: string, includePeriodicity: boolean, alwaysStateYear = false): string => {
   const startOfReportPeriod = getDateFromMonthAndYear(reportPeriod.start);
   const endOfReportPeriod = getDateFromMonthAndYear(reportPeriod.end);
 
@@ -146,7 +146,9 @@ const getFormattedReportPeriod = (reportPeriod: ReportPeriod, monthFormat: strin
   }
 
   const formattedStartOfPeriod =
-    reportPeriod.start.year === reportPeriod.end.year ? format(startOfReportPeriod, monthFormat) : format(startOfReportPeriod, `${monthFormat} yyyy`);
+    reportPeriod.start.year === reportPeriod.end.year && !alwaysStateYear
+      ? format(startOfReportPeriod, monthFormat)
+      : format(startOfReportPeriod, `${monthFormat} yyyy`);
   return includePeriodicity ? `${formattedStartOfPeriod} to ${formattedEndOfPeriod} (quarterly)` : `${formattedStartOfPeriod} to ${formattedEndOfPeriod}`;
 };
 
@@ -187,6 +189,8 @@ export const getFormattedReportPeriodWithLongMonth = (reportPeriod: ReportPeriod
  * Gets the formatted report period with the month in short format
  * @param reportPeriod - The report period
  * @param includePeriodicity - Whether to suffix the formatted period with the periodicity
+ * @param alwaysStateYear (optional - defaults to false) - Whether to state the year for the
+ * start of the report period when the period spans only a single year
  * @returns The formatted report period
  * @example
  * const reportPeriod = {
@@ -206,6 +210,14 @@ export const getFormattedReportPeriodWithLongMonth = (reportPeriod: ReportPeriod
  * console.log(formattedReportPeriod); // Jan to Feb 2024 (quarterly)
  * @example
  * const reportPeriod = {
+ *   start: { month: 10, year: 2023 },
+ *   end: { month: 12, year: 2023 },
+ * };
+ *
+ * const formattedReportPeriod = getFormattedReportPeriod(reportPeriod, false, true);
+ * console.log(formattedReportPeriod); // Oct 2023 to Dec 2023
+ * @example
+ * const reportPeriod = {
  *   start: { month: 12, year: 2023 },
  *   end: { month: 1, year: 2024 },
  * };
@@ -213,6 +225,6 @@ export const getFormattedReportPeriodWithLongMonth = (reportPeriod: ReportPeriod
  * const formattedReportPeriod = getFormattedReportPeriod(reportPeriod, false);
  * console.log(formattedReportPeriod); // Dec 2023 to Jan 2024
  */
-export const getFormattedReportPeriodWithShortMonth = (reportPeriod: ReportPeriod, includePeriodicity: boolean): string => {
-  return getFormattedReportPeriod(reportPeriod, 'MMM', includePeriodicity);
+export const getFormattedReportPeriodWithShortMonth = (reportPeriod: ReportPeriod, includePeriodicity: boolean, alwaysStateYear = false): string => {
+  return getFormattedReportPeriod(reportPeriod, 'MMM', includePeriodicity, alwaysStateYear);
 };

--- a/portal-api/src/v1/controllers/utilisation-report-service/previous-reports.controller.test.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/previous-reports.controller.test.js
@@ -1,4 +1,4 @@
-const { getYears, groupReportsByStartYear, populateOmittedYears, groupAndSortReports } = require('./previous-reports.controller');
+const { getYears, groupReportsByYear, populateOmittedYears, groupAndSortReports } = require('./previous-reports.controller');
 
 describe('controllers/utilisation-report-service/previous-reports', () => {
   const azureFileInfo = {
@@ -52,27 +52,11 @@ describe('controllers/utilisation-report-service/previous-reports', () => {
       bankId: '9',
       reportPeriod: {
         start: {
-          month: 1,
-          year: 2023,
-        },
-        end: {
-          month: 1,
-          year: 2023,
-        },
-      },
-      dateUploaded: '2023-02-01T00:00',
-      azureFileInfo,
-      uploadedById: '1',
-    },
-    {
-      bankId: '9',
-      reportPeriod: {
-        start: {
           month: 2,
           year: 2023,
         },
         end: {
-          month: 2,
+          month: 4,
           year: 2023,
         },
       },
@@ -82,21 +66,38 @@ describe('controllers/utilisation-report-service/previous-reports', () => {
     },
   ];
 
-  const reports = [...year2020Reports, ...year2022Reports, ...year2023Reports];
+  const reportSpanning2022and2023 = {
+    bankId: '9',
+    reportPeriod: {
+      start: {
+        month: 11,
+        year: 2022,
+      },
+      end: {
+        month: 1,
+        year: 2023,
+      },
+    },
+    dateUploaded: '2023-02-01T00:00',
+    azureFileInfo,
+    uploadedById: '1',
+  };
+
+  const reports = [...year2020Reports, ...year2022Reports, ...year2023Reports, reportSpanning2022and2023];
 
   const years = [2020, 2022, 2023];
 
   const groupedReports = [
     { year: 2020, reports: year2020Reports },
-    { year: 2022, reports: year2022Reports },
-    { year: 2023, reports: year2023Reports },
+    { year: 2022, reports: [...year2022Reports, reportSpanning2022and2023] },
+    { year: 2023, reports: [...year2023Reports, reportSpanning2022and2023] },
   ];
 
   const groupedReportsWithOmittedYears = [...groupedReports, { year: 2021, reports: [] }];
 
   const sortedReportsByDescendingYear = [
-    { year: 2023, reports: year2023Reports },
-    { year: 2022, reports: year2022Reports },
+    { year: 2023, reports: [...year2023Reports, reportSpanning2022and2023] },
+    { year: 2022, reports: [...year2022Reports, reportSpanning2022and2023] },
     { year: 2021, reports: [] },
     { year: 2020, reports: year2020Reports },
   ];
@@ -109,9 +110,9 @@ describe('controllers/utilisation-report-service/previous-reports', () => {
     });
   });
 
-  describe('getReportsGroupedByYear', () => {
+  describe('groupReportsByYear', () => {
     it('should return list of reports grouped by year', () => {
-      const groupedListOfReports = groupReportsByStartYear(years, reports);
+      const groupedListOfReports = groupReportsByYear(years, reports);
 
       expect(groupedListOfReports).toEqual(groupedReports);
     });
@@ -119,7 +120,7 @@ describe('controllers/utilisation-report-service/previous-reports', () => {
 
   describe('populateOmittedYears', () => {
     it('should return grouped reports with omitted years populated at the end of the array', () => {
-      const groupedListOfReports = groupReportsByStartYear(years, reports);
+      const groupedListOfReports = groupReportsByYear(years, reports);
       const reportsGroupedByYear = populateOmittedYears(groupedListOfReports, years);
 
       expect(reportsGroupedByYear).toEqual(groupedReportsWithOmittedYears);

--- a/portal/component-tests/utilisation-report-service/previous-reports.component-test.js
+++ b/portal/component-tests/utilisation-report-service/previous-reports.component-test.js
@@ -28,15 +28,19 @@ describe(page, () => {
   }];
 
   const reportLinks = [{
+    text: 'January 2023',
     month: 'January',
     path: 'www.abc.com',
   }, {
+    text: 'February 2023',
     month: 'February',
     path: 'www.abc.com',
   }, {
+    text: 'March 2023',
     month: 'March',
     path: 'www.abc.com',
   }, {
+    text: 'May 2023',
     month: 'May',
     path: 'www.abc.com',
   }];

--- a/portal/server/controllers/utilisation-report-service/previous-reports/index.ts
+++ b/portal/server/controllers/utilisation-report-service/previous-reports/index.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
-import api from '../../../api';
+import { getFormattedReportPeriodWithLongMonth, getFormattedReportPeriodWithShortMonth, isEqualMonthAndYear } from '@ukef/dtfs2-common';
 import { getMonthName } from '../../../helpers/getMonthName';
+import api from '../../../api';
 import { PRIMARY_NAV_KEY } from '../../../constants';
 import { asLoggedInUserSession } from '../../../helpers/express-session';
 
@@ -40,7 +41,10 @@ export const getPreviousReports = async (req: GetPreviousReportsRequest, res: Re
     const previousReportsInTargetYear = activeYearIndex === -1 ? previousReportsByBank[0] : previousReportsByBank[activeYearIndex];
 
     const reportLinks = previousReportsInTargetYear.reports.map(({ reportPeriod, id }) => ({
-      month: getMonthName(reportPeriod.start.month),
+      month: getMonthName(reportPeriod.end.month),
+      text: isEqualMonthAndYear(reportPeriod.start, reportPeriod.end)
+        ? getFormattedReportPeriodWithLongMonth(reportPeriod)
+        : getFormattedReportPeriodWithShortMonth(reportPeriod, true, true),
       path: `/banks/${bankId}/utilisation-report-download/${id}`,
     }));
 

--- a/portal/templates/utilisation-report-service/previous-reports/previous-reports.njk
+++ b/portal/templates/utilisation-report-service/previous-reports/previous-reports.njk
@@ -34,9 +34,9 @@
                                   class="govuk-link"
                                   href="{{ reportLink.path }}"
                                   data-cy="list-item-link-{{ reportLink.month }}"
-                                  aria-label="{{ reportLink.month }} {{ year }} GEF report"
+                                  aria-label="{{ reportLink.text }} GEF report"
                                 >
-                                    {{ reportLink.month }} {{ year }} GEF report
+                                    {{ reportLink.text }} GEF report
                                 </a>
                             </li>
                         {% endfor %}


### PR DESCRIPTION
## Introduction :pencil2:
Display previous quarterly reports to portal users.

## Resolution :heavy_check_mark:
- Display quarterly reports in the tabs for all years they span on the portal previous reports page
- Include the formatted period in the link text for quarterly reports and the fact it is quarterly

