### PR TITLE
fix(DTFS2-7105): consistent ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,19 @@
+# Root
+node_modules/
+dist/
+build/
+public/
 generated_reports/
+coverage/
+package*.json
+.cache
+
+# Sub-directories
+**/node_modules/
+**/dist/
+**/build/
+**/public/
+**/generated_reports/
+**/coverage/
+**/package*.json
+**/.cache

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,19 @@
+# Root
+node_modules/
 dist/
-.cache/
+build/
+public/
+generated_reports/
+coverage/
+package*.json
+.cache
+
+# Sub-directories
+**/node_modules/
+**/dist/
+**/build/
+**/public/
+**/generated_reports/
 **/coverage/
-**/node_modules/**
-/node_modules
-/package-lock.json
+**/package*.json
+**/.cache

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,7 +13,7 @@ package*.json
 **/dist/
 **/build/
 **/public/
-**/generated_reports/
+**/**/**/generated_reports/
 **/coverage/
 **/package*.json
 **/.cache

--- a/azure-functions/acbs-function/.eslintignore
+++ b/azure-functions/acbs-function/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-public

--- a/azure-functions/acbs-function/api-test.jest.config.js
+++ b/azure-functions/acbs-function/api-test.jest.config.js
@@ -2,7 +2,7 @@ const commonSettings = require('./api-test-common.jest.config');
 
 module.exports = {
   collectCoverageFrom: ['acbs*/*.{js,}', 'activity*/*.{js,}', 'helpers/**/*.{js,}', 'mappings/**/*.{js,}'],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.js'],
   ...commonSettings,
 };

--- a/azure-functions/acbs-function/unit.jest.config.js
+++ b/azure-functions/acbs-function/unit.jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   collectCoverageFrom: ['./**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}'],
 };

--- a/dtfs-central-api/api-test.jest.config.js
+++ b/dtfs-central-api/api-test.jest.config.js
@@ -2,7 +2,7 @@ const commonSettings = require('./api-test-common.jest.config');
 
 module.exports = {
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.{js,ts}'],
   ...commonSettings,
 };

--- a/dtfs-central-api/unit.jest.config.js
+++ b/dtfs-central-api/unit.jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}'],
 };

--- a/external-api/.eslintignore
+++ b/external-api/.eslintignore
@@ -1,5 +1,0 @@
-node_modules
-node_modules/
-dist
-.eslintrc.js
-generated_reports/

--- a/external-api/.prettierignore
+++ b/external-api/.prettierignore
@@ -1,6 +1,0 @@
-dist/
-.cache/
-**/coverage/
-**/node_modules/**
-/node_modules
-/package-lock.json

--- a/external-api/api-test.jest.config.js
+++ b/external-api/api-test.jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,}'],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',

--- a/external-api/unit.jest.config.js
+++ b/external-api/unit.jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.ts'],
   preset: 'ts-jest',
 };

--- a/gef-ui/.eslintignore
+++ b/gef-ui/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-public/*

--- a/gef-ui/api-test.jest.config.js
+++ b/gef-ui/api-test.jest.config.js
@@ -1,12 +1,7 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
-  collectCoverageFrom: [
-    'server/controllers/**/*.{js,}',
-    'server/routes/**/*.{js,}',
-    'server/helpers/*.{js,}',
-    'scripts/**/*.{js,}',
-  ],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  collectCoverageFrom: ['server/controllers/**/*.{js,}', 'server/routes/**/*.{js,}', 'server/helpers/*.{js,}', 'scripts/**/*.{js,}'],
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.js'],
   moduleNameMapper: {
     '^.+\\.(css|less|scss)$': 'babel-jest',

--- a/gef-ui/unit.jest.config.js
+++ b/gef-ui/unit.jest.config.js
@@ -1,12 +1,7 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-babel',
-  collectCoverageFrom: [
-    'server/routes/**/*.{js,}',
-    'server/controllers/**/*.{js,}',
-    'server/services/**/*.{js,}',
-    'server/utils/**/*.{js,}',
-  ],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  collectCoverageFrom: ['server/routes/**/*.{js,}', 'server/controllers/**/*.{js,}', 'server/services/**/*.{js,}', 'server/utils/**/*.{js,}'],
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.js', '**/*.component-test.js'],
   moduleNameMapper: {
     '^.+\\.(css|less|scss)$': 'babel-jest',

--- a/libs/common/unit.jest.config.js
+++ b/libs/common/unit.jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}'],
 };

--- a/package.json
+++ b/package.json
@@ -34,22 +34,24 @@
     "install:all": "npm install --if-present",
     "lint:all": "npm run lint --workspaces --if-present",
     "lint:fix:all": "npm run lint --fix --workspaces --if-present",
-    "type:all": "npm run type-check --workspaces --if-present",
+    "load": "node utils/mock-data-loader/re-insert-mocks.js",
     "prettier:all": "npm run prettier --workspaces --if-present",
     "prettier:fix:all": "npm run prettier:fix --workspaces --if-present",
-    "load": "node utils/mock-data-loader/re-insert-mocks.js",
     "spellcheck": "cspell lint --gitignore --no-must-find-files --unique --no-progress --show-suggestions --color '**/*'",
     "start": "docker compose up --build",
     "start:detach": "npm run dev -- --detach",
     "stop": "docker compose down",
     "type-check:all": "npm run type-check --workspaces --if-present",
+    "type:all": "npm run type-check --workspaces --if-present",
     "update:all": "npm update --save --if-present"
   },
   "lint-staged": {
     "**/package.json": "sort-package-json",
     "**/*.{js,ts}": [
       "eslint --fix",
-      "prettier --write",
+      "prettier --write"
+    ],
+    "**/*.ts": [
       "tsc --noEmit"
     ],
     "**/*": [

--- a/portal-api/.prettierignore
+++ b/portal-api/.prettierignore
@@ -1,6 +1,0 @@
-dist/
-.cache/
-**/coverage/
-**/node_modules/**
-/node_modules
-/package-lock.json

--- a/portal-api/api-test.jest.config.js
+++ b/portal-api/api-test.jest.config.js
@@ -3,7 +3,7 @@ const commonConfig = require('./jest.common.config');
 module.exports = {
   ...commonConfig,
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.{js,ts}'],
   setupFilesAfterEnv: ['./api-test-setup.jest.config.js'],
   testTimeout: 5000,

--- a/portal-api/unit.jest.config.js
+++ b/portal-api/unit.jest.config.js
@@ -3,6 +3,6 @@ const commonConfig = require('./jest.common.config');
 module.exports = {
   ...commonConfig,
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}'],
 };

--- a/portal/.eslintignore
+++ b/portal/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-public/*

--- a/portal/api-test.jest.config.js
+++ b/portal/api-test.jest.config.js
@@ -2,13 +2,8 @@ const commonSettings = require('./jest.common.config');
 
 module.exports = {
   ...commonSettings,
-  collectCoverageFrom: [
-    'server/controllers/**/*.{js,ts}',
-    'server/routes/**/*.{js,ts}',
-    'server/helpers/**/*.{js,ts}',
-    'scripts/**/*.{js,ts}',
-  ],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  collectCoverageFrom: ['server/controllers/**/*.{js,ts}', 'server/routes/**/*.{js,ts}', 'server/helpers/**/*.{js,ts}', 'scripts/**/*.{js,ts}'],
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.{js,ts}'],
   moduleNameMapper: {
     '^.+\\.(css|less|scss)$': 'babel-jest',

--- a/portal/unit.jest.config.js
+++ b/portal/unit.jest.config.js
@@ -3,7 +3,7 @@ const commonSettings = require('./jest.common.config');
 module.exports = {
   ...commonSettings,
   collectCoverageFrom: ['server/controllers/**/*.{js,ts}', 'server/routes/**/*.{js,ts}', 'server/helpers/**/*.{js,ts}', 'scripts/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}', '**/*.component-test.{js,ts}'],
   testEnvironment: 'jsdom',
 };

--- a/trade-finance-manager-api/api-test.jest.config.js
+++ b/trade-finance-manager-api/api-test.jest.config.js
@@ -3,7 +3,7 @@ const commonSettings = require('./jest.common.config');
 module.exports = {
   ...commonSettings,
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.{js,ts}'],
   setupFilesAfterEnv: ['./api-test-setup.jest.config.js'],
 };

--- a/trade-finance-manager-api/unit.jest.config.js
+++ b/trade-finance-manager-api/unit.jest.config.js
@@ -3,6 +3,6 @@ const commonSettings = require('./jest.common.config');
 module.exports = {
   ...commonSettings,
   collectCoverageFrom: ['src/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}'],
 };

--- a/trade-finance-manager-ui/.eslintignore
+++ b/trade-finance-manager-ui/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-public/*

--- a/trade-finance-manager-ui/api-test.jest.config.js
+++ b/trade-finance-manager-ui/api-test.jest.config.js
@@ -2,11 +2,8 @@ const commonConfig = require('./jest.common.config');
 
 module.exports = {
   ...commonConfig,
-  collectCoverageFrom: [
-    'server/**/*.{js,ts}',
-    'scripts/**/*.{js,ts}',
-  ],
-  coverageDirectory: 'generated_reports/coverage/api-test',
+  collectCoverageFrom: ['server/**/*.{js,ts}', 'scripts/**/*.{js,ts}'],
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.api-test.{js,ts}'],
   modulePathIgnorePatterns: ['prototype'],
   testTimeout: 80000,

--- a/trade-finance-manager-ui/unit.jest.config.js
+++ b/trade-finance-manager-ui/unit.jest.config.js
@@ -3,7 +3,7 @@ const commonConfig = require('./jest.common.config');
 module.exports = {
   ...commonConfig,
   collectCoverageFrom: ['server/**/*.{js,ts}', 'scripts/**/*.{js,ts}'],
-  coverageDirectory: 'generated_reports/coverage/unit',
+  coverageReporters: ['text', 'text-summary'],
   testMatch: ['**/*.test.{js,ts}', '**/*.component-test.{js,ts}'],
   modulePathIgnorePatterns: ['prototype'],
 };

--- a/utils/reporting/tfm/.eslintignore
+++ b/utils/reporting/tfm/.eslintignore
@@ -1,2 +1,0 @@
-node_modules
-public


### PR DESCRIPTION
## Introduction :pencil2:
Ensure consistent `.*ignore` files content

## Resolution :heavy_check_mark:
* Single root `.prettierignore` and `.eslintignore` files.
* Removed micro-service specific files, since they will not be required during build process.

## Miscellaneous :heavy_plus_sign:
* Disabled Jest generated reports as per https://github.com/jthodge/til/blob/main/javascript/disable-jests-auto-generated-coverage-reports.md guide.
* `tsc --noEmit` to be executed on `*.ts` staged files only.
* Few lint fixes.

