### PR TITLE
feat(DTFS2-7120): add audit logs to gef routes of portal api

### DIFF
--- a/portal-api/api-tests/v1/gef/application-submit.api-test.js
+++ b/portal-api/api-tests/v1/gef/application-submit.api-test.js
@@ -119,7 +119,7 @@ describe('submissionPortalActivity()', () => {
 
     const res = await as(aMaker).post(req.body).to(baseUrl);
 
-    await updateFacility(res.body.details._id, mockFacilities[4], aMaker);
+    await updateFacility(res.body.details._id, mockFacilities[4], generatePortalAuditDetails(aMaker._id));
 
     const result = await submissionPortalActivity(MOCK_APPLICATION_FACILITIES);
 
@@ -156,7 +156,7 @@ describe('submissionPortalActivity()', () => {
 
     const res = await as(aMaker).post(req.body).to(baseUrl);
 
-    await updateFacility(res.body.details._id, mockFacilities[4], aMaker);
+    await updateFacility(res.body.details._id, mockFacilities[4], generatePortalAuditDetails(aMaker._id));
 
     const result = await submissionPortalActivity(MOCK_APPLICATION_FACILITIES);
 
@@ -406,7 +406,7 @@ describe('addSubmissionDateToIssuedFacilities()', () => {
         shouldCoverStartOnSubmission: true,
         hasBeenIssuedAndAcknowledged: null
       },
-      aMaker,
+      generatePortalAuditDetails(aMaker._id),
     );
 
     await addSubmissionDateToIssuedFacilities(mockApplication.body._id, generatePortalAuditDetails(aMaker._id));
@@ -448,7 +448,7 @@ describe('addSubmissionDateToIssuedFacilities()', () => {
         shouldCoverStartOnSubmission: true,
         hasBeenIssuedAndAcknowledged: true,
       },
-      aMaker,
+      generatePortalAuditDetails(aMaker._id),
     );
 
     await addSubmissionDateToIssuedFacilities(mockApplication.body._id, generatePortalAuditDetails(aMaker._id));

--- a/portal-api/api-tests/v1/gef/application-submit.api-test.js
+++ b/portal-api/api-tests/v1/gef/application-submit.api-test.js
@@ -118,7 +118,7 @@ describe('submissionPortalActivity()', () => {
 
     const res = await as(aMaker).post(req.body).to(baseUrl);
 
-    await updateFacility(res.body.details._id, mockFacilities[4]);
+    await updateFacility(res.body.details._id, mockFacilities[4], aMaker);
 
     const result = await submissionPortalActivity(MOCK_APPLICATION_FACILITIES);
 
@@ -155,7 +155,7 @@ describe('submissionPortalActivity()', () => {
 
     const res = await as(aMaker).post(req.body).to(baseUrl);
 
-    await updateFacility(res.body.details._id, mockFacilities[4]);
+    await updateFacility(res.body.details._id, mockFacilities[4], aMaker);
 
     const result = await submissionPortalActivity(MOCK_APPLICATION_FACILITIES);
 
@@ -231,7 +231,7 @@ describe('updateChangedToIssued()', () => {
 
     const { body } = await as(aChecker).get(baseUrl, mockQuery);
     // changes to false to test
-    await updateChangedToIssued(body.items[0].dealId);
+    await updateChangedToIssued(body.items[0].dealId, aMaker);
   });
 
   it('changes canResubmitIssuedFacilities to false', async () => {
@@ -265,7 +265,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
   });
 
   it('Should return false and set `coverDateConfirmed` to false with following conditions:\n\n1. AIN\n2. Have one unissued facility and cover date is not true \n3. Not yet submitted to UKEF', async () => {
@@ -285,7 +285,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body)).toEqual(false);
+    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(false);
   });
 
   it('Should return true and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one issued facility \n3. Not yet submitted to UKEF', async () => {
@@ -305,7 +305,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
   });
 
   it('Should return false and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one unissued facility \n3. Not yet submitted to UKEF', async () => {
@@ -325,7 +325,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body)).toEqual(false);
+    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(false);
   });
 
   it('Should return true and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one issued facility with cover date set to true \n3. Not yet submitted to UKEF', async () => {
@@ -345,7 +345,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: true,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
   });
 
   it('Should return true and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one issued and unissued facilities with cover date set to true \n3. Not yet submitted to UKEF', async () => {
@@ -372,7 +372,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: true,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
   });
 });
 
@@ -398,13 +398,17 @@ describe('addSubmissionDateToIssuedFacilities()', () => {
     const facility = await getAllFacilitiesByDealId(mockApplication.body._id);
 
     // updates facility and sets flags
-    await updateFacility(facility[0]._id, {
-      hasBeenIssued: true,
-      shouldCoverStartOnSubmission: true,
-      hasBeenIssuedAndAcknowledged: null
-    });
+    await updateFacility(
+      facility[0]._id,
+      {
+        hasBeenIssued: true,
+        shouldCoverStartOnSubmission: true,
+        hasBeenIssuedAndAcknowledged: null
+      },
+      aMaker,
+    );
 
-    await addSubmissionDateToIssuedFacilities(mockApplication.body._id);
+    await addSubmissionDateToIssuedFacilities(mockApplication.body._id, aMaker);
 
     // gets facilities from collection
     const updatedFacility = await getAllFacilitiesByDealId(mockApplication.body._id);
@@ -436,13 +440,17 @@ describe('addSubmissionDateToIssuedFacilities()', () => {
     const facility = await getAllFacilitiesByDealId(mockApplication.body._id);
 
     // sets both flags to true
-    await updateFacility(facility[0]._id, {
-      hasBeenIssued: true,
-      shouldCoverStartOnSubmission: true,
-      hasBeenIssuedAndAcknowledged: true,
-    });
+    await updateFacility(
+      facility[0]._id,
+      {
+        hasBeenIssued: true,
+        shouldCoverStartOnSubmission: true,
+        hasBeenIssuedAndAcknowledged: true,
+      },
+      aMaker,
+    );
 
-    await addSubmissionDateToIssuedFacilities(mockApplication.body._id);
+    await addSubmissionDateToIssuedFacilities(mockApplication.body._id, aMaker);
 
     // gets facilities from collection
     const updatedFacility = await getAllFacilitiesByDealId(mockApplication.body._id);

--- a/portal-api/api-tests/v1/gef/application-submit.api-test.js
+++ b/portal-api/api-tests/v1/gef/application-submit.api-test.js
@@ -1,4 +1,5 @@
 const { format, fromUnixTime } = require('date-fns');
+const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details');
 const db = require('../../../src/drivers/db-client');
 const { FACILITY_TYPE } = require('../../../src/v1/gef/enums');
 const { DB_COLLECTIONS } = require('../../fixtures/constants');
@@ -231,7 +232,7 @@ describe('updateChangedToIssued()', () => {
 
     const { body } = await as(aChecker).get(baseUrl, mockQuery);
     // changes to false to test
-    await updateChangedToIssued(body.items[0].dealId, aMaker);
+    await updateChangedToIssued(body.items[0].dealId, generatePortalAuditDetails(aMaker._id));
   });
 
   it('changes canResubmitIssuedFacilities to false', async () => {
@@ -265,7 +266,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, generatePortalAuditDetails(aMaker._id))).toEqual(true);
   });
 
   it('Should return false and set `coverDateConfirmed` to false with following conditions:\n\n1. AIN\n2. Have one unissued facility and cover date is not true \n3. Not yet submitted to UKEF', async () => {
@@ -285,7 +286,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(false);
+    expect(await checkCoverDateConfirmed(mockApplication.body, generatePortalAuditDetails(aMaker._id))).toEqual(false);
   });
 
   it('Should return true and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one issued facility \n3. Not yet submitted to UKEF', async () => {
@@ -305,7 +306,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, generatePortalAuditDetails(aMaker._id))).toEqual(true);
   });
 
   it('Should return false and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one unissued facility \n3. Not yet submitted to UKEF', async () => {
@@ -325,7 +326,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: null,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(false);
+    expect(await checkCoverDateConfirmed(mockApplication.body, generatePortalAuditDetails(aMaker._id))).toEqual(false);
   });
 
   it('Should return true and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one issued facility with cover date set to true \n3. Not yet submitted to UKEF', async () => {
@@ -345,7 +346,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: true,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, generatePortalAuditDetails(aMaker._id))).toEqual(true);
   });
 
   it('Should return true and set `coverDateConfirmed` to false with following conditions:\n\n1. MIA\n2. Have one issued and unissued facilities with cover date set to true \n3. Not yet submitted to UKEF', async () => {
@@ -372,7 +373,7 @@ describe('checkCoverDateConfirmed()', () => {
       coverDateConfirmed: true,
     }).to(baseUrl);
 
-    expect(await checkCoverDateConfirmed(mockApplication.body, aMaker)).toEqual(true);
+    expect(await checkCoverDateConfirmed(mockApplication.body, generatePortalAuditDetails(aMaker._id))).toEqual(true);
   });
 });
 
@@ -408,7 +409,7 @@ describe('addSubmissionDateToIssuedFacilities()', () => {
       aMaker,
     );
 
-    await addSubmissionDateToIssuedFacilities(mockApplication.body._id, aMaker);
+    await addSubmissionDateToIssuedFacilities(mockApplication.body._id, generatePortalAuditDetails(aMaker._id));
 
     // gets facilities from collection
     const updatedFacility = await getAllFacilitiesByDealId(mockApplication.body._id);
@@ -450,7 +451,7 @@ describe('addSubmissionDateToIssuedFacilities()', () => {
       aMaker,
     );
 
-    await addSubmissionDateToIssuedFacilities(mockApplication.body._id, aMaker);
+    await addSubmissionDateToIssuedFacilities(mockApplication.body._id, generatePortalAuditDetails(aMaker._id));
 
     // gets facilities from collection
     const updatedFacility = await getAllFacilitiesByDealId(mockApplication.body._id);

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -1,4 +1,5 @@
 const { format, fromUnixTime } = require('date-fns');
+const { generateParsedMockPortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/test-helpers/generate-mock-audit-database-record');
 const databaseHelper = require('../../database-helper');
 
 const app = require('../../../src/createApp');
@@ -139,6 +140,7 @@ describe(baseUrl, () => {
           ukefDealId: null,
           checkerId: null,
           portalActivities: [],
+          auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aMaker._id)
         })),
       };
 
@@ -205,6 +207,7 @@ describe(baseUrl, () => {
         ukefDealId: null,
         checkerId: null,
         portalActivities: [],
+        auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aMaker._id)
       };
       expect(body).toEqual(expectMongoId(expected));
     });
@@ -296,6 +299,7 @@ describe(baseUrl, () => {
           status: expect.any(String),
           updatedAt: expect.any(Number),
         },
+        auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aMaker._id),
       });
 
       expect(body.maker.token).toBeUndefined();

--- a/portal-api/api-tests/v1/gef/application.api-test.js
+++ b/portal-api/api-tests/v1/gef/application.api-test.js
@@ -40,6 +40,11 @@ const mockSuccessfulResponse = {
   },
 };
 
+const expectedEligibilityCriteriaAuditRecord = {
+  ...generateParsedMockPortalUserAuditDatabaseRecord('abcdef123456abcdef123456'),
+  lastUpdatedByPortalUserId: expect.any(String),
+}
+
 jest.mock('../../../src/external-api/api', () => ({
   sendEmail: jest.fn(() => Promise.resolve({})),
   number: {
@@ -127,6 +132,7 @@ describe(baseUrl, () => {
               ...criterion,
               answer: null,
             })),
+            auditRecord: expectedEligibilityCriteriaAuditRecord,
           },
           editedBy: expect.any(Array),
           createdAt: expect.any(Number),
@@ -192,6 +198,7 @@ describe(baseUrl, () => {
             answer: null,
           })),
           status: CONSTANTS.DEAL.DEAL_STATUS.NOT_STARTED,
+          auditRecord: expectedEligibilityCriteriaAuditRecord,
         },
         status: CONSTANTS.DEAL.DEAL_STATUS.DRAFT,
         editedBy: expect.any(Array),
@@ -290,6 +297,7 @@ describe(baseUrl, () => {
             ...criterion,
             answer: null,
           })),
+          auditRecord: expectedEligibilityCriteriaAuditRecord,
         },
       };
       expect(body).toEqual({

--- a/portal-api/api-tests/v1/gef/eligibility-criteria.api-test.js
+++ b/portal-api/api-tests/v1/gef/eligibility-criteria.api-test.js
@@ -1,3 +1,4 @@
+const { generateParsedMockPortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/test-helpers/generate-mock-audit-database-record');
 const databaseHelper = require('../../database-helper');
 
 const app = require('../../../src/createApp');
@@ -105,6 +106,7 @@ describe(baseUrl, () => {
         isInDraft: expect.any(Boolean),
         createdAt: expect.any(Number),
         criteria: expect.any(Array),
+        auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(anAdmin._id),
       };
       expect(body).toEqual(expected);
     });

--- a/portal-api/api-tests/v1/gef/facilities.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities.api-test.js
@@ -1,3 +1,4 @@
+const { generateParsedMockPortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/test-helpers/generate-mock-audit-database-record')
 const databaseHelper = require('../../database-helper');
 const CONSTANTS = require('../../../src/constants');
 const {
@@ -72,6 +73,7 @@ describe(baseUrl, () => {
         issueDate: null,
         unissuedToIssuedByMaker: expect.any(Object),
         hasBeenIssuedAndAcknowledged: null,
+        auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aMaker._id),
       },
       validation: {
         required: ['monthsOfCover', 'details', 'currency', 'value', 'coverPercentage', 'interestPercentage', 'feeType', 'feeFrequency', 'dayCountBasis'],

--- a/portal-api/api-tests/v1/gef/mandatory-criteria-versioned.api-test.js
+++ b/portal-api/api-tests/v1/gef/mandatory-criteria-versioned.api-test.js
@@ -1,3 +1,6 @@
+const {
+  generateParsedMockPortalUserAuditDatabaseRecord,
+} = require('@ukef/dtfs2-common/src/test-helpers/generate-mock-audit-database-record');
 const databaseHelper = require('../../database-helper');
 
 const app = require('../../../src/createApp');
@@ -125,6 +128,7 @@ describe(baseUrl, () => {
             body: expect.any(String),
           }),
         ]),
+        auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(anAdmin._id),
       };
       expect(body).toEqual(expected);
     });
@@ -199,6 +203,7 @@ describe(baseUrl, () => {
         criteria: [
           { id: '1', body: 'Testing' },
         ],
+        auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(anAdmin._id)
       }));
     });
   });

--- a/portal-api/src/v1/gef/controllers/application-submit.js
+++ b/portal-api/src/v1/gef/controllers/application-submit.js
@@ -69,7 +69,7 @@ const generateUkefId = async (entity, application) => {
   }
 };
 
-const addSubmissionDateToIssuedFacilities = async (dealId) => {
+const addSubmissionDateToIssuedFacilities = async (dealId, sessionUser) => {
   const facilities = await getAllFacilitiesByDealId(dealId);
   // eslint-disable-next-line no-restricted-syntax
   for (const facility of facilities) {
@@ -96,7 +96,7 @@ const addSubmissionDateToIssuedFacilities = async (dealId) => {
         }
       }
       // eslint-disable-next-line no-await-in-loop
-      await updateFacility(_id, update);
+      await updateFacility(_id, update, sessionUser);
     }
   }
   return facilities;
@@ -107,7 +107,7 @@ const addSubmissionDateToIssuedFacilities = async (dealId) => {
   When submitting to UKEF, have to remove the canResubmitIssuedFacilities flag
   Ensures that cannot update this facility anymore
 */
-const updateChangedToIssued = async (dealId) => {
+const updateChangedToIssued = async (dealId, sessionUser) => {
   const facilities = await getAllFacilitiesByDealId(dealId);
 
   facilities.forEach(async (facility) => {
@@ -118,7 +118,7 @@ const updateChangedToIssued = async (dealId) => {
         canResubmitIssuedFacilities: false,
       };
 
-      await updateFacility(_id, update);
+      await updateFacility(_id, update, sessionUser);
     }
   });
 };
@@ -127,10 +127,11 @@ const updateChangedToIssued = async (dealId) => {
  * Adds UKEF facility ID to facilities.
  *
  * @param {string} dealId - The ID of the deal.
+ * @param {object} sessionUser - logged in user
  * @returns {Promise<Array>} - A promise that resolves to an array of facilities.
  * @throws {Error} - If unable to generate facility ID.
  */
-const addUkefFacilityIdToFacilities = async (dealId) => {
+const addUkefFacilityIdToFacilities = async (dealId, sessionUser) => {
   const facilities = await getAllFacilitiesByDealId(dealId);
 
   await Promise.all(
@@ -141,7 +142,7 @@ const addUkefFacilityIdToFacilities = async (dealId) => {
           ukefFacilityId: maskedId,
         };
 
-        await updateFacility(facility._id, update);
+        await updateFacility(facility._id, update, sessionUser);
       }
     }),
   );
@@ -182,10 +183,11 @@ const submissionPortalActivity = async (application) => {
 
 /**
  * Check the `coverDateConfirmed` property of the facility has the correct boolean flag.
- * @param {Object} app Application object
- * @returns {Bool} Facility(ies) was(were) updated or not
+ * @param {object} app Application object
+ * @param {object} sessionUser - logged in user
+ * @returns {boolean} Facility(ies) was(were) updated or not
  */
-const checkCoverDateConfirmed = async (app) => {
+const checkCoverDateConfirmed = async (app, sessionUser) => {
   let hasUpdated = false;
 
   if (app) {
@@ -201,9 +203,11 @@ const checkCoverDateConfirmed = async (app) => {
           .filter((f) => f.hasBeenIssued && !f.coverDateConfirmed)
           .map(async (f) => {
             hasUpdated = true;
-            await updateFacility(f._id, {
-              coverDateConfirmed: Boolean(isAIN),
-            });
+            await updateFacility(
+              f._id,
+              { coverDateConfirmed: Boolean(isAIN) },
+              sessionUser,
+            );
           });
 
         // Iterate through unissued facilities
@@ -211,9 +215,11 @@ const checkCoverDateConfirmed = async (app) => {
           .filter((f) => !f.hasBeenIssued && f.coverDateConfirmed)
           .map(async (f) => {
             hasUpdated = true;
-            await updateFacility(f._id, {
-              coverDateConfirmed: false,
-            });
+            await updateFacility(
+              f._id,
+              { coverDateConfirmed: false },
+              sessionUser,
+            );
           });
         return hasUpdated;
       }
@@ -228,17 +234,18 @@ const checkCoverDateConfirmed = async (app) => {
  * Adds submission data to an existing application.
  * @param {string} dealId - The ID of the deal.
  * @param {object} existingApplication - An object representing the existing application.
+ * @param {object} sessionUser - logged in user
  * @returns {Promise<object>} - An object containing the submission count, submission date, portal activities, and UKEF deal ID.
  */
-const addSubmissionData = async (dealId, existingApplication) => {
-  await checkCoverDateConfirmed(existingApplication);
-  await addSubmissionDateToIssuedFacilities(dealId);
+const addSubmissionData = async (dealId, existingApplication, sessionUser) => {
+  await checkCoverDateConfirmed(existingApplication, sessionUser);
+  await addSubmissionDateToIssuedFacilities(dealId, sessionUser);
 
   const { count, date } = await generateSubmissionData(existingApplication);
   const updatedPortalActivity = await submissionPortalActivity(existingApplication);
 
   if (existingApplication.submissionType !== CONSTANTS.DEAL.SUBMISSION_TYPE.MIA) {
-    await updateChangedToIssued(dealId);
+    await updateChangedToIssued(dealId, sessionUser);
   }
 
   const submissionData = {
@@ -252,7 +259,7 @@ const addSubmissionData = async (dealId, existingApplication) => {
     submissionData.ukefDealId = maskedId;
   }
 
-  await addUkefFacilityIdToFacilities(dealId);
+  await addUkefFacilityIdToFacilities(dealId, sessionUser);
 
   return submissionData;
 };

--- a/portal-api/src/v1/gef/controllers/application-submit.js
+++ b/portal-api/src/v1/gef/controllers/application-submit.js
@@ -185,7 +185,7 @@ const submissionPortalActivity = async (application) => {
  * Check the `coverDateConfirmed` property of the facility has the correct boolean flag.
  * @param {object} app Application object
  * @param {import("@ukef/dtfs2-common/src/types/audit-details").AuditDetails} auditDetails - user making the request
- * @returns {boolean} Facility(ies) was(were) updated or not
+ * @returns {Promise<boolean>} Facility(ies) was(were) updated or not
  */
 const checkCoverDateConfirmed = async (app, auditDetails) => {
   let hasUpdated = false;

--- a/portal-api/src/v1/gef/controllers/application-submit.js
+++ b/portal-api/src/v1/gef/controllers/application-submit.js
@@ -69,7 +69,7 @@ const generateUkefId = async (entity, application) => {
   }
 };
 
-const addSubmissionDateToIssuedFacilities = async (dealId, sessionUser) => {
+const addSubmissionDateToIssuedFacilities = async (dealId, auditDetails) => {
   const facilities = await getAllFacilitiesByDealId(dealId);
   // eslint-disable-next-line no-restricted-syntax
   for (const facility of facilities) {
@@ -96,7 +96,7 @@ const addSubmissionDateToIssuedFacilities = async (dealId, sessionUser) => {
         }
       }
       // eslint-disable-next-line no-await-in-loop
-      await updateFacility(_id, update, sessionUser);
+      await updateFacility(_id, update, auditDetails);
     }
   }
   return facilities;
@@ -107,7 +107,7 @@ const addSubmissionDateToIssuedFacilities = async (dealId, sessionUser) => {
   When submitting to UKEF, have to remove the canResubmitIssuedFacilities flag
   Ensures that cannot update this facility anymore
 */
-const updateChangedToIssued = async (dealId, sessionUser) => {
+const updateChangedToIssued = async (dealId, auditDetails) => {
   const facilities = await getAllFacilitiesByDealId(dealId);
 
   facilities.forEach(async (facility) => {
@@ -118,7 +118,7 @@ const updateChangedToIssued = async (dealId, sessionUser) => {
         canResubmitIssuedFacilities: false,
       };
 
-      await updateFacility(_id, update, sessionUser);
+      await updateFacility(_id, update, auditDetails);
     }
   });
 };
@@ -127,11 +127,11 @@ const updateChangedToIssued = async (dealId, sessionUser) => {
  * Adds UKEF facility ID to facilities.
  *
  * @param {string} dealId - The ID of the deal.
- * @param {object} sessionUser - logged in user
+ * @param {import("@ukef/dtfs2-common/src/types/audit-details").AuditDetails} auditDetails - user making the request
  * @returns {Promise<Array>} - A promise that resolves to an array of facilities.
  * @throws {Error} - If unable to generate facility ID.
  */
-const addUkefFacilityIdToFacilities = async (dealId, sessionUser) => {
+const addUkefFacilityIdToFacilities = async (dealId, auditDetails) => {
   const facilities = await getAllFacilitiesByDealId(dealId);
 
   await Promise.all(
@@ -142,7 +142,7 @@ const addUkefFacilityIdToFacilities = async (dealId, sessionUser) => {
           ukefFacilityId: maskedId,
         };
 
-        await updateFacility(facility._id, update, sessionUser);
+        await updateFacility(facility._id, update, auditDetails);
       }
     }),
   );
@@ -184,10 +184,10 @@ const submissionPortalActivity = async (application) => {
 /**
  * Check the `coverDateConfirmed` property of the facility has the correct boolean flag.
  * @param {object} app Application object
- * @param {object} sessionUser - logged in user
+ * @param {import("@ukef/dtfs2-common/src/types/audit-details").AuditDetails} auditDetails - user making the request
  * @returns {boolean} Facility(ies) was(were) updated or not
  */
-const checkCoverDateConfirmed = async (app, sessionUser) => {
+const checkCoverDateConfirmed = async (app, auditDetails) => {
   let hasUpdated = false;
 
   if (app) {
@@ -206,7 +206,7 @@ const checkCoverDateConfirmed = async (app, sessionUser) => {
             await updateFacility(
               f._id,
               { coverDateConfirmed: Boolean(isAIN) },
-              sessionUser,
+              auditDetails,
             );
           });
 
@@ -218,7 +218,7 @@ const checkCoverDateConfirmed = async (app, sessionUser) => {
             await updateFacility(
               f._id,
               { coverDateConfirmed: false },
-              sessionUser,
+              auditDetails,
             );
           });
         return hasUpdated;
@@ -234,18 +234,18 @@ const checkCoverDateConfirmed = async (app, sessionUser) => {
  * Adds submission data to an existing application.
  * @param {string} dealId - The ID of the deal.
  * @param {object} existingApplication - An object representing the existing application.
- * @param {object} sessionUser - logged in user
+ * @param {import("@ukef/dtfs2-common/src/types/audit-details").AuditDetails} auditDetails - user making the request
  * @returns {Promise<object>} - An object containing the submission count, submission date, portal activities, and UKEF deal ID.
  */
-const addSubmissionData = async (dealId, existingApplication, sessionUser) => {
-  await checkCoverDateConfirmed(existingApplication, sessionUser);
-  await addSubmissionDateToIssuedFacilities(dealId, sessionUser);
+const addSubmissionData = async (dealId, existingApplication, auditDetails) => {
+  await checkCoverDateConfirmed(existingApplication, auditDetails);
+  await addSubmissionDateToIssuedFacilities(dealId, auditDetails);
 
   const { count, date } = await generateSubmissionData(existingApplication);
   const updatedPortalActivity = await submissionPortalActivity(existingApplication);
 
   if (existingApplication.submissionType !== CONSTANTS.DEAL.SUBMISSION_TYPE.MIA) {
-    await updateChangedToIssued(dealId, sessionUser);
+    await updateChangedToIssued(dealId, auditDetails);
   }
 
   const submissionData = {
@@ -259,7 +259,7 @@ const addSubmissionData = async (dealId, existingApplication, sessionUser) => {
     submissionData.ukefDealId = maskedId;
   }
 
-  await addUkefFacilityIdToFacilities(dealId, sessionUser);
+  await addUkefFacilityIdToFacilities(dealId, auditDetails);
 
   return submissionData;
 };

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -1,5 +1,6 @@
 const { ObjectId } = require('mongodb');
 const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details')
 const db = require('../../../drivers/db-client');
 const utils = require('../utils.service');
 const { validateApplicationReferences, validatorStatusCheckEnums } = require('./validation/application');
@@ -248,7 +249,7 @@ exports.changeStatus = async (req, res) => {
   let applicationUpdate = { status, ...{ updatedAt: Date.now() } };
 
   if (status === DEAL_STATUS.SUBMITTED_TO_UKEF) {
-    const submissionData = await addSubmissionData(dealId, existingApplication, req.user);
+    const submissionData = await addSubmissionData(dealId, existingApplication, generatePortalAuditDetails(req.user._id));
 
     applicationUpdate = {
       ...applicationUpdate,

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -1,4 +1,5 @@
 const { ObjectId } = require('mongodb');
+const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
 const db = require('../../../drivers/db-client');
 const utils = require('../utils.service');
 const { validateApplicationReferences, validatorStatusCheckEnums } = require('./validation/application');
@@ -51,6 +52,7 @@ exports.create = async (req, res) => {
     if (response?.data?.version) {
       newDeal.mandatoryVersionId = response.data.version;
     }
+    newDeal.auditRecord = generatePortalUserAuditDatabaseRecord(req.user._id);
 
     const createdApplication = await applicationCollection.insertOne(new Application(newDeal, eligibility));
 

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -186,7 +186,7 @@ exports.updateSupportingInformation = async (req, res) => {
     {
       $addToSet: { editedBy: editorId },
       // set the updatedAt property to the current time in EPOCH format
-      $set: { updatedAt: Date.now() },
+      $set: { updatedAt: Date.now(), auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id) },
       // insert new documents into the supportingInformation object -> array. i.e. supportingInformation.manualInclusion
       $push: { [`supportingInformation.${field}`]: application },
     },
@@ -253,6 +253,7 @@ exports.changeStatus = async (req, res) => {
     applicationUpdate = {
       ...applicationUpdate,
       ...submissionData,
+      auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id)
     };
   }
 

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -253,7 +253,7 @@ exports.changeStatus = async (req, res) => {
     applicationUpdate = {
       ...applicationUpdate,
       ...submissionData,
-      auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id)
+      auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id),
     };
   }
 

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -138,7 +138,7 @@ exports.update = async (req, res) => {
   }
 
   const collection = await db.getCollection(dealsCollection);
-  const update = new Application(req.body);
+  const update = new Application({ ...req.body, auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id) });
   const validateErrs = validateApplicationReferences(update);
   if (validateErrs) {
     return res.status(422).send(validateErrs);

--- a/portal-api/src/v1/gef/controllers/application.controller.js
+++ b/portal-api/src/v1/gef/controllers/application.controller.js
@@ -248,7 +248,7 @@ exports.changeStatus = async (req, res) => {
   let applicationUpdate = { status, ...{ updatedAt: Date.now() } };
 
   if (status === DEAL_STATUS.SUBMITTED_TO_UKEF) {
-    const submissionData = await addSubmissionData(dealId, existingApplication);
+    const submissionData = await addSubmissionData(dealId, existingApplication, req.user);
 
     applicationUpdate = {
       ...applicationUpdate,

--- a/portal-api/src/v1/gef/controllers/clone-gef-deal.controller.js
+++ b/portal-api/src/v1/gef/controllers/clone-gef-deal.controller.js
@@ -64,7 +64,7 @@ const cloneFacilities = async (currentDealId, newDealId, sessionUser) => {
       allFacilities[index].unissuedToIssuedByMaker = {};
       allFacilities[index].hasBeenIssuedAndAcknowledged = null;
       allFacilities[index].submittedAsIssuedDate = null;
-      allFacilities[index].auditRecord = generatePortalUserAuditDatabaseRecord(sessionUser);
+      allFacilities[index].auditRecord = generatePortalUserAuditDatabaseRecord(sessionUser._id);
 
       const currentTime = new Date();
       currentTime.setHours(0, 0, 0, 0);

--- a/portal-api/src/v1/gef/controllers/eligibilityCriteria.controller.js
+++ b/portal-api/src/v1/gef/controllers/eligibilityCriteria.controller.js
@@ -63,13 +63,13 @@ exports.getLatest = async (req, res) => {
 exports.create = async (req, res) => {
   const collection = await db.getCollection('eligibilityCriteria');
 
-  if (payloadVerification(req.body, PAYLOAD.CRITERIA.ELIGIBILITY)) {
-    const criteria = { ...req?.body, auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id) };
-    const result = await collection.insertOne(new EligibilityCriteria(criteria));
-    return res.status(201).send({ _id: result.insertedId });
+  if (!payloadVerification(req.body, PAYLOAD.CRITERIA.ELIGIBILITY)) {
+    return res.status(400).send({ status: 400, message: 'Invalid GEF eligibility criteria payload' });
   }
 
-  return res.status(400).send({ status: 400, message: 'Invalid GEF eligibility criteria payload' });
+  const criteria = { ...req?.body, auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id) };
+  const result = await collection.insertOne(new EligibilityCriteria(criteria));
+  return res.status(201).send({ _id: result.insertedId });
 };
 
 exports.delete = async (req, res) => {

--- a/portal-api/src/v1/gef/controllers/eligibilityCriteria.controller.js
+++ b/portal-api/src/v1/gef/controllers/eligibilityCriteria.controller.js
@@ -1,3 +1,4 @@
+const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
 const { EligibilityCriteria } = require('../models/eligibilityCriteria');
 const db = require('../../../drivers/db-client');
 const utils = require('../utils.service');
@@ -61,9 +62,9 @@ exports.getLatest = async (req, res) => {
 
 exports.create = async (req, res) => {
   const collection = await db.getCollection('eligibilityCriteria');
-  const criteria = req?.body;
 
-  if (payloadVerification(criteria, PAYLOAD.CRITERIA.ELIGIBILITY)) {
+  if (payloadVerification(req.body, PAYLOAD.CRITERIA.ELIGIBILITY)) {
+    const criteria = { ...req?.body, auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id) };
     const result = await collection.insertOne(new EligibilityCriteria(criteria));
     return res.status(201).send({ _id: result.insertedId });
   }

--- a/portal-api/src/v1/gef/controllers/eligibilityCriteria.controller.js
+++ b/portal-api/src/v1/gef/controllers/eligibilityCriteria.controller.js
@@ -1,4 +1,5 @@
-const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const { generateAuditDatabaseRecordFromAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details');
 const { EligibilityCriteria } = require('../models/eligibilityCriteria');
 const db = require('../../../drivers/db-client');
 const utils = require('../utils.service');
@@ -67,7 +68,9 @@ exports.create = async (req, res) => {
     return res.status(400).send({ status: 400, message: 'Invalid GEF eligibility criteria payload' });
   }
 
-  const criteria = { ...req?.body, auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id) };
+  const auditDetails = generatePortalAuditDetails(req.user._id);
+
+  const criteria = { ...req?.body, auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) };
   const result = await collection.insertOne(new EligibilityCriteria(criteria));
   return res.status(201).send({ _id: result.insertedId });
 };

--- a/portal-api/src/v1/gef/controllers/facilities.controller.js
+++ b/portal-api/src/v1/gef/controllers/facilities.controller.js
@@ -1,8 +1,16 @@
 const { ObjectId } = require('mongodb');
-const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const {
+  generateAuditDatabaseRecordFromAuditDetails,
+} = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details');
 const db = require('../../../drivers/db-client');
 const utils = require('../utils.service');
-const { facilitiesValidation, facilitiesStatus, facilitiesOverallStatus, facilitiesCheckEnums } = require('./validation/facilities');
+const {
+  facilitiesValidation,
+  facilitiesStatus,
+  facilitiesOverallStatus,
+  facilitiesCheckEnums,
+} = require('./validation/facilities');
 const { Facility } = require('../models/facilities');
 const { Application } = require('../models/application');
 const { calculateUkefExposure, calculateGuaranteeFee } = require('../calculations/facility-calculations');
@@ -14,15 +22,22 @@ const dealsCollectionName = 'deals';
 exports.create = async (req, res) => {
   const enumValidationErr = facilitiesCheckEnums(req.body);
   if (!req.body.type || !req.body.dealId) {
-    return res.status(422).send([{ status: 422, errCode: 'MANDATORY_FIELD', errMsg: 'No Application ID and/or facility type sent with request' }]);
+    return res
+      .status(422)
+      .send([
+        { status: 422, errCode: 'MANDATORY_FIELD', errMsg: 'No Application ID and/or facility type sent with request' },
+      ]);
   }
 
   if (enumValidationErr) {
     return res.status(422).send(enumValidationErr);
   }
+  const auditDetails = generatePortalAuditDetails(req.user._id);
 
   const facilitiesQuery = await db.getCollection(facilitiesCollectionName);
-  const createdFacility = await facilitiesQuery.insertOne(new Facility({ ...req.body, auditRecord: generatePortalUserAuditDatabaseRecord(req.user._id)}));
+  const createdFacility = await facilitiesQuery.insertOne(
+    new Facility({ ...req.body, auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) }),
+  );
 
   const { insertedId } = createdFacility;
 
@@ -111,13 +126,12 @@ exports.getById = async (req, res) => {
 };
 
 /**
- * 
  * @param {ObjectId | string} id - facility id to update
  * @param {object} updateBody - update to make
- * @param {object} sessionUser - logged in user
- * @returns 
+ * @param {import("@ukef/dtfs2-common/src/types/audit-details").AuditDetails} auditDetails - user making the request
+ * @returns
  */
-const update = async (id, updateBody, sessionUser) => {
+const update = async (id, updateBody, auditDetails) => {
   try {
     const facilitiesCollection = await db.getCollection(facilitiesCollectionName);
     const dealsCollection = await db.getCollection(dealsCollectionName);
@@ -133,7 +147,7 @@ const update = async (id, updateBody, sessionUser) => {
       ...updateBody,
       ukefExposure: calculateUkefExposure(updateBody, existingFacility),
       guaranteeFee: calculateGuaranteeFee(updateBody, existingFacility),
-      auditRecord: generatePortalUserAuditDatabaseRecord(sessionUser._id),
+      auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
     });
 
     const updatedFacility = await facilitiesCollection.findOneAndUpdate(
@@ -146,7 +160,7 @@ const update = async (id, updateBody, sessionUser) => {
       // update facilitiesUpdated timestamp in the deal
       const dealUpdateObj = {
         facilitiesUpdated: new Date().valueOf(),
-        auditRecord: generatePortalUserAuditDatabaseRecord(sessionUser._id),
+        auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
       };
       const dealUpdate = new Application(dealUpdateObj);
 
@@ -171,7 +185,7 @@ exports.updatePUT = async (req, res) => {
   }
 
   let response;
-  const updatedFacility = await update(req.params.id, req.body, req.user);
+  const updatedFacility = await update(req.params.id, req.body, generatePortalAuditDetails(req.user._id));
 
   if (updatedFacility.value) {
     response = {

--- a/portal-api/src/v1/gef/controllers/files.controller.js
+++ b/portal-api/src/v1/gef/controllers/files.controller.js
@@ -2,6 +2,7 @@ const stream = require('stream');
 const { ObjectId } = require('mongodb');
 const filesize = require('filesize');
 
+const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
 const db = require('../../../drivers/db-client');
 const utils = require('../utils.service');
 const File = require('../models/files');
@@ -89,7 +90,9 @@ exports.create = async (req, res) => {
         const fileObject = { ...file, documentPath };
 
         const collection = await db.getCollection(filesCollection);
-        const insertedFile = await collection.insertOne(new File(fileObject, parentId));
+        const insertedFile = await collection.insertOne(
+          new File(fileObject, parentId, generatePortalUserAuditDatabaseRecord(req.user._id)),
+        );
         const insertedId = String(insertedFile.insertedId);
 
         if (!ObjectId.isValid(insertedId)) {

--- a/portal-api/src/v1/gef/controllers/mandatoryCriteriaVersioned.controller.js
+++ b/portal-api/src/v1/gef/controllers/mandatoryCriteriaVersioned.controller.js
@@ -84,6 +84,7 @@ exports.update = async (req, res) => {
   const collection = await db.getCollection(collectionName);
   const update = req.body;
   update.updatedAt = Date.now();
+  update.auditRecord = generatePortalUserAuditDatabaseRecord(req.user._id);
   const response = await collection.findOneAndUpdate(
     { _id: { $eq: ObjectId(id) } },
     { $set: update },

--- a/portal-api/src/v1/gef/models/application.js
+++ b/portal-api/src/v1/gef/models/application.js
@@ -1,7 +1,7 @@
 const { DEAL_TYPE, DEAL_STATUS } = require('../enums');
 
 class Application {
-  constructor(req, eligibility) {
+  constructor(req, eligibility = null) {
     const editedBy = [];
 
     if (eligibility) {
@@ -90,6 +90,7 @@ class Application {
         }
       });
     }
+    this.auditRecord = req.auditRecord
   }
 }
 

--- a/portal-api/src/v1/gef/models/eligibilityCriteria.js
+++ b/portal-api/src/v1/gef/models/eligibilityCriteria.js
@@ -5,6 +5,7 @@ class EligibilityCriteria {
     this.isInDraft = req.isInDraft;
     this.criteria = req.criteria;
     this.createdAt = req.createdAt;
+    this.auditRecord = req.auditRecord;
   }
 }
 

--- a/portal-api/src/v1/gef/models/facilities.js
+++ b/portal-api/src/v1/gef/models/facilities.js
@@ -190,6 +190,7 @@ class Facility {
 
       this.updatedAt = Date.now();
     }
+    this.auditRecord = req.auditRecord;
   }
 }
 

--- a/portal-api/src/v1/gef/models/files.js
+++ b/portal-api/src/v1/gef/models/files.js
@@ -2,13 +2,14 @@ const { ObjectId } = require('mongodb');
 const filesize = require('filesize');
 
 class File {
-  constructor(file, parentId) {
+  constructor(file, parentId, auditRecord) {
     this.parentId = ObjectId(String(parentId));
     this.filename = file.originalname;
     this.mimetype = file.mimetype;
     this.encoding = file.encoding;
     this.size = filesize(file.size, { round: 0 });
     this.documentPath = file.documentPath;
+    this.auditRecord = auditRecord
   }
 }
 

--- a/portal-api/src/v1/gef/models/mandatoryCriteria.js
+++ b/portal-api/src/v1/gef/models/mandatoryCriteria.js
@@ -7,6 +7,7 @@ class MandatoryCriteria {
     this.criteria = req.criteria;
     this.createdAt = Date.now();
     this.updatedAt = null;
+    this.auditRecord = req.auditRecord;
   }
 }
 

--- a/portal-api/src/v1/users/routes.js
+++ b/portal-api/src/v1/users/routes.js
@@ -1,4 +1,5 @@
-const { generatePortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const { generateAuditDatabaseRecordFromAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-database-record');
+const { generatePortalAuditDetails } = require('@ukef/dtfs2-common/src/helpers/change-stream/generate-audit-details');
 const utils = require('../../crypto/utils');
 const { login } = require('./login.controller');
 const { userIsBlocked, userIsDisabled, usernameOrPasswordIncorrect } = require('../../constants/login-results');
@@ -332,6 +333,7 @@ module.exports.resetPasswordWithToken = async (req, res, next) => {
       },
     });
   }
+  const auditDetails = generatePortalAuditDetails(user._id);
   const updateData = {
     password,
     passwordConfirm,
@@ -340,7 +342,7 @@ module.exports.resetPasswordWithToken = async (req, res, next) => {
     currentPassword: '',
     loginFailureCount: 0,
     passwordUpdatedAt: `${Date.now()}`,
-    auditRecord: generatePortalUserAuditDatabaseRecord(user._id)
+    auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
   };
 
   return update(user._id, updateData, (updateErr) => {


### PR DESCRIPTION
## Introduction :pencil2:
All endpoints in portal-api should add `auditRecords` when inserting/updating data. This PR covers the gef router.
## Resolution :heavy_check_mark:
- Add audit record to database changes for gef routes

