### PR TITLE
feat(FN-1615): add seeder for fee records

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ on:
       - "azure-functions/**"
       - "e2e-tests/**"
       - "utils/mock-data-loader/**"
+      - "utils/sql-db-seeder/**"
       - "libs/**"
 
   push:

--- a/cspell.json
+++ b/cspell.json
@@ -185,6 +185,7 @@
     "Renminbi",
     "ABD-HJLNP-UW-Zabd-hjlnp-uw-z",
     "perc",
+    "predb",
     "Stringifying",
     "SSRF",
     "TYPEA",

--- a/doc/sql-db.md
+++ b/doc/sql-db.md
@@ -106,13 +106,15 @@ Use as a quick way to start from scratch instead of deleting and re-building the
 
 #### - Seeding data
 
-The seeder can be run from `utils/sql-db-seeder` via the
+The seeder can be run from either the project root or the `utils` directory via the
 
 ```shell
 npm run db:seed
 ```
 
-command. This command runs the seeder to insert mock data into the SQL database. Seeds and factories are defined as files in the `utils/sql-db-seeder/src/<name-of-entity>` directory with `<name-of-entity>.seed.ts` and `<name-of-entity>.factory.ts` file extensions respectively (see the [utilisation reports seeder](../libs/common/src/sql-db-seeder/utilisation-report/) for an example). Seed tracking is set to `true` by default such that, once a seed successfully runs, it will not run again through the `npm run db:seed` command. If you want to run the seeder again, you will first need to run the `npm run db:reset` command from `libs/common`.
+command. This command first runs the `predb:seed` script (see details below) and then runs the seeder to insert mock data into the SQL database. Seeds and factories are defined as files in the `utils/sql-db-seeder/src/<name-of-entity>` directory with `<name-of-entity>.seed.ts` and `<name-of-entity>.factory.ts` file extensions respectively (see the [utilisation reports seeder](../libs/common/src/sql-db-seeder/utilisation-report/) for an example). Seed tracking is set to `true` by default such that, once a seed successfully runs, it will not run again through the `npm run db:seed` command. If you want to run the seeder again, you will first need to run the `npm run db:reset` command from `libs/common`.
+
+As a result of not building the project, the `typeorm-extension` executable needs to be run directly from the `node_modules` via `ts-node ./node_modules/typeorm-extension/bin/cli.cjs seed:run`. The `node_modules` directory where `typeorm-extension` is located needs to be at the same level as the root of the seeder which, in this case, is `utils/sql-db-seeder`. Due to conflicting versions of `mongodb`, the `typeorm-extension` package actually gets placed within the root level `node_modules` after running `npm i`. To overcome this issue, the `predb:seed` script copies the required node modules to `utils/sql-db-seeder` before executing the `db:seed` script.
 
 ## Adding DB access to a package
 

--- a/utils/sql-db-seeder/src/fee-record/fee-record.helper.ts
+++ b/utils/sql-db-seeder/src/fee-record/fee-record.helper.ts
@@ -58,7 +58,7 @@ export const createFeeRecord = ({
   feeRecord.feesPaidToUkefForThePeriod = feesPaidToUkefForThePeriod;
   feeRecord.feesPaidToUkefForThePeriodCurrency = feesPaidToUkefForThePeriodCurrency ?? baseCurrency;
 
-  feeRecord.paymentCurrency = paymentCurrency ?? baseCurrency;
+  feeRecord.paymentCurrency = paymentCurrency ?? feeRecord.feesPaidToUkefForThePeriodCurrency;
   feeRecord.paymentExchangeRate = paymentCurrency ? paymentExchangeRate : 1;
 
   feeRecord.updateLastUpdatedBy({ platform: 'SYSTEM' });

--- a/utils/sql-db-seeder/src/fee-record/fee-record.helper.ts
+++ b/utils/sql-db-seeder/src/fee-record/fee-record.helper.ts
@@ -1,0 +1,65 @@
+import { Currency, FeeRecordEntity } from '@ukef/dtfs2-common';
+
+type CreateFeeRecordOptions = {
+  facilityId: string;
+  exporter: string;
+  baseCurrency: Currency;
+  facilityUtilisation: number;
+  totalFeesAccruedForThePeriod: number;
+  feesPaidToUkefForThePeriod: number;
+  feesPaidToUkefForThePeriodCurrency?: Currency;
+} & (
+  | {
+      totalFeesAccruedForThePeriodCurrency: Currency;
+      totalFeesAccruedForThePeriodExchangeRate: number;
+    }
+  | {
+      totalFeesAccruedForThePeriodCurrency?: undefined;
+      totalFeesAccruedForThePeriodExchangeRate?: undefined;
+    }
+) &
+  (
+    | {
+        paymentCurrency: Currency;
+        paymentExchangeRate: number;
+      }
+    | {
+        paymentCurrency?: undefined;
+        paymentExchangeRate?: undefined;
+      }
+  );
+
+export const createFeeRecord = ({
+  facilityId,
+  exporter,
+  baseCurrency,
+  facilityUtilisation,
+  totalFeesAccruedForThePeriod,
+  totalFeesAccruedForThePeriodCurrency,
+  totalFeesAccruedForThePeriodExchangeRate,
+  feesPaidToUkefForThePeriod,
+  feesPaidToUkefForThePeriodCurrency,
+  paymentCurrency,
+  paymentExchangeRate,
+}: CreateFeeRecordOptions): FeeRecordEntity => {
+  const feeRecord = new FeeRecordEntity();
+
+  feeRecord.facilityId = facilityId;
+  feeRecord.exporter = exporter;
+  feeRecord.baseCurrency = baseCurrency;
+  feeRecord.facilityUtilisation = facilityUtilisation;
+
+  feeRecord.totalFeesAccruedForThePeriod = totalFeesAccruedForThePeriod;
+  feeRecord.totalFeesAccruedForThePeriodCurrency = totalFeesAccruedForThePeriodCurrency ?? baseCurrency;
+  feeRecord.totalFeesAccruedForThePeriodExchangeRate = totalFeesAccruedForThePeriodCurrency ? totalFeesAccruedForThePeriodExchangeRate : 1;
+
+  feeRecord.feesPaidToUkefForThePeriod = feesPaidToUkefForThePeriod;
+  feeRecord.feesPaidToUkefForThePeriodCurrency = feesPaidToUkefForThePeriodCurrency ?? baseCurrency;
+
+  feeRecord.paymentCurrency = paymentCurrency ?? baseCurrency;
+  feeRecord.paymentExchangeRate = paymentCurrency ? paymentExchangeRate : 1;
+
+  feeRecord.updateLastUpdatedBy({ platform: 'SYSTEM' });
+
+  return feeRecord;
+};

--- a/utils/sql-db-seeder/src/fee-record/fee-record.helper.ts
+++ b/utils/sql-db-seeder/src/fee-record/fee-record.helper.ts
@@ -51,7 +51,9 @@ export const createFeeRecord = ({
 
   feeRecord.totalFeesAccruedForThePeriod = totalFeesAccruedForThePeriod;
   feeRecord.totalFeesAccruedForThePeriodCurrency = totalFeesAccruedForThePeriodCurrency ?? baseCurrency;
-  feeRecord.totalFeesAccruedForThePeriodExchangeRate = totalFeesAccruedForThePeriodCurrency ? totalFeesAccruedForThePeriodExchangeRate : 1;
+  feeRecord.totalFeesAccruedForThePeriodExchangeRate = totalFeesAccruedForThePeriodCurrency
+    ? totalFeesAccruedForThePeriodExchangeRate
+    : 1;
 
   feeRecord.feesPaidToUkefForThePeriod = feesPaidToUkefForThePeriod;
   feeRecord.feesPaidToUkefForThePeriodCurrency = feesPaidToUkefForThePeriodCurrency ?? baseCurrency;

--- a/utils/sql-db-seeder/src/utilisation-report/utilisation-report.helper.ts
+++ b/utils/sql-db-seeder/src/utilisation-report/utilisation-report.helper.ts
@@ -103,10 +103,10 @@ export const createUploadedReport = (
 };
 
 export const createFeeRecordsForReport = (): {
-  feeRecordWithMatchingCurrencies: FeeRecordEntity;
-  feeRecordWithDifferingCurrencies: FeeRecordEntity;
+  feeRecordWithMatchingPaymentCurrencies: FeeRecordEntity;
+  feeRecordWithDifferingPaymentCurrencies: FeeRecordEntity;
 } => {
-  const feeRecordWithMatchingCurrencies = createFeeRecord({
+  const feeRecordWithMatchingPaymentCurrencies = createFeeRecord({
     facilityId: '12345678',
     exporter: 'Test exporter',
     baseCurrency: 'GBP',
@@ -115,7 +115,7 @@ export const createFeeRecordsForReport = (): {
     feesPaidToUkefForThePeriod: 50,
   });
 
-  const feeRecordWithDifferingCurrencies = createFeeRecord({
+  const feeRecordWithDifferingPaymentCurrencies = createFeeRecord({
     facilityId: '22345678',
     exporter: 'Test exporter 2',
     baseCurrency: 'GBP',
@@ -128,7 +128,7 @@ export const createFeeRecordsForReport = (): {
   });
 
   return {
-    feeRecordWithMatchingCurrencies,
-    feeRecordWithDifferingCurrencies,
+    feeRecordWithMatchingPaymentCurrencies,
+    feeRecordWithDifferingPaymentCurrencies,
   };
 };

--- a/utils/sql-db-seeder/src/utilisation-report/utilisation-report.helper.ts
+++ b/utils/sql-db-seeder/src/utilisation-report/utilisation-report.helper.ts
@@ -8,7 +8,9 @@ import {
   TfmUser,
   ReportPeriod,
   DbRequestSource,
+  FeeRecordEntity,
 } from '@ukef/dtfs2-common';
+import { createFeeRecord } from '../fee-record/fee-record.helper';
 
 /**
  * Generates a report in a not received state, effectively mocking the scheduled
@@ -98,4 +100,35 @@ export const createUploadedReport = (
   utilisationReport.azureFileInfo = azureFileInfo;
 
   return utilisationReport;
+};
+
+export const createFeeRecordsForReport = (): {
+  feeRecordWithMatchingCurrencies: FeeRecordEntity;
+  feeRecordWithDifferingCurrencies: FeeRecordEntity;
+} => {
+  const feeRecordWithMatchingCurrencies = createFeeRecord({
+    facilityId: '12345678',
+    exporter: 'Test exporter',
+    baseCurrency: 'GBP',
+    facilityUtilisation: 1000000,
+    totalFeesAccruedForThePeriod: 100,
+    feesPaidToUkefForThePeriod: 50,
+  });
+
+  const feeRecordWithDifferingCurrencies = createFeeRecord({
+    facilityId: '22345678',
+    exporter: 'Test exporter 2',
+    baseCurrency: 'GBP',
+    facilityUtilisation: 200000,
+    totalFeesAccruedForThePeriod: 150,
+    feesPaidToUkefForThePeriod: 100,
+    feesPaidToUkefForThePeriodCurrency: 'EUR',
+    paymentCurrency: 'GBP',
+    paymentExchangeRate: 1.1,
+  });
+
+  return {
+    feeRecordWithMatchingCurrencies,
+    feeRecordWithDifferingCurrencies,
+  }
 };

--- a/utils/sql-db-seeder/src/utilisation-report/utilisation-report.helper.ts
+++ b/utils/sql-db-seeder/src/utilisation-report/utilisation-report.helper.ts
@@ -130,5 +130,5 @@ export const createFeeRecordsForReport = (): {
   return {
     feeRecordWithMatchingCurrencies,
     feeRecordWithDifferingCurrencies,
-  }
+  };
 };

--- a/utils/sql-db-seeder/src/utilisation-report/utilisation-report.seed.ts
+++ b/utils/sql-db-seeder/src/utilisation-report/utilisation-report.seed.ts
@@ -5,6 +5,7 @@ import {
   createNotReceivedReport,
   createMarkedAsCompletedReport,
   createUploadedReport,
+  createFeeRecordsForReport,
 } from './utilisation-report.helper';
 import { getAllBanksFromMongoDb, getUsersFromMongoDbOrFail } from '../helpers';
 
@@ -36,6 +37,10 @@ export default class UtilisationReportSeeder implements Seeder {
       uploadedReportReportPeriod,
       'PENDING_RECONCILIATION',
     );
+
+    // The reports need to be seeded either before or with the fee records
+    const { feeRecordWithMatchingCurrencies, feeRecordWithDifferingCurrencies } = createFeeRecordsForReport();
+    uploadedReport.feeRecords = [feeRecordWithMatchingCurrencies, feeRecordWithDifferingCurrencies];
 
     const [bankToCreateMarkedAsCompletedReportFor, ...banksToCreateNotReceivedReportsFor] = banksVisibleInTfm.filter(
       (bank) => bank.id !== paymentReportOfficer.bank.id,

--- a/utils/sql-db-seeder/src/utilisation-report/utilisation-report.seed.ts
+++ b/utils/sql-db-seeder/src/utilisation-report/utilisation-report.seed.ts
@@ -39,8 +39,9 @@ export default class UtilisationReportSeeder implements Seeder {
     );
 
     // The reports need to be seeded either before or with the fee records
-    const { feeRecordWithMatchingCurrencies, feeRecordWithDifferingCurrencies } = createFeeRecordsForReport();
-    uploadedReport.feeRecords = [feeRecordWithMatchingCurrencies, feeRecordWithDifferingCurrencies];
+    const { feeRecordWithMatchingPaymentCurrencies, feeRecordWithDifferingPaymentCurrencies } =
+      createFeeRecordsForReport();
+    uploadedReport.feeRecords = [feeRecordWithMatchingPaymentCurrencies, feeRecordWithDifferingPaymentCurrencies];
 
     const [bankToCreateMarkedAsCompletedReportFor, ...banksToCreateNotReceivedReportsFor] = banksVisibleInTfm.filter(
       (bank) => bank.id !== paymentReportOfficer.bank.id,


### PR DESCRIPTION
## Introduction :pencil2:
We need a way of seeding fee record data to view parts of the premium payments table.

## Resolution :heavy_check_mark:
Adds a new seeder for a fee record which:
- has matching currencies
- has differening currencies*

*This will have an affect on the `Reported fees` and `Reported payments` columns of the TFM premium payments table.

## Miscellaneous :heavy_plus_sign:
Updates documentation for the sql seeder.
