### PR TITLE
feat(FN-1615): add generic for express render options

### DIFF
--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
@@ -1,16 +1,8 @@
 import { Request, Response } from 'express';
-import { SessionBank, ValuesOf, getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-common';
+import { getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-common';
 import api from '../../../api';
 import { asUserSession } from '../../../helpers/express-session';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
-import { TfmSessionUser } from '../../../types/tfm-session-user';
-
-type RenderOptions = {
-  user: TfmSessionUser;
-  activePrimaryNavigation: ValuesOf<typeof PRIMARY_NAVIGATION_KEYS>;
-  bank: SessionBank;
-  formattedReportPeriod: string;
-};
 
 export const getUtilisationReportReconciliationByReportId = async (req: Request, res: Response) => {
   const { userToken, user } = asUserSession(req.session);
@@ -26,7 +18,7 @@ export const getUtilisationReportReconciliationByReportId = async (req: Request,
       utilisationReportReconciliationDetails.reportPeriod,
     );
 
-    return res.render<RenderOptions>('utilisation-reports/utilisation-report-reconciliation-for-report.njk', {
+    return res.render('utilisation-reports/utilisation-report-reconciliation-for-report.njk', {
       user,
       activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
       bank: utilisationReportReconciliationDetails.bank,

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
@@ -1,19 +1,32 @@
 import { Request, Response } from 'express';
-import { getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-common';
+import { SessionBank, ValuesOf, getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-common';
 import api from '../../../api';
 import { asUserSession } from '../../../helpers/express-session';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+import { TfmSessionUser } from '../../../types/tfm-session-user';
+
+type RenderOptions = {
+  user: TfmSessionUser;
+  activePrimaryNavigation: ValuesOf<typeof PRIMARY_NAVIGATION_KEYS>;
+  bank: SessionBank;
+  formattedReportPeriod: string;
+};
 
 export const getUtilisationReportReconciliationByReportId = async (req: Request, res: Response) => {
   const { userToken, user } = asUserSession(req.session);
   const { reportId } = req.params;
 
   try {
-    const utilisationReportReconciliationDetails = await api.getUtilisationReportReconciliationDetailsById(reportId, userToken);
+    const utilisationReportReconciliationDetails = await api.getUtilisationReportReconciliationDetailsById(
+      reportId,
+      userToken,
+    );
 
-    const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(utilisationReportReconciliationDetails.reportPeriod);
+    const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(
+      utilisationReportReconciliationDetails.reportPeriod,
+    );
 
-    return res.render('utilisation-reports/utilisation-report-reconciliation-for-report.njk', {
+    return res.render<RenderOptions>('utilisation-reports/utilisation-report-reconciliation-for-report.njk', {
       user,
       activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
       bank: utilisationReportReconciliationDetails.bank,

--- a/trade-finance-manager-ui/server/types/express-serve-static-core.d.ts
+++ b/trade-finance-manager-ui/server/types/express-serve-static-core.d.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Express } from 'express';
+import { NunjucksTemplateName, NunjucksTemplateViewModel } from './view-models';
 
 declare module 'express-serve-static-core' {
   export interface Response {
@@ -7,9 +8,9 @@ declare module 'express-serve-static-core' {
      * Extends the base `core.Response.render` function to use a generic for
      * the render locals (see https://www.geeksforgeeks.org/express-js-res-render-function/)
      */
-    render<RenderOptions extends object>(
-      view: string,
-      options?: RenderOptions,
+    render<View extends NunjucksTemplateName>(
+      view: View,
+      viewModel?: NunjucksTemplateViewModel<View>,
       callback?: (err: Error, html: string) => void,
     ): void;
   }

--- a/trade-finance-manager-ui/server/types/express-serve-static-core.d.ts
+++ b/trade-finance-manager-ui/server/types/express-serve-static-core.d.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { Express } from 'express';
+
+declare module 'express-serve-static-core' {
+  export interface Response {
+    /**
+     * Extends the base `core.Response.render` function to use a generic for
+     * the render locals (see https://www.geeksforgeeks.org/express-js-res-render-function/)
+     */
+    render<RenderOptions extends object>(
+      view: string,
+      options?: RenderOptions,
+      callback?: (err: Error, html: string) => void,
+    ): void;
+  }
+}

--- a/trade-finance-manager-ui/server/types/primary-navigation-key.ts
+++ b/trade-finance-manager-ui/server/types/primary-navigation-key.ts
@@ -1,0 +1,4 @@
+import { ValuesOf } from '@ukef/dtfs2-common';
+import { PRIMARY_NAVIGATION_KEYS } from '../constants';
+
+export type PrimaryNavigationKey = ValuesOf<typeof PRIMARY_NAVIGATION_KEYS>;

--- a/trade-finance-manager-ui/server/types/view-models/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/index.ts
@@ -1,0 +1,13 @@
+import { ProblemWithServiceViewModel } from './problem-with-service-view-model';
+import { UtilisationReportReconciliationForReportViewModel } from './utilisation-report-reconciliation-for-report-view-model';
+
+export type NunjucksTemplateName =
+  | '_partials/problem-with-service.njk'
+  | 'utilisation-reports/utilisation-report-reconciliation-for-report.njk';
+
+export type NunjucksTemplateViewModel<View extends NunjucksTemplateName> =
+  View extends '_partials/problem-with-service.njk'
+    ? ProblemWithServiceViewModel
+    : View extends 'utilisation-reports/utilisation-report-reconciliation-for-report.njk'
+    ? UtilisationReportReconciliationForReportViewModel
+    : object;

--- a/trade-finance-manager-ui/server/types/view-models/problem-with-service-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/problem-with-service-view-model.ts
@@ -1,0 +1,5 @@
+import { TfmSessionUser } from '../tfm-session-user';
+
+export type ProblemWithServiceViewModel = {
+  user: TfmSessionUser;
+};

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -1,0 +1,10 @@
+import { SessionBank } from '@ukef/dtfs2-common';
+import { PrimaryNavigationKey } from '../primary-navigation-key';
+import { TfmSessionUser } from '../tfm-session-user';
+
+export type UtilisationReportReconciliationForReportViewModel = {
+  user: TfmSessionUser;
+  activePrimaryNavigation: PrimaryNavigationKey;
+  bank: SessionBank;
+  formattedReportPeriod: string;
+};


### PR DESCRIPTION
## Introduction :pencil2:
It would be nice to have a way of defining the type we want to use for the express `res.render` method.

## Resolution :heavy_check_mark:
- Adds a new declaration file to merge the declaration for the express `core.Response.render` function
- Updates `res.render` in the controller for `getUtilisationReportReconciliationForReport` in TFM-UI

## Miscellaneous :heavy_plus_sign:

