### PR TITLE
feat(FN-1615): add default value for fee record status column

### DIFF
--- a/libs/common/src/sql-db-connection/migrations/1715613302494-AddFeeRecordStatusColumn.ts
+++ b/libs/common/src/sql-db-connection/migrations/1715613302494-AddFeeRecordStatusColumn.ts
@@ -1,16 +1,19 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddFeeRecordStatusColumn1714741183254 implements MigrationInterface {
-  name = 'AddFeeRecordStatusColumn1714741183254';
+export class AddFeeRecordStatusColumn1715613302494 implements MigrationInterface {
+  name = 'AddFeeRecordStatusColumn1715613302494';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
             ALTER TABLE "FeeRecord"
-            ADD "status" nvarchar(255) NOT NULL
+            ADD "status" nvarchar(255) NOT NULL CONSTRAINT "DF_1eb3a649cce84deaa2a20390401" DEFAULT 'TO_DO'
         `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord" DROP CONSTRAINT "DF_1eb3a649cce84deaa2a20390401"
+        `);
     await queryRunner.query(`
             ALTER TABLE "FeeRecord" DROP COLUMN "status"
         `);

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -94,7 +94,7 @@ export class FeeRecordEntity extends AuditableBaseEntity {
   /**
    * Status code representing the reconciliation state of the fee record
    */
-  @Column({ type: 'nvarchar' })
+  @Column({ type: 'nvarchar', default: 'TO_DO' })
   status!: FeeRecordStatus;
 
   // TODO FN-1726 - when we have a status on this entity we should make this method name specific to the initial status


### PR DESCRIPTION
## Introduction :pencil2:
We need a default value for the new status column in the `FeeRecord` SQL table.

## Resolution :heavy_check_mark:
- Updates the entity to have the default value
- Replaces the old migration

## Miscellaneous :heavy_plus_sign:

