### PR TITLE
fix(deployment): added release-2.0 to deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -53,6 +53,7 @@ on:
       - feature
       - staging
       - prod
+      - release-2.0
 
 env:
   PRODUCT: dtfs


### PR DESCRIPTION
## Introduction :pencil2:
Add `release-2.0` to deployment to avoid rebasing `dev` branch

