### PR TITLE
fix(FN-1615): add update query to fee record status migration

### DIFF
--- a/libs/common/src/sql-db-connection/migrations/1715613302494-AddFeeRecordStatusColumn.ts
+++ b/libs/common/src/sql-db-connection/migrations/1715613302494-AddFeeRecordStatusColumn.ts
@@ -9,6 +9,10 @@ export class AddFeeRecordStatusColumn1715613302494 implements MigrationInterface
             ADD "status" nvarchar(255) NULL CONSTRAINT "DF_1eb3a649cce84deaa2a20390401" DEFAULT 'TO_DO'
         `);
     await queryRunner.query(`
+            UPDATE "FeeRecord"
+            SET "status" = 'TO_DO'
+        `);
+    await queryRunner.query(`
             ALTER TABLE "FeeRecord"
             ALTER COLUMN "status" nvarchar(255) NOT NULL
         `);


### PR DESCRIPTION
## Introduction :pencil2:
We need to fix the migration which adds the status column to the fee record table.

## Resolution :heavy_check_mark:
The current migration tries to set the `status` column of all existing fee records to `null`, whereas we actually want it to set it to `TO_DO`. This PR makes that change.

## Miscellaneous :heavy_plus_sign:


