### PR TITLE
feat(FN-1615): update the formatting for the currency and amount string

### DIFF
--- a/libs/common/src/helpers/currency.test.ts
+++ b/libs/common/src/helpers/currency.test.ts
@@ -3,14 +3,46 @@ import { getFormattedCurrencyAndAmount } from './currency';
 
 describe('currency helpers', () => {
   describe('getFormattedCurrencyAndAmount', () => {
-    it('gets the formatted the current and amount string with thousands separated by comma and only 2 decimal places', () => {
+    it('gets the formatted the current and amount string with thousands separated by comma', () => {
       // Arrange
       const currencyAndAmount: CurrencyAndAmount = {
         currency: 'GBP',
-        amount: 1234567.8912,
+        amount: 1234567.89,
       };
 
       const expectedFormattedCurrencyAndAmount = 'GBP 1,234,567.89';
+
+      // Act
+      const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);
+
+      // Assert
+      expect(formattedCurrencyAndAmount).toBe(expectedFormattedCurrencyAndAmount);
+    });
+
+    it('gets the formatted the current and amount string with 2 decimal places when the amount has more than 2 decimal places', () => {
+      // Arrange
+      const currencyAndAmount: CurrencyAndAmount = {
+        currency: 'GBP',
+        amount: 1234567.89123,
+      };
+
+      const expectedFormattedCurrencyAndAmount = 'GBP 1,234,567.89';
+
+      // Act
+      const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);
+
+      // Assert
+      expect(formattedCurrencyAndAmount).toBe(expectedFormattedCurrencyAndAmount);
+    });
+
+    it('gets the formatted the current and amount string with 2 decimal places when the amount has no decimal places', () => {
+      // Arrange
+      const currencyAndAmount: CurrencyAndAmount = {
+        currency: 'GBP',
+        amount: 1234567,
+      };
+
+      const expectedFormattedCurrencyAndAmount = 'GBP 1,234,567.00';
 
       // Act
       const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);

--- a/libs/common/src/helpers/currency.test.ts
+++ b/libs/common/src/helpers/currency.test.ts
@@ -1,0 +1,22 @@
+import { CurrencyAndAmount } from '../types';
+import { getFormattedCurrencyAndAmount } from './currency';
+
+describe('currency helpers', () => {
+  describe('getFormattedCurrencyAndAmount', () => {
+    it('gets the formatted the current and amount string with thousands separated by comma and only 2 decimal places', () => {
+      // Arrange
+      const currencyAndAmount: CurrencyAndAmount = {
+        currency: 'GBP',
+        amount: 1234567.8912,
+      };
+
+      const expectedFormattedCurrencyAndAmount = 'GBP 1,234,567.89';
+
+      // Act
+      const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);
+
+      // Assert
+      expect(formattedCurrencyAndAmount).toBe(expectedFormattedCurrencyAndAmount);
+    });
+  });
+});

--- a/libs/common/src/helpers/currency.ts
+++ b/libs/common/src/helpers/currency.ts
@@ -9,7 +9,10 @@ import { CurrencyAndAmount, CurrencyAndAmountString } from '../types';
  * const amount = getFormattedCurrencyAndAmount({ currency: 'GBP', amount: 3.14159 }); // 'GBP 3.14'
  */
 export const getFormattedCurrencyAndAmount = (currencyAndAmount: CurrencyAndAmount): CurrencyAndAmountString => {
-  const formatter = new Intl.NumberFormat('en-GB', { maximumFractionDigits: 2 });
+  const formatter = new Intl.NumberFormat('en-GB', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
   const formattedAmount = formatter.format(currencyAndAmount.amount);
   return `${currencyAndAmount.currency} ${formattedAmount}`;
 };

--- a/libs/common/src/helpers/currency.ts
+++ b/libs/common/src/helpers/currency.ts
@@ -1,11 +1,15 @@
 import { CurrencyAndAmount, CurrencyAndAmountString } from '../types';
 
 /**
- * Gets the formatted currency and amount
+ * Gets the formatted currency and amount using the 'en-GB' number formatting
+ * for the amount
  * @param currencyAndAmount - The currency and amount object
  * @returns The formatted currency and amount
  * @example
  * const amount = getFormattedCurrencyAndAmount({ currency: 'GBP', amount: 3.14159 }); // 'GBP 3.14'
  */
-export const getFormattedCurrencyAndAmount = (currencyAndAmount: CurrencyAndAmount): CurrencyAndAmountString =>
-  `${currencyAndAmount.currency} ${currencyAndAmount.amount.toFixed(2)}`;
+export const getFormattedCurrencyAndAmount = (currencyAndAmount: CurrencyAndAmount): CurrencyAndAmountString => {
+  const formatter = new Intl.NumberFormat('en-GB', { maximumFractionDigits: 2 });
+  const formattedAmount = formatter.format(currencyAndAmount.amount);
+  return `${currencyAndAmount.currency} ${formattedAmount}`;
+};


### PR DESCRIPTION
## Introduction :pencil2:
We want to use proper formatting for currency and amount strings.

## Resolution :heavy_check_mark:
- Updates the currency helper to use a formatter
- Adds unit tests for the currency helpers

## Miscellaneous :heavy_plus_sign:


