### PR TITLE
fix(dtfs2-none): fix boolean coersion for sql config

### DIFF
--- a/libs/common/src/helpers/schemas/z-boolean-coerce.test.ts
+++ b/libs/common/src/helpers/schemas/z-boolean-coerce.test.ts
@@ -1,0 +1,59 @@
+import { zBooleanCoerce } from './z-boolean-coerce';
+
+describe('zBooleanCoerce', () => {
+  describe('when parsing a value with zBooleanCoerce', () => {
+    describe('when the provided value can be coerced to a boolean', () => {
+      it.each(getSuccessTestCases())('should return $result when the provided value is $description', ({ value, result }) => {
+        expect(zBooleanCoerce.parse(value)).toBe(result);
+      });
+    });
+
+    describe('when the provided value cannot be coerced to a boolean', () => {
+      it.each(getFailureTestCases())('should throw an error when the provided value is $description', ({ value }) => {
+        expect(() => zBooleanCoerce.parse(value)).toThrow();
+      });
+    });
+  });
+
+  describe('when parsing a value with zBooleanCoerce and additional chaining', () => {
+    describe('when chaining with .optional()', () => {
+      it('should return undefined when the provided value is undefined', () => {
+        expect(zBooleanCoerce.optional().parse(undefined)).toBe(undefined);
+      });
+    });
+
+    describe('when chaining with .nullable()', () => {
+      it('should return null when the provided value is null', () => {
+        expect(zBooleanCoerce.nullable().parse(null)).toBe(null);
+      });
+    });
+  });
+
+  function getSuccessTestCases() {
+    return [
+      { value: true, result: true, description: 'true' },
+      { value: false, result: false, description: 'false' },
+      { value: 'true', result: true, description: '"true"' },
+      { value: 'false', result: false, description: '"false"' },
+      { value: 'TRUE', result: true, description: '"TRUE"' },
+      { value: 'FALSE', result: false, description: '"FALSE"' },
+      { value: 'True', result: true, description: '"True"' },
+      { value: 'False', result: false, description: '"False"' },
+      { value: '1', result: true, description: '"1"' },
+      { value: '0', result: false, description: '"0"' },
+      { value: 1, result: true, description: '1' },
+      { value: 0, result: false, description: '0' },
+    ];
+  }
+
+  function getFailureTestCases() {
+    return [
+      { value: '', description: 'should throw an error when value is an empty string' },
+      { value: undefined, description: 'should throw an error when value is undefined' },
+      { value: null, description: 'should throw an error when value is null' },
+      { value: {}, description: 'should throw an error when value is an object' },
+      { value: 'random', description: 'should throw an error when value is a non boolean string' },
+      { value: 2, description: 'should throw an error when value is a non boolean number' },
+    ];
+  }
+});

--- a/libs/common/src/helpers/schemas/z-boolean-coerce.ts
+++ b/libs/common/src/helpers/schemas/z-boolean-coerce.ts
@@ -1,0 +1,16 @@
+import z from 'zod';
+
+export const zBooleanCoerce = z.preprocess((val) => {
+  if (typeof val === 'string' && ['true', 'false', '1', '0'].includes(val.toLowerCase())) {
+    return val.toLowerCase() === 'true' || val === '1';
+  }
+
+  if (typeof val === 'number' && [0, 1].includes(val)) {
+    return val === 1;
+  }
+
+  if (typeof val === 'boolean') {
+    return val;
+  }
+  return null;
+}, z.boolean());

--- a/libs/common/src/sql-db-connection/config.ts
+++ b/libs/common/src/sql-db-connection/config.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import dotenv from 'dotenv';
+import { zBooleanCoerce } from '../helpers/schemas/z-boolean-coerce';
 
 dotenv.config();
 
@@ -9,7 +10,7 @@ const sqlDbConfigSchema = z.object({
   SQL_DB_USERNAME: z.string(),
   SQL_DB_PASSWORD: z.string(),
   SQL_DB_NAME: z.string(),
-  SQL_DB_LOGGING_ENABLED: z.coerce.boolean(),
+  SQL_DB_LOGGING_ENABLED: zBooleanCoerce,
 });
 
 export const sqlDbConfig = sqlDbConfigSchema.parse(process.env);


### PR DESCRIPTION
## Introduction :pencil2:
There is a surprising way that zod coerces booleans (https://zod.dev/?id=coercion-for-primitives). This means that `"false"` would parse as `true`

## Resolution :heavy_check_mark:
I've made the coercion a lot more restrictive. We could have simply checked and done `typeof val === 'string' && val.toLowerCase() === 'false' ? false : val`, however I'm not sure we want to coerse all things truthy and falsy.


