### PR TITLE
feat(FN-2882): update premium payments table alignment

### DIFF
--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/premium-payments-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/premium-payments-table.component-test.js
@@ -57,13 +57,24 @@ describe(component, () => {
     wrapper.expectElement(`${tableSelector} thead th:contains("Status")`).toExist();
   });
 
+  it("should use the 'govuk-table__header--numeric' class for numeric columns", () => {
+    const wrapper = getWrapper();
+    const numericHeaderClass = 'govuk-table__header--numeric';
+    wrapper.expectElement(`${tableSelector} thead th:contains("Reported fees")`).hasClass(numericHeaderClass);
+    wrapper.expectElement(`${tableSelector} thead th:contains("Reported payments")`).hasClass(numericHeaderClass);
+    wrapper.expectElement(`${tableSelector} thead th:contains("Total reported payments")`).hasClass(numericHeaderClass);
+    wrapper.expectElement(`${tableSelector} thead th:contains("Payments received")`).hasClass(numericHeaderClass);
+    wrapper.expectElement(`${tableSelector} thead th:contains("Total payments received")`).hasClass(numericHeaderClass);
+  });
+
   it('should render the select all checkbox in the table headings row', () => {
     const wrapper = getWrapper();
     wrapper.expectElement(`${tableSelector} thead th input[type="checkbox"]#select-all-checkbox`).toExist();
   });
 
-  it('should render the table data', () => {
+  it("should render the table data and use the 'govuk-table__cell--numeric' class for numeric cells", () => {
     const wrapper = getWrapper();
+    const numericCellClass = 'govuk-table__cell--numeric';
 
     feeRecords.forEach((feeRecord) => {
       const rowSelector = `[data-cy="premium-payments-table-row--feeRecordId-${feeRecord.id}"]`;
@@ -77,22 +88,26 @@ describe(component, () => {
       wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.exporter}")`).toExist();
 
       wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.reportedFees.formattedCurrencyAndAmount}")`).toExist();
+      wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.reportedFees.formattedCurrencyAndAmount}")`).hasClass(numericCellClass);
       wrapper
         .expectElement(`${rowSelector} td:contains("${feeRecord.reportedFees.formattedCurrencyAndAmount}")`)
         .toHaveAttribute('data-sort-value', feeRecord.reportedFees.dataSortValue.toString());
 
       wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.reportedPayments.formattedCurrencyAndAmount}")`).toExist();
+      wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.reportedPayments.formattedCurrencyAndAmount}")`).hasClass(numericCellClass);
       wrapper
         .expectElement(`${rowSelector} td:contains("${feeRecord.reportedPayments.formattedCurrencyAndAmount}")`)
         .toHaveAttribute('data-sort-value', feeRecord.reportedPayments.dataSortValue.toString());
 
       wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.totalReportedPayments.formattedCurrencyAndAmount}")`).toExist();
+      wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.totalReportedPayments.formattedCurrencyAndAmount}")`).hasClass(numericCellClass);
       wrapper
         .expectElement(`${rowSelector} td:contains("${feeRecord.totalReportedPayments.formattedCurrencyAndAmount}")`)
         .toHaveAttribute('data-sort-value', feeRecord.totalReportedPayments.dataSortValue.toString());
 
       if (feeRecord.paymentsReceived.formattedCurrencyAndAmount) {
         wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.paymentsReceived.formattedCurrencyAndAmount}")`).toExist();
+        wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.paymentsReceived.formattedCurrencyAndAmount}")`).hasClass(numericCellClass);
         wrapper
           .expectElement(`${rowSelector} td:contains("${feeRecord.paymentsReceived.formattedCurrencyAndAmount}")`)
           .toHaveAttribute('data-sort-value', feeRecord.paymentsReceived.dataSortValue.toString());
@@ -100,6 +115,7 @@ describe(component, () => {
 
       if (feeRecord.totalPaymentsReceived.formattedCurrencyAndAmount) {
         wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.totalPaymentsReceived.formattedCurrencyAndAmount}")`).toExist();
+        wrapper.expectElement(`${rowSelector} td:contains("${feeRecord.totalPaymentsReceived.formattedCurrencyAndAmount}")`).hasClass(numericCellClass);
         wrapper
           .expectElement(`${rowSelector} td:contains("${feeRecord.paymentsReceived.formattedCurrencyAndAmount}")`)
           .toHaveAttribute('data-sort-value', feeRecord.totalPaymentsReceived.dataSortValue.toString());

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
@@ -9,17 +9,17 @@
   <table class="govuk-table" data-module="moj-sortable-table" data-cy="premium-payments-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header" aria-sort="ascending">Facility ID</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Exporter</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Reported fees</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Reported payments</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Total reported payments</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Payments received</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Total payments received</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Status</th>
         <th scope="col" class="govuk-table__header">
           {{ selectAllTableCellCheckbox.render() }}
         </th>
-        <th scope="col" class="govuk-table__header" aria-sort="ascending">Facility ID</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Exporter</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Reported fees</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Reported payments</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Total reported payments</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Payments received</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Total payments received</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Status</th>
       </tr>
     </thead>
 
@@ -29,14 +29,6 @@
         class="govuk-table__row"
         data-cy="premium-payments-table-row--feeRecordId-{{ feeRecord.id }}"
       >
-        <td class="govuk-table__cell">
-          {% if feeRecord.status === 'TO_DO' or feeRecord.status === 'DOES_NOT_MATCH' %}
-            {{ tableCellCheckbox.render({
-              checkboxId: feeRecord.checkboxId,
-              checked: feeRecord.isChecked
-            }) }}
-          {% endif %}
-        </td>
         <th
           scope="row"
           class="govuk-table__header govuk-!-font-weight-regular"
@@ -47,19 +39,19 @@
         <td class="govuk-table__cell" data-sort-value="{{ feeRecord.exported }}">
           {{ feeRecord.exporter }}
         </td>
-        <td class="govuk-table__cell" data-sort-value="{{ feeRecord.reportedFees.dataSortValue }}">
+        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ feeRecord.reportedFees.dataSortValue }}">
           {{ feeRecord.reportedFees.formattedCurrencyAndAmount }}
         </td>
-        <td class="govuk-table__cell" data-sort-value="{{ feeRecord.reportedPayments.dataSortValue }}">
+        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ feeRecord.reportedPayments.dataSortValue }}">
           {{ feeRecord.reportedPayments.formattedCurrencyAndAmount }}
         </td>
-        <td class="govuk-table__cell" data-sort-value="{{ feeRecord.totalReportedPayments.dataSortValue }}">
+        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ feeRecord.totalReportedPayments.dataSortValue }}">
           {{ feeRecord.totalReportedPayments.formattedCurrencyAndAmount }}
         </td>
-        <td class="govuk-table__cell" data-sort-value="{{ feeRecord.paymentsReceived.dataSortValue }}">
+        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ feeRecord.paymentsReceived.dataSortValue }}">
           {{ feeRecord.paymentsReceived.formattedCurrencyAndAmount }}
         </td>
-        <td class="govuk-table__cell" data-sort-value="{{ feeRecord.totalPaymentsReceived.dataSortValue }}">
+        <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="{{ feeRecord.totalPaymentsReceived.dataSortValue }}">
           {{ feeRecord.totalPaymentsReceived.formattedCurrencyAndAmount }}
         </td>
         <td class="govuk-table__cell" data-sort-value="{{ feeRecord.displayStatus }}">
@@ -67,6 +59,14 @@
             status: feeRecord.status,
             displayStatus: feeRecord.displayStatus
           }) }}
+        </td>
+        <td class="govuk-table__cell">
+          {% if feeRecord.status === 'TO_DO' or feeRecord.status === 'DOES_NOT_MATCH' %}
+            {{ tableCellCheckbox.render({
+              checkboxId: feeRecord.checkboxId,
+              checked: feeRecord.isChecked
+            }) }}
+          {% endif %}
         </td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
## Introduction :pencil2:
We want to update the alignment on columns in the premium payments table which contain numeric values.

## Resolution :heavy_check_mark:
- Updates the template to use the `govuk-table__header--numeric` and `govuk-table__cell--numeric` classes
- Updates the component tests to check these classes are used where they are needed

## Miscellaneous :heavy_plus_sign:


