### PR TITLE
feat(FN-2900): update local SQL to use ledger tables

### DIFF
--- a/doc/sql-db.md
+++ b/doc/sql-db.md
@@ -6,6 +6,38 @@ The project uses the [Microsoft SQL Server](https://learn.microsoft.com/en-gb/sq
 
 As of January 2024 the project is in the process of migrating from a MongoDB (NoSQL) database to a SQL Server (SQL) database. MongoDB collections will gradually be replaced with SQL Server tables until MongoDB can be completely removed.
 
+## Ledger tables
+
+The SQL Server database tables all have ledger enabled which has some impacts on how we alter tables. For more details than those discussed below, refer to [the SQL Server docs](https://learn.microsoft.com/en-us/sql/relational-databases/security/ledger/ledger-limits?view=sql-server-ver16).
+
+### Adding a new, non-nullable column
+
+Nullable columns can be added to a ledger table with no issues. If you want to add a non-nullable column, you need your column to have a default value and need to manually update the migration generated via [`npm run db:generate-migration`](#--generate-new-migration). For example, as we use typeorm to generate our migrations, consider the following column
+
+```typescript
+@Column({ nullable: false, default: 0 })
+age!: number;
+```
+
+The `npm run db:generate-migration` command will then generate a query similar to
+
+```sql
+ALTER TABLE "Person" ADD "age" int CONSTRAINT "DF_abc123" DEFAULT 0
+```
+
+However, this will cause an error as the existing rows will do not satisfy the non-nullable constraint. To overcome this, you need to manually update your migration to have the following three steps:
+
+```sql
+-- Add column as nullable
+ALTER TABLE "Person" ADD "age" int NULL CONSTRAINT "DF_abc123" DEFAULT 0;
+
+-- Update all existing columns to have the default value
+UPDATE "Person" SET "age" = 0;
+
+-- Set the new column to non-nullable
+ALTER TABLE "Person" ALTER COLUMN "age" int NOT NULL;
+```
+
 ## Running locally
 
 The SQL Server database will be spun up in Docker along with all the other services (see the docker-compose step in [Setup](../README.md#setup-gear) in the main README).

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -25,7 +25,7 @@
   },
   "main": "src/index.ts",
   "scripts": {
-    "db:drop-all": "npm run typeorm -- schema:drop -d src/sql-db-connection/data-source.ts",
+    "db:drop-all": "dotenv bash src/sql-db-connection/reset-database.sh dtfs",
     "db:generate-migration": "cross-var npm run typeorm -- migration:generate -d src/sql-db-connection/data-source.ts -p src/sql-db-connection/migrations/$npm_config_name",
     "db:migrate": "npm run typeorm -- migration:run -d src/sql-db-connection/data-source.ts",
     "db:migrate:down": "npm run typeorm -- migration:revert -d src/sql-db-connection/data-source.ts",
@@ -55,6 +55,7 @@
     "@types/node": "^20.12.8",
     "@types/node-cron": "^3.0.11",
     "cross-var": "^1.1.0",
+    "dotenv-cli": "^7.4.2",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",

--- a/libs/common/src/sql-db-connection/migrations/1712063692770-AddUtilisationReportTables.ts
+++ b/libs/common/src/sql-db-connection/migrations/1712063692770-AddUtilisationReportTables.ts
@@ -18,6 +18,9 @@ export class AddUtilisationReportTables1712063692770 implements MigrationInterfa
                 "lastUpdatedByTfmUserId" nvarchar(255),
                 "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_5b2813faa091ae4c63bc13a88ec" DEFAULT 0,
                 CONSTRAINT "PK_ea6ad35b38f9b9e248b432d1a1e" PRIMARY KEY ("id")
+            ) WITH (
+                SYSTEM_VERSIONING = ON,
+                LEDGER = ON
             )
         `);
     await queryRunner.query(`
@@ -44,6 +47,9 @@ export class AddUtilisationReportTables1712063692770 implements MigrationInterfa
                 "lastUpdatedByTfmUserId" nvarchar(255),
                 "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_7121ac2f65fd8b070ffd591ed37" DEFAULT 0,
                 CONSTRAINT "PK_9488afe4d9d39fec32e7c53d47a" PRIMARY KEY ("id")
+            ) WITH (
+                SYSTEM_VERSIONING = ON,
+                LEDGER = ON
             )
         `);
     await queryRunner.query(`
@@ -62,6 +68,9 @@ export class AddUtilisationReportTables1712063692770 implements MigrationInterfa
                 "lastUpdatedByTfmUserId" nvarchar(255),
                 "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_edb079a13cd83e211bc24c2b0b9" DEFAULT 0,
                 CONSTRAINT "PK_98a789a9ebdc731bd04ec00860a" PRIMARY KEY ("id")
+            ) WITH (
+                SYSTEM_VERSIONING = ON,
+                LEDGER = ON
             )
         `);
     await queryRunner.query(`

--- a/libs/common/src/sql-db-connection/reset-database.sh
+++ b/libs/common/src/sql-db-connection/reset-database.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+execute_docker_sql_command() {
+  docker exec dtfs2-dtfs-sql-1 //opt//mssql-tools//bin//sqlcmd -S localhost -U sa -P "AbC!2345" -Q "$1"
+  return $?
+}
+
+echo "Attempting to drop and recreate database '$SQL_DB_NAME'..."
+
+execute_docker_sql_command "DROP DATABASE $SQL_DB_NAME"
+execute_docker_sql_command "CREATE DATABASE $SQL_DB_NAME"
+
+echo "Successfully recreated database '$SQL_DB_NAME'"
+
+echo "Attempting to create database user '$1' for database '$SQL_DB_NAME'..."
+
+# Create a new user in the database and map it to the login
+execute_docker_sql_command "USE [$SQL_DB_NAME]; CREATE USER $1 FOR LOGIN $1;"
+
+# Grant the new user required permissions
+execute_docker_sql_command "USE [$SQL_DB_NAME]; ALTER ROLE db_datareader ADD MEMBER $1;"
+execute_docker_sql_command "USE [$SQL_DB_NAME]; ALTER ROLE db_datawriter ADD MEMBER $1;"
+execute_docker_sql_command "USE [$SQL_DB_NAME]; ALTER ROLE db_ddladmin ADD MEMBER $1;"

--- a/package-lock.json
+++ b/package-lock.json
@@ -939,6 +939,7 @@
         "@types/node": "^20.12.8",
         "@types/node-cron": "^3.0.11",
         "cross-var": "^1.1.0",
+        "dotenv-cli": "^7.4.2",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
@@ -13060,6 +13061,80 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-7.4.2.tgz",
+      "integrity": "sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dtfs-utilities": {


### PR DESCRIPTION
## Introduction :pencil2:
The database we use in deployed environments uses ledger tables, but our local setup does not. This means that it is possible for migrations to work locally and on the test pipeline, but fail once deployed. To get around this, we want to update the initial migration to create all tables with ledger enabled. This results in the original `db:drop-all` command we have to fail as we cannot drop tables in the same way, so we also need to update this command to properly reset the database.

## Resolution :heavy_check_mark:
- Updates the initial migration without changing the filename*
- Adds a new `reset-database.sh` script to `libs/common/src/sql-db-connection`

*we don't need to run this migration as a new migration in deployed environments, so there is no need to generate a new migration for it

## Miscellaneous :heavy_plus_sign:


