### PR TITLE
feat(FN-1697): implement payment added to fee record event

### DIFF
--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/payment-added-to-fee-record/payment-added-to-fee-record.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/payment-added-to-fee-record/payment-added-to-fee-record.event-handler.test.ts
@@ -1,19 +1,140 @@
-import { UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { DbRequestSource, UTILISATION_REPORT_RECONCILIATION_STATUS, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { handleUtilisationReportPaymentAddedToFeeRecordEvent } from './payment-added-to-fee-record.event-handler';
-import { NotImplementedError } from '../../../../../errors';
+import { UtilisationReportRepo } from '../../../../../repositories/utilisation-reports-repo';
 
 describe('handleUtilisationReportPaymentAddedToFeeRecordEvent', () => {
-  // TODO FN-1697 - update tests when functionality implemented
-  it('throws a NotImplementedError', () => {
-    // Arrange
-    const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
+  const tfmUserId = 'abc123';
+  const requestSource: DbRequestSource = {
+    platform: 'TFM',
+    userId: tfmUserId,
+  };
 
-    // Act / Assert
-    expect(() =>
-      handleUtilisationReportPaymentAddedToFeeRecordEvent(report, {
-        feeRecordId: 1,
-        paymentId: 1,
-      }),
-    ).toThrow(NotImplementedError);
+  const saveSpy = jest.spyOn(UtilisationReportRepo, 'save');
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe(`when the report status is '${UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION}'`, () => {
+    it("calls the 'UtilisationReportRepo.save' method once", async () => {
+      // Arrange
+      const PENDING_RECONCILIATION_REPORT = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
+
+      saveSpy.mockResolvedValue(PENDING_RECONCILIATION_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(PENDING_RECONCILIATION_REPORT, { requestSource });
+
+      // Assert
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(saveSpy).toHaveBeenCalledWith(PENDING_RECONCILIATION_REPORT);
+    });
+
+    it(`sets the report status to '${UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS}'`, async () => {
+      // Arrange
+      const PENDING_RECONCILIATION_REPORT = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
+
+      saveSpy.mockResolvedValue(PENDING_RECONCILIATION_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(PENDING_RECONCILIATION_REPORT, { requestSource });
+
+      // Assert
+      expect(PENDING_RECONCILIATION_REPORT.status).toBe(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS);
+    });
+
+    it(`sets the report 'lastUpdatedByIsSystemUser' field to 'false'`, async () => {
+      // Arrange
+      const PENDING_RECONCILIATION_REPORT = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
+
+      saveSpy.mockResolvedValue(PENDING_RECONCILIATION_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(PENDING_RECONCILIATION_REPORT, { requestSource });
+
+      // Assert
+      expect(PENDING_RECONCILIATION_REPORT.lastUpdatedByIsSystemUser).toBe(false);
+    });
+
+    it(`sets the report 'lastUpdatedByPortalUserId' field to 'null'`, async () => {
+      // Arrange
+      const PENDING_RECONCILIATION_REPORT = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
+
+      saveSpy.mockResolvedValue(PENDING_RECONCILIATION_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(PENDING_RECONCILIATION_REPORT, { requestSource });
+
+      // Assert
+      expect(PENDING_RECONCILIATION_REPORT.lastUpdatedByPortalUserId).toBe(null);
+    });
+
+    it(`sets the report 'lastUpdatedByTfmUserId' field to the request source user id`, async () => {
+      // Arrange
+      const PENDING_RECONCILIATION_REPORT = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
+
+      saveSpy.mockResolvedValue(PENDING_RECONCILIATION_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(PENDING_RECONCILIATION_REPORT, { requestSource });
+
+      // Assert
+      expect(PENDING_RECONCILIATION_REPORT.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    });
+  });
+
+  describe(`when the report status is '${UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS}'`, () => {
+    it("calls the 'UtilisationReportRepo.save' method once", async () => {
+      // Arrange
+      const RECONCILIATION_IN_PROGRESS_REPORT = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
+
+      saveSpy.mockResolvedValue(RECONCILIATION_IN_PROGRESS_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(RECONCILIATION_IN_PROGRESS_REPORT, { requestSource });
+
+      // Assert
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(saveSpy).toHaveBeenCalledWith(RECONCILIATION_IN_PROGRESS_REPORT);
+    });
+
+    it(`sets the report 'lastUpdatedByIsSystemUser' field to 'false'`, async () => {
+      // Arrange
+      const RECONCILIATION_IN_PROGRESS_REPORT = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
+
+      saveSpy.mockResolvedValue(RECONCILIATION_IN_PROGRESS_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(RECONCILIATION_IN_PROGRESS_REPORT, { requestSource });
+
+      // Assert
+      expect(RECONCILIATION_IN_PROGRESS_REPORT.lastUpdatedByIsSystemUser).toBe(false);
+    });
+
+    it(`sets the report 'lastUpdatedByPortalUserId' field to 'null'`, async () => {
+      // Arrange
+      const RECONCILIATION_IN_PROGRESS_REPORT = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
+
+      saveSpy.mockResolvedValue(RECONCILIATION_IN_PROGRESS_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(RECONCILIATION_IN_PROGRESS_REPORT, { requestSource });
+
+      // Assert
+      expect(RECONCILIATION_IN_PROGRESS_REPORT.lastUpdatedByPortalUserId).toBe(null);
+    });
+
+    it(`sets the report 'lastUpdatedByTfmUserId' field to the request source user id`, async () => {
+      // Arrange
+      const RECONCILIATION_IN_PROGRESS_REPORT = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
+
+      saveSpy.mockResolvedValue(RECONCILIATION_IN_PROGRESS_REPORT);
+
+      // Act
+      await handleUtilisationReportPaymentAddedToFeeRecordEvent(RECONCILIATION_IN_PROGRESS_REPORT, { requestSource });
+
+      // Assert
+      expect(RECONCILIATION_IN_PROGRESS_REPORT.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    });
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
@@ -116,7 +116,12 @@ describe('UtilisationReportStateMachine', () => {
       // Act
       await stateMachine.handleEvent({
         type: 'PAYMENT_ADDED_TO_FEE_RECORD',
-        payload: { feeRecordId: 1, paymentId: 2 },
+        payload: {
+          requestSource: {
+            platform: 'TFM',
+            userId: 'abc123',
+          },
+        },
       });
 
       // Assert
@@ -172,7 +177,12 @@ describe('UtilisationReportStateMachine', () => {
       // Act
       await stateMachine.handleEvent({
         type: 'PAYMENT_ADDED_TO_FEE_RECORD',
-        payload: { feeRecordId: 1, paymentId: 2 },
+        payload: {
+          requestSource: {
+            platform: 'TFM',
+            userId: 'abc123',
+          },
+        },
       });
 
       // Assert


### PR DESCRIPTION
## Introduction :pencil2:
We want to implement the `'PAYMENT_ADDED_TO_FEE_RECORD'` utilisation report state machine event.

## Resolution :heavy_check_mark:
- Implements the event handler
- Updates unit tests
- Removes linked `TODO` comments

## Miscellaneous :heavy_plus_sign:

