### PR TITLE
feat(dtfs2-6966): add audit logs to create multiple facilities endpoint

### DIFF
--- a/dtfs-central-api/src/v1/controllers/portal/facility/create-multiple-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/create-multiple-facilities.controller.js
@@ -1,5 +1,4 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { InvalidAuditDetailsError } = require('@ukef/dtfs2-common/errors');
 const { MONGO_DB_COLLECTIONS, InvalidAuditDetailsError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const { mongoDbClient: db } = require('../../../../drivers/db-client');

--- a/dtfs-central-api/src/v1/controllers/portal/facility/create-multiple-facilities.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/create-multiple-facilities.controller.js
@@ -16,18 +16,16 @@ const createFacilities = async (facilities, dealId, auditDetails) => {
 
     const auditRecord = generateAuditDatabaseRecordFromAuditDetails(auditDetails);
 
-    const facilitiesWithId = await Promise.all(
-      facilities.map(async (f) => {
-        const facility = f;
+    const facilitiesWithId = facilities.map((f) => {
+      const facility = f;
 
-        facility._id = new ObjectId(facility._id);
-        facility.createdDate = Date.now();
-        facility.updatedAt = Date.now();
-        facility.dealId = new ObjectId(dealId);
-        facility.auditRecord = auditRecord;
-        return facility;
-      }),
-    );
+      facility._id = new ObjectId(facility._id);
+      facility.createdDate = Date.now();
+      facility.updatedAt = Date.now();
+      facility.dealId = new ObjectId(dealId);
+      facility.auditRecord = auditRecord;
+      return facility;
+    });
 
     const idsArray = [];
     facilitiesWithId.forEach((f) => {

--- a/portal-api/api-tests/createFacilities.js
+++ b/portal-api/api-tests/createFacilities.js
@@ -1,12 +1,13 @@
 const app = require('../src/createApp');
 const { as } = require('./api')(app);
 
-const createFacilities = async (user, dealId, facilities) => {
+const createFacilities = async (user, dealId, facilities, auditDetails) => {
   const response = await as(user)
     .post({
       facilities,
       dealId,
       user,
+      auditDetails,
     })
     .to(`/v1/deals/${dealId}/multiple-facilities`);
   return response.body;

--- a/portal-api/api-tests/createFacilities.js
+++ b/portal-api/api-tests/createFacilities.js
@@ -1,13 +1,12 @@
 const app = require('../src/createApp');
 const { as } = require('./api')(app);
 
-const createFacilities = async (user, dealId, facilities, auditDetails) => {
+const createFacilities = async (user, dealId, facilities) => {
   const response = await as(user)
     .post({
       facilities,
       dealId,
       user,
-      auditDetails,
     })
     .to(`/v1/deals/${dealId}/multiple-facilities`);
   return response.body;

--- a/portal-api/api-tests/v1/deals/deals-status-facilities.api-test.js
+++ b/portal-api/api-tests/v1/deals/deals-status-facilities.api-test.js
@@ -1,3 +1,4 @@
+const { generateParsedMockPortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/change-stream/test-helpers');
 const { add, format } = require('date-fns');
 const databaseHelper = require('../../database-helper');
 const app = require('../../../src/createApp');
@@ -586,6 +587,7 @@ describe('/v1/deals/:id/status - facilities', () => {
             'requestedCoverStartDate-year': expect.any(Number),
             _id: expect.any(String),
             dealId,
+            auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aBarclaysMaker._id),
           });
 
           expect(body.deal.bondTransactions.items[2]).toEqual({
@@ -600,6 +602,7 @@ describe('/v1/deals/:id/status - facilities', () => {
             'requestedCoverStartDate-year': expect.any(Number),
             _id: expect.any(String),
             dealId,
+            auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aBarclaysMaker._id),
           });
         });
       });
@@ -623,6 +626,7 @@ describe('/v1/deals/:id/status - facilities', () => {
             'requestedCoverStartDate-year': expect.any(Number),
             _id: expect.any(String),
             dealId,
+            auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aBarclaysMaker._id),
           });
 
           expect(body.deal.loanTransactions.items[2]).toEqual({
@@ -637,6 +641,7 @@ describe('/v1/deals/:id/status - facilities', () => {
             'requestedCoverStartDate-year': expect.any(Number),
             _id: expect.any(String),
             dealId,
+            auditRecord: generateParsedMockPortalUserAuditDatabaseRecord(aBarclaysMaker._id),
           });
         });
       });


### PR DESCRIPTION
## Introduction :pencil2:
We need to add audit details to portal endpoints

## Resolution :heavy_check_mark:
This PR adds audit details to the `create multiple facility` endpoint
