### PR TITLE
feat(FN-1739): add payment table

### DIFF
--- a/libs/common/src/sql-db-connection/migrations/1716990167763-AddPaymentTable.ts
+++ b/libs/common/src/sql-db-connection/migrations/1716990167763-AddPaymentTable.ts
@@ -6,15 +6,15 @@ export class AddPaymentTable1716990167763 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
             CREATE TABLE "Payment" (
-                "lastUpdatedAt" datetime2 NOT NULL CONSTRAINT "DF_3c7c91b94fc3c2cb358a90fa629" DEFAULT getdate(),
-                "lastUpdatedByPortalUserId" nvarchar(255),
-                "lastUpdatedByTfmUserId" nvarchar(255),
-                "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_c095a0510351d4262872da05235" DEFAULT 0,
                 "id" int NOT NULL IDENTITY(1, 1),
                 "currency" nvarchar(255) NOT NULL,
                 "amountReceived" int NOT NULL,
                 "dateReceived" datetime NOT NULL,
                 "paymentReference" nvarchar(255),
+                "lastUpdatedAt" datetime2 NOT NULL CONSTRAINT "DF_3c7c91b94fc3c2cb358a90fa629" DEFAULT getdate(),
+                "lastUpdatedByPortalUserId" nvarchar(255),
+                "lastUpdatedByTfmUserId" nvarchar(255),
+                "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_c095a0510351d4262872da05235" DEFAULT 0,
                 CONSTRAINT "PK_07e9fb9a8751923eb876d57a575" PRIMARY KEY ("id")
             ) WITH (
                 SYSTEM_VERSIONING = ON,

--- a/libs/common/src/sql-db-connection/migrations/1716990167763-AddPaymentTable.ts
+++ b/libs/common/src/sql-db-connection/migrations/1716990167763-AddPaymentTable.ts
@@ -16,6 +16,9 @@ export class AddPaymentTable1716990167763 implements MigrationInterface {
                 "dateReceived" datetime NOT NULL,
                 "paymentReference" nvarchar(255),
                 CONSTRAINT "PK_07e9fb9a8751923eb876d57a575" PRIMARY KEY ("id")
+            ) WITH (
+                SYSTEM_VERSIONING = ON,
+                LEDGER = ON
             )
         `);
     await queryRunner.query(`

--- a/libs/common/src/sql-db-connection/migrations/1716990167763-AddPaymentTable.ts
+++ b/libs/common/src/sql-db-connection/migrations/1716990167763-AddPaymentTable.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPaymentTable1716990167763 implements MigrationInterface {
+  name = 'AddPaymentTable1716990167763';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TABLE "Payment" (
+                "lastUpdatedAt" datetime2 NOT NULL CONSTRAINT "DF_3c7c91b94fc3c2cb358a90fa629" DEFAULT getdate(),
+                "lastUpdatedByPortalUserId" nvarchar(255),
+                "lastUpdatedByTfmUserId" nvarchar(255),
+                "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_c095a0510351d4262872da05235" DEFAULT 0,
+                "id" int NOT NULL IDENTITY(1, 1),
+                "currency" nvarchar(255) NOT NULL,
+                "amountReceived" int NOT NULL,
+                "dateReceived" datetime NOT NULL,
+                "paymentReference" nvarchar(255),
+                CONSTRAINT "PK_07e9fb9a8751923eb876d57a575" PRIMARY KEY ("id")
+            )
+        `);
+    await queryRunner.query(`
+            CREATE TABLE "fee_record_payments_payment" (
+                "feeRecordId" int NOT NULL,
+                "paymentId" int NOT NULL,
+                CONSTRAINT "PK_b27631d6ebc4d310641d876f8a4" PRIMARY KEY ("feeRecordId", "paymentId")
+            )
+        `);
+    await queryRunner.query(`
+            CREATE INDEX "IDX_7a9b7aa849fc3bb09d80fa1f81" ON "fee_record_payments_payment" ("feeRecordId")
+        `);
+    await queryRunner.query(`
+            CREATE INDEX "IDX_23bbb10be5f2136a5a5086654e" ON "fee_record_payments_payment" ("paymentId")
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "fee_record_payments_payment"
+            ADD CONSTRAINT "FK_7a9b7aa849fc3bb09d80fa1f812" FOREIGN KEY ("feeRecordId") REFERENCES "FeeRecord"("id") ON DELETE CASCADE ON UPDATE CASCADE
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "fee_record_payments_payment"
+            ADD CONSTRAINT "FK_23bbb10be5f2136a5a5086654e8" FOREIGN KEY ("paymentId") REFERENCES "Payment"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "fee_record_payments_payment" DROP CONSTRAINT "FK_23bbb10be5f2136a5a5086654e8"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "fee_record_payments_payment" DROP CONSTRAINT "FK_7a9b7aa849fc3bb09d80fa1f812"
+        `);
+    await queryRunner.query(`
+            DROP INDEX "IDX_23bbb10be5f2136a5a5086654e" ON "fee_record_payments_payment"
+        `);
+    await queryRunner.query(`
+            DROP INDEX "IDX_7a9b7aa849fc3bb09d80fa1f81" ON "fee_record_payments_payment"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "fee_record_payments_payment"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "Payment"
+        `);
+  }
+}

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -1,10 +1,11 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinTable, ManyToMany, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import Big from 'big.js';
 import { UtilisationReportEntity } from '../utilisation-report';
 import { Currency, FeeRecordStatus } from '../../types';
 import { AuditableBaseEntity } from '../base-entities';
 import { CreateFeeRecordParams } from './fee-record.types';
 import { MonetaryColumn, ExchangeRateColumn } from '../custom-columns';
+import { PaymentEntity } from '../payment';
 
 @Entity('FeeRecord')
 export class FeeRecordEntity extends AuditableBaseEntity {
@@ -97,6 +98,15 @@ export class FeeRecordEntity extends AuditableBaseEntity {
   @Column({ type: 'nvarchar', default: 'TO_DO' })
   status!: FeeRecordStatus;
 
+  /**
+   * The payments associated with the fee record
+   */
+  @ManyToMany(() => PaymentEntity, (payment) => payment.feeRecords, {
+    cascade: ['insert'],
+  })
+  @JoinTable()
+  payments!: PaymentEntity[];
+
   // TODO FN-1726 - when we have a status on this entity we should make this method name specific to the initial status
   static create({
     facilityId,
@@ -129,6 +139,7 @@ export class FeeRecordEntity extends AuditableBaseEntity {
     feeRecord.status = status;
     feeRecord.report = report;
     feeRecord.updateLastUpdatedBy(requestSource);
+    feeRecord.payments = [];
     return feeRecord;
   }
 

--- a/libs/common/src/sql-db-entities/index.ts
+++ b/libs/common/src/sql-db-entities/index.ts
@@ -1,6 +1,6 @@
 export { AzureFileInfoEntity } from './azure-file-info';
-export { DbRequestSource } from './helpers';
 export { FeeRecordEntity } from './fee-record';
 export { UtilisationReportEntity } from './utilisation-report';
+export { PaymentEntity } from './payment';
 export { MonthAndYearPartialEntity, ReportPeriodPartialEntity } from './partial-entities';
 export * from './helpers';

--- a/libs/common/src/sql-db-entities/payment/index.ts
+++ b/libs/common/src/sql-db-entities/payment/index.ts
@@ -1,0 +1,1 @@
+export * from './payment.entity';

--- a/libs/common/src/sql-db-entities/payment/payment.entity.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.entity.ts
@@ -1,0 +1,54 @@
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Currency } from '../../types';
+import { AuditableBaseEntity } from '../base-entities';
+import { CreatePaymentParams } from './payment.types';
+import { FeeRecordEntity } from '../fee-record';
+
+@Entity('Payment')
+export class PaymentEntity extends AuditableBaseEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  /**
+   * The currency the payment was made in
+   */
+  @Column({ type: 'nvarchar' })
+  currency!: Currency;
+
+  /**
+   * The amount received in the payment
+   */
+  @Column()
+  amountReceived!: number;
+
+  /**
+   * The date the payment was received
+   */
+  @Column()
+  dateReceived!: Date;
+
+  /**
+   * The payment reference (optional)
+   */
+  @Column({ nullable: true, type: 'nvarchar' })
+  paymentReference?: string;
+
+  /**
+   * The fee records attached to the payment
+   */
+  @ManyToMany(() => FeeRecordEntity, (feeRecord) => feeRecord.payments, {
+    cascade: ['insert'],
+  })
+  feeRecords!: FeeRecordEntity[];
+
+  static create({ currency, amountReceived, dateReceived, paymentReference, feeRecords, requestSource }: CreatePaymentParams): PaymentEntity {
+    const payment = new PaymentEntity();
+    payment.currency = currency;
+    payment.amountReceived = amountReceived;
+    payment.dateReceived = dateReceived;
+    payment.paymentReference = paymentReference;
+    payment.feeRecords = feeRecords;
+    payment.updateLastUpdatedBy(requestSource);
+    return payment;
+  }
+}

--- a/libs/common/src/sql-db-entities/payment/payment.types.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.types.ts
@@ -1,0 +1,12 @@
+import { Currency } from '../../types';
+import { FeeRecordEntity } from '../fee-record';
+import { DbRequestSource } from '../helpers';
+
+export type CreatePaymentParams = {
+  currency: Currency;
+  amountReceived: number;
+  dateReceived: Date;
+  paymentReference?: string;
+  feeRecords: FeeRecordEntity[];
+  requestSource: DbRequestSource;
+};

--- a/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
@@ -1,4 +1,5 @@
 import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity } from '../../sql-db-entities';
+import { PaymentEntity } from '../../sql-db-entities/payment';
 import { Currency, FeeRecordStatus } from '../../types';
 
 export class FeeRecordEntityMockBuilder {
@@ -30,6 +31,7 @@ export class FeeRecordEntityMockBuilder {
     data.paymentCurrency = 'GBP';
     data.paymentExchangeRate = 1;
     data.status = 'TO_DO';
+    data.payments = [];
     data.updateLastUpdatedBy(requestSource);
     return new FeeRecordEntityMockBuilder(data);
   }
@@ -96,6 +98,11 @@ export class FeeRecordEntityMockBuilder {
 
   public withStatus(status: FeeRecordStatus): FeeRecordEntityMockBuilder {
     this.feeRecord.status = status;
+    return this;
+  }
+
+  public withPayments(payments: PaymentEntity[]): FeeRecordEntityMockBuilder {
+    this.feeRecord.payments = payments;
     return this;
   }
 

--- a/libs/common/src/test-helpers/mock-data/index.ts
+++ b/libs/common/src/test-helpers/mock-data/index.ts
@@ -2,3 +2,4 @@ export * from './azure-file-info.mock';
 export * from './utilisation-report.entity.mock-builder';
 export * from './fee-record.entity.mock-builder';
 export * from './fee-record.entity.mock';
+export * from './payment.entity.mock-builder';

--- a/libs/common/src/test-helpers/mock-data/payment.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/payment.entity.mock-builder.ts
@@ -1,0 +1,51 @@
+import { FeeRecordEntity, PaymentEntity } from '../../sql-db-entities';
+import { Currency } from '../../types';
+
+export class PaymentEntityMockBuilder {
+  private readonly payment: PaymentEntity;
+
+  private constructor(payment: PaymentEntity) {
+    this.payment = payment;
+  }
+
+  public static forCurrency(currency: Currency): PaymentEntityMockBuilder {
+    const payment = new PaymentEntity();
+    payment.currency = currency;
+
+    payment.id = 1;
+    payment.amountReceived = 100;
+    payment.dateReceived = new Date();
+    payment.paymentReference = undefined;
+
+    return new PaymentEntityMockBuilder(payment);
+  }
+
+  public withId(id: number): PaymentEntityMockBuilder {
+    this.payment.id = id;
+    return this;
+  }
+
+  public withAmountReceived(amountReceived: number): PaymentEntityMockBuilder {
+    this.payment.amountReceived = amountReceived;
+    return this;
+  }
+
+  public withDateReceived(dateReceived: Date): PaymentEntityMockBuilder {
+    this.payment.dateReceived = dateReceived;
+    return this;
+  }
+
+  public withPaymentReference(paymentReference: string): PaymentEntityMockBuilder {
+    this.payment.paymentReference = paymentReference;
+    return this;
+  }
+
+  public withFeeRecords(feeRecords: FeeRecordEntity[]): PaymentEntityMockBuilder {
+    this.payment.feeRecords = feeRecords;
+    return this;
+  }
+
+  public build(): PaymentEntity {
+    return this.payment;
+  }
+}


### PR DESCRIPTION
## Introduction :pencil2:
We want to add a new SQL `Payment` table.

## Resolution :heavy_check_mark:
- Adds the new entity
- Generates the new migration (with ledger enabled)
- Adds the new `ManyToMany` relation to the fee record entity
- Adds a new entity mock builder for the `Payment`
- Adds new methods to the fee record entity mock builder to allow for defining payments

## Miscellaneous :heavy_plus_sign:


