### PR TITLE
feat(FN-2846): add ordering to utilisation reports request

### DIFF
--- a/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
+++ b/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
@@ -42,7 +42,21 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
       findByOptionsWhere.status = Not('REPORT_NOT_RECEIVED');
     }
 
-    return await this.findBy(findByOptionsWhere);
+    return await this.find({
+      where: findByOptionsWhere,
+      order: {
+        reportPeriod: {
+          start: {
+            year: 'ASC',
+            month: 'ASC',
+          },
+          end: {
+            year: 'ASC',
+            month: 'ASC',
+          },
+        },
+      },
+    });
   },
 
   /**

--- a/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
+++ b/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report-sql.repo.ts
@@ -101,6 +101,14 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
       relations: {
         feeRecords: includeFeeRecords,
       },
+      order: {
+        reportPeriod: {
+          end: {
+            year: 'ASC',
+            month: 'ASC',
+          },
+        },
+      },
     });
   },
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
@@ -1,13 +1,14 @@
 const { utilisationReportUpload } = require('../../../pages');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
 const relativeURL = require('../../../relativeURL');
-const { february2023ReportDetails } = require('../../../../fixtures/mockUtilisationReportDetails');
+const { february2023ReportDetails, march2023ReportDetails } = require('../../../../fixtures/mockUtilisationReportDetails');
 
 const { BANK1_PAYMENT_REPORT_OFFICER1 } = MOCK_USERS;
 
 context('Monthly utilisation report upload', () => {
   beforeEach(() => {
     cy.removeAllUtilisationReports();
+    cy.insertUtilisationReports(march2023ReportDetails);
     cy.insertUtilisationReports(february2023ReportDetails);
 
     cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
@@ -19,6 +20,10 @@ context('Monthly utilisation report upload', () => {
   });
 
   describe('Submitting a file to the utilisation report upload', () => {
+    it('Should display due reports in report period order when inserted in the wrong order', () => {
+      utilisationReportUpload.overdueListItem(2, 2023).should('exist');
+    });
+
     it('Should route to the Confirm and Send page when a file is successfully validated', () => {
       utilisationReportUpload.utilisationReportFileInput().attachFile('valid-utilisation-report-February_2023_monthly.xlsx');
       utilisationReportUpload.continueButton().click();
@@ -27,7 +32,7 @@ context('Monthly utilisation report upload', () => {
       utilisationReportUpload.currentUrl().should('contain', '/confirm-and-send');
     });
 
-    it('should display an error if the file selected does not contain the current report period', () => {
+    it('should display an error if the filename of the file selected does not contain the current report period', () => {
       utilisationReportUpload.utilisationReportFileInput().attachFile('valid-utilisation-report-September_2023_monthly.xlsx');
       utilisationReportUpload.continueButton().click();
 

--- a/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/utilisationReportUpload.js
+++ b/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/utilisationReportUpload.js
@@ -13,6 +13,8 @@ const page = {
     this.utilisationReportFileInput().should('exist');
     this.continueButton().should('exist');
   },
+  overdueListItem: (reportPeriodStartMonth, reportPeriodStartYear) =>
+    cy.get(`[data-cy="list-item-${reportPeriodStartMonth}-${reportPeriodStartYear}__overdue"]`),
 };
 
 module.exports = page;

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -52,6 +52,17 @@ const february2023ReportDetails = [
     .build(),
 ];
 
+const march2023ReportDetails = [
+  UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED')
+    .withId(reportIdGenerator.next().value)
+    .withBankId(bankId)
+    .withReportPeriod({
+      start: { month: 3, year: 2023 },
+      end: { month: 3, year: 2023 },
+    })
+    .build(),
+];
+
 const december2023ToFebruary2024ReportDetails = [
   UtilisationReportEntityMockBuilder.forStatus('REPORT_NOT_RECEIVED')
     .withId(reportIdGenerator.next().value)
@@ -76,6 +87,7 @@ const upToDateReportDetails = generateUpToDateReportDetails();
 module.exports = {
   previousReportDetails,
   february2023ReportDetails,
+  march2023ReportDetails,
   upToDateReportDetails,
   december2023ToFebruary2024ReportDetails,
 };

--- a/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
+++ b/portal/component-tests/utilisation-report-service/utilisation-report-upload.component-test.js
@@ -13,41 +13,35 @@ describe(page, () => {
   };
   const dueReportPeriods = [
     {
-      reportPeriod: {
-        start: {
-          month: 12,
-          year: 2022,
-        },
-        end: {
-          month: 12,
-          year: 2022,
-        },
+      start: {
+        month: 12,
+        year: 2022,
+      },
+      end: {
+        month: 12,
+        year: 2022,
       },
       formattedReportPeriod: 'December 2022',
     },
     {
-      reportPeriod: {
-        start: {
-          month: 1,
-          year: 2023,
-        },
-        end: {
-          month: 1,
-          year: 2023,
-        },
+      start: {
+        month: 1,
+        year: 2023,
+      },
+      end: {
+        month: 1,
+        year: 2023,
       },
       formattedReportPeriod: 'January 2023',
     },
     {
-      reportPeriod: {
-        start: {
-          month: 2,
-          year: 2023,
-        },
-        end: {
-          month: 2,
-          year: 2023,
-        },
+      start: {
+        month: 2,
+        year: 2023,
+      },
+      end: {
+        month: 2,
+        year: 2023,
       },
       formattedReportPeriod: 'February 2023',
     },

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-status.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-status.js
@@ -31,7 +31,7 @@ const getReportDueDate = async (userToken, reportPeriodEndDate = subMonths(new D
  * the year and the report period with format 'MMMM yyyy'
  * @param {string} userToken - Token to validate session
  * @param {string} bankId - ID of the bank
- * @returns {Promise<{ month: number, year: number, formattedReportPeriod: string }[]>}
+ * @returns {Promise<{ start: {month: number, year: number}, end: {month: number, year: number}, formattedReportPeriod: string }[]>}
  */
 const getDueReportPeriodsByBankId = async (userToken, bankId) => {
   const dueReportPeriods = await api.getDueReportPeriodsByBankId(userToken, bankId);

--- a/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
+++ b/portal/templates/utilisation-report-service/utilisation-report-upload/utilisation-report-upload.njk
@@ -48,11 +48,11 @@
         }) }}
         <ul class="govuk-list govuk-list--bullet" data-cy="due-reports-list">
             {% for dueReport in dueReportPeriods.slice(0, -1) %}
-                <li data-cy="list-item-{{ dueReport.reportPeriod.start.month }}-{{ dueReport.reportPeriod.start.year }}__overdue">
+                <li data-cy="list-item-{{ dueReport.start.month }}-{{ dueReport.start.year }}__overdue">
                     {{ dueReport.formattedReportPeriod }} report is overdue
                 </li>
             {% endfor %}
-            <li data-cy="list-item-{{ dueReportPeriods.at(-1).reportPeriod.start.month }}-{{ dueReportPeriods.at(-1).reportPeriod.start.year }}__now-due">
+            <li data-cy="list-item-{{ dueReportPeriods.at(-1).start.month }}-{{ dueReportPeriods.at(-1).start.year }}__now-due">
                 {{ dueReportPeriods.at(-1).formattedReportPeriod }} report is now due
             </li>
         </ul>


### PR DESCRIPTION
## Introduction :pencil2:
 When reports are inserted in the wrong order into the database the next report due to be uploaded is incorrect.

## Resolution :heavy_check_mark:
- in `findAllByBankId` method add sorting reports by report period


