### PR TITLE
feat(DTFS2-7055): update docker-compose.gha.yml to use replica set

### DIFF
--- a/docker-compose.gha.yml
+++ b/docker-compose.gha.yml
@@ -21,14 +21,22 @@ services:
       - ./dtfs-sql-volume-dtfs-submissions:/data/db
 
   dtfs-submissions-data:
-    image: mongo:5.0.5
-    restart: always
+    build:
+      context: ./mongodb
+      dockerfile: Dockerfile
     environment:
       - MONGO_INITDB_DATABASE=dtfs-submissions
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=r00t
     ports:
-      - '27017-27019:27017-27019'
+      - "27017:27017"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --quiet) -eq 1
+      interval: 10s
+      start_period: 30s
+    command: "--bind_ip_all --keyFile /mongo-keyfile --replSet rs0"
     volumes:
       - ./dtfs-submissions-data-volume-dtfs-submissions:/data/db
 


### PR DESCRIPTION
## Introduction :pencil2:
Change streams & transactions need mongodb to use a replica set. In order to test these features the GHA should run on one.

## Resolution :heavy_check_mark:
- Update the docker-compose file

## Misc
It's unclear if this change affects the flakiness of the tests. To check this I've run the pipeline 6 times & found:
- 16 test suites failed flakily
- 7 of these were genuine test failures, the remainder `write EPIPE`, docker failures, MDL failures, etc.
- The `dtfs-central-api` utilisisation report tests seem to be the most flakey, accounting for 4 of these 7 and failing more often than not.
Aside from the utilisisation report, this doesnt seem to be a notable increase in flakiness over a normal PR (at a glance)
