### PR TITLE
feat(FN-1739): update table column names and data types

### DIFF
--- a/doc/sql-db.md
+++ b/doc/sql-db.md
@@ -10,33 +10,11 @@ As of January 2024 the project is in the process of migrating from a MongoDB (No
 
 The SQL Server database tables all have ledger enabled which has some impacts on how we alter tables. For more details than those discussed below, refer to [the SQL Server docs](https://learn.microsoft.com/en-us/sql/relational-databases/security/ledger/ledger-limits?view=sql-server-ver16).
 
-### Adding a new, non-nullable column
+### Adding a new column
 
-Nullable columns can be added to a ledger table with no issues. If you want to add a non-nullable column, you need your column to have a default value and need to manually update the migration generated via [`npm run db:generate-migration`](#--generate-new-migration). For example, as we use typeorm to generate our migrations, consider the following column
+Nullable columns can be added to a ledger table with no issues. Non-nullable columns should not be added to tables after they have been created, and existing columns should not be converted to non-nullable. For more details, read [here](https://learn.microsoft.com/en-us/sql/relational-databases/security/ledger/ledger-limits?view=sql-server-ver16#adding-columns).
 
-```typescript
-@Column({ nullable: false, default: 0 })
-age!: number;
-```
-
-The `npm run db:generate-migration` command will then generate a query similar to
-
-```sql
-ALTER TABLE "Person" ADD "age" int CONSTRAINT "DF_abc123" DEFAULT 0
-```
-
-However, this will cause an error as the existing rows will do not satisfy the non-nullable constraint. To overcome this, you need to manually update your migration to have the following three steps:
-
-```sql
--- Add column as nullable
-ALTER TABLE "Person" ADD "age" int NULL CONSTRAINT "DF_abc123" DEFAULT 0;
-
--- Update all existing columns to have the default value
-UPDATE "Person" SET "age" = 0;
-
--- Set the new column to non-nullable
-ALTER TABLE "Person" ALTER COLUMN "age" int NOT NULL;
-```
+NOTE: it can sometimes be possible to add a new, non-nullable column to a table if certain conditions are met, but it is usually more safe to assume that new columns need to be nullable.
 
 ## Running locally
 
@@ -136,7 +114,7 @@ Note: this only reverts the latest executed migration. If you need to revert mul
 npm run db:reset
 ```
 
-Use as a quick way to start from scratch instead of deleting and re-building the docker container. This will drop all tables then run all migrations to get back to a clean state.
+Use to start the SQL Server database from scratch. This will restart the docker container, delete and recreate the database, recreate the database user which is used inside the other services and run all the migrations. In effect, this resets the database to a clean state, with all the data wiped and all the ledger history reset.
 
 #### - Seeding data
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-payment.api-test.ts
@@ -269,7 +269,7 @@ describe('POST /v1/utilisation-reports/:reportId/payment', () => {
     // Arrange
     const feeRecordId = 10;
     const existingPaymentReference = 'First payment';
-    const existingPayment = PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(feeRecordId).withPaymentReference(existingPaymentReference).build();
+    const existingPayment = PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(feeRecordId).withReference(existingPaymentReference).build();
     const newFeeRecord = FeeRecordEntityMockBuilder.forReport(uploadedUtilisationReport)
       .withId(10)
       .withPaymentCurrency(paymentCurrency)
@@ -303,13 +303,13 @@ describe('POST /v1/utilisation-reports/:reportId/payment', () => {
       expect.objectContaining<Partial<PaymentEntity>>({
         id: feeRecordId,
         currency: paymentCurrency,
-        paymentReference: existingPaymentReference,
+        reference: existingPaymentReference,
       }),
     );
     expect(payments[1]).toEqual(
       expect.objectContaining<Partial<PaymentEntity>>({
         currency: paymentCurrency,
-        paymentReference: newPaymentReference,
+        reference: newPaymentReference,
       }),
     );
   });
@@ -338,7 +338,7 @@ describe('POST /v1/utilisation-reports/:reportId/payment', () => {
       .build();
 
     const firstPayment = PaymentEntityMockBuilder.forCurrency(paymentCurrency)
-      .withAmountReceived(firstPaymentAmount)
+      .withAmount(firstPaymentAmount)
       .withFeeRecords([firstFeeRecord, secondFeeRecord])
       .build();
 
@@ -388,7 +388,7 @@ describe('POST /v1/utilisation-reports/:reportId/payment', () => {
       .build();
 
     const firstPayment = PaymentEntityMockBuilder.forCurrency(paymentCurrency)
-      .withAmountReceived(firstPaymentAmount)
+      .withAmount(firstPaymentAmount)
       .withFeeRecords([firstFeeRecord, secondFeeRecord])
       .build();
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.test.ts
@@ -31,9 +31,9 @@ describe('handleUtilisationReportAddAPaymentEvent', () => {
   const paymentCurrency: Currency = 'GBP';
   const paymentDetails: NewPaymentDetails = {
     currency: paymentCurrency,
-    amountReceived: 100,
+    amount: 100,
     dateReceived: new Date(),
-    paymentReference: 'A payment reference',
+    reference: 'A payment reference',
   };
 
   const aListOfFeeRecordsForReport = (report: UtilisationReportEntity): FeeRecordEntity[] => [

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/helpers.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/helpers.test.ts
@@ -72,8 +72,8 @@ describe('payment-added-to-fee-record.event-handler helpers', () => {
       ];
 
       const payments = [
-        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(1).withAmountReceived(firstPaymentAmount).build(),
-        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(2).withAmountReceived(secondPaymentAmount).build(),
+        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(1).withAmount(firstPaymentAmount).build(),
+        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(2).withAmount(secondPaymentAmount).build(),
       ];
 
       jest.mocked(mockFind).mockResolvedValue(addPaymentsToFeeRecords(feeRecords, payments));
@@ -110,8 +110,8 @@ describe('payment-added-to-fee-record.event-handler helpers', () => {
       ];
 
       const payments = [
-        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(1).withAmountReceived(firstPaymentAmount).build(),
-        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(2).withAmountReceived(secondPaymentAmount).build(),
+        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(1).withAmount(firstPaymentAmount).build(),
+        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(2).withAmount(secondPaymentAmount).build(),
       ];
 
       jest.mocked(mockFind).mockResolvedValue(addPaymentsToFeeRecords(feeRecords, payments));
@@ -153,8 +153,8 @@ describe('payment-added-to-fee-record.event-handler helpers', () => {
       ];
 
       const payments = [
-        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(1).withAmountReceived(firstPaymentAmount).build(),
-        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(2).withAmountReceived(secondPaymentAmount).build(),
+        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(1).withAmount(firstPaymentAmount).build(),
+        PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(2).withAmount(secondPaymentAmount).build(),
       ];
 
       jest.mocked(mockFind).mockResolvedValue(addPaymentsToFeeRecords(feeRecords, payments));

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/helpers.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/helpers.ts
@@ -17,9 +17,7 @@ export const feeRecordsMatchAttachedPayments = async (feeRecords: FeeRecordEntit
 
   const attachedPayments = await getPaymentsAttachedToFeeRecord(feeRecords[0], transactionEntityManager);
 
-  const totalPaymentsReceived = attachedPayments
-    .map((payment) => payment.amountReceived)
-    .reduce((total, amountReceived) => total.add(amountReceived), new Big(0));
+  const totalPaymentsReceived = attachedPayments.map((payment) => payment.amount).reduce((total, amount) => total.add(amount), new Big(0));
 
   const difference = totalReportedPayments.minus(totalPaymentsReceived).abs();
   const tolerance = 0;

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
@@ -121,9 +121,9 @@ describe('UtilisationReportStateMachine', () => {
           feeRecords: [],
           paymentDetails: {
             currency: 'GBP',
-            amountReceived: 100,
+            amount: 100,
             dateReceived: new Date(),
-            paymentReference: 'A payment reference',
+            reference: 'A payment reference',
           },
           requestSource: {
             platform: 'TFM',
@@ -187,9 +187,9 @@ describe('UtilisationReportStateMachine', () => {
           feeRecords: [],
           paymentDetails: {
             currency: 'GBP',
-            amountReceived: 100,
+            amount: 100,
             dateReceived: new Date(),
-            paymentReference: 'A payment reference',
+            reference: 'A payment reference',
           },
           requestSource: {
             platform: 'TFM',

--- a/dtfs-central-api/src/types/utilisation-reports.ts
+++ b/dtfs-central-api/src/types/utilisation-reports.ts
@@ -117,7 +117,7 @@ export type UtilisationReportReconciliationDetails = {
 
 export type NewPaymentDetails = {
   currency: Currency;
-  amountReceived: number;
+  amount: number;
   dateReceived: Date;
-  paymentReference?: string;
+  reference?: string;
 };

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/helpers.test.ts
@@ -25,9 +25,9 @@ describe('post-add-payment.controller helpers', () => {
 
     const newPaymentDetails: NewPaymentDetails = {
       currency: paymentCurrency,
-      amountReceived: 100,
+      amount: 100,
       dateReceived: new Date(),
-      paymentReference: 'A payment reference',
+      reference: 'A payment reference',
     };
 
     const utilisationReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/index.test.ts
@@ -56,9 +56,9 @@ describe('post-payment.controller', () => {
 
       const newPaymentDetails: NewPaymentDetails = {
         currency: paymentCurrency,
-        amountReceived: paymentAmount,
+        amount: paymentAmount,
         dateReceived: datePaymentReceived,
-        paymentReference,
+        reference: paymentReference,
       };
 
       // Act

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/index.ts
@@ -22,9 +22,9 @@ export const postPayment = async (req: PostPaymentRequest, res: Response) => {
   try {
     const newPaymentDetails: NewPaymentDetails = {
       currency: paymentCurrency,
-      amountReceived: paymentAmount,
+      amount: paymentAmount,
       dateReceived: datePaymentReceived,
-      paymentReference,
+      reference: paymentReference,
     };
 
     await addPaymentToUtilisationReport(parseInt(reportId, 10), feeRecordIds, user, newPaymentDetails);

--- a/libs/common/src/sql-db-connection/migrations/1717746522387-PaymentTableUpdateAmountColumns.ts
+++ b/libs/common/src/sql-db-connection/migrations/1717746522387-PaymentTableUpdateAmountColumns.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * This migration has been manually modified in order to work
+ * with ledger tables.
+ */
+export class PaymentTableUpdateAmountColumns1717746522387 implements MigrationInterface {
+  name = 'PaymentTableUpdateAmountColumns1717746522387';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create the new columns with the required data-type and set to nullable
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            ADD "amount" decimal(14, 2) NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            ADD "reference" nvarchar(255) NULL
+        `);
+
+    // Copy all the values from the old columns to the new columns
+    await queryRunner.query(`
+            UPDATE "Payment" SET "amount" = "amountReceived"
+        `);
+    await queryRunner.query(`
+            UPDATE "Payment" SET "reference" = "paymentReference"
+        `);
+
+    // Delete the old columns
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            DROP COLUMN "amountReceived"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            DROP COLUMN "paymentReference"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Create the new columns with the required data-type and set to nullable
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            ADD "amountReceived" int NULL
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            ADD "paymentReference" nvarchar(255) NULL
+        `);
+
+    // Copy all the values from the old columns to the new columns
+    await queryRunner.query(`
+            UPDATE "Payment" SET "amountReceived" = "amount"
+        `);
+    await queryRunner.query(`
+            UPDATE "Payment" SET "paymentReference" = "reference"
+        `);
+
+    // Delete the old columns
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            DROP COLUMN "amount"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "Payment"
+            DROP COLUMN "reference"
+        `);
+  }
+}

--- a/libs/common/src/sql-db-connection/reset-database.sh
+++ b/libs/common/src/sql-db-connection/reset-database.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
-execute_docker_sql_command() {
-  docker exec dtfs2-dtfs-sql-1 //opt//mssql-tools//bin//sqlcmd -S localhost -U sa -P "AbC!2345" -Q "$1"
+
+restart_docker_sql_container() {
+  docker restart $container_name
   return $?
 }
+
+execute_docker_sql_command() {
+  docker exec $container_name //opt//mssql-tools//bin//sqlcmd -S localhost -U sa -P "AbC!2345" -Q "$1"
+  return $?
+}
+
+readonly container_name=dtfs2-dtfs-sql-1
+readonly container_start_wait_time=20
+
+echo "Restarting docker container '$container_name'..."
+
+restart_docker_sql_container
+
+echo "Waiting $container_start_wait_time seconds for container to start..."
+sleep $container_start_wait_time
 
 echo "Attempting to drop and recreate database '$SQL_DB_NAME'..."
 

--- a/libs/common/src/sql-db-entities/custom-columns/monetary-column.ts
+++ b/libs/common/src/sql-db-entities/custom-columns/monetary-column.ts
@@ -1,8 +1,15 @@
 import { Column } from 'typeorm';
 
-export const MonetaryColumn = (): PropertyDecorator =>
+type MonetaryColumnOptions = {
+  nullable?: boolean;
+  defaultValue?: number;
+};
+
+export const MonetaryColumn = (options?: MonetaryColumnOptions): PropertyDecorator =>
   Column({
     type: 'decimal',
     precision: 14,
     scale: 2,
+    nullable: options?.nullable,
+    default: options?.defaultValue,
   });

--- a/libs/common/src/sql-db-entities/payment/payment.entity.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.entity.ts
@@ -3,6 +3,7 @@ import { Currency } from '../../types';
 import { AuditableBaseEntity } from '../base-entities';
 import { CreatePaymentParams } from './payment.types';
 import { FeeRecordEntity } from '../fee-record';
+import { MonetaryColumn } from '../custom-columns';
 
 @Entity('Payment')
 export class PaymentEntity extends AuditableBaseEntity {
@@ -18,8 +19,8 @@ export class PaymentEntity extends AuditableBaseEntity {
   /**
    * The amount received in the payment
    */
-  @Column()
-  amountReceived!: number;
+  @MonetaryColumn({ nullable: true, defaultValue: 0 })
+  amount!: number;
 
   /**
    * The date the payment was received
@@ -31,7 +32,7 @@ export class PaymentEntity extends AuditableBaseEntity {
    * The payment reference (optional)
    */
   @Column({ nullable: true, type: 'nvarchar' })
-  paymentReference?: string;
+  reference?: string;
 
   /**
    * The fee records attached to the payment
@@ -42,12 +43,12 @@ export class PaymentEntity extends AuditableBaseEntity {
   })
   feeRecords!: FeeRecordEntity[];
 
-  static create({ currency, amountReceived, dateReceived, paymentReference, feeRecords, requestSource }: CreatePaymentParams): PaymentEntity {
+  static create({ currency, amount, dateReceived, reference, feeRecords, requestSource }: CreatePaymentParams): PaymentEntity {
     const payment = new PaymentEntity();
     payment.currency = currency;
-    payment.amountReceived = amountReceived;
+    payment.amount = amount;
     payment.dateReceived = dateReceived;
-    payment.paymentReference = paymentReference;
+    payment.reference = reference;
     payment.feeRecords = feeRecords;
     payment.updateLastUpdatedBy(requestSource);
     return payment;

--- a/libs/common/src/sql-db-entities/payment/payment.types.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.types.ts
@@ -4,9 +4,9 @@ import { DbRequestSource } from '../helpers';
 
 export type CreatePaymentParams = {
   currency: Currency;
-  amountReceived: number;
+  amount: number;
   dateReceived: Date;
-  paymentReference?: string;
+  reference?: string;
   feeRecords: FeeRecordEntity[];
   requestSource: DbRequestSource;
 };

--- a/libs/common/src/test-helpers/mock-data/payment.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/payment.entity.mock-builder.ts
@@ -13,9 +13,9 @@ export class PaymentEntityMockBuilder {
     payment.currency = currency;
 
     payment.id = 1;
-    payment.amountReceived = 100;
+    payment.amount = 100;
     payment.dateReceived = new Date();
-    payment.paymentReference = undefined;
+    payment.reference = undefined;
 
     return new PaymentEntityMockBuilder(payment);
   }
@@ -25,8 +25,8 @@ export class PaymentEntityMockBuilder {
     return this;
   }
 
-  public withAmountReceived(amountReceived: number): PaymentEntityMockBuilder {
-    this.payment.amountReceived = amountReceived;
+  public withAmount(amount: number): PaymentEntityMockBuilder {
+    this.payment.amount = amount;
     return this;
   }
 
@@ -35,8 +35,8 @@ export class PaymentEntityMockBuilder {
     return this;
   }
 
-  public withPaymentReference(paymentReference: string): PaymentEntityMockBuilder {
-    this.payment.paymentReference = paymentReference;
+  public withReference(reference: string): PaymentEntityMockBuilder {
+    this.payment.reference = reference;
     return this;
   }
 


### PR DESCRIPTION
## Introduction :pencil2:
We want to rename some of the Payment table columns and update one of the data types to match our other monetary value columns.

## Resolution :heavy_check_mark:
- Updates the `PaymentEntity` class
- Updates references to the old column names

## Miscellaneous :heavy_plus_sign:
- Makes the `reset-database.sh` script more robust

