### PR TITLE
feat(FN-1739): link add payment frontend to backend

### DIFF
--- a/trade-finance-manager-api/src/types/custom-express-request.ts
+++ b/trade-finance-manager-api/src/types/custom-express-request.ts
@@ -1,17 +1,20 @@
 import { Request } from 'express';
 
 /**
- * Obtained from the express `core.ParamsDictionary` type
+ * Obtained from the express 'core.ParamsDictionary' type
  */
 type RequestParams = Record<string, string>;
 
 /**
- * Obtained from the express `core.Query` type
+ * Obtained from the express 'core.Query' type
  */
 interface RequestQuery {
   [key: string]: string | string[] | RequestQuery | RequestQuery[] | undefined;
 }
 
+/**
+ * Types match generic params of base express {@link Request} type
+ */
 type CustomExpressRequestOptions = {
   params?: RequestParams;
   /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -22,10 +25,10 @@ type CustomExpressRequestOptions = {
 };
 
 export type CustomExpressRequest<Options extends CustomExpressRequestOptions> = Request<
-  keyof Options extends 'params' ? Options['params'] : RequestParams,
+  'params' extends keyof Options ? Options['params'] : RequestParams,
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  keyof Options extends 'resBody' ? Options['resBody'] : any,
-  keyof Options extends 'reqBody' ? Options['reqBody'] : any,
+  'resBody' extends keyof Options ? Options['resBody'] : any,
+  'reqBody' extends keyof Options ? Options['reqBody'] : any,
   /* eslint-enable @typescript-eslint/no-explicit-any */
-  keyof Options extends 'query' ? Options['query'] : RequestQuery
+  'query' extends keyof Options ? Options['query'] : RequestQuery
 >;

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -237,4 +237,5 @@ module.exports = {
   getUtilisationReportById: jest.fn(() => Promise.resolve(MOCK_UTILISATION_REPORT)),
   updateUtilisationReportStatus: jest.fn(),
   getUtilisationReportReconciliationDetailsById: jest.fn(),
+  addPaymentToFeeRecords: jest.fn(),
 };

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -1234,7 +1234,7 @@ const getUtilisationReportById = async (id) => {
 /**
  * Sends a payload to DTFS central API to update
  * the status of one or more utilisation reports
- * @param {import('../types/utilisation-reports').ReportWithStatus[]} reportsWithStatus
+ * @param {import('@ukef/dtfs2-common').ReportWithStatus[]} reportsWithStatus
  * @param {import('../types/tfm-session-user').TfmSessionUser} user - The current user stored in the session
  * @returns {Promise<{ status: number }>}
  */
@@ -1285,7 +1285,7 @@ const getSelectedFeeRecordsDetails = async (reportId, feeRecordIds) => {
 /**
  * Gets the utilisation report summaries by bank id and year
  * @param {string} bankId - The bank id
- * @param { string} year - The year which a report period ends in
+ * @param {string} year - The year which a report period ends in
  * @returns {Promise<import('./api-response-types').UtilisationReportSummariesByBankAndYearResponseBody>}
  */
 const getUtilisationReportSummariesByBankIdAndYear = async (bankId, year) => {
@@ -1294,6 +1294,33 @@ const getUtilisationReportSummariesByBankIdAndYear = async (bankId, year) => {
     headers: headers.central,
   });
 
+  return response.data;
+};
+
+/**
+ * Adds a new payment to the supplied fee records
+ * @param {string} reportId - The report id
+ * @param {number[]} feeRecordIds - The list of fee record ids to add the payment to
+ * @param {import('../types/tfm-session-user').TfmSessionUser} user - The user adding the payment
+ * @param {import('@ukef/dtfs2-common').Currency} paymentCurrency - The payment currency
+ * @param {number} paymentAmount - The payment amount
+ * @param {import('@ukef/dtfs2-common').IsoDateTimeStamp} datePaymentReceived - The date the payment was received
+ * @param {string | undefined} paymentReference - The payment reference
+ */
+const addPaymentToFeeRecords = async (reportId, feeRecordIds, user, paymentCurrency, paymentAmount, datePaymentReceived, paymentReference) => {
+  const response = await axios({
+    url: `${DTFS_CENTRAL_API_URL}/v1/utilisation-reports/${reportId}/payment`,
+    method: 'post',
+    headers: headers.central,
+    data: {
+      feeRecordIds,
+      user,
+      paymentCurrency,
+      paymentAmount,
+      datePaymentReceived,
+      paymentReference,
+    },
+  });
   return response.data;
 };
 
@@ -1359,4 +1386,5 @@ module.exports = {
   getUtilisationReportReconciliationDetailsById,
   getSelectedFeeRecordsDetails,
   getUtilisationReportSummariesByBankIdAndYear,
+  addPaymentToFeeRecords,
 };

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/index.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/index.ts
@@ -4,3 +4,4 @@ export { updateUtilisationReportStatus } from './update-utilisation-report-statu
 export { getUtilisationReportReconciliationDetailsById } from './get-utilisation-report-reconciliation-details-by-id.controller';
 export { getSelectedFeeRecordsDetails } from './get-selected-fee-records-details.controller';
 export { getUtilisationReportSummariesByBankAndYear } from './get-utilisation-reports-by-bank-and-year.controller';
+export { postPayment } from './post-payment.controller';

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.test.ts
@@ -1,0 +1,139 @@
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode, AxiosError, AxiosResponse } from 'axios';
+import { Currency } from '@ukef/dtfs2-common';
+import api from '../../api';
+import { PostPaymentRequest, PostPaymentRequestBody, PostPaymentRequestParams, postPayment } from './post-payment.controller';
+import { aTfmSessionUser } from '../../../../test-helpers/tfm-session-user';
+
+jest.mock('../../api');
+
+console.error = jest.fn();
+
+describe('postPayment', () => {
+  const reportId = '1';
+  const feeRecordIds = [1, 2, 3];
+  const user = aTfmSessionUser();
+  const paymentCurrency: Currency = 'GBP';
+  const paymentAmount = 123.45;
+  const datePaymentReceived = new Date().toISOString();
+  const paymentReference = 'A payment reference';
+
+  const aPostPaymentRequestBody = (): PostPaymentRequestBody => ({
+    feeRecordIds,
+    paymentCurrency,
+    paymentAmount,
+    datePaymentReceived,
+    paymentReference,
+    user,
+  });
+
+  const aPostPaymentRequestParams = (): PostPaymentRequestParams => ({ reportId });
+
+  const getHttpMocks = () =>
+    httpMocks.createMocks<PostPaymentRequest>({
+      body: aPostPaymentRequestBody(),
+      params: aPostPaymentRequestParams(),
+    });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.mocked(api.addPaymentToFeeRecords).mockResolvedValue({});
+  });
+
+  it('adds a payment to the fee records', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postPayment(req, res);
+
+    // Assert
+    expect(api.addPaymentToFeeRecords).toHaveBeenCalledTimes(1);
+    expect(api.addPaymentToFeeRecords).toHaveBeenCalledWith(
+      reportId,
+      feeRecordIds,
+      user,
+      paymentCurrency,
+      paymentAmount,
+      datePaymentReceived,
+      paymentReference,
+    );
+  });
+
+  it('responds with a 200', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postPayment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('responds with a 500 if an unknown error occurs', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(new Error('Some error'));
+
+    // Act
+    await postPayment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('responds with a generic error message if an unknown error occurs', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(new Error('Some error'));
+
+    // Act
+    await postPayment(req, res);
+
+    // Assert
+    expect(res._getData()).toBe('Failed to add payment');
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('responds with a specific error code if an axios error is thrown', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    const errorStatus = HttpStatusCode.BadRequest;
+    const axiosError = new AxiosError(undefined, undefined, undefined, undefined, { status: errorStatus } as AxiosResponse);
+
+    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(axiosError);
+
+    // Act
+    await postPayment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toBe(errorStatus);
+    expect(res._isEndCalled()).toBe(true);
+  });
+
+  it('responds with a specific error message if an axios error is thrown', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    const errorMessage = 'Some specific error';
+    const axiosError = new AxiosError(errorMessage);
+
+    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(axiosError);
+
+    // Act
+    await postPayment(req, res);
+
+    // Assert
+    expect(res._getData()).toBe(`Failed to add payment: ${errorMessage}`);
+    expect(res._isEndCalled()).toBe(true);
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.test.ts
@@ -89,20 +89,6 @@ describe('postPayment', () => {
     expect(res._isEndCalled()).toBe(true);
   });
 
-  it('responds with a generic error message if an unknown error occurs', async () => {
-    // Arrange
-    const { req, res } = getHttpMocks();
-
-    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(new Error('Some error'));
-
-    // Act
-    await postPayment(req, res);
-
-    // Assert
-    expect(res._getData()).toBe('Failed to add payment');
-    expect(res._isEndCalled()).toBe(true);
-  });
-
   it('responds with a specific error code if an axios error is thrown', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
@@ -120,20 +106,17 @@ describe('postPayment', () => {
     expect(res._isEndCalled()).toBe(true);
   });
 
-  it('responds with a specific error message if an axios error is thrown', async () => {
+  it('responds with an error message', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
 
-    const errorMessage = 'Some specific error';
-    const axiosError = new AxiosError(errorMessage);
-
-    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(axiosError);
+    jest.mocked(api.addPaymentToFeeRecords).mockRejectedValue(new Error('Some error'));
 
     // Act
     await postPayment(req, res);
 
     // Assert
-    expect(res._getData()).toBe(`Failed to add payment: ${errorMessage}`);
+    expect(res._getData()).toBe('Failed to add payment');
     expect(res._isEndCalled()).toBe(true);
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.ts
@@ -1,0 +1,42 @@
+import { isAxiosError, HttpStatusCode } from 'axios';
+import { Response } from 'express';
+import { Currency } from '@ukef/dtfs2-common';
+import api from '../../api';
+import { CustomExpressRequest } from '../../../types/custom-express-request';
+import { TfmSessionUser } from '../../../types/tfm-session-user';
+
+export type PostPaymentRequestBody = {
+  feeRecordIds: number[];
+  paymentCurrency: Currency;
+  paymentAmount: number;
+  datePaymentReceived: string;
+  paymentReference?: string;
+  user: TfmSessionUser;
+};
+
+export type PostPaymentRequestParams = {
+  reportId: string;
+};
+
+export type PostPaymentRequest = CustomExpressRequest<{
+  reqBody: PostPaymentRequestBody;
+  params: PostPaymentRequestParams;
+}>;
+
+export const postPayment = async (req: PostPaymentRequest, res: Response) => {
+  try {
+    const { reportId } = req.params;
+    const { feeRecordIds, paymentCurrency, paymentAmount, datePaymentReceived, paymentReference, user } = req.body;
+
+    await api.addPaymentToFeeRecords(reportId, feeRecordIds, user, paymentCurrency, paymentAmount, datePaymentReceived, paymentReference);
+    return res.sendStatus(HttpStatusCode.Ok);
+  } catch (error) {
+    const errorMessage = 'Failed to add payment';
+    if (isAxiosError(error)) {
+      console.error(`${errorMessage}: ${error.message}`);
+      return res.status(error.response?.status || HttpStatusCode.InternalServerError).send(`${errorMessage}: ${error.message}`);
+    }
+    console.error(errorMessage);
+    return res.status(HttpStatusCode.InternalServerError).send(errorMessage);
+  }
+};

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.ts
@@ -32,11 +32,8 @@ export const postPayment = async (req: PostPaymentRequest, res: Response) => {
     return res.sendStatus(HttpStatusCode.Ok);
   } catch (error) {
     const errorMessage = 'Failed to add payment';
-    if (isAxiosError(error)) {
-      console.error(`${errorMessage}: ${error.message}`);
-      return res.status(error.response?.status || HttpStatusCode.InternalServerError).send(`${errorMessage}: ${error.message}`);
-    }
-    console.error(errorMessage);
-    return res.status(HttpStatusCode.InternalServerError).send(errorMessage);
+    const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
+    console.error(errorMessage, error);
+    return res.status(errorStatus).send(errorMessage);
   }
 };

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -146,6 +146,10 @@ authRouter
   .route('/utilisation-reports/:id/selected-fee-records-details')
   .get(validation.sqlIdValidation('id'), handleExpressValidatorResult, utilisationReportsController.getSelectedFeeRecordsDetails);
 
+authRouter
+  .route('/utilisation-reports/:reportId/payment')
+  .post(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, utilisationReportsController.postPayment);
+
 authRouter.route('/banks').get(banksController.getAllBanks);
 
 authRouter

--- a/trade-finance-manager-api/test-helpers/tfm-session-user.ts
+++ b/trade-finance-manager-api/test-helpers/tfm-session-user.ts
@@ -1,0 +1,13 @@
+import { ObjectId } from 'mongodb';
+import { TfmSessionUser } from '../src/types/tfm-session-user';
+
+export const aTfmSessionUser = (): TfmSessionUser => ({
+  username: 'test-user',
+  email: 'test@test.com',
+  teams: [],
+  timezone: 'London',
+  firstName: 'Test',
+  lastName: 'User',
+  status: 'active',
+  _id: new ObjectId().toString(),
+});

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -879,7 +879,7 @@ const getUtilisationReportReconciliationDetailsById = async (reportId, userToken
 };
 
 /**
- * @param {number} reportId - The report id
+ * @param {string} reportId - The report id
  * @param {number[]} feeRecordIds - The ids of the selected fee records
  * @param {string} userToken - The user token
  * @returns {Promise<import('@ukef/dtfs2-common').SelectedFeeRecordsDetails>}
@@ -936,6 +936,35 @@ const getReportSummariesByBankAndYear = async (userToken, bankId, year) => {
   }
 };
 
+/**
+ *
+ * @param {string} reportId - The report id
+ * @param {import('./types/add-payment-form-values').AddPaymentFormValues} addPaymentFormValues - The submitted form values
+ * @param {number[]} feeRecordIds - The list of fee record ids to add the payment to
+ * @param {import('./types/tfm-session-user').TfmSessionUser} user - The user adding the payment
+ * @param {string} userToken - The user token
+ */
+const addPaymentToFeeRecords = async (reportId, addPaymentFormValues, feeRecordIds, user, userToken) => {
+  const { paymentCurrency, paymentAmount, paymentDate, paymentReference } = addPaymentFormValues;
+
+  const datePaymentReceived = new Date(`${paymentDate.year}-${paymentDate.month}-${paymentDate.day}`);
+
+  const response = await axios({
+    method: 'post',
+    url: `${TFM_API_URL}/v1/utilisation-reports/${reportId}/payment`,
+    headers: generateHeaders(userToken),
+    data: {
+      feeRecordIds,
+      paymentCurrency,
+      paymentAmount: Number(paymentAmount),
+      datePaymentReceived,
+      paymentReference,
+      user,
+    },
+  });
+  return response.data;
+};
+
 module.exports = {
   getDeal,
   getDeals,
@@ -978,4 +1007,5 @@ module.exports = {
   getAllBanks,
   getSelectedFeeRecordsDetails,
   getReportSummariesByBankAndYear,
+  addPaymentToFeeRecords,
 };

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/add-payment-form-values-validator.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/add-payment-form-values-validator.test.ts
@@ -6,6 +6,9 @@ import { AddPaymentPaymentDateErrorViewModel } from '../../../types/view-models'
 
 describe('add payment form values validator', () => {
   describe('validateAddPaymentRequestFormValues', () => {
+    const paymentCurrency: Currency = 'GBP';
+    const feeRecordPaymentCurrency = paymentCurrency;
+
     it('should set payment currency error when no payment currency is provided', () => {
       // Arrange
       const formValues: AddPaymentFormValues = {
@@ -14,7 +17,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Select payment currency', href: '#paymentCurrency' }]);
@@ -29,11 +32,30 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Select payment currency', href: '#paymentCurrency' }]);
       expect(errors.paymentCurrencyErrorMessage).toEqual('Select payment currency');
+    });
+
+    it('should set payment currency error when payment currency value provided does not match fee record payment currency', () => {
+      // Arrange
+      const formValues: AddPaymentFormValues = {
+        ...aValidSetOfFormValues(),
+        paymentCurrency: CURRENCY.GBP,
+      };
+
+      const nonMatchingFeeRecordPaymentCurrency = CURRENCY.EUR;
+
+      // Act
+      const errors = validateAddPaymentRequestFormValues(formValues, nonMatchingFeeRecordPaymentCurrency);
+
+      // Assert
+      expect(errors.errorSummary).toEqual([
+        { text: 'The new payment currency must be the same as the reported payment currency of the selected fees', href: '#paymentCurrency' },
+      ]);
+      expect(errors.paymentCurrencyErrorMessage).toBe('The new payment currency must be the same as the reported payment currency of the selected fees');
     });
 
     it.each(Object.values(CURRENCY))('should not set payment currency error when payment currency value is %s', (currency: Currency) => {
@@ -44,7 +66,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, currency);
 
       // Assert
       expect(errors.errorSummary.length).toEqual(0);
@@ -59,7 +81,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Enter a valid amount received', href: '#paymentAmount' }]);
@@ -79,7 +101,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Enter a valid amount received', href: '#paymentAmount' }]);
@@ -100,7 +122,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary.length).toEqual(0);
@@ -115,7 +137,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Payment reference must be 50 characters or less', href: '#paymentReference' }]);
@@ -130,7 +152,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary.length).toEqual(0);
@@ -145,7 +167,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary.length).toEqual(0);
@@ -160,7 +182,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Select add another payment choice', href: '#addAnotherPayment' }]);
@@ -171,18 +193,18 @@ describe('add payment form values validator', () => {
       // Arrange
       const formValues: AddPaymentFormValues = {
         ...aValidSetOfFormValues(),
-        addAnotherPayment: 'not an option',
+        addAnotherPayment: 'not an option' as 'true' | 'false',
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'Select add another payment choice', href: '#addAnotherPayment' }]);
       expect(errors.addAnotherPaymentErrorMessage).toEqual('Select add another payment choice');
     });
 
-    it.each(['true', 'false'])('should not set add another payment error when value provided is %s', (addAnotherPaymentChoice: string) => {
+    it.each(['true', 'false'] as const)('should not set add another payment error when value provided is %s', (addAnotherPaymentChoice) => {
       // Arrange
       const formValues: AddPaymentFormValues = {
         ...aValidSetOfFormValues(),
@@ -190,7 +212,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary.length).toEqual(0);
@@ -222,7 +244,7 @@ describe('add payment form values validator', () => {
         };
 
         // Act
-        const errors = validateAddPaymentRequestFormValues(formValues);
+        const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
         // Assert
         expect(errors.errorSummary.length).toEqual(1);
@@ -260,7 +282,7 @@ describe('add payment form values validator', () => {
         };
 
         // Act
-        const errors = validateAddPaymentRequestFormValues(formValues);
+        const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
         // Assert
         expect(errors.paymentDateError?.dayError).toEqual(hasDayError);
@@ -288,7 +310,7 @@ describe('add payment form values validator', () => {
         };
 
         // Act
-        const errors = validateAddPaymentRequestFormValues(formValues);
+        const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
         // Assert
         expect(errors.errorSummary.length).toEqual(1);
@@ -311,7 +333,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'The date payment received must be a real date', href: '#paymentDate-day' }]);
@@ -338,7 +360,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'The date payment received must be a real date', href: '#paymentDate-month' }]);
@@ -365,7 +387,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'The date payment received must be a real date', href: '#paymentDate-year' }]);
@@ -385,7 +407,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'The date payment received must be a real date', href: '#paymentDate-day' }]);
@@ -406,7 +428,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([{ text: 'The date payment received must be in the past', href: '#paymentDate-day' }]);
@@ -428,7 +450,7 @@ describe('add payment form values validator', () => {
       };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary.length).toEqual(0);
@@ -440,7 +462,7 @@ describe('add payment form values validator', () => {
       const formValues: AddPaymentFormValues = { paymentDate: {} };
 
       // Act
-      const errors = validateAddPaymentRequestFormValues(formValues);
+      const errors = validateAddPaymentRequestFormValues(formValues, feeRecordPaymentCurrency);
 
       // Assert
       expect(errors.errorSummary).toEqual([
@@ -453,7 +475,7 @@ describe('add payment form values validator', () => {
 
     function aValidSetOfFormValues(): AddPaymentFormValues {
       return {
-        paymentCurrency: 'GBP',
+        paymentCurrency,
         paymentAmount: '100.00',
         paymentDate: {
           day: '11',

--- a/trade-finance-manager-ui/server/types/view-models/add-payment-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/add-payment-view-model.ts
@@ -34,7 +34,7 @@ export type AddPaymentErrorsViewModel = {
 };
 
 export type AddPaymentViewModel = BaseViewModel & {
-  reportId: number;
+  reportId: string;
   bank: { name: string };
   formattedReportPeriod: string;
   reportedFeeDetails: SelectedReportedFeesDetailsViewModel;

--- a/trade-finance-manager-ui/test-helpers/test-data/add-payment-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/add-payment-view-model.ts
@@ -5,7 +5,7 @@ import { aTfmSessionUser } from './tfm-session-user';
 export const anAddPaymentViewModel = (): AddPaymentViewModel => ({
   user: aTfmSessionUser(),
   activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
-  reportId: 12,
+  reportId: '12',
   bank: { name: 'Test bank ' },
   formattedReportPeriod: 'Some reporting period',
   reportedFeeDetails: {


### PR DESCRIPTION
## Introduction :pencil2:
We want to link up the adding a payment frontend to the backend.

This PR also resolves the [FN-1742](https://ukef-dtfs.atlassian.net/browse/FN-1742) ticket.

## Resolution :heavy_check_mark:
- Adds a new route to `TFM-API`
- Adds tests
- Updates the `TFM-UI` controller to allow for adding a new payment

## Miscellaneous :heavy_plus_sign:
- Fixes the `TFM-API` `custom-express-request.ts` file

