### PR TITLE
fix(FN): fix swagger docs and open route

### DIFF
--- a/dtfs-central-api/src/generateApp.js
+++ b/dtfs-central-api/src/generateApp.js
@@ -18,6 +18,8 @@ SqlDbDataSource.initialize()
 const generateApp = () => {
   const app = express();
 
+  app.use(`/v1/${SWAGGER_ROUTE}`, swaggerRoutes);
+
   app.use(seo);
   app.use(security);
   app.use(healthcheck);
@@ -39,7 +41,6 @@ const generateApp = () => {
   app.use(`/v1/${TFM_ROUTE}`, tfmRoutes);
   app.use(`/v1/${USER_ROUTE}`, userRoutes);
   app.use(`/v1/${UTILISATION_REPORTS_ROUTE}`, utilisationReportsRoutes);
-  app.use(`/v1/${SWAGGER_ROUTE}`, swaggerRoutes);
 
   // Return 200 on get to / to confirm to Azure that
   // the container has started successfully:

--- a/dtfs-central-api/src/v1/routes/bank-routes.js
+++ b/dtfs-central-api/src/v1/routes/bank-routes.js
@@ -98,7 +98,7 @@ bankRouter.route('/').get(getBanksController.getAllBanksGet);
  * /bank/:bankId/utilisation-reports:
  *   get:
  *     summary: Get utilisation reports by bank ID
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Get a banks utilisation reports by ID.
  *     parameters:
  *       - in: path
@@ -144,7 +144,7 @@ bankRouter.route('/:bankId/utilisation-reports').get(validation.bankIdValidation
  * /bank/:bankId/next-report-period:
  *   get:
  *     summary: Get utilisation reports by bank ID
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Get a banks utilisation reports by ID.
  *     parameters:
  *       - in: path
@@ -181,7 +181,7 @@ bankRouter
  *       Utilisation reports for the specified submission
  *       year and bank. This includes status and details of
  *       reports that have been submitted.
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: |
  *       Utilisation reports for the specified submission
  *       year and bank. This includes status and details of

--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -148,7 +148,7 @@ utilisationReportsRouter.route('/set-status').put(putUtilisationReportStatusCont
 
 /**
  * @openapi
- * /:utilisation-reports/reconciliation-details/:reportId:
+ * /utilisation-reports/reconciliation-details/:reportId:
  *   get:
  *     summary: Get the reconciliation details for the utilisation report by the report id
  *     tags: [Utilisation Report]

--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -57,7 +57,7 @@ utilisationReportsRouter.route('/').post(postUploadUtilisationReportPayloadValid
  * /utilisation-reports/:id:
  *   get:
  *     summary: Get utilisation report with the specified id ('id')
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Get utilisation report with the specified id ('id')
  *     parameters:
  *       - in: path
@@ -94,7 +94,7 @@ utilisationReportsRouter.route('/:id').get(validation.sqlIdValidation('id'), han
  *       month. This includes status of reports for all banks in the current
  *       submission month, and details of any open reports from previous
  *       submission months
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: |
  *       Get a summary of utilisation report reconciliation status for all banks
  *       in the specified report submission month, and open reports from
@@ -122,7 +122,7 @@ utilisationReportsRouter
  * /utilisation-reports/set-status:
  *   put:
  *     summary: Put utilisation report status for multiple utilisation reports
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Set the status of many utilisation reports to completed or not completed.
  *     requestBody:
  *       content:
@@ -148,10 +148,10 @@ utilisationReportsRouter.route('/set-status').put(putUtilisationReportStatusCont
 
 /**
  * @openapi
- * /utilisation-reports/reconciliation-details/:reportId:
+ * /:utilisation-reports/reconciliation-details/:reportId:
  *   get:
  *     summary: Get the reconciliation details for the utilisation report by the report id
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Gets the reconciliation details for the utilisation report by the report id
  *     responses:
  *       200:
@@ -177,7 +177,7 @@ utilisationReportsRouter
  * /utilisation-reports/:id/selected-fee-records-details:
  *   get:
  *     summary: Get the fee record details for the selected fee record ids
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Get the fee record details for the selected fee record ids
  *     parameters:
  *       - in: path
@@ -192,7 +192,7 @@ utilisationReportsRouter
  *         application/json:
  *           schema:
  *             type: object
- *              properties:
+ *             properties:
  *               feeRecordIds:
  *                 description: The ids of the selected fee records
  *                 type: array
@@ -222,7 +222,7 @@ utilisationReportsRouter
  * /utilisation-reports/:reportId/payment:
  *   post:
  *     summary: Add a payment to the utilisation report
- *     tags: [UtilisationReport]
+ *     tags: [Utilisation Report]
  *     description: Adds a new payment to the utilisation report with the supplied report id
  *     parameters:
  *       - in: path
@@ -237,7 +237,7 @@ utilisationReportsRouter
  *         application/json:
  *           schema:
  *             type: object
- *              properties:
+ *             properties:
  *               feeRecordIds:
  *                 description: The ids of the selected fee records
  *                 type: array

--- a/dtfs-central-api/src/v1/swagger-definitions/tfm.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/tfm.js
@@ -67,11 +67,15 @@
  *   TFMUser:
  *     type: object
  *     properties:
+ *       _id:
+ *         type: string
+ *         example: 5c0a7922c9d89830f4911426
  *       username:
  *         type: string
  *         example: T1_USER_1
  *       email:
- *         type: test@testing.com
+ *         type: string
+ *         example: test@testing.com
  *       teams:
  *         type: array
  *         items:

--- a/dtfs-central-api/src/v1/swagger.js
+++ b/dtfs-central-api/src/v1/swagger.js
@@ -1,4 +1,5 @@
 const swaggerJsdoc = require('swagger-jsdoc');
+const path = require('path');
 
 const swaggerDefinition = {
   openapi: '3.0.0',
@@ -28,11 +29,16 @@ const swaggerDefinition = {
       name: 'User',
       description: 'Get and create Portal (BSS/GEF) users. This is only used in the central API.',
     },
+    {
+      name: 'Utilisation Report',
+      description: 'Get, create and update utilisation reports. Consumed by PORTAL and TFM.',
+    },
   ],
 };
+
 const swaggerSpec = swaggerJsdoc({
-  swaggerDefinition,
-  apis: ['./src/v1/swagger-definitions/*.js', './src/v1/swagger-definitions/*/*.js', './src/v1/routes/*.js'],
+  definition: swaggerDefinition,
+  apis: [path.join(__dirname, 'swagger-definitions/**/*.js'), path.join(__dirname, 'routes/*.js')],
 });
 
 const swaggerUiOptions = {


### PR DESCRIPTION
## Introduction :pencil2:
We want to open the route for `/api-docs` locally in `dtfs-central-api`. After opening the route, it was discovered that the swagger docs were not displaying properly.

## Resolution :heavy_check_mark:
- Opens the route
- Fixes the swagger docs `api` definition so that they docs are visible at the `/v1/api-docs` route

## Miscellaneous :heavy_plus_sign:
- Puts some extraneous routes into the `Utilisation Report` tag

