### PR TITLE
feat(FN-2902): disable sorting when payments columns are empty

### DIFF
--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/premium-payments-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/premium-payments-table.component-test.js
@@ -41,7 +41,7 @@ describe(component, () => {
     },
   ];
 
-  const getWrapper = () => render({ feeRecords });
+  const getWrapper = () => render({ feeRecords, enablePaymentsReceivedSorting: true });
 
   it('should render the table headings', () => {
     const wrapper = getWrapper();
@@ -65,6 +65,20 @@ describe(component, () => {
     wrapper.expectElement(`${tableSelector} thead th:contains("Total reported payments")`).hasClass(numericHeaderClass);
     wrapper.expectElement(`${tableSelector} thead th:contains("Payments received")`).hasClass(numericHeaderClass);
     wrapper.expectElement(`${tableSelector} thead th:contains("Total payments received")`).hasClass(numericHeaderClass);
+  });
+
+  it("should set the payments received and total payments received column headers to sortable if 'enablePaymentsReceivedSorting' is set to true", () => {
+    const wrapper = render({ feeRecords, enablePaymentsReceivedSorting: true });
+
+    wrapper.expectElement(`${tableSelector} thead th:contains("Payments received")`).toHaveAttribute('aria-sort', 'none');
+    wrapper.expectElement(`${tableSelector} thead th:contains("Total payments received")`).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it("should not set the payments received and total payments received column headers to sortable if 'enablePaymentsReceivedSorting' is set to false", () => {
+    const wrapper = render({ feeRecords, enablePaymentsReceivedSorting: false });
+
+    wrapper.expectElement(`${tableSelector} thead th:contains("Payments received")`).toHaveAttribute('aria-sort', undefined);
+    wrapper.expectElement(`${tableSelector} thead th:contains("Total payments received")`).toHaveAttribute('aria-sort', undefined);
   });
 
   it('should render the select all checkbox in the table headings row', () => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.js
@@ -21,6 +21,7 @@ describe(page, () => {
     formattedReportPeriod,
     reportId,
     feeRecords: [],
+    enablePaymentsReceivedSorting: false,
     errorSummary: undefined,
   };
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
@@ -8,7 +8,7 @@ import { UtilisationReportReconciliationForReportViewModel } from '../../../type
 import { getAndClearAddPaymentFieldsFromRedirectSessionData } from './get-and-clear-add-payment-fields-from-redirect-session-data';
 import { FeeRecordItem } from '../../../api-response-types';
 
-const isAtLeastOnePaymentReceivedNonNull = (feeRecords: FeeRecordItem[]): boolean => feeRecords.some(({ paymentsReceived }) => paymentsReceived !== null);
+const feeRecordsHaveAtLeastOnePaymentReceived = (feeRecords: FeeRecordItem[]): boolean => feeRecords.some(({ paymentsReceived }) => paymentsReceived !== null);
 
 const renderUtilisationReportReconciliationForReport = (res: Response, viewModel: UtilisationReportReconciliationForReportViewModel) =>
   res.render('utilisation-reports/utilisation-report-reconciliation-for-report.njk', viewModel);
@@ -26,7 +26,7 @@ export const getUtilisationReportReconciliationByReportId = async (req: Request,
 
     const feeRecordViewModel = mapFeeRecordItemsToFeeRecordViewModelItems(feeRecords, isCheckboxChecked);
 
-    const enablePaymentsReceivedSorting = isAtLeastOnePaymentReceivedNonNull(feeRecords);
+    const enablePaymentsReceivedSorting = feeRecordsHaveAtLeastOnePaymentReceived(feeRecords);
 
     return renderUtilisationReportReconciliationForReport(res, {
       user,

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -28,7 +28,8 @@ export type FeeRecordViewModelItem = {
 export type UtilisationReportReconciliationForReportViewModel = BaseViewModel & {
   bank: SessionBank;
   formattedReportPeriod: string;
-  reportId: number;
+  reportId: string;
   feeRecords: FeeRecordViewModelItem[];
+  enablePaymentsReceivedSorting: boolean;
   errorSummary: [ErrorSummaryViewModel] | undefined;
 };

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
@@ -5,18 +5,37 @@
 
 {% macro render(params) %}
   {% set feeRecords = params.feeRecords %}
+  {% set enablePaymentsReceivedSorting = params.enablePaymentsReceivedSorting %}
+
+  {% macro tableHeader(params) %}
+    {% set headerText = params.headerText %}
+    {% set isNumericColumn = params.isNumericColumn %}
+    {% set enableSorting = params.enableSorting %}
+    {% set ariaSort = params.ariaSort %}
+
+    {% set class = 'govuk-table__header' %}
+    {% if isNumericColumn %}
+      {% set class = 'govuk-table__header govuk-table__header--numeric' %}
+    {% endif %}
+
+    {% if enableSorting %}
+      <th scope="col" class="{{ class }}" aria-sort="{{ ariaSort }}">{{ headerText }}</th>
+    {% else %}
+      <th scope="col" class="{{ class }}">{{ headerText }}</th>
+    {% endif %}
+  {% endmacro %}
 
   <table class="govuk-table" data-module="moj-sortable-table" data-cy="premium-payments-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header" aria-sort="ascending">Facility ID</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Exporter</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Reported fees</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Reported payments</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Total reported payments</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Payments received</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Total payments received</th>
-        <th scope="col" class="govuk-table__header" aria-sort="none">Status</th>
+        {{ tableHeader({ headerText: 'Facility ID', isNumericColumn: false, enableSorting: true, ariaSort: 'ascending' }) }}
+        {{ tableHeader({ headerText: 'Exporter', isNumericColumn: false, enableSorting: true, ariaSort: 'none' }) }}
+        {{ tableHeader({ headerText: 'Reported fees', isNumericColumn: true, enableSorting: true, ariaSort: 'none' }) }}
+        {{ tableHeader({ headerText: 'Reported payments', isNumericColumn: true, enableSorting: true, ariaSort: 'none' }) }}
+        {{ tableHeader({ headerText: 'Total reported payments', isNumericColumn: true, enableSorting: true, ariaSort: 'none' }) }}
+        {{ tableHeader({ headerText: 'Payments received', isNumericColumn: true, enableSorting: enablePaymentsReceivedSorting, ariaSort: 'none' }) }}
+        {{ tableHeader({ headerText: 'Total payments received', isNumericColumn: true, enableSorting: enablePaymentsReceivedSorting, ariaSort: 'none' }) }}
+        {{ tableHeader({ headerText: 'Status', isNumericColumn: false, enableSorting: true, ariaSort: 'none' }) }}
         <th scope="col" class="govuk-table__header">
           {{ selectAllTableCellCheckbox.render() }}
         </th>

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -55,7 +55,8 @@
       </div>
 
       {{ premiumPaymentsTable.render({
-        feeRecords: feeRecords
+        feeRecords: feeRecords,
+        enablePaymentsReceivedSorting: enablePaymentsReceivedSorting
       }) }}
     </form>
   {% if errorSummary %}


### PR DESCRIPTION
## Introduction :pencil2:
We want to disable sorting on the premium payments table "Payments received" and "Total payments received" column when the fee record table `paymentsReceived` column contains no values.

## Resolution :heavy_check_mark:
- Updates the controller to supply a `enablePaymentsReceivedSorting` flag
- Updates associated tests

## Miscellaneous :heavy_plus_sign:

