### PR TITLE
chore(DTFS2-NONE): add sleep to utilisation recon summary test

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
@@ -30,6 +30,12 @@ describe('/v1/utilisation-reports/reconciliation-summary/:submissionMonth', () =
     await api.post(withoutMongoId(MOCK_BANKS.BARCLAYS)).to('/v1/bank');
 
     await SqlDbHelper.initialize();
+
+    // TODO: DTFS2-7202 - Refactor generateApp to be an asynchronous function
+    // This timeout is needed as the SQL db connection is not being awaited & the first test is often run before the database has connected
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5000);
+    });
   });
 
   describe('GET /v1/utilisation-reports/reconciliation-summary/:submissionMonth', () => {


### PR DESCRIPTION
## Introduction :pencil2:
`get-utilisation-reports-reconciliation-summary.api-test.ts` is failing because it runs code before the SQL db connection has been initialised.

## Resolution :heavy_check_mark:
Add a timeout to prevent the code from running before the DB connection is initialised. This should only be a temporary fix but a large refactor of the `createApi` & `createApp` files would be needed otherwise

