### PR TITLE
feat(FN-1739): add parser to parse form values before sending

### DIFF
--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -939,15 +939,13 @@ const getReportSummariesByBankAndYear = async (userToken, bankId, year) => {
 /**
  *
  * @param {string} reportId - The report id
- * @param {import('./types/add-payment-form-values').AddPaymentFormValues} addPaymentFormValues - The submitted form values
+ * @param {import('./types/add-payment-form-values').ParsedAddPaymentFormValues} parsedAddPaymentFormValues - The parsed submitted form values
  * @param {number[]} feeRecordIds - The list of fee record ids to add the payment to
  * @param {import('./types/tfm-session-user').TfmSessionUser} user - The user adding the payment
  * @param {string} userToken - The user token
  */
-const addPaymentToFeeRecords = async (reportId, addPaymentFormValues, feeRecordIds, user, userToken) => {
-  const { paymentCurrency, paymentAmount, paymentDate, paymentReference } = addPaymentFormValues;
-
-  const datePaymentReceived = new Date(`${paymentDate.year}-${paymentDate.month}-${paymentDate.day}`);
+const addPaymentToFeeRecords = async (reportId, parsedAddPaymentFormValues, feeRecordIds, user, userToken) => {
+  const { paymentCurrency, paymentAmount, datePaymentReceived, paymentReference } = parsedAddPaymentFormValues;
 
   const response = await axios({
     method: 'post',
@@ -956,7 +954,7 @@ const addPaymentToFeeRecords = async (reportId, addPaymentFormValues, feeRecordI
     data: {
       feeRecordIds,
       paymentCurrency,
-      paymentAmount: Number(paymentAmount),
+      paymentAmount,
       datePaymentReceived,
       paymentReference,
       user,

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.test.ts
@@ -640,22 +640,22 @@ describe('controllers/utilisation-reports/:id/add-payment', () => {
           body: addPaymentFormSubmissionRequestBody,
         });
 
-        const addPaymentFormValues: AddPaymentFormValues = {
-          paymentCurrency: addPaymentFormSubmissionRequestBody.paymentCurrency,
-          paymentAmount: addPaymentFormSubmissionRequestBody.paymentAmount,
-          paymentDate: {
-            day: addPaymentFormSubmissionRequestBody['paymentDate-day'],
-            month: addPaymentFormSubmissionRequestBody['paymentDate-month'],
-            year: addPaymentFormSubmissionRequestBody['paymentDate-year'],
-          },
-          paymentReference: addPaymentFormSubmissionRequestBody.paymentReference,
-        };
-
         // Act
         await addPayment(req, res);
 
         // Assert
-        expect(addPaymentToFeeRecordsSpy).toHaveBeenCalledWith(reportId, addPaymentFormValues, feeRecordIds, requestSession.user, requestSession.userToken);
+        expect(addPaymentToFeeRecordsSpy).toHaveBeenCalledWith(
+          reportId,
+          {
+            paymentCurrency: CURRENCY.GBP,
+            paymentAmount: 100,
+            datePaymentReceived: new Date('2024-5-1'),
+            paymentReference: 'A payment reference',
+          },
+          feeRecordIds,
+          requestSession.user,
+          requestSession.userToken,
+        );
       });
 
       it("redirects to premium payments if 'addAnotherPayment' is set to 'false'", async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/parse-validated-add-payment-form-values.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/parse-validated-add-payment-form-values.test.ts
@@ -1,0 +1,135 @@
+import { Currency } from '@ukef/dtfs2-common';
+import { parseValidatedAddPaymentFormValues } from './parse-validated-add-payment-form-values';
+import { ValidatedAddPaymentFormValues } from '../../../types/add-payment-form-values';
+
+describe('parseValidatedAddPaymentFormValues', () => {
+  const aValidatedAddPaymentFormValuesObject = (): Omit<ValidatedAddPaymentFormValues, 'addAnotherPayment'> => ({
+    paymentCurrency: 'GBP',
+    paymentDate: {
+      day: '12',
+      month: '5',
+      year: '2024',
+    },
+    paymentAmount: '100',
+    paymentReference: 'A payment reference',
+  });
+
+  it('returns an object containing the supplied payment currency', () => {
+    // Arrange
+    const paymentCurrency: Currency = 'EUR';
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentCurrency,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.paymentCurrency).toBe(paymentCurrency);
+  });
+
+  it('returns an object containing the supplied payment reference', () => {
+    // Arrange
+    const paymentReference = 'Some payment reference';
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentReference,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.paymentReference).toBe(paymentReference);
+  });
+
+  it('parses the supplied payment date to a date object', () => {
+    // Arrange
+    const parsedPaymentDate = new Date('2024-3-2');
+    const paymentDate: ValidatedAddPaymentFormValues['paymentDate'] = {
+      day: '2',
+      month: '3',
+      year: '2024',
+    };
+
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentDate,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.datePaymentReceived).toEqual(parsedPaymentDate);
+  });
+
+  it('parses the supplied payment amount to a number when the amount does not contain any commas or decimals', () => {
+    // Arrange
+    const paymentAmount = 100;
+    const paymentAmountAsString = paymentAmount.toString();
+
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentAmount: paymentAmountAsString,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+  });
+
+  it('parses the supplied payment amount to a number when the amount does not contain any commas but has decimals', () => {
+    // Arrange
+    const paymentAmount = 123.45;
+    const paymentAmountAsString = paymentAmount.toString();
+
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentAmount: paymentAmountAsString,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+  });
+
+  it('parses the supplied payment amount to a number when the amount does not contain decimals but has commas', () => {
+    // Arrange
+    const paymentAmount = 1234567;
+    const paymentAmountAsString = '1,234,567';
+
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentAmount: paymentAmountAsString,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+  });
+
+  it('parses the supplied payment amount to a number when the amount contains commas and decimals', () => {
+    // Arrange
+    const paymentAmount = 1234567.89;
+    const paymentAmountAsString = '1,234,567.89';
+
+    const formValues = {
+      ...aValidatedAddPaymentFormValuesObject(),
+      paymentAmount: paymentAmountAsString,
+    };
+
+    // Act
+    const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
+
+    // Assert
+    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/parse-validated-add-payment-form-values.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/parse-validated-add-payment-form-values.ts
@@ -1,0 +1,20 @@
+import { ParsedAddPaymentFormValues, ValidatedAddPaymentFormValues } from '../../../types/add-payment-form-values';
+
+export const parseValidatedAddPaymentFormValues = (
+  validatedFormValues: Omit<ValidatedAddPaymentFormValues, 'addAnotherPayment'>,
+): ParsedAddPaymentFormValues => {
+  const { paymentCurrency, paymentDate, paymentAmount, paymentReference } = validatedFormValues;
+
+  const { day, month, year } = paymentDate;
+  const datePaymentReceived = new Date(`${year}-${month}-${day}`);
+
+  const paymentAmountWithoutCommas = paymentAmount.replaceAll(',', '');
+  const paymentAmountAsNumber = Number(paymentAmountWithoutCommas);
+
+  return {
+    paymentCurrency,
+    paymentAmount: paymentAmountAsNumber,
+    datePaymentReceived,
+    paymentReference,
+  };
+};

--- a/trade-finance-manager-ui/server/types/add-payment-form-values.ts
+++ b/trade-finance-manager-ui/server/types/add-payment-form-values.ts
@@ -1,3 +1,5 @@
+import { Currency } from '@ukef/dtfs2-common';
+
 export type AddPaymentFormValues = {
   paymentCurrency?: string;
   paymentAmount?: string;
@@ -8,4 +10,23 @@ export type AddPaymentFormValues = {
   };
   paymentReference?: string;
   addAnotherPayment?: string;
+};
+
+export type ValidatedAddPaymentFormValues = {
+  paymentCurrency: Currency;
+  paymentAmount: string;
+  paymentDate: {
+    day: string;
+    month: string;
+    year: string;
+  };
+  paymentReference?: string;
+  addAnotherPayment: 'true' | 'false';
+};
+
+export type ParsedAddPaymentFormValues = {
+  paymentCurrency: Currency;
+  paymentAmount: number;
+  datePaymentReceived: Date;
+  paymentReference?: string;
 };


### PR DESCRIPTION
## Introduction :pencil2:
The parsing of comma separated payment amounts in the add payment form was not working as expected.

## Resolution :heavy_check_mark:
- Add a separate function to parse the form data before it is submitted
- Add unit tests for the new function

## Miscellaneous :heavy_plus_sign:


