### PR TITLE
feat(FN-1714): update query when getting reports

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
@@ -184,4 +184,25 @@ describe('GET /v1/utilisation-reports/:reportId/fee-records-to-key', () => {
       },
     ]);
   });
+
+  it('returns a body containing an empty fee records array when there are no fee records at the MATCH status', async () => {
+    // Arrange
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+
+    const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
+
+    const toDoFeeRecords = [
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('TO_DO').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('TO_DO').build(),
+    ];
+    report.feeRecords = toDoFeeRecords;
+
+    await SqlDbHelper.saveNewEntry('UtilisationReport', report);
+
+    // Act
+    const response: CustomResponse = await api.get(getUrl(reportId));
+
+    // Assert
+    expect(response.body.feeRecords).toEqual([]);
+  });
 });

--- a/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report.repo.ts
+++ b/dtfs-central-api/src/repositories/utilisation-reports-repo/utilisation-report.repo.ts
@@ -1,6 +1,7 @@
 import { SqlDbDataSource } from '@ukef/dtfs2-common/sql-db-connection';
 import { UtilisationReportEntity, ReportPeriod, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { Not, Equal, FindOptionsWhere, LessThan, In } from 'typeorm';
+import { FeeRecordRepo } from '../fee-record-repo';
 
 export type GetUtilisationReportDetailsOptions = {
   reportPeriod?: ReportPeriod;
@@ -154,7 +155,7 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
    * @returns The utilisation report with the attached fee records
    */
   async findOneByIdWithFeeRecordsFilteredByIdWithPayments(reportId: number, feeRecordIds: number[]): Promise<UtilisationReportEntity | null> {
-    return await UtilisationReportRepo.findOne({
+    return await this.findOne({
       where: {
         id: reportId,
         feeRecords: {
@@ -174,15 +175,21 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
    * @returns The utilisation report with attached fee records
    */
   async findOneByIdWithFeeRecordsFilteredByStatus(reportId: number, feeRecordStatuses: FeeRecordStatus[]): Promise<UtilisationReportEntity | null> {
-    return await UtilisationReportRepo.findOne({
-      where: {
-        id: reportId,
-        feeRecords: {
-          status: In(feeRecordStatuses),
-        },
-      },
-      relations: { feeRecords: true },
+    const report = await this.findOne({
+      where: { id: reportId },
     });
+
+    if (!report) {
+      return null;
+    }
+
+    report.feeRecords = await FeeRecordRepo.find({
+      where: {
+        status: In(feeRecordStatuses),
+        report: { id: report.id },
+      },
+    });
+    return report;
   },
 
   /**
@@ -194,14 +201,22 @@ export const UtilisationReportRepo = SqlDbDataSource.getRepository(UtilisationRe
    * @returns The utilisation report with attached fee records and payments
    */
   async findOneByIdWithFeeRecordsFilteredByStatusWithPayments(reportId: number, feeRecordStatuses: FeeRecordStatus[]): Promise<UtilisationReportEntity | null> {
-    return await UtilisationReportRepo.findOne({
-      where: {
-        id: reportId,
-        feeRecords: {
-          status: In(feeRecordStatuses),
-        },
-      },
-      relations: { feeRecords: { payments: true } },
+    const report = await this.findOne({
+      where: { id: reportId },
     });
+
+    if (!report) {
+      return null;
+    }
+
+    report.feeRecords = await FeeRecordRepo.find({
+      where: {
+        status: In(feeRecordStatuses),
+        report: { id: report.id },
+      },
+      relations: { payments: true },
+    });
+
+    return report;
   },
 });


### PR DESCRIPTION
## Introduction :pencil2:
The original query would return `null` if there are no fee records matching the supplied status. This PR makes it so that the `feeRecords` array will instead be empty.

## Resolution :heavy_check_mark:
- Updates the `UtilisationReportRepo`

## Miscellaneous :heavy_plus_sign:


