### PR TITLE
feat(FN-1720): add confirm delete payment page

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/delete-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/delete-payment.api-test.ts
@@ -1,4 +1,3 @@
-import { Response } from 'supertest';
 import { HttpStatusCode } from 'axios';
 import { Currency, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { testApi } from '../../test-api';
@@ -11,8 +10,8 @@ import { aTfmSessionUser } from '../../../test-helpers/test-data/tfm-session-use
 
 console.error = jest.fn();
 
-describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
-  const getUrl = (reportId: number | string, paymentId: number | string) => `/v1/utilisation-reports/${reportId}/payments/${paymentId}`;
+describe('DELETE /v1/utilisation-reports/:reportId/payment/:paymentId', () => {
+  const getUrl = (reportId: number | string, paymentId: number | string) => `/v1/utilisation-reports/${reportId}/payment/${paymentId}`;
 
   const reportId = 1;
 
@@ -69,7 +68,7 @@ describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
 
   it('returns a 200 when payment can be deleted', async () => {
     // Act
-    const response: Response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, paymentId));
+    const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, paymentId));
 
     // Assert
     expect(response.status).toBe(HttpStatusCode.Ok);
@@ -77,7 +76,7 @@ describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
 
   it('returns a 400 when the report id is not a valid id', async () => {
     // Act
-    const response: Response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl('invalid-id', paymentId));
+    const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl('invalid-id', paymentId));
 
     // Assert
     expect(response.status).toBe(HttpStatusCode.BadRequest);
@@ -85,7 +84,7 @@ describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
 
   it('returns a 400 when the payment id is not a valid id', async () => {
     // Act
-    const response: Response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, 'invalid-id'));
+    const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, 'invalid-id'));
 
     // Assert
     expect(response.status).toBe(HttpStatusCode.BadRequest);
@@ -98,7 +97,7 @@ describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
     };
 
     // Act
-    const response: Response = await testApi.remove(requestBody).to(getUrl(reportId, paymentId));
+    const response = await testApi.remove(requestBody).to(getUrl(reportId, paymentId));
 
     // Assert
     expect(response.status).toBe(HttpStatusCode.BadRequest);
@@ -109,7 +108,7 @@ describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
     const invalidReportId = reportId + 1;
 
     // Act
-    const response: Response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(invalidReportId, paymentId));
+    const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(invalidReportId, paymentId));
 
     // Assert
     expect(response.status).toBe(HttpStatusCode.NotFound);
@@ -120,7 +119,7 @@ describe('DELETE /v1/utilisation-reports/:reportId/payments/:paymentId', () => {
     const invalidPaymentId = paymentId + 1;
 
     // Act
-    const response: Response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, invalidPaymentId));
+    const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, invalidPaymentId));
 
     // Assert
     expect(response.status).toBe(HttpStatusCode.NotFound);

--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -224,44 +224,6 @@ utilisationReportsRouter
 
 /**
  * @openapi
- * /utilisation-reports/:reportId/payment/:paymentId:
- *   delete:
- *     summary: Delete a payment
- *     tags: [Utilisation Report]
- *     description: Deletes a payment
- *     parameters:
- *       - in: path
- *         name: reportId
- *         schema:
- *           type: string
- *         required: true
- *         description: the id for the report the payment belongs to
- *       - in: path
- *         name: paymentId
- *         schema:
- *           type: string
- *         required: true
- *         description: the id for the payment to delete
- *     responses:
- *       200:
- *         description: OK
- *       404:
- *         description: Not Found
- *       500:
- *         description: Internal Server Error
- */
-utilisationReportsRouter
-  .route('/:reportId/payments/:paymentId')
-  .delete(
-    validation.sqlIdValidation('reportId'),
-    validation.sqlIdValidation('paymentId'),
-    handleExpressValidatorResult,
-    validateDeletePaymentPayload,
-    deletePayment,
-  );
-
-/**
- * @openapi
  * /utilisation-reports/:reportId/payment:
  *   post:
  *     summary: Add a payment to the utilisation report
@@ -389,16 +351,50 @@ utilisationReportsRouter.route('/:reportId/fee-records-to-key').get(validation.s
  *           type: string
  *         required: true
  *         description: the id for the payment
+ *       - in: query
+ *         name: includeFeeRecords
+ *         schema:
+ *           type: string
+ *           enum: [true, false]
+ *           required: false
+ *         description: Whether or not to include the fee records and total reported payments in the response body
  *     responses:
  *       200:
  *         description: OK
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               $ref: '#/definitions/PaymentDetailsResponseBody'
+ *               oneOf:
+ *                 - $ref: '#/definitions/PaymentDetailsWithFeeRecordsResponseBody'
+ *                 - $ref: '#/definitions/PaymentDetailsWithoutFeeRecordsResponseBody'
  *       400:
  *         description: Bad request
+ *       404:
+ *         description: Not Found
+ *       500:
+ *         description: Internal Server Error
+ *   delete:
+ *     summary: Delete a payment
+ *     tags: [Utilisation Report]
+ *     description: Deletes a payment
+ *     parameters:
+ *       - in: path
+ *         name: reportId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: the id for the report the payment belongs to
+ *       - in: path
+ *         name: paymentId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: the id for the payment to delete
+ *     responses:
+ *       200:
+ *         description: OK
+ *       400:
+ *         description: Bad Request
  *       404:
  *         description: Not Found
  *       500:
@@ -406,6 +402,8 @@ utilisationReportsRouter.route('/:reportId/fee-records-to-key').get(validation.s
  */
 utilisationReportsRouter
   .route('/:reportId/payment/:paymentId')
-  .get(validation.sqlIdValidation('reportId'), validation.sqlIdValidation('paymentId'), handleExpressValidatorResult, getPaymentDetailsById);
+  .all(validation.sqlIdValidation('reportId'), validation.sqlIdValidation('paymentId'), handleExpressValidatorResult)
+  .get(getPaymentDetailsById)
+  .delete(validateDeletePaymentPayload, deletePayment);
 
 module.exports = utilisationReportsRouter;

--- a/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/payment-details-response-body.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/payment-details-response-body.js
@@ -1,7 +1,7 @@
 /**
  * @openapi
  * definitions:
- *   PaymentDetailsResponseBody:
+ *   PaymentDetailsWithFeeRecordsResponseBody:
  *     type: object
  *     properties:
  *       bank:
@@ -24,4 +24,20 @@
  *       totalReportedPayments:
  *         type: object
  *         $ref: '#/definitions/CurrencyAndAmount'
+ *   PaymentDetailsWithoutFeeRecordsResponseBody:
+ *     type: object
+ *     properties:
+ *       bank:
+ *         type: object
+ *         properties:
+ *           id:
+ *             type: string
+ *           name:
+ *             type: string
+ *       reportPeriod:
+ *         type: object
+ *         $ref: '#/definitions/ReportPeriod'
+ *       payment:
+ *         type: object
+ *         $ref: '#/definitions/Payment'
  */

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -241,4 +241,5 @@ module.exports = {
   generateKeyingData: jest.fn(),
   getUtilisationReportWithFeeRecordsToKey: jest.fn(),
   getPaymentDetails: jest.fn(),
+  deletePaymentById: jest.fn(),
 };

--- a/trade-finance-manager-api/src/v1/api-response-types/payment-details-response-body.ts
+++ b/trade-finance-manager-api/src/v1/api-response-types/payment-details-response-body.ts
@@ -6,6 +6,13 @@ export type PaymentDetailsResponseBody = {
   bank: SessionBank;
   reportPeriod: ReportPeriod;
   payment: Payment;
-  feeRecords: FeeRecord[];
-  totalReportedPayments: CurrencyAndAmount;
-};
+} & (
+  | {
+      feeRecords: FeeRecord[];
+      totalReportedPayments: CurrencyAndAmount;
+    }
+  | {
+      feeRecords?: undefined;
+      totalReportedPayments?: undefined;
+    }
+);

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -1366,13 +1366,33 @@ const getUtilisationReportWithFeeRecordsToKey = async (reportId) => {
  * Gets the payment details
  * @param {string} reportId - The report id
  * @param {string} paymentId - The payment id
+ * @param {boolean} includeFeeRecords - Whether or not to include the fee records in the response
  * @returns {Promise<import('./api-response-types').PaymentDetailsResponseBody>} The payment details
  */
-const getPaymentDetails = async (reportId, paymentId) => {
+const getPaymentDetails = async (reportId, paymentId, includeFeeRecords) => {
   const response = await axios.get(`${DTFS_CENTRAL_API_URL}/v1/utilisation-reports/${reportId}/payment/${paymentId}`, {
     headers: headers.central,
+    params: {
+      includeFeeRecords,
+    },
   });
   return response.data;
+};
+
+/**
+ * Deletes the payment with the specified id
+ * @param {string} reportId - The report id
+ * @param {string} paymentId - The payment id
+ * @param {import('../types/tfm-session-user').TfmSessionUser} user - The session user
+ * @returns {Promise<void>}
+ */
+const deletePaymentById = async (reportId, paymentId, user) => {
+  await axios({
+    url: `${DTFS_CENTRAL_API_URL}/v1/utilisation-reports/${reportId}/payment/${paymentId}`,
+    method: 'delete',
+    headers: headers.central,
+    data: { user },
+  });
 };
 
 module.exports = {
@@ -1441,4 +1461,5 @@ module.exports = {
   generateKeyingData,
   getUtilisationReportWithFeeRecordsToKey,
   getPaymentDetails,
+  deletePaymentById,
 };

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.test.ts
@@ -1,0 +1,93 @@
+import httpMocks from 'node-mocks-http';
+import { AxiosResponse, HttpStatusCode, AxiosError } from 'axios';
+import { deletePayment } from './delete-payment.controller';
+import api from '../../api';
+import { aTfmSessionUser } from '../../../../test-helpers';
+
+console.error = jest.fn();
+
+jest.mock('../../api');
+
+describe('delete-payment.controller', () => {
+  describe('deletePayment', () => {
+    beforeEach(() => {
+      jest.mocked(api.deletePaymentById).mockResolvedValue();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    const reportId = '12';
+    const paymentId = '6';
+
+    const getHttpMocks = () =>
+      httpMocks.createMocks({
+        params: { reportId, paymentId },
+        body: {
+          user: aTfmSessionUser(),
+        },
+      });
+
+    it('deletes the payment and responds with a 200', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const user = aTfmSessionUser();
+      req.body = { user };
+
+      // Act
+      await deletePayment(req, res);
+
+      // Assert
+      expect(api.deletePaymentById).toHaveBeenCalledWith(reportId, paymentId, user);
+      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with a 500 if an unknown error occurs', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.deletePaymentById).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await deletePayment(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with a specific error code if an axios error is thrown', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const errorStatus = HttpStatusCode.BadRequest;
+      const axiosError = new AxiosError(undefined, undefined, undefined, undefined, { status: errorStatus } as AxiosResponse);
+
+      jest.mocked(api.deletePaymentById).mockRejectedValue(axiosError);
+
+      // Act
+      await deletePayment(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with an error message', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.deletePaymentById).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await deletePayment(req, res);
+
+      // Assert
+      expect(res._getData()).toBe('Failed to delete payment');
+      expect(res._isEndCalled()).toBe(true);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.ts
@@ -1,8 +1,16 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { HttpStatusCode, isAxiosError } from 'axios';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
 import api from '../../api';
+import { TfmSessionUser } from '../../../types/tfm-session-user';
 
-export const deletePayment = async (req: Request, res: Response) => {
+type DeletePaymentRequest = CustomExpressRequest<{
+  reqBody: {
+    user: TfmSessionUser;
+  };
+}>;
+
+export const deletePayment = async (req: DeletePaymentRequest, res: Response) => {
   const { reportId, paymentId } = req.params;
   const { user } = req.body;
 

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import { HttpStatusCode, isAxiosError } from 'axios';
+import api from '../../api';
+
+export const deletePayment = async (req: Request, res: Response) => {
+  const { reportId, paymentId } = req.params;
+  const { user } = req.body;
+
+  try {
+    await api.deletePaymentById(reportId, paymentId, user);
+    return res.sendStatus(HttpStatusCode.Ok);
+  } catch (error) {
+    const errorMessage = 'Failed to delete payment';
+    console.error(errorMessage, error);
+    const statusCode = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
+    return res.status(statusCode).send(errorMessage);
+  }
+};

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.test.ts
@@ -17,6 +17,7 @@ describe('get-payment-details-by-id.controller', () => {
     const getHttpMocks = () =>
       httpMocks.createMocks({
         params: { reportId, paymentId },
+        query: { includeFeeRecords: 'true' },
       });
 
     const aPaymentDetailsResponseBody = (): PaymentDetailsResponseBody => ({
@@ -38,13 +39,55 @@ describe('get-payment-details-by-id.controller', () => {
       const { req, res } = getHttpMocks();
 
       const responseBody = aPaymentDetailsResponseBody();
-      jest.mocked(api.getPaymentDetails).mockResolvedValue(aPaymentDetailsResponseBody());
+      jest.mocked(api.getPaymentDetails).mockResolvedValue(responseBody);
 
       // Act
       await getPaymentDetailsById(req, res);
 
       // Assert
       expect(res._getData()).toEqual(responseBody);
+    });
+
+    it("includes the attached fee records when the includeFeeRecords query is set to 'true'", async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+      req.query = { includeFeeRecords: 'true' };
+
+      jest.mocked(api.getPaymentDetails).mockResolvedValue(aPaymentDetailsResponseBody());
+
+      // Act
+      await getPaymentDetailsById(req, res);
+
+      // Assert
+      expect(api.getPaymentDetails).toHaveBeenCalledWith(reportId, paymentId, true);
+    });
+
+    it("does not include the attached fee records when the includeFeeRecords query is set to 'false'", async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+      req.query = { includeFeeRecords: 'false' };
+
+      jest.mocked(api.getPaymentDetails).mockResolvedValue(aPaymentDetailsResponseBody());
+
+      // Act
+      await getPaymentDetailsById(req, res);
+
+      // Assert
+      expect(api.getPaymentDetails).toHaveBeenCalledWith(reportId, paymentId, false);
+    });
+
+    it('does not include the attached fee records when the includeFeeRecords query is undefined', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+      req.query = {};
+
+      jest.mocked(api.getPaymentDetails).mockResolvedValue(aPaymentDetailsResponseBody());
+
+      // Act
+      await getPaymentDetailsById(req, res);
+
+      // Assert
+      expect(api.getPaymentDetails).toHaveBeenCalledWith(reportId, paymentId, false);
     });
 
     it('responds with a 200', async () => {

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.ts
@@ -1,8 +1,8 @@
 import { Response } from 'express';
 import { HttpStatusCode, isAxiosError } from 'axios';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
 import { PaymentDetailsResponseBody } from '../../api-response-types';
 import api from '../../api';
-import { CustomExpressRequest } from '@ukef/dtfs2-common';
 
 type GetPaymentDetailsByIdRequest = CustomExpressRequest<{
   query: {

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.ts
@@ -1,15 +1,24 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { HttpStatusCode, isAxiosError } from 'axios';
 import { PaymentDetailsResponseBody } from '../../api-response-types';
 import api from '../../api';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+
+type GetPaymentDetailsByIdRequest = CustomExpressRequest<{
+  query: {
+    includeFeeRecords?: 'true' | 'false';
+  };
+}>;
 
 type GetPaymentDetailsByIdResponse = Response<PaymentDetailsResponseBody | string>;
 
-export const getPaymentDetailsById = async (req: Request, res: GetPaymentDetailsByIdResponse) => {
+export const getPaymentDetailsById = async (req: GetPaymentDetailsByIdRequest, res: GetPaymentDetailsByIdResponse) => {
   const { reportId, paymentId } = req.params;
+  const { includeFeeRecords } = req.query;
 
   try {
-    const paymentDetails = await api.getPaymentDetails(reportId, paymentId);
+    const includeFeeRecordsQuery = includeFeeRecords === 'true';
+    const paymentDetails = await api.getPaymentDetails(reportId, paymentId, includeFeeRecordsQuery);
 
     return res.status(HttpStatusCode.Ok).send(paymentDetails);
   } catch (error) {

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/index.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/index.ts
@@ -8,3 +8,4 @@ export { postPayment } from './post-payment.controller';
 export { postKeyingData } from './post-keying-data.controller';
 export { getFeeRecordsToKey } from './get-fee-records-to-key.controller';
 export { getPaymentDetailsById } from './get-payment-details-by-id.controller';
+export { deletePayment } from './delete-payment.controller';

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -171,11 +171,8 @@ authRouter
 
 authRouter
   .route('/utilisation-reports/:reportId/payment/:paymentId')
-  .get(
-    validation.sqlIdValidation('reportId'),
-    validation.sqlIdValidation('paymentId'),
-    handleExpressValidatorResult,
-    utilisationReportsController.getPaymentDetailsById,
-  );
+  .all(validation.sqlIdValidation('reportId'), validation.sqlIdValidation('paymentId'), handleExpressValidatorResult)
+  .get(utilisationReportsController.getPaymentDetailsById)
+  .delete(utilisationReportsController.deletePayment);
 
 module.exports = { authRouter, openRouter };

--- a/trade-finance-manager-ui/component-tests/assertions.js
+++ b/trade-finance-manager-ui/component-tests/assertions.js
@@ -52,6 +52,15 @@ const assertions = (wrapper, html, params) => ({
       expect(wrapper(selector).text().trim()).toEqual(text);
     },
   }),
+  expectWarningButton: (selector) => ({
+    toLinkTo: (href, text) => {
+      expect(wrapper(selector).hasClass('govuk-button--disabled')).toEqual(false);
+      expect(wrapper(selector).hasClass('govuk-button--warning')).toEqual(true);
+      expect(wrapper(selector).attr('href')).toEqual(href);
+      expect(wrapper(selector).attr('disabled')).toBeUndefined();
+      expect(wrapper(selector).text().trim()).toEqual(text);
+    },
+  }),
   expectText: (selector) => ({
     notToExist: () => {
       expect(wrapper(selector).html()).toBeNull();

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/confirm-delete-payment.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/confirm-delete-payment.component-test.js
@@ -1,0 +1,52 @@
+const pageRenderer = require('../pageRenderer');
+
+const page = '../templates/utilisation-reports/confirm-delete-payment.njk';
+const render = pageRenderer(page);
+
+describe(page, () => {
+  const getListRow = (key, value) => ({ key: { text: key }, value: { text: value } });
+
+  const getWrapper = ({ paymentSummaryListRows } = { paymentSummaryListRows: [] }) => render({ paymentSummaryListRows });
+
+  it('renders the page heading', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectText('h1').toRead('Are you sure you want to delete the payment?');
+  });
+
+  it('renders a summary list item for each supplied row', () => {
+    const paymentSummaryListRows = [
+      getListRow('First item', 'First value'),
+      getListRow('Second item', 'Second value'),
+      getListRow('Third item', 'Third value'),
+    ];
+    const wrapper = getWrapper({ paymentSummaryListRows });
+
+    const summaryListSelector = 'dl.govuk-summary-list';
+    wrapper.expectElement(summaryListSelector).toExist();
+    paymentSummaryListRows.forEach(({ key, value }) => {
+      wrapper.expectElement(`${summaryListSelector} dt.govuk-summary-list__key:contains("${key.text}")`).toExist();
+      wrapper.expectElement(`${summaryListSelector} dd.govuk-summary-list__value:contains("${value.text}")`).toExist();
+    });
+  });
+
+  it('renders the yes and no radios', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement('div.govuk-radios__item').toHaveCount(2);
+
+    const yesRadioLabelSelector = 'label.govuk-radios__label:contains("Yes")';
+    wrapper.expectElement(yesRadioLabelSelector).toExist();
+    wrapper.expectInput(`div.govuk-radios__item:has(${yesRadioLabelSelector}) input`).toHaveValue('yes');
+
+    const noRadioLabelSelector = 'label.govuk-radios__label:contains("No")';
+    wrapper.expectElement(noRadioLabelSelector).toExist();
+    wrapper.expectInput(`div.govuk-radios__item:has(${noRadioLabelSelector}) input`).toHaveValue('no');
+  });
+
+  it('renders the confirm button', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectPrimaryButton('button.govuk-button').toLinkTo(undefined, 'Continue');
+  });
+});

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/edit-payment.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/edit-payment.component-test.js
@@ -125,11 +125,16 @@ describe(page, () => {
     wrapper.expectElement(saveChangesButtonSelector).toHaveAttribute('formaction', '/utilisation-reports/12/edit-payment/34');
   });
 
-  it('should render the delete payment button', () => {
-    const wrapper = render(anEditPaymentViewModel());
+  it('should render the delete payment button which links to the confirm delete payment url', () => {
+    const viewModel = {
+      ...anEditPaymentViewModel(),
+      reportId: '12',
+      paymentId: '34',
+    };
+    const wrapper = render(viewModel);
 
-    wrapper.expectElement('button[data-cy="delete-payment-button"]').toExist();
-    wrapper.expectElement('button[data-cy="delete-payment-button"]').hasClass('govuk-button--warning');
+    wrapper.expectElement('a[data-cy="delete-payment-button"]').toExist();
+    wrapper.expectWarningButton('a[data-cy="delete-payment-button"]').toLinkTo('/utilisation-reports/12/edit-payment/34/confirm-delete', 'Delete payment');
   });
 
   it('should render the cancel link which links to the premium payments table', () => {

--- a/trade-finance-manager-ui/server/api-response-types/get-payment-details-response-body.ts
+++ b/trade-finance-manager-ui/server/api-response-types/get-payment-details-response-body.ts
@@ -2,10 +2,16 @@ import { CurrencyAndAmount, ReportPeriod, SessionBank } from '@ukef/dtfs2-common
 import { FeeRecord } from './fee-record';
 import { Payment } from './payment';
 
-export type GetPaymentDetailsResponseBody = {
+export type GetPaymentDetailsWithFeeRecordsResponseBody = {
   bank: SessionBank;
   reportPeriod: ReportPeriod;
   payment: Payment;
   feeRecords: FeeRecord[];
   totalReportedPayments: CurrencyAndAmount;
+};
+
+export type GetPaymentDetailsWithoutFeeRecordsResponseBody = {
+  bank: SessionBank;
+  reportPeriod: ReportPeriod;
+  payment: Payment;
 };

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -995,17 +995,54 @@ const getUtilisationReportWithFeeRecordsToKey = async (reportId, userToken) => {
 };
 
 /**
- * Gets the payment details required to render the edit payment page
+ * Gets the payment details with the attached fee records
  * @param {string} reportId - The report id
  * @param {string} paymentId - The payment id
  * @param {string} userToken - The user token
- * @returns {Promise<import('./api-response-types').GetPaymentDetailsResponseBody>}
+ * @returns {Promise<import('./api-response-types').GetPaymentDetailsWithFeeRecordsResponseBody>}
  */
-const getPaymentDetails = async (reportId, paymentId, userToken) => {
+const getPaymentDetailsWithFeeRecords = async (reportId, paymentId, userToken) => {
   const response = await axios.get(`${TFM_API_URL}/v1/utilisation-reports/${reportId}/payment/${paymentId}`, {
     headers: generateHeaders(userToken),
+    params: {
+      includeFeeRecords: true,
+    },
   });
   return response.data;
+};
+
+/**
+ * Gets the payment details without the attached fee records
+ * @param {string} reportId - The report id
+ * @param {string} paymentId - The payment id
+ * @param {string} userToken - The user token
+ * @returns {Promise<import('./api-response-types').GetPaymentDetailsWithoutFeeRecordsResponseBody>}
+ */
+const getPaymentDetailsWithoutFeeRecords = async (reportId, paymentId, userToken) => {
+  const response = await axios.get(`${TFM_API_URL}/v1/utilisation-reports/${reportId}/payment/${paymentId}`, {
+    headers: generateHeaders(userToken),
+    params: {
+      includeFeeRecords: false,
+    },
+  });
+  return response.data;
+};
+
+/**
+ * Deletes the payment with the specified id
+ * @param {string} reportId - The report id
+ * @param {string} paymentId - The payment id
+ * @param {import('./types/tfm-session-user').TfmSessionUser} user - The session user
+ * @param {string} userToken - The user token
+ * @returns {Promise<void>}
+ */
+const deletePaymentById = async (reportId, paymentId, user, userToken) => {
+  await axios({
+    url: `${TFM_API_URL}/v1/utilisation-reports/${reportId}/payment/${paymentId}`,
+    method: 'delete',
+    headers: generateHeaders(userToken),
+    data: { user },
+  });
 };
 
 module.exports = {
@@ -1053,5 +1090,7 @@ module.exports = {
   addPaymentToFeeRecords,
   generateKeyingData,
   getUtilisationReportWithFeeRecordsToKey,
-  getPaymentDetails,
+  getPaymentDetailsWithFeeRecords,
+  getPaymentDetailsWithoutFeeRecords,
+  deletePaymentById,
 };

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/confirm-delete-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/confirm-delete-payment/index.test.ts
@@ -1,0 +1,232 @@
+import httpMocks from 'node-mocks-http';
+import { getConfirmDeletePayment, postConfirmDeletePayment } from '.';
+import api from '../../../api';
+import { ConfirmDeletePaymentViewModel } from '../../../types/view-models';
+import { aPayment, aPaymentDetailsWithoutFeeRecordsResponseBody, aTfmSessionUser } from '../../../../test-helpers';
+import { GetPaymentDetailsWithoutFeeRecordsResponseBody } from '../../../api-response-types';
+
+console.error = jest.fn();
+
+jest.mock('../../../api');
+
+describe('controllers/utilisation-reports/confirm-delete-payment', () => {
+  const requestSession = {
+    user: aTfmSessionUser(),
+    userToken: 'abc123',
+  };
+
+  describe('getConfirmDeletePayment', () => {
+    const reportId = '1';
+    const paymentId = '2';
+
+    const getHttpMocks = () =>
+      httpMocks.createMocks({
+        session: requestSession,
+        params: {
+          reportId,
+          paymentId,
+        },
+      });
+
+    beforeEach(() => {
+      jest.mocked(api.getPaymentDetailsWithoutFeeRecords).mockResolvedValue(aPaymentDetailsWithoutFeeRecordsResponseBody());
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('gets the payment details and renders the confirm delete payment page', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getConfirmDeletePayment(req, res);
+
+      // Assert
+      expect(api.getPaymentDetailsWithoutFeeRecords).toHaveBeenCalledWith(reportId, paymentId, requestSession.userToken);
+      expect(res._getRenderView()).toBe('utilisation-reports/confirm-delete-payment.njk');
+    });
+
+    it('renders the confirm delete payment page with the payment summary list rows', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getConfirmDeletePayment(req, res);
+
+      // Assert
+      const viewModel = res._getRenderData() as ConfirmDeletePaymentViewModel;
+      expect(viewModel.paymentSummaryListRows).toHaveLength(3);
+    });
+
+    it("renders the confirm delete payment page with the 'Amount' key-value pair at row index 0", async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const responseBody: GetPaymentDetailsWithoutFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithoutFeeRecordsResponseBody(),
+        payment: {
+          ...aPayment(),
+          currency: 'GBP',
+          amount: 100,
+        },
+      };
+      jest.mocked(api.getPaymentDetailsWithoutFeeRecords).mockResolvedValue(responseBody);
+
+      // Act
+      await getConfirmDeletePayment(req, res);
+
+      // Assert
+      const viewModel = res._getRenderData() as ConfirmDeletePaymentViewModel;
+      expect(viewModel.paymentSummaryListRows[0]).toEqual({
+        key: { text: 'Amount' },
+        value: { text: 'GBP 100.00' },
+      });
+    });
+
+    it("renders the confirm delete payment page with the 'Payment reference' key-value pair at row index 1", async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const responseBody: GetPaymentDetailsWithoutFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithoutFeeRecordsResponseBody(),
+        payment: {
+          ...aPayment(),
+          reference: 'Some reference',
+        },
+      };
+      jest.mocked(api.getPaymentDetailsWithoutFeeRecords).mockResolvedValue(responseBody);
+
+      // Act
+      await getConfirmDeletePayment(req, res);
+
+      // Assert
+      const viewModel = res._getRenderData() as ConfirmDeletePaymentViewModel;
+      expect(viewModel.paymentSummaryListRows[1]).toEqual({
+        key: { text: 'Payment reference' },
+        value: { text: 'Some reference' },
+      });
+    });
+
+    it("renders the confirm delete payment page with the 'Date received' key-value pair at row index 2", async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const responseBody: GetPaymentDetailsWithoutFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithoutFeeRecordsResponseBody(),
+        payment: {
+          ...aPayment(),
+          dateReceived: '2024-06-19T12:00:00.000',
+        },
+      };
+      jest.mocked(api.getPaymentDetailsWithoutFeeRecords).mockResolvedValue(responseBody);
+
+      // Act
+      await getConfirmDeletePayment(req, res);
+
+      // Assert
+      const viewModel = res._getRenderData() as ConfirmDeletePaymentViewModel;
+      expect(viewModel.paymentSummaryListRows[2]).toEqual({
+        key: { text: 'Date received' },
+        value: { text: '19 Jun 2024' },
+      });
+    });
+  });
+
+  describe('postConfirmDeletePayment', () => {
+    beforeEach(() => {
+      jest.mocked(api.deletePaymentById);
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    describe("when 'confirmDeletePayment' is set to 'yes'", () => {
+      const reportId = '5';
+      const paymentId = '6';
+
+      const getHttpMocks = () =>
+        httpMocks.createMocks({
+          session: requestSession,
+          params: { reportId, paymentId },
+          body: { confirmDeletePayment: 'yes' },
+        });
+
+      it('deletes the payment', async () => {
+        // Arrange
+        const { req, res } = getHttpMocks();
+
+        // Act
+        await postConfirmDeletePayment(req, res);
+
+        // Assert
+        expect(api.deletePaymentById).toHaveBeenCalledWith(reportId, paymentId, requestSession.user, requestSession.userToken);
+      });
+
+      it('redirects to the premium payments page', async () => {
+        // Arrange
+        const { req, res } = getHttpMocks();
+
+        // Act
+        await postConfirmDeletePayment(req, res);
+
+        // Assert
+        expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}`);
+      });
+    });
+
+    describe("when 'confirmDeletePayment' is set to 'no'", () => {
+      const reportId = '5';
+      const paymentId = '6';
+
+      const getHttpMocks = () =>
+        httpMocks.createMocks({
+          session: requestSession,
+          params: { reportId, paymentId },
+          body: { confirmDeletePayment: 'no' },
+        });
+
+      it('does not delete the payment', async () => {
+        // Arrange
+        const { req, res } = getHttpMocks();
+
+        // Act
+        await postConfirmDeletePayment(req, res);
+
+        // Assert
+        expect(api.deletePaymentById).not.toHaveBeenCalled();
+      });
+
+      it('redirects to the edit payment url with the same report id and payment id specified in the request params', async () => {
+        // Arrange
+        const { req, res } = getHttpMocks();
+
+        // Act
+        await postConfirmDeletePayment(req, res);
+
+        // Assert
+        expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`);
+      });
+    });
+
+    it('renders the problem with service page when an error occurs', async () => {
+      // Arrange
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId: '1', paymentId: '1' },
+        body: { confirmDeletePayment: 'yes' },
+      });
+
+      jest.mocked(api.deletePaymentById).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await postConfirmDeletePayment(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderData()).toEqual({ user: requestSession.user });
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/confirm-delete-payment/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/confirm-delete-payment/index.ts
@@ -1,0 +1,69 @@
+import { Request, Response } from 'express';
+import { format } from 'date-fns';
+import { getFormattedCurrencyAndAmount } from '@ukef/dtfs2-common';
+import api from '../../../api';
+import { GetPaymentDetailsWithoutFeeRecordsResponseBody } from '../../../api-response-types';
+import { ConfirmDeletePaymentViewModel } from '../../../types/view-models';
+import { asUserSession } from '../../../helpers/express-session';
+import { CustomExpressRequest } from '../../../types/custom-express-request';
+
+const renderConfirmDeletePayment = (res: Response, viewModel: ConfirmDeletePaymentViewModel) =>
+  res.render('utilisation-reports/confirm-delete-payment.njk', viewModel);
+
+const getPaymentSummaryListRows = (paymentResponse: GetPaymentDetailsWithoutFeeRecordsResponseBody) => {
+  const formattedDateReceived = format(new Date(paymentResponse.payment.dateReceived), 'd MMM yyyy');
+  return [
+    {
+      key: { text: 'Amount' },
+      value: { text: getFormattedCurrencyAndAmount(paymentResponse.payment) },
+    },
+    {
+      key: { text: 'Payment reference' },
+      value: { text: paymentResponse.payment.reference ?? '' },
+    },
+    {
+      key: { text: 'Date received' },
+      value: { text: formattedDateReceived },
+    },
+  ];
+};
+
+export const getConfirmDeletePayment = async (req: Request, res: Response) => {
+  const { reportId, paymentId } = req.params;
+  const { userToken, user } = asUserSession(req.session);
+
+  try {
+    const paymentResponse = await api.getPaymentDetailsWithoutFeeRecords(reportId, paymentId, userToken);
+
+    const paymentSummaryListRows = getPaymentSummaryListRows(paymentResponse);
+
+    return renderConfirmDeletePayment(res, { paymentSummaryListRows });
+  } catch (error) {
+    console.error('Failed to render confirm delete payment page', error);
+    return res.render('_partials/problem-with-service.njk', { user });
+  }
+};
+
+type PostConfirmDeletePaymentRequest = CustomExpressRequest<{
+  reqBody: {
+    confirmDeletePayment?: 'yes' | 'no';
+  };
+}>;
+
+export const postConfirmDeletePayment = async (req: PostConfirmDeletePaymentRequest, res: Response) => {
+  const { user, userToken } = asUserSession(req.session);
+  const { reportId, paymentId } = req.params;
+  const { confirmDeletePayment } = req.body;
+
+  try {
+    if (confirmDeletePayment === 'yes') {
+      await api.deletePaymentById(reportId, paymentId, user, userToken);
+      return res.redirect(`/utilisation-reports/${reportId}`);
+    }
+
+    return res.redirect(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`);
+  } catch (error) {
+    console.error('Failed to delete payment', error);
+    return res.render('_partials/problem-with-service.njk', { user });
+  }
+};

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.test.ts
@@ -2,7 +2,7 @@ import httpMocks from 'node-mocks-http';
 import { Currency, CurrencyAndAmount, ReportPeriod, SessionBank } from '@ukef/dtfs2-common';
 import { PostEditPaymentRequest, getEditPayment, postEditPayment } from '.';
 import api from '../../../api';
-import { aPaymentDetailsResponseBody, aTfmSessionUser, aPayment, aFeeRecord } from '../../../../test-helpers';
+import { aPaymentDetailsWithFeeRecordsResponseBody, aTfmSessionUser, aPayment, aFeeRecord } from '../../../../test-helpers';
 import { EMPTY_PAYMENT_ERRORS_VIEW_MODEL, EditPaymentFormRequestBody } from '../helpers';
 import { EditPaymentViewModel } from '../../../types/view-models/edit-payment-view-model';
 import { SortedAndFormattedCurrencyAndAmount } from '../../../types/view-models';
@@ -17,7 +17,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
   });
 
   beforeEach(() => {
-    jest.mocked(api.getPaymentDetails).mockResolvedValue(aPaymentDetailsResponseBody());
+    jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue(aPaymentDetailsWithFeeRecordsResponseBody());
   });
 
   afterEach(() => {
@@ -75,8 +75,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       const paymentCurrency: Currency = 'USD';
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           currency: paymentCurrency,
@@ -97,8 +97,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       const bank: SessionBank = { id: '123', name: 'Test bank' };
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         bank,
       });
 
@@ -120,8 +120,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       };
       const formattedReportPeriod = 'January 2024';
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         reportPeriod,
       });
 
@@ -140,8 +140,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const feeRecordIds = [1, 2];
       const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -161,8 +161,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const feeRecordFacilityIds = ['12345678', '87654321'];
       const feeRecords = feeRecordFacilityIds.map((facilityId) => ({ ...aFeeRecord(), facilityId }));
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -182,8 +182,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const feeRecordExporters = ['12345678', '87654321'];
       const feeRecords = feeRecordExporters.map((exporter) => ({ ...aFeeRecord(), exporter }));
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -210,8 +210,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       ];
       const feeRecords = feeRecordReportedFees.map((reportedFees) => ({ ...aFeeRecord(), reportedFees }));
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -238,8 +238,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       ];
       const feeRecords = feeRecordReportedPayments.map((reportedPayments) => ({ ...aFeeRecord(), reportedPayments }));
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -259,8 +259,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const feeRecordIds = [1, 2];
       const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -279,8 +279,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       const feeRecords = [aFeeRecord(), aFeeRecord(), aFeeRecord(), aFeeRecord()];
 
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       });
 
@@ -298,8 +298,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const { req, res } = getHttpMocks();
 
       const totalReportedPayments: CurrencyAndAmount = { currency: 'USD', amount: 314.59 };
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         totalReportedPayments,
       });
 
@@ -328,8 +328,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const { req, res } = getHttpMocks();
 
       const paymentAmount = 100;
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           amount: paymentAmount,
@@ -350,8 +350,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       const day = '10';
       const dateReceived = new Date(`2024-05-${day}`).toISOString();
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           dateReceived,
@@ -372,8 +372,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       const month = '5';
       const dateReceived = new Date(`2024-${month}-1`).toISOString();
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           dateReceived,
@@ -394,8 +394,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       const year = '2024';
       const dateReceived = new Date(`${year}-5-1`).toISOString();
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           dateReceived,
@@ -415,8 +415,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       const { req, res } = getHttpMocks();
 
       const reference = 'A payment reference';
-      jest.mocked(api.getPaymentDetails).mockResolvedValue({
-        ...aPaymentDetailsResponseBody(),
+      jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           reference,
@@ -515,8 +515,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         const paymentCurrency: Currency = 'USD';
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           payment: {
             ...aPayment(),
             currency: paymentCurrency,
@@ -537,8 +537,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         const bank: SessionBank = { id: '123', name: 'Test bank' };
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           bank,
         });
 
@@ -560,8 +560,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         };
         const formattedReportPeriod = 'January 2024';
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           reportPeriod,
         });
 
@@ -580,8 +580,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         const feeRecordIds = [1, 2];
         const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -601,8 +601,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         const feeRecordFacilityIds = ['12345678', '87654321'];
         const feeRecords = feeRecordFacilityIds.map((facilityId) => ({ ...aFeeRecord(), facilityId }));
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -622,8 +622,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         const feeRecordExporters = ['12345678', '87654321'];
         const feeRecords = feeRecordExporters.map((exporter) => ({ ...aFeeRecord(), exporter }));
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -650,8 +650,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         ];
         const feeRecords = feeRecordReportedFees.map((reportedFees) => ({ ...aFeeRecord(), reportedFees }));
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -678,8 +678,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         ];
         const feeRecords = feeRecordReportedPayments.map((reportedPayments) => ({ ...aFeeRecord(), reportedPayments }));
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -699,8 +699,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         const feeRecordIds = [1, 2];
         const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -719,8 +719,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         const feeRecords = [aFeeRecord(), aFeeRecord(), aFeeRecord(), aFeeRecord()];
 
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           feeRecords,
         });
 
@@ -738,8 +738,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         const { req, res } = getHttpMocks();
 
         const totalReportedPayments: CurrencyAndAmount = { currency: 'USD', amount: 314.59 };
-        jest.mocked(api.getPaymentDetails).mockResolvedValue({
-          ...aPaymentDetailsResponseBody(),
+        jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue({
+          ...aPaymentDetailsWithFeeRecordsResponseBody(),
           totalReportedPayments,
         });
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.ts
@@ -18,7 +18,7 @@ export const getEditPayment = async (req: Request, res: Response) => {
   const { reportId, paymentId } = req.params;
 
   try {
-    const paymentDetails = await api.getPaymentDetails(reportId, paymentId, userToken);
+    const paymentDetails = await api.getPaymentDetailsWithFeeRecords(reportId, paymentId, userToken);
     const editPaymentViewModel = getEditPaymentViewModel(paymentDetails, reportId, paymentId);
     return renderEditPaymentPage(res, editPaymentViewModel);
   } catch (error) {
@@ -45,7 +45,7 @@ export const postEditPayment = async (req: PostEditPaymentRequest, res: Response
       return res.redirect(`/utilisation-reports/${reportId}`);
     }
 
-    const paymentDetails = await api.getPaymentDetails(reportId, paymentId, userToken);
+    const paymentDetails = await api.getPaymentDetailsWithFeeRecords(reportId, paymentId, userToken);
     const editPaymentViewModel = getEditPaymentViewModelWithFormValuesAndErrors(paymentDetails, reportId, paymentId, formValues, editPaymentErrors);
     return renderEditPaymentPage(res, editPaymentViewModel);
   } catch (error) {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/edit-payment-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/edit-payment-helper.test.ts
@@ -1,7 +1,7 @@
 import { Currency, CurrencyAndAmount } from '@ukef/dtfs2-common';
 import { getEditPaymentViewModel, getEditPaymentViewModelWithFormValuesAndErrors } from './edit-payment-helper';
-import { aPaymentDetailsResponseBody, aPayment, aFeeRecord } from '../../../../test-helpers';
-import { GetPaymentDetailsResponseBody } from '../../../api-response-types';
+import { aPaymentDetailsWithFeeRecordsResponseBody, aPayment, aFeeRecord } from '../../../../test-helpers';
+import { GetPaymentDetailsWithFeeRecordsResponseBody } from '../../../api-response-types';
 import { PaymentErrorsViewModel, SortedAndFormattedCurrencyAndAmount } from '../../../types/view-models';
 import { EditPaymentFormValues } from '../../../types/edit-payment-form-values';
 import { EMPTY_PAYMENT_ERRORS_VIEW_MODEL } from './payment-form-helpers';
@@ -13,7 +13,7 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model reportId the supplied reportId', () => {
       // Arrange
-      const editPaymentResponseBody = aPaymentDetailsResponseBody();
+      const editPaymentResponseBody = aPaymentDetailsWithFeeRecordsResponseBody();
 
       // Act
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId);
@@ -24,7 +24,7 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model paymentId the supplied paymentId', () => {
       // Arrange
-      const editPaymentResponseBody = aPaymentDetailsResponseBody();
+      const editPaymentResponseBody = aPaymentDetailsWithFeeRecordsResponseBody();
 
       // Act
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId);
@@ -35,8 +35,8 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model paymentCurrency to the edit payment response payment currency', () => {
       // Arrange
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           currency: 'USD',
@@ -52,8 +52,8 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model bank to the edit payment response bank', () => {
       // Arrange
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         bank: {
           id: '123',
           name: 'Test bank',
@@ -69,8 +69,8 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model formattedReportPeriod to the formatted edit payment response reportPeriod', () => {
       // Arrange
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         reportPeriod: {
           start: { month: 1, year: 2024 },
           end: { month: 1, year: 2024 },
@@ -88,8 +88,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const paymentCurrency: Currency = 'USD';
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           currency: paymentCurrency,
@@ -108,8 +108,8 @@ describe('edit-payment-helper', () => {
       const feeRecordIds = [1, 2];
       const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -126,8 +126,8 @@ describe('edit-payment-helper', () => {
       const feeRecordFacilityIds = ['12345678', '87654321'];
       const feeRecords = feeRecordFacilityIds.map((facilityId) => ({ ...aFeeRecord(), facilityId }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -144,8 +144,8 @@ describe('edit-payment-helper', () => {
       const feeRecordExporters = ['12345678', '87654321'];
       const feeRecords = feeRecordExporters.map((exporter) => ({ ...aFeeRecord(), exporter }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -169,8 +169,8 @@ describe('edit-payment-helper', () => {
       ];
       const feeRecords = feeRecordReportedFees.map((reportedFees) => ({ ...aFeeRecord(), reportedFees }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -194,8 +194,8 @@ describe('edit-payment-helper', () => {
       ];
       const feeRecords = feeRecordReportedPayments.map((reportedPayments) => ({ ...aFeeRecord(), reportedPayments }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -212,8 +212,8 @@ describe('edit-payment-helper', () => {
       const feeRecordIds = [1, 2];
       const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -229,8 +229,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const feeRecords = [aFeeRecord(), aFeeRecord(), aFeeRecord(), aFeeRecord()];
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -245,8 +245,8 @@ describe('edit-payment-helper', () => {
     it('sets the render view model totalReportedPayments to the edit payment details response formatted totalReportedPayments', () => {
       // Arrange
       const totalReportedPayments: CurrencyAndAmount = { currency: 'USD', amount: 314.59 };
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         totalReportedPayments,
       };
 
@@ -259,7 +259,7 @@ describe('edit-payment-helper', () => {
 
     it('sets the render view model errors to the empty errors', () => {
       // Act
-      const viewModel = getEditPaymentViewModel(aPaymentDetailsResponseBody(), reportId, paymentId);
+      const viewModel = getEditPaymentViewModel(aPaymentDetailsWithFeeRecordsResponseBody(), reportId, paymentId);
 
       // Assert
       expect(viewModel.errors).toEqual(EMPTY_PAYMENT_ERRORS_VIEW_MODEL);
@@ -268,8 +268,8 @@ describe('edit-payment-helper', () => {
     it('sets the render view model formValues paymentAmount to the edit payment details response payment amount', () => {
       // Arrange
       const paymentAmount = 100;
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           amount: paymentAmount,
@@ -287,8 +287,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const day = '10';
       const dateReceived = new Date(`2024-05-${day}`).toISOString();
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           dateReceived,
@@ -306,8 +306,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const month = '5';
       const dateReceived = new Date(`2024-${month}-1`).toISOString();
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           dateReceived,
@@ -325,8 +325,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const year = '2024';
       const dateReceived = new Date(`${year}-5-1`).toISOString();
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           dateReceived,
@@ -343,8 +343,8 @@ describe('edit-payment-helper', () => {
     it('sets the render view model formValues paymentReference to the edit payment details response payment reference', () => {
       // Arrange
       const reference = 'A payment reference';
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           reference,
@@ -365,7 +365,7 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model reportId the supplied reportId', () => {
       // Arrange
-      const editPaymentResponseBody = aPaymentDetailsResponseBody();
+      const editPaymentResponseBody = aPaymentDetailsWithFeeRecordsResponseBody();
 
       // Act
       const viewModel = getEditPaymentViewModelWithFormValuesAndErrors(
@@ -382,7 +382,7 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model paymentId the supplied paymentId', () => {
       // Arrange
-      const editPaymentResponseBody = aPaymentDetailsResponseBody();
+      const editPaymentResponseBody = aPaymentDetailsWithFeeRecordsResponseBody();
 
       // Act
       const viewModel = getEditPaymentViewModelWithFormValuesAndErrors(
@@ -399,8 +399,8 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model paymentCurrency to the edit payment response payment currency', () => {
       // Arrange
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           currency: 'USD',
@@ -422,8 +422,8 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model bank to the edit payment response bank', () => {
       // Arrange
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         bank: {
           id: '123',
           name: 'Test bank',
@@ -445,8 +445,8 @@ describe('edit-payment-helper', () => {
 
     it('sets the view model formattedReportPeriod to the formatted edit payment response reportPeriod', () => {
       // Arrange
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         reportPeriod: {
           start: { month: 1, year: 2024 },
           end: { month: 1, year: 2024 },
@@ -470,8 +470,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const paymentCurrency: Currency = 'USD';
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         payment: {
           ...aPayment(),
           currency: paymentCurrency,
@@ -496,8 +496,8 @@ describe('edit-payment-helper', () => {
       const feeRecordIds = [1, 2];
       const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -520,8 +520,8 @@ describe('edit-payment-helper', () => {
       const feeRecordFacilityIds = ['12345678', '87654321'];
       const feeRecords = feeRecordFacilityIds.map((facilityId) => ({ ...aFeeRecord(), facilityId }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -544,8 +544,8 @@ describe('edit-payment-helper', () => {
       const feeRecordExporters = ['12345678', '87654321'];
       const feeRecords = feeRecordExporters.map((exporter) => ({ ...aFeeRecord(), exporter }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -575,8 +575,8 @@ describe('edit-payment-helper', () => {
       ];
       const feeRecords = feeRecordReportedFees.map((reportedFees) => ({ ...aFeeRecord(), reportedFees }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -606,8 +606,8 @@ describe('edit-payment-helper', () => {
       ];
       const feeRecords = feeRecordReportedPayments.map((reportedPayments) => ({ ...aFeeRecord(), reportedPayments }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -630,8 +630,8 @@ describe('edit-payment-helper', () => {
       const feeRecordIds = [1, 2];
       const feeRecords = feeRecordIds.map((id) => ({ ...aFeeRecord(), id }));
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -653,8 +653,8 @@ describe('edit-payment-helper', () => {
       // Arrange
       const feeRecords = [aFeeRecord(), aFeeRecord(), aFeeRecord(), aFeeRecord()];
 
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         feeRecords,
       };
 
@@ -675,8 +675,8 @@ describe('edit-payment-helper', () => {
     it('sets the render view model totalReportedPayments to the edit payment details response formatted totalReportedPayments', () => {
       // Arrange
       const totalReportedPayments: CurrencyAndAmount = { currency: 'USD', amount: 314.59 };
-      const editPaymentResponseBody: GetPaymentDetailsResponseBody = {
-        ...aPaymentDetailsResponseBody(),
+      const editPaymentResponseBody: GetPaymentDetailsWithFeeRecordsResponseBody = {
+        ...aPaymentDetailsWithFeeRecordsResponseBody(),
         totalReportedPayments,
       };
 
@@ -702,7 +702,7 @@ describe('edit-payment-helper', () => {
 
       // Act
       const viewModel = getEditPaymentViewModelWithFormValuesAndErrors(
-        aPaymentDetailsResponseBody(),
+        aPaymentDetailsWithFeeRecordsResponseBody(),
         reportId,
         paymentId,
         aValidEditPaymentFormValuesObject(),
@@ -722,7 +722,7 @@ describe('edit-payment-helper', () => {
 
       // Act
       const viewModel = getEditPaymentViewModelWithFormValuesAndErrors(
-        aPaymentDetailsResponseBody(),
+        aPaymentDetailsWithFeeRecordsResponseBody(),
         reportId,
         paymentId,
         formValues,
@@ -746,7 +746,7 @@ describe('edit-payment-helper', () => {
 
       // Act
       const viewModel = getEditPaymentViewModelWithFormValuesAndErrors(
-        aPaymentDetailsResponseBody(),
+        aPaymentDetailsWithFeeRecordsResponseBody(),
         reportId,
         paymentId,
         formValues,
@@ -770,7 +770,7 @@ describe('edit-payment-helper', () => {
 
       // Act
       const viewModel = getEditPaymentViewModelWithFormValuesAndErrors(
-        aPaymentDetailsResponseBody(),
+        aPaymentDetailsWithFeeRecordsResponseBody(),
         reportId,
         paymentId,
         formValues,

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/edit-payment-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/edit-payment-helper.ts
@@ -1,6 +1,6 @@
 import { isValid, parseISO } from 'date-fns';
 import { IsoDateTimeStamp, getFormattedCurrencyAndAmount, getFormattedReportPeriodWithLongMonth, getOneIndexedMonth } from '@ukef/dtfs2-common';
-import { GetPaymentDetailsResponseBody, FeeRecord, Payment } from '../../../api-response-types';
+import { GetPaymentDetailsWithFeeRecordsResponseBody, FeeRecord, Payment } from '../../../api-response-types';
 import { getKeyToCurrencyAndAmountSortValueMap } from './get-key-to-currency-and-amount-sort-value-map-helper';
 import { EditPaymentFormValues } from '../../../types/edit-payment-form-values';
 import { PaymentErrorsViewModel, EditPaymentViewModel } from '../../../types/view-models';
@@ -53,7 +53,11 @@ const mapToEditPaymentFormValues = (payment: Payment): EditPaymentFormValues => 
  * @param reportId - The report id
  * @returns The edit payment view model
  */
-export const getEditPaymentViewModel = (editPaymentResponse: GetPaymentDetailsResponseBody, reportId: string, paymentId: string): EditPaymentViewModel => ({
+export const getEditPaymentViewModel = (
+  editPaymentResponse: GetPaymentDetailsWithFeeRecordsResponseBody,
+  reportId: string,
+  paymentId: string,
+): EditPaymentViewModel => ({
   reportId,
   paymentId,
   paymentCurrency: editPaymentResponse.payment.currency,
@@ -72,7 +76,7 @@ export const getEditPaymentViewModel = (editPaymentResponse: GetPaymentDetailsRe
  * @returns The edit payment view model
  */
 export const getEditPaymentViewModelWithFormValuesAndErrors = (
-  editPaymentResponse: GetPaymentDetailsResponseBody,
+  editPaymentResponse: GetPaymentDetailsWithFeeRecordsResponseBody,
   reportId: string,
   paymentId: string,
   formValues: EditPaymentFormValues,

--- a/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
+++ b/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
@@ -11,6 +11,7 @@ import { addPayment } from '../../controllers/utilisation-reports/add-payment';
 import { postKeyingData } from '../../controllers/utilisation-reports/keying-data';
 import { postCheckKeyingData } from '../../controllers/utilisation-reports/check-keying-data';
 import { getEditPayment, postEditPayment } from '../../controllers/utilisation-reports/edit-payment';
+import { getConfirmDeletePayment, postConfirmDeletePayment } from '../../controllers/utilisation-reports/confirm-delete-payment';
 
 export const utilisationReportsRoutes = express.Router();
 
@@ -71,4 +72,22 @@ utilisationReportsRoutes.post(
   validateSqlId('reportId'),
   validateSqlId('paymentId'),
   postEditPayment,
+);
+
+utilisationReportsRoutes.get(
+  '/:reportId/edit-payment/:paymentId/confirm-delete',
+  validateTfmPaymentReconciliationFeatureFlagIsEnabled,
+  validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
+  validateSqlId('reportId'),
+  validateSqlId('paymentId'),
+  getConfirmDeletePayment,
+);
+
+utilisationReportsRoutes.post(
+  '/:reportId/edit-payment/:paymentId/confirm-delete',
+  validateTfmPaymentReconciliationFeatureFlagIsEnabled,
+  validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
+  validateSqlId('reportId'),
+  validateSqlId('paymentId'),
+  postConfirmDeletePayment,
 );

--- a/trade-finance-manager-ui/server/types/view-models/confirm-delete-payment-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/confirm-delete-payment-view-model.ts
@@ -1,0 +1,6 @@
+export type ConfirmDeletePaymentViewModel = {
+  paymentSummaryListRows: {
+    key: { text: string };
+    value: { text: string };
+  }[];
+};

--- a/trade-finance-manager-ui/server/types/view-models/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/index.ts
@@ -7,3 +7,4 @@ export * from './check-keying-data-view-model';
 export * from './fee-record-details-view-model';
 export * from './payment-errors-view-model';
 export * from './edit-payment-view-model';
+export * from './confirm-delete-payment-view-model';

--- a/trade-finance-manager-ui/templates/utilisation-reports/confirm-delete-payment.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/confirm-delete-payment.njk
@@ -1,0 +1,35 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "index.njk" %}
+{% block pageTitle %}
+  Confirm delete payment
+{% endblock %}
+{% block content %}
+  <h1 class="govuk-heading-1">Are you sure you want to delete the payment?</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukSummaryList({
+        rows: paymentSummaryListRows
+      }) }}
+    </div>
+  </div>
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/> {{ govukRadios({
+      classes: "govuk-radios--inline",
+      name: "confirmDeletePayment",
+      items: [
+        {
+          value: "yes",
+          text: "Yes"
+        },
+        {
+          value: "no",
+          text: "No"
+        }
+      ]
+    }) }}
+    {{ govukButton({ "text": "Continue" }) }}
+  </form>
+{% endblock %}
+{% block subcontent %}{% endblock %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/edit-payment.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/edit-payment.njk
@@ -82,6 +82,7 @@
         {{ govukButton({
       text: "Delete payment",
       classes: "govuk-button--warning",
+      href: ["/utilisation-reports/", reportId, "/edit-payment/", paymentId, "/confirm-delete"] | join,
       attributes: {
         "data-cy": "delete-payment-button"
       }

--- a/trade-finance-manager-ui/test-helpers/payment-details-response-body.ts
+++ b/trade-finance-manager-ui/test-helpers/payment-details-response-body.ts
@@ -1,8 +1,8 @@
-import { GetPaymentDetailsResponseBody } from '../server/api-response-types';
+import { GetPaymentDetailsWithFeeRecordsResponseBody, GetPaymentDetailsWithoutFeeRecordsResponseBody } from '../server/api-response-types';
 import { aFeeRecord } from './fee-record';
 import { aPayment } from './payment';
 
-export const aPaymentDetailsResponseBody = (): GetPaymentDetailsResponseBody => ({
+export const aPaymentDetailsWithFeeRecordsResponseBody = (): GetPaymentDetailsWithFeeRecordsResponseBody => ({
   bank: {
     id: '123',
     name: 'Test bank',
@@ -17,4 +17,16 @@ export const aPaymentDetailsResponseBody = (): GetPaymentDetailsResponseBody => 
     currency: 'GBP',
     amount: 100,
   },
+});
+
+export const aPaymentDetailsWithoutFeeRecordsResponseBody = (): GetPaymentDetailsWithoutFeeRecordsResponseBody => ({
+  bank: {
+    id: '123',
+    name: 'Test bank',
+  },
+  reportPeriod: {
+    start: { month: 1, year: 2024 },
+    end: { month: 1, year: 2024 },
+  },
+  payment: aPayment(),
 });


### PR DESCRIPTION
## Introduction :pencil2:
We want to add a page to allow the user to confirm that they want to delete the selected payment.

## Resolution :heavy_check_mark:
- Adds the page
- Adds a new query to the `GET /v1/utilisation-reports/:reportId/payment/:paymentId` endpoint which decides whether or not to include the fee record related fields in the response
  - This is added as a payment can be attached to many fee records, and sending all that information in the response body when it isn't needed is unnecessary
- Updates api tests to test for the new query paramater

![image](https://github.com/UK-Export-Finance/dtfs2/assets/108285982/a3b33aa2-b505-4e3b-aecc-de8c9665ad56)


## Miscellaneous :heavy_plus_sign:

