### PR TITLE
feat(FN-1720): add e2e tests for deleting payments

### DIFF
--- a/e2e-tests/e2e-fixtures/constants.fixture.js
+++ b/e2e-tests/e2e-fixtures/constants.fixture.js
@@ -126,4 +126,6 @@ export const NODE_TASKS = {
   GET_ALL_BANKS: 'getAllBanks',
   INSERT_UTILISATION_REPORTS_INTO_DB: 'insertUtilisationReportsIntoDb',
   REMOVE_ALL_UTILISATION_REPORTS_FROM_DB: 'removeAllUtilisationReportsFromDb',
+  INSERT_FEE_RECORDS_INTO_DB: 'insertFeeRecordsIntoDb',
+  REMOVE_ALL_PAYMENTS_FROM_DB: 'removeAllPaymentsFromDb',
 };

--- a/e2e-tests/e2e-fixtures/dbCollections.ts
+++ b/e2e-tests/e2e-fixtures/dbCollections.ts
@@ -1,4 +1,3 @@
 export const DB_COLLECTIONS = {
   BANKS: 'banks',
-  UTILISATION_REPORTS: 'utilisationReports',
 } as const;

--- a/e2e-tests/support/tasks.js
+++ b/e2e-tests/support/tasks.js
@@ -1,7 +1,7 @@
 const crypto = require('node:crypto');
 const { MongoDbClient } = require('@ukef/dtfs2-common/mongo-db-client');
 const { SqlDbDataSource } = require('@ukef/dtfs2-common/sql-db-connection');
-const { UtilisationReportEntity } = require('@ukef/dtfs2-common');
+const { UtilisationReportEntity, FeeRecordEntity, PaymentEntity } = require('@ukef/dtfs2-common');
 const createTfmDealToInsertIntoDb = require('../tfm/cypress/fixtures/create-tfm-deal-to-insert-into-db');
 const createTfmFacilityToInsertIntoDb = require('../tfm/cypress/fixtures/create-tfm-facility-to-insert-into-db');
 const { DB_COLLECTIONS } = require('../e2e-fixtures/dbCollections');
@@ -97,6 +97,18 @@ module.exports = {
      */
     const removeAllUtilisationReportsFromDb = async () => await SqlDbDataSource.manager.getRepository(UtilisationReportEntity).delete({});
 
+    /**
+     * Inserts fee records to the SQL database
+     * @param {FeeRecordEntity[]} feeRecords
+     * @returns {FeeRecordEntity[]} The inserted fee records
+     */
+    const insertFeeRecordsIntoDb = async (feeRecords) => await SqlDbDataSource.manager.save(FeeRecordEntity, feeRecords);
+
+    /**
+     * Deletes all the rows from the payment table
+     */
+    const removeAllPaymentsFromDb = async () => await SqlDbDataSource.manager.delete(PaymentEntity, {});
+
     const getAllBanks = async () => {
       const banks = await db.getCollection(DB_COLLECTIONS.BANKS);
       return banks.find().toArray();
@@ -112,16 +124,6 @@ module.exports = {
           },
         },
       );
-    };
-
-    const insertUtilisationReportDetailsIntoDb = async (utilisationReportDetails) => {
-      const utilisationReports = await db.getCollection(DB_COLLECTIONS.UTILISATION_REPORTS);
-      return utilisationReports.insertMany(utilisationReportDetails);
-    };
-
-    const removeAllUtilisationReportDetailsFromDb = async () => {
-      const utilisationReports = await db.getCollection(DB_COLLECTIONS.UTILISATION_REPORTS);
-      return utilisationReports.deleteMany({});
     };
 
     /**
@@ -193,15 +195,15 @@ module.exports = {
       overridePortalUserSignInTokensByUsername,
       resetPortalUserStatusAndNumberOfSignInLinks,
       disablePortalUserByUsername,
-      insertUtilisationReportDetailsIntoDb,
       insertManyTfmDeals,
       deleteAllTfmDeals,
       insertManyTfmFacilitiesAndTwoLinkedDeals,
       deleteAllTfmFacilities,
-      removeAllUtilisationReportDetailsFromDb,
       getAllBanks,
       insertUtilisationReportsIntoDb,
       removeAllUtilisationReportsFromDb,
+      insertFeeRecordsIntoDb,
+      removeAllPaymentsFromDb,
     };
   },
 };

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/delete-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/delete-payment.spec.js
@@ -6,11 +6,11 @@ import {
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
-import pages from '../../../pages';
-import { PDC_TEAMS } from '../../../../fixtures/teams';
-import { NODE_TASKS } from '../../../../../../e2e-fixtures';
-import USERS from '../../../../fixtures/users';
-import relative from '../../../relativeURL';
+import pages from '../../pages';
+import { PDC_TEAMS } from '../../../fixtures/teams';
+import { NODE_TASKS } from '../../../../../e2e-fixtures';
+import USERS from '../../../fixtures/users';
+import relative from '../../relativeURL';
 
 context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
   const reportIdGenerator = idGenerator();
@@ -72,7 +72,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}`));
   });
 
-  it(`allows the user to delete the payment a resets the status to '${FEE_RECORD_STATUS.DOES_NOT_MATCH}' when the remaining payments do not match`, () => {
+  it(`allows the user to delete the payment and resets the status to '${FEE_RECORD_STATUS.DOES_NOT_MATCH}' when the remaining payments do not match`, () => {
     const report = aUtilisationReport();
 
     const firstPayment = aPaymentWithAmount(100);
@@ -104,7 +104,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
   });
 
-  it(`allows the user to delete the payment a resets the status to '${FEE_RECORD_STATUS.MATCH}' when the remaining payments match`, () => {
+  it(`allows the user to delete the payment and resets the status to '${FEE_RECORD_STATUS.MATCH}' when the remaining payments match`, () => {
     const report = aUtilisationReport();
 
     const firstPayment = aPaymentWithAmount(100);
@@ -136,7 +136,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
   });
 
-  it(`allows the user to delete the payment a resets the status to '${FEE_RECORD_STATUS.TO_DO}' when all payments are deleted`, () => {
+  it(`allows the user to delete the payment and resets the status to '${FEE_RECORD_STATUS.TO_DO}' when all payments are deleted`, () => {
     const report = aUtilisationReport();
 
     const payment = aPaymentWithAmount(100);

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/mark-report-as-done.spec.js
@@ -4,13 +4,13 @@ import {
   getPreviousReportPeriodForBankScheduleByMonth,
   toIsoMonthStamp,
 } from '@ukef/dtfs2-common';
-import pages from '../../../pages';
-import USERS from '../../../../fixtures/users';
-import { PDC_TEAMS } from '../../../../fixtures/teams';
-import { getMonthlyReportPeriodFromIsoSubmissionMonth } from '../../../../support/utils/dateHelpers';
-import { NODE_TASKS } from '../../../../../../e2e-fixtures';
-import { aliasSelector } from '../../../../../../support/alias-selector';
-import { BANK1_PAYMENT_REPORT_OFFICER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
+import pages from '../../pages';
+import USERS from '../../../fixtures/users';
+import { PDC_TEAMS } from '../../../fixtures/teams';
+import { getMonthlyReportPeriodFromIsoSubmissionMonth } from '../../../support/utils/dateHelpers';
+import { NODE_TASKS } from '../../../../../e2e-fixtures';
+import { aliasSelector } from '../../../../../support/alias-selector';
+import { BANK1_PAYMENT_REPORT_OFFICER1 } from '../../../../../e2e-fixtures/portal-users.fixture';
 
 context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`, () => {
   let uploadedByUserId;

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/delete-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/pdc-reconcile/delete-payment.spec.js
@@ -1,0 +1,173 @@
+import {
+  CURRENCY,
+  FEE_RECORD_STATUS,
+  FeeRecordEntityMockBuilder,
+  PaymentEntityMockBuilder,
+  UTILISATION_REPORT_RECONCILIATION_STATUS,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
+import pages from '../../../pages';
+import { PDC_TEAMS } from '../../../../fixtures/teams';
+import { NODE_TASKS } from '../../../../../../e2e-fixtures';
+import USERS from '../../../../fixtures/users';
+import relative from '../../../relativeURL';
+
+context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
+  const reportIdGenerator = idGenerator();
+  const feeRecordIdGenerator = idGenerator();
+  const paymentIdGenerator = idGenerator();
+  const paymentCurrency = CURRENCY.GBP;
+
+  const aUtilisationReport = () =>
+    UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
+      .withId(reportIdGenerator.next().value)
+      .withBankId('961')
+      .withDateUploaded(new Date())
+      .build();
+
+  const aPaymentWithAmount = (amount) =>
+    PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(paymentIdGenerator.next().value).withAmount(amount).build();
+
+  const aFeeRecordForReportWithAmountStatusAndPayments = (report, amount, status, payments) =>
+    FeeRecordEntityMockBuilder.forReport(report)
+      .withId(feeRecordIdGenerator.next().value)
+      .withStatus(status)
+      .withFeesPaidToUkefForThePeriod(amount)
+      .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
+      .withPaymentCurrency(paymentCurrency)
+      .withPayments(payments)
+      .build();
+
+  beforeEach(() => {
+    cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
+    cy.task(NODE_TASKS.REMOVE_ALL_PAYMENTS_FROM_DB);
+
+    pages.landingPage.visit();
+    cy.login(USERS.PDC_RECONCILE);
+  });
+
+  it('navigates back to the edit-payment page when the No button is selected on the confirm delete payment page', () => {
+    const report = aUtilisationReport();
+
+    const payment = aPaymentWithAmount(100);
+
+    const feeRecord = aFeeRecordForReportWithAmountStatusAndPayments(report, 300, FEE_RECORD_STATUS.DOES_NOT_MATCH, [payment]);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    cy.visit(`/utilisation-reports/${report.id}`);
+
+    pages.utilisationReportsPage.clickPaymentLink(payment.id);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}`));
+
+    pages.utilisationReportEditPaymentPage.clickDeletePaymentButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}/confirm-delete`));
+
+    pages.utilisationReportConfirmDeletePaymentPage.selectNoRadio();
+    pages.utilisationReportConfirmDeletePaymentPage.clickContinueButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}`));
+  });
+
+  it(`allows the user to delete the payment a resets the status to '${FEE_RECORD_STATUS.DOES_NOT_MATCH}' when the remaining payments do not match`, () => {
+    const report = aUtilisationReport();
+
+    const firstPayment = aPaymentWithAmount(100);
+
+    const secondPayment = aPaymentWithAmount(200);
+
+    const feeRecord = aFeeRecordForReportWithAmountStatusAndPayments(report, 300, FEE_RECORD_STATUS.MATCH, [firstPayment, secondPayment]);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    cy.visit(`/utilisation-reports/${report.id}`);
+
+    cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
+    pages.utilisationReportsPage.clickPaymentLink(firstPayment.id);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${firstPayment.id}`));
+
+    pages.utilisationReportEditPaymentPage.clickDeletePaymentButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${firstPayment.id}/confirm-delete`));
+
+    pages.utilisationReportConfirmDeletePaymentPage.selectYesRadio();
+    pages.utilisationReportConfirmDeletePaymentPage.clickContinueButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}`));
+
+    pages.utilisationReportsPage.getPaymentLink(firstPayment.id).should('not.exist');
+    cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
+  });
+
+  it(`allows the user to delete the payment a resets the status to '${FEE_RECORD_STATUS.MATCH}' when the remaining payments match`, () => {
+    const report = aUtilisationReport();
+
+    const firstPayment = aPaymentWithAmount(100);
+
+    const secondPayment = aPaymentWithAmount(200);
+
+    const feeRecord = aFeeRecordForReportWithAmountStatusAndPayments(report, 200, FEE_RECORD_STATUS.DOES_NOT_MATCH, [firstPayment, secondPayment]);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    cy.visit(`/utilisation-reports/${report.id}`);
+
+    cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
+    pages.utilisationReportsPage.clickPaymentLink(firstPayment.id);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${firstPayment.id}`));
+
+    pages.utilisationReportEditPaymentPage.clickDeletePaymentButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${firstPayment.id}/confirm-delete`));
+
+    pages.utilisationReportConfirmDeletePaymentPage.selectYesRadio();
+    pages.utilisationReportConfirmDeletePaymentPage.clickContinueButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}`));
+
+    pages.utilisationReportsPage.getPaymentLink(firstPayment.id).should('not.exist');
+    cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
+  });
+
+  it(`allows the user to delete the payment a resets the status to '${FEE_RECORD_STATUS.TO_DO}' when all payments are deleted`, () => {
+    const report = aUtilisationReport();
+
+    const payment = aPaymentWithAmount(100);
+
+    const feeRecord = aFeeRecordForReportWithAmountStatusAndPayments(report, 300, FEE_RECORD_STATUS.DOES_NOT_MATCH, [payment]);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    cy.visit(`/utilisation-reports/${report.id}`);
+
+    pages.utilisationReportsPage.clickPaymentLink(payment.id);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}`));
+
+    pages.utilisationReportEditPaymentPage.clickDeletePaymentButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}/confirm-delete`));
+
+    pages.utilisationReportConfirmDeletePaymentPage.selectYesRadio();
+    pages.utilisationReportConfirmDeletePaymentPage.clickContinueButton();
+
+    pages.utilisationReportsPage.getPaymentLink(payment.id).should('not.exist');
+    cy.get('strong[data-cy="fee-record-status"]:contains("TO DO")').should('exist');
+  });
+
+  function* idGenerator() {
+    let id = 0;
+    while (true) {
+      id += 1;
+      yield id;
+    }
+  }
+});

--- a/e2e-tests/tfm/cypress/e2e/pages/index.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/index.js
@@ -25,9 +25,11 @@ import amendmentsPage from './amendments/amendmentsPage';
 import feedbackPage from './feedbackPage';
 import footer from './footer';
 import activitiesPage from './activities/activitiesPage';
-import utilisationReportsPage from './utilisationReportsPage';
+import { utilisationReportsPage } from './utilisationReportsPage';
 import { searchUtilisationReportsFormPage, searchUtilisationReportsResultsPage } from './searchUtilisationReportsPage';
 import { utilisationReportAddPaymentPage } from './utilisationReportAddPaymentPage';
+import { utilisationReportConfirmDeletePaymentPage } from './utilisationReportConfirmDeletePaymentPage';
+import { utilisationReportEditPaymentPage } from './utilisationReportEditPaymentPage';
 
 export default {
   landingPage,
@@ -61,4 +63,6 @@ export default {
   searchUtilisationReportsFormPage,
   searchUtilisationReportsResultsPage,
   utilisationReportAddPaymentPage,
+  utilisationReportConfirmDeletePaymentPage,
+  utilisationReportEditPaymentPage,
 };

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportConfirmDeletePaymentPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportConfirmDeletePaymentPage.js
@@ -1,0 +1,7 @@
+const utilisationReportConfirmDeletePaymentPage = {
+  selectNoRadio: () => cy.get('input[type=radio][value="no"]').click(),
+  selectYesRadio: () => cy.get('input[type=radio][value="yes"]').click(),
+  clickContinueButton: () => cy.get('button:contains("Continue")').click(),
+};
+
+module.exports = { utilisationReportConfirmDeletePaymentPage };

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportEditPaymentPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportEditPaymentPage.js
@@ -1,0 +1,5 @@
+const utilisationReportEditPaymentPage = {
+  clickDeletePaymentButton: () => cy.get('a[data-cy="delete-payment-button"]').click(),
+};
+
+module.exports = { utilisationReportEditPaymentPage };

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportsPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportsPage.js
@@ -12,6 +12,8 @@ const utilisationReportsPage = {
     cy.get(`[data-cy="utilisation-reports-form--${submissionMonth}"]`).within(($form) => {
       cy.wrap($form).get('[data-cy="mark-as-not-completed-button"]').click();
     }),
+  getPaymentLink: (paymentId) => cy.get(`a[data-cy="edit-payment-link--paymentId-${paymentId}"]`),
+  clickPaymentLink: (paymentId) => cy.get(`a[data-cy="edit-payment-link--paymentId-${paymentId}"]`).click(),
 };
 
-module.exports = utilisationReportsPage;
+module.exports = { utilisationReportsPage };

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
@@ -1,11 +1,9 @@
 {% import "./fee-record-status.njk" as feeRecordStatus %}
 {% import "../../_macros/table-cell-checkbox.njk" as tableCellCheckbox %}
-
 {% macro render(params) %}
   {% set reportId = params.reportId %}
   {% set feeRecordPaymentGroup = params.feeRecordPaymentGroup %}
   {% set userCanEdit = params.userCanEdit %}
-
   {% set feeRecords = feeRecordPaymentGroup.feeRecords %}
   {% set totalReportedPayments = feeRecordPaymentGroup.totalReportedPayments %}
   {% set paymentsReceived = feeRecordPaymentGroup.paymentsReceived %}
@@ -14,19 +12,11 @@
   {% set displayStatus = feeRecordPaymentGroup.displayStatus %}
   {% set checkboxId = feeRecordPaymentGroup.checkboxId %}
   {% set isChecked = feeRecordPaymentGroup.isChecked %}
-
   {% for feeRecord in feeRecords %}
     {% set isFirstFeeRecordInGroup = loop.index === 1 %}
     {% set isLastFeeRecordInGroup = loop.index === feeRecords.length %}
-
-    <tr
-      class="govuk-table__row"
-      data-cy="premium-payments-table-row--feeRecordId-{{ feeRecord.id }}"
-    >
-      <th
-        scope="row"
-        class="govuk-table__header govuk-!-font-weight-regular{{ " no-border" if not isLastFeeRecordInGroup }}"
-      >
+    <tr class="govuk-table__row" data-cy="premium-payments-table-row--feeRecordId-{{ feeRecord.id }}">
+      <th scope="row" class="govuk-table__header govuk-!-font-weight-regular{{ " no-border" if not isLastFeeRecordInGroup }}">
         {{ feeRecord.facilityId }}
       </th>
       <td class="govuk-table__cell{{ " no-border" if not isLastFeeRecordInGroup }}">
@@ -38,21 +28,18 @@
       <td class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}">
         {{ feeRecord.reportedPayments }}
       </td>
-
-      <td
-        class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}"
-        data-sort-value="{{ totalReportedPayments.dataSortValue }}"
-      >
+      <td class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}" data-sort-value="{{ totalReportedPayments.dataSortValue }}">
         {{ totalReportedPayments.formattedCurrencyAndAmount if isFirstFeeRecordInGroup else "" }}
       </td>
-      
       <td class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}">
         {% if isFirstFeeRecordInGroup and paymentsReceived %}
           <ul class="payments-list">
             {% for paymentReceived in paymentsReceived %}
               <li class="payments-list-item">
                 {% if userCanEdit and (status === 'MATCH' or status === 'DOES_NOT_MATCH') %}
-                  <a href="/utilisation-reports/{{ reportId }}/edit-payment/{{ paymentReceived.id }}">
+                  <a
+                    href="/utilisation-reports/{{ reportId }}/edit-payment/{{ paymentReceived.id }}"
+                    data-cy="edit-payment-link--paymentId-{{ paymentReceived.id }}">
                     {{ paymentReceived.formattedCurrencyAndAmount }}
                   </a>
                 {% else %}
@@ -63,14 +50,9 @@
           </ul>
         {% endif %}
       </td>
-
-      <td
-        class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}"
-        data-sort-value="{{ totalPaymentsReceived.dataSortValue }}"
-      >
+      <td class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}" data-sort-value="{{ totalPaymentsReceived.dataSortValue }}">
         {{ totalPaymentsReceived.formattedCurrencyAndAmount if isFirstFeeRecordInGroup else "" }}
       </td>
-
       <td class="govuk-table__cell{{ " no-border" if not isLastFeeRecordInGroup }}" data-sort-value="{{ displayStatus }}">
         {{ feeRecordStatus.render({
           status: status,


### PR DESCRIPTION
## Introduction :pencil2:
We want to add e2e tests for the TFM delete payment journey.

## Resolution :heavy_check_mark:
- Adds the e2e test
- Adds new functions to the `tasks.js` support file
- Adds some `data-cy` selectors to templates

## Miscellaneous :heavy_plus_sign:
- Removes the `utilisation-reports/pdc-reconcile` e2e test directory


