### PR TITLE
feat(FN-1718): add edit payment e2e tests

### DIFF
--- a/e2e-tests/e2e-fixtures/constants.fixture.js
+++ b/e2e-tests/e2e-fixtures/constants.fixture.js
@@ -128,4 +128,5 @@ export const NODE_TASKS = {
   REMOVE_ALL_UTILISATION_REPORTS_FROM_DB: 'removeAllUtilisationReportsFromDb',
   INSERT_FEE_RECORDS_INTO_DB: 'insertFeeRecordsIntoDb',
   REMOVE_ALL_PAYMENTS_FROM_DB: 'removeAllPaymentsFromDb',
+  REMOVE_ALL_FEE_RECORDS_FROM_DB: 'removeAllFeeRecordsFromDb',
 };

--- a/e2e-tests/support/tasks.js
+++ b/e2e-tests/support/tasks.js
@@ -109,6 +109,11 @@ module.exports = {
      */
     const removeAllPaymentsFromDb = async () => await SqlDbDataSource.manager.delete(PaymentEntity, {});
 
+    /**
+     * Deletes all the rows from the payment table
+     */
+    const removeAllFeeRecordsFromDb = async () => await SqlDbDataSource.manager.delete(FeeRecordEntity, {});
+
     const getAllBanks = async () => {
       const banks = await db.getCollection(DB_COLLECTIONS.BANKS);
       return banks.find().toArray();
@@ -204,6 +209,7 @@ module.exports = {
       removeAllUtilisationReportsFromDb,
       insertFeeRecordsIntoDb,
       removeAllPaymentsFromDb,
+      removeAllFeeRecordsFromDb,
     };
   },
 };

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
@@ -1,4 +1,5 @@
 import {
+  FEE_RECORD_STATUS,
   FeeRecordEntityMockBuilder,
   PaymentEntityMockBuilder,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
@@ -15,7 +16,6 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
     const FEE_RECORD_ID_ONE = '11';
     const FEE_RECORD_ID_TWO = '22';
     const PAYMENT_CURRENCY = 'GBP';
-    const FEE_RECORD_STATUS = 'TO_DO';
     cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
 
     const report = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION)
@@ -35,7 +35,7 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
       .withFeesPaidToUkefForThePeriod(100)
       .withFeesPaidToUkefForThePeriodCurrency('JPY')
       .withPaymentExchangeRate(2)
-      .withStatus('TO_DO')
+      .withStatus('DOES_NOT_MATCH')
       .withPayments([payment])
       .build();
     const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(undefined)
@@ -46,7 +46,7 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
       .withFeesPaidToUkefForThePeriodCurrency('EUR')
       .withPaymentCurrency(PAYMENT_CURRENCY)
       .withPaymentExchangeRate(0.5)
-      .withStatus('TO_DO')
+      .withStatus('DOES_NOT_MATCH')
       .withPayments([payment])
       .build();
     report.feeRecords = [feeRecordOne, feeRecordTwo];
@@ -58,7 +58,7 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
 
     cy.visit(`utilisation-reports/${REPORT_ID}`);
     cy.get(
-      `[type="checkbox"][id="feeRecordIds-${FEE_RECORD_ID_ONE},${FEE_RECORD_ID_TWO}-reportedPaymentsCurrency-${PAYMENT_CURRENCY}-status-${FEE_RECORD_STATUS}"]`,
+      `[type="checkbox"][id="feeRecordIds-${FEE_RECORD_ID_ONE},${FEE_RECORD_ID_TWO}-reportedPaymentsCurrency-${PAYMENT_CURRENCY}-status-${FEE_RECORD_STATUS.DOES_NOT_MATCH}"]`,
     ).check();
     cy.get('[type="submit"]').contains('Add a payment').click();
   });
@@ -68,23 +68,23 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
   });
 
   it('should render the selected fee record details', () => {
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('11111111').should('exist');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Exporter 1').should('exist');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('JPY 100').should('exist');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('GBP 50').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', '11111111');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', 'Exporter 1');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', 'JPY 100');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', 'GBP 50');
 
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('22222222').should('exist');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Exporter 2').should('exist');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('EUR 200').should('exist');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('GBP 400').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', '22222222');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', 'Exporter 2');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', 'EUR 200');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().should('contain', 'GBP 400');
 
     pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Total reported payments GBP 450').should('exist');
   });
 
   it('should render the recorded payment details table', () => {
-    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('GBP 60').should('exist');
-    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('2 Feb 2023').should('exist');
-    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('REF01234').should('exist');
+    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().should('contain', 'GBP 60');
+    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().should('contain', '2 Feb 2023');
+    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().should('contain', 'REF01234');
   });
 
   it('should display errors when form submitted with invalid values', () => {
@@ -95,13 +95,13 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
 
     cy.contains('button', 'Continue').click();
 
-    cy.get('a').contains('Select payment currency').should('exist');
-    cy.get('a').contains('The date payment received must be a real date').should('exist');
-    cy.get('a').contains('Select add another payment choice').should('exist');
+    cy.get('a').should('contain', 'Select payment currency');
+    cy.get('a').should('contain', 'The date payment received must be a real date');
+    cy.get('a').should('contain', 'Select add another payment choice');
 
-    cy.get('form').contains('Select payment currency').should('exist');
-    cy.get('form').contains('The date payment received must be a real date').should('exist');
-    cy.get('form').contains('Select add another payment choice').should('exist');
+    cy.get('form').should('contain', 'Select payment currency');
+    cy.get('form').should('contain', 'The date payment received must be a real date');
+    cy.get('form').should('contain', 'Select add another payment choice');
 
     cy.getInputByLabelText('Amount received').should('have.value', '100');
     cy.getInputByLabelText('Day').should('have.value', '56');

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
@@ -68,23 +68,23 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
   });
 
   it('should render the selected fee record details', () => {
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('11111111');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Exporter 1');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('JPY 100');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('GBP 50');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('11111111').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Exporter 1').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('JPY 100').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('GBP 50').should('exist');
 
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('22222222');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Exporter 2');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('EUR 200');
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('GBP 400');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('22222222').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Exporter 2').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('EUR 200').should('exist');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('GBP 400').should('exist');
 
-    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Total reported payments GBP 450');
+    pages.utilisationReportAddPaymentPage.selectedReportedFeesDetailsTable().contains('Total reported payments GBP 450').should('exist');
   });
 
   it('should render the recorded payment details table', () => {
-    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('GBP 60');
-    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('2 Feb 2023');
-    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('REF01234');
+    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('GBP 60').should('exist');
+    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('2 Feb 2023').should('exist');
+    pages.utilisationReportAddPaymentPage.recordedPaymentsDetailsTable().contains('REF01234').should('exist');
   });
 
   it('should display errors when form submitted with invalid values', () => {
@@ -95,13 +95,13 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
 
     cy.contains('button', 'Continue').click();
 
-    cy.get('a').contains('Select payment currency');
-    cy.get('a').contains('The date payment received must be a real date');
-    cy.get('a').contains('Select add another payment choice');
+    cy.get('a').contains('Select payment currency').should('exist');
+    cy.get('a').contains('The date payment received must be a real date').should('exist');
+    cy.get('a').contains('Select add another payment choice').should('exist');
 
-    cy.get('form').contains('Select payment currency');
-    cy.get('form').contains('The date payment received must be a real date');
-    cy.get('form').contains('Select add another payment choice');
+    cy.get('form').contains('Select payment currency').should('exist');
+    cy.get('form').contains('The date payment received must be a real date').should('exist');
+    cy.get('form').contains('Select add another payment choice').should('exist');
 
     cy.getInputByLabelText('Amount received').should('have.value', '100');
     cy.getInputByLabelText('Day').should('have.value', '56');
@@ -119,7 +119,7 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
 
     cy.contains('button', 'Continue').click();
 
-    cy.contains('Premium payments');
+    cy.contains('Premium payments').should('exist');
   });
 
   it('submits form and reloads the page with no values when user submits form with valid values and user selects yes to adding another payment', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
@@ -1,0 +1,232 @@
+import {
+  CURRENCY,
+  FEE_RECORD_STATUS,
+  FeeRecordEntityMockBuilder,
+  PaymentEntityMockBuilder,
+  UTILISATION_REPORT_RECONCILIATION_STATUS,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
+import pages from '../../pages';
+import { PDC_TEAMS } from '../../../fixtures/teams';
+import { NODE_TASKS } from '../../../../../e2e-fixtures';
+import USERS from '../../../fixtures/users';
+import relative from '../../relativeURL';
+
+context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
+  const reportId = 12;
+  const paymentId = 15;
+  const feeRecordId = 7;
+  const paymentCurrency = CURRENCY.GBP;
+  const paymentAmount = 100;
+
+  const paymentDateDay = '1';
+  const paymentDateMonth = '1';
+  const paymentDateYear = '2024';
+  const datePaymentReceived = new Date(`${paymentDateYear}-${paymentDateMonth}-${paymentDateDay}`);
+
+  const paymentReference = 'A payment reference';
+
+  const clearFormValues = () => {
+    cy.getInputByLabelText('Amount received').clear();
+    cy.getInputByLabelText('Day').clear();
+    cy.getInputByLabelText('Month').clear();
+    cy.getInputByLabelText('Year').clear();
+    cy.getInputByLabelText('Payment reference (optional)').clear();
+  };
+
+  const utilisationReport = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
+    .withId(reportId)
+    .withBankId('961')
+    .withDateUploaded(new Date())
+    .build();
+
+  const aPaymentWithAmount = (amount) =>
+    PaymentEntityMockBuilder.forCurrency(paymentCurrency)
+      .withId(paymentId)
+      .withAmount(amount)
+      .withDateReceived(datePaymentReceived)
+      .withReference(paymentReference)
+      .build();
+
+  const aFeeRecordWithAmountStatusAndPayments = (amount, status, payments) =>
+    FeeRecordEntityMockBuilder.forReport(utilisationReport)
+      .withId(feeRecordId)
+      .withStatus(status)
+      .withFeesPaidToUkefForThePeriod(amount)
+      .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
+      .withPaymentCurrency(paymentCurrency)
+      .withPayments(payments)
+      .build();
+
+  beforeEach(() => {
+    cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
+    cy.task(NODE_TASKS.REMOVE_ALL_PAYMENTS_FROM_DB);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [utilisationReport]);
+
+    const payment = aPaymentWithAmount(paymentAmount);
+    const feeRecord = aFeeRecordWithAmountStatusAndPayments(paymentAmount, FEE_RECORD_STATUS.MATCH, [payment]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    pages.landingPage.visit();
+    cy.login(USERS.PDC_RECONCILE);
+
+    cy.visit(`/utilisation-reports/${reportId}`);
+  });
+
+  it('should allow the user to navigate to the edit payment page', () => {
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+  });
+
+  it('should display the payment currency as a fixed value next to the payment amount', () => {
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    cy.get('[data-cy="payment-currency-prefix"]').should('have.text', paymentCurrency);
+  });
+
+  it('should populate the edit payment form values with the current payment values', () => {
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    cy.getInputByLabelText('Amount received').should('have.value', paymentAmount.toString());
+    cy.getInputByLabelText('Day').should('have.value', paymentDateDay);
+    cy.getInputByLabelText('Month').should('have.value', paymentDateMonth);
+    cy.getInputByLabelText('Year').should('have.value', paymentDateYear);
+    cy.getInputByLabelText('Payment reference (optional)').should('have.value', paymentReference);
+  });
+
+  it('should display errors when form submitted with invalid values and persist the inputted values', () => {
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    clearFormValues();
+
+    cy.getInputByLabelText('Amount received').type('nonsense');
+    cy.getInputByLabelText('Day').type('nonsense');
+    cy.getInputByLabelText('Month').type('nonsense');
+    cy.getInputByLabelText('Year').type('nonsense');
+    cy.getInputByLabelText('Payment reference (optional)').type('This is valid');
+
+    pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
+
+    cy.get('a').contains('Enter a valid amount received').should('exist');
+    cy.get('a').contains('The date payment received must be a real date').should('exist');
+
+    cy.get('form').contains('Enter a valid amount received').should('exist');
+    cy.get('form').contains('The date payment received must be a real date').should('exist');
+
+    cy.getInputByLabelText('Amount received').should('have.value', 'nonsense');
+    cy.getInputByLabelText('Day').should('have.value', 'nonsense');
+    cy.getInputByLabelText('Month').should('have.value', 'nonsense');
+    cy.getInputByLabelText('Year').should('have.value', 'nonsense');
+    cy.getInputByLabelText('Payment reference (optional)').should('have.value', 'This is valid');
+  });
+
+  it('should return to the premium payments table after the user clicks the save changes button', () => {
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}`));
+  });
+
+  it('should update the payment with the supplied values after clicking the save changes button', () => {
+    const newPaymentAmount = '314.59';
+    const newPaymentDateDay = '12';
+    const newPaymentDateMonth = '2';
+    const newPaymentDateYear = '2021';
+    const newPaymentReference = 'New payment reference';
+
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    cy.getInputByLabelText('Amount received').should('have.value', paymentAmount.toString());
+    cy.getInputByLabelText('Day').should('have.value', paymentDateDay);
+    cy.getInputByLabelText('Month').should('have.value', paymentDateMonth);
+    cy.getInputByLabelText('Year').should('have.value', paymentDateYear);
+    cy.getInputByLabelText('Payment reference (optional)').should('have.value', paymentReference);
+
+    clearFormValues();
+
+    cy.getInputByLabelText('Amount received').type(newPaymentAmount.toString());
+    cy.getInputByLabelText('Day').type(newPaymentDateDay);
+    cy.getInputByLabelText('Month').type(newPaymentDateMonth);
+    cy.getInputByLabelText('Year').type(newPaymentDateYear);
+    cy.getInputByLabelText('Payment reference (optional)').type(newPaymentReference);
+
+    pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}`));
+
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    cy.getInputByLabelText('Amount received').should('have.value', newPaymentAmount.toString());
+    cy.getInputByLabelText('Day').should('have.value', newPaymentDateDay);
+    cy.getInputByLabelText('Month').should('have.value', newPaymentDateMonth);
+    cy.getInputByLabelText('Year').should('have.value', newPaymentDateYear);
+    cy.getInputByLabelText('Payment reference (optional)').should('have.value', newPaymentReference);
+  });
+
+  it(`should set the fee record status to '${FEE_RECORD_STATUS.DOES_NOT_MATCH}' if the new payment amount does not match the fee record amount`, () => {
+    cy.task(NODE_TASKS.REMOVE_ALL_FEE_RECORDS_FROM_DB);
+    cy.task(NODE_TASKS.REMOVE_ALL_PAYMENTS_FROM_DB);
+
+    const payment = aPaymentWithAmount(200);
+    const feeRecord = aFeeRecordWithAmountStatusAndPayments(200, FEE_RECORD_STATUS.MATCH, [payment]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    cy.reload();
+
+    cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    cy.getInputByLabelText('Amount received').should('have.value', '200');
+    cy.getInputByLabelText('Amount received').clear();
+    cy.getInputByLabelText('Amount received').type('100');
+
+    pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}`));
+    cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
+  });
+
+  it(`should set the fee record status to '${FEE_RECORD_STATUS.MATCH}' if the new payment amount matches the fee record amount`, () => {
+    cy.task(NODE_TASKS.REMOVE_ALL_FEE_RECORDS_FROM_DB);
+    cy.task(NODE_TASKS.REMOVE_ALL_PAYMENTS_FROM_DB);
+
+    const payment = aPaymentWithAmount(100);
+    const feeRecord = aFeeRecordWithAmountStatusAndPayments(200, FEE_RECORD_STATUS.DOES_NOT_MATCH, [payment]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    cy.reload();
+
+    cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
+
+    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
+
+    cy.getInputByLabelText('Amount received').should('have.value', '100');
+    cy.getInputByLabelText('Amount received').clear();
+    cy.getInputByLabelText('Amount received').type('200');
+
+    pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}`));
+    cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('not.exist');
+    cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
@@ -115,11 +115,11 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
     pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 
-    cy.get('a').contains('Enter a valid amount received').should('exist');
-    cy.get('a').contains('The date payment received must be a real date').should('exist');
+    cy.get('a').should('contain', 'Enter a valid amount received');
+    cy.get('a').should('contain', 'The date payment received must be a real date');
 
-    cy.get('form').contains('Enter a valid amount received').should('exist');
-    cy.get('form').contains('The date payment received must be a real date').should('exist');
+    cy.get('form').should('contain', 'Enter a valid amount received');
+    cy.get('form').should('contain', 'The date payment received must be a real date');
 
     cy.getInputByLabelText('Amount received').should('have.value', 'nonsense');
     cy.getInputByLabelText('Day').should('have.value', 'nonsense');

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportEditPaymentPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportEditPaymentPage.js
@@ -1,4 +1,5 @@
 const utilisationReportEditPaymentPage = {
+  clickSaveChangesButton: () => cy.get('input[data-cy="save-changes-button"]').click(),
   clickDeletePaymentButton: () => cy.get('a[data-cy="delete-payment-button"]').click(),
 };
 

--- a/trade-finance-manager-ui/templates/utilisation-reports/edit-payment.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/edit-payment.njk
@@ -45,7 +45,10 @@
           text: "The currency cannot be changed"
         },
         prefix: {
-          text: paymentCurrency
+          text: paymentCurrency,
+          attributes: {
+            "data-cy": "payment-currency-prefix"
+          }
         },
         id: "paymentAmount",
         name: "paymentAmount",


### PR DESCRIPTION
## Introduction :pencil2:
We want to add some e2e tests for the TFM edit payment journey.

## Resolution :heavy_check_mark:
- Adds the e2e test

## Miscellaneous :heavy_plus_sign:
- Adds some extra assertions to the `add-payment.spec.js` test


