### PR TITLE
feat(FN-1617): add e2e tests for filtering by facility id

### DIFF
--- a/e2e-tests/e2e-fixtures/constants.fixture.js
+++ b/e2e-tests/e2e-fixtures/constants.fixture.js
@@ -127,6 +127,7 @@ export const NODE_TASKS = {
   INSERT_UTILISATION_REPORTS_INTO_DB: 'insertUtilisationReportsIntoDb',
   REMOVE_ALL_UTILISATION_REPORTS_FROM_DB: 'removeAllUtilisationReportsFromDb',
   INSERT_FEE_RECORDS_INTO_DB: 'insertFeeRecordsIntoDb',
+  INSERT_PAYMENTS_INTO_DB: 'insertPaymentsIntoDb',
   REMOVE_ALL_PAYMENTS_FROM_DB: 'removeAllPaymentsFromDb',
   REMOVE_ALL_FEE_RECORDS_FROM_DB: 'removeAllFeeRecordsFromDb',
 };

--- a/e2e-tests/support/tasks.js
+++ b/e2e-tests/support/tasks.js
@@ -105,6 +105,13 @@ module.exports = {
     const insertFeeRecordsIntoDb = async (feeRecords) => await SqlDbDataSource.manager.save(FeeRecordEntity, feeRecords);
 
     /**
+     * Inserts payments to the SQL database
+     * @param {PaymentEntity[]} payments
+     * @returns The inserted payments
+     */
+    const insertPaymentsIntoDb = async (payments) => await SqlDbDataSource.manager.save(PaymentEntity, payments);
+
+    /**
      * Deletes all the rows from the payment table
      */
     const removeAllPaymentsFromDb = async () => await SqlDbDataSource.manager.delete(PaymentEntity, {});
@@ -208,6 +215,7 @@ module.exports = {
       insertUtilisationReportsIntoDb,
       removeAllUtilisationReportsFromDb,
       insertFeeRecordsIntoDb,
+      insertPaymentsIntoDb,
       removeAllPaymentsFromDb,
       removeAllFeeRecordsFromDb,
     };

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/delete-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/delete-payment.spec.js
@@ -58,7 +58,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
 
     cy.visit(`/utilisation-reports/${report.id}`);
 
-    pages.utilisationReportsPage.clickPaymentLink(payment.id);
+    pages.utilisationReportPage.clickPaymentLink(payment.id);
 
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}`));
 
@@ -87,7 +87,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     cy.visit(`/utilisation-reports/${report.id}`);
 
     cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
-    pages.utilisationReportsPage.clickPaymentLink(firstPayment.id);
+    pages.utilisationReportPage.clickPaymentLink(firstPayment.id);
 
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${firstPayment.id}`));
 
@@ -100,7 +100,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
 
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}`));
 
-    pages.utilisationReportsPage.getPaymentLink(firstPayment.id).should('not.exist');
+    pages.utilisationReportPage.getPaymentLink(firstPayment.id).should('not.exist');
     cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
   });
 
@@ -119,7 +119,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     cy.visit(`/utilisation-reports/${report.id}`);
 
     cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
-    pages.utilisationReportsPage.clickPaymentLink(firstPayment.id);
+    pages.utilisationReportPage.clickPaymentLink(firstPayment.id);
 
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${firstPayment.id}`));
 
@@ -132,7 +132,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
 
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}`));
 
-    pages.utilisationReportsPage.getPaymentLink(firstPayment.id).should('not.exist');
+    pages.utilisationReportPage.getPaymentLink(firstPayment.id).should('not.exist');
     cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
   });
 
@@ -148,7 +148,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
 
     cy.visit(`/utilisation-reports/${report.id}`);
 
-    pages.utilisationReportsPage.clickPaymentLink(payment.id);
+    pages.utilisationReportPage.clickPaymentLink(payment.id);
 
     cy.url().should('eq', relative(`/utilisation-reports/${report.id}/edit-payment/${payment.id}`));
 
@@ -159,7 +159,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     pages.utilisationReportConfirmDeletePaymentPage.selectYesRadio();
     pages.utilisationReportConfirmDeletePaymentPage.clickContinueButton();
 
-    pages.utilisationReportsPage.getPaymentLink(payment.id).should('not.exist');
+    pages.utilisationReportPage.getPaymentLink(payment.id).should('not.exist');
     cy.get('strong[data-cy="fee-record-status"]:contains("TO DO")').should('exist');
   });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
@@ -75,13 +75,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
   });
 
   it('should allow the user to navigate to the edit payment page', () => {
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
   });
 
   it('should display the payment currency as a fixed value next to the payment amount', () => {
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -89,7 +89,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
   });
 
   it('should populate the edit payment form values with the current payment values', () => {
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -101,7 +101,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
   });
 
   it('should display errors when form submitted with invalid values and persist the inputted values', () => {
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -129,7 +129,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
   });
 
   it('should return to the premium payments table after the user clicks the save changes button', () => {
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -145,7 +145,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
     const newPaymentDateYear = '2021';
     const newPaymentReference = 'New payment reference';
 
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -167,7 +167,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}`));
 
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -189,7 +189,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
     cy.reload();
 
     cy.get('strong[data-cy="fee-record-status"]:contains("MATCH")').should('exist');
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 
@@ -215,7 +215,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
     cy.get('strong[data-cy="fee-record-status"]:contains("DOES NOT MATCH")').should('exist');
 
-    pages.utilisationReportsPage.clickPaymentLink(paymentId);
+    pages.utilisationReportPage.clickPaymentLink(paymentId);
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}/edit-payment/${paymentId}`));
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
@@ -1,0 +1,189 @@
+import {
+  FeeRecordEntityMockBuilder,
+  PaymentEntityMockBuilder,
+  UTILISATION_REPORT_RECONCILIATION_STATUS,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
+import pages from '../../pages';
+import { PDC_TEAMS } from '../../../fixtures/teams';
+import { NODE_TASKS } from '../../../../../e2e-fixtures';
+import USERS from '../../../fixtures/users';
+import relative from '../../relativeURL';
+
+context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`, () => {
+  const bankId = '961';
+  const reportId = 12;
+
+  const utilisationReport = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
+    .withId(reportId)
+    .withBankId(bankId)
+    .withDateUploaded(new Date())
+    .build();
+
+  beforeEach(() => {
+    cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [utilisationReport]);
+
+    pages.landingPage.visit();
+    cy.login(USERS.PDC_RECONCILE);
+
+    cy.visit(`/utilisation-reports/${reportId}`);
+  });
+
+  it('should display all the fee records attached to the utilisation report', () => {
+    const feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withFacilityId('11111111').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withFacilityId('22222222').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(3).withFacilityId('33333333').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(4).withFacilityId('44444444').build(),
+    ];
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, feeRecords);
+
+    cy.reload();
+
+    feeRecords.forEach(({ id, facilityId }) => {
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('exist');
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
+    });
+  });
+
+  it('should only display the fee record with the facility id inputted in the filter', () => {
+    const feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withFacilityId('11111111').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withFacilityId('22222222').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(3).withFacilityId('33333333').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(4).withFacilityId('44444444').build(),
+    ];
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, feeRecords);
+
+    cy.reload();
+
+    pages.utilisationReportsPage.getFacilityIdFilterInput().type('11111111');
+    pages.utilisationReportsPage.submitFacilityIdFilter();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=11111111`));
+
+    const [visibleFeeRecord, ...removedFeeRecords] = feeRecords;
+
+    pages.utilisationReportsPage.getPremiumPaymentsTableRow(visibleFeeRecord.id).should('exist');
+    pages.utilisationReportsPage.getPremiumPaymentsTableRow(visibleFeeRecord.id).should('contain', visibleFeeRecord.facilityId);
+
+    removedFeeRecords.forEach(({ id }) => {
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('not.exist');
+    });
+  });
+
+  it('should display the fee records which partially match the supplied facility id query', () => {
+    const feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withFacilityId('11111111').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withFacilityId('11112222').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(3).withFacilityId('33333333').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(4).withFacilityId('44444444').build(),
+    ];
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, feeRecords);
+
+    cy.reload();
+
+    pages.utilisationReportsPage.getFacilityIdFilterInput().type('1111');
+    pages.utilisationReportsPage.submitFacilityIdFilter();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=1111`));
+
+    const [firstVisibleFeeRecord, secondVisibleFeeRecord, ...removedFeeRecords] = feeRecords;
+
+    pages.utilisationReportsPage.getPremiumPaymentsTableRow(firstVisibleFeeRecord.id).should('exist');
+    pages.utilisationReportsPage.getPremiumPaymentsTableRow(firstVisibleFeeRecord.id).should('contain', firstVisibleFeeRecord.facilityId);
+
+    pages.utilisationReportsPage.getPremiumPaymentsTableRow(secondVisibleFeeRecord.id).should('exist');
+    pages.utilisationReportsPage.getPremiumPaymentsTableRow(secondVisibleFeeRecord.id).should('contain', secondVisibleFeeRecord.facilityId);
+
+    removedFeeRecords.forEach(({ id }) => {
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('not.exist');
+    });
+  });
+
+  it('should display an error if the supplied facility id query is an invalid value and persist the inputted value', () => {
+    pages.utilisationReportsPage.getFacilityIdFilterInput().type('nonsense');
+    pages.utilisationReportsPage.submitFacilityIdFilter();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=nonsense`));
+
+    pages.utilisationReportsPage.getFacilityIdFilterInput().should('have.value', 'nonsense');
+
+    cy.get('a').should('contain', 'Enter 4-10 characters of a facility ID');
+  });
+
+  it('should display an error if the facility id is submitted with no value', () => {
+    pages.utilisationReportsPage.submitFacilityIdFilter();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=`));
+
+    pages.utilisationReportsPage.getFacilityIdFilterInput().should('be.empty');
+
+    cy.get('a').should('contain', 'Enter 4-10 characters of a facility ID');
+  });
+
+  it('should display the entire fee record payment group when only one of the fee records in the group has a matching facility id', () => {
+    const groupedFeeRecords = [
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withStatus('DOES_NOT_MATCH').withFacilityId('11111111').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withStatus('DOES_NOT_MATCH').withFacilityId('22222222').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(3).withStatus('DOES_NOT_MATCH').withFacilityId('33333333').build(),
+    ];
+
+    const toDoFeeRecords = [
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(4).withStatus('TO_DO').withFacilityId('44444444').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(5).withStatus('TO_DO').withFacilityId('55555555').build(),
+    ];
+
+    const allFeeRecords = [...groupedFeeRecords, ...toDoFeeRecords];
+
+    const paymentId = 15;
+    const payment = PaymentEntityMockBuilder.forCurrency('GBP').withId(paymentId).withAmount(100).withFeeRecords(groupedFeeRecords).build();
+
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, allFeeRecords);
+    cy.task(NODE_TASKS.INSERT_PAYMENTS_INTO_DB, [payment]);
+
+    cy.reload();
+
+    allFeeRecords.forEach(({ id, facilityId }) => {
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('exist');
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
+    });
+
+    pages.utilisationReportsPage.getPaymentLink(paymentId).should('exist');
+
+    pages.utilisationReportsPage.getFacilityIdFilterInput().type('1111');
+    pages.utilisationReportsPage.submitFacilityIdFilter();
+
+    toDoFeeRecords.forEach(({ id }) => {
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('not.exist');
+    });
+
+    groupedFeeRecords.forEach(({ id, facilityId }) => {
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('exist');
+      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
+    });
+
+    pages.utilisationReportsPage.getPaymentLink(paymentId).should('exist');
+  });
+
+  it('displays a message when the supplied facility id matches no fee records', () => {
+    const feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withFacilityId('11111111').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withFacilityId('22222222').build(),
+    ];
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, feeRecords);
+
+    cy.reload();
+
+    pages.utilisationReportsPage.getFacilityIdFilterInput().type('33333333');
+    pages.utilisationReportsPage.submitFacilityIdFilter();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=33333333`));
+
+    cy.get('[data-cy="no-matched-facilities-message"]').should('exist');
+    cy.get('[data-cy="no-matched-facilities-message"]').should('contain', 'Your search matched no facilities');
+    cy.get('[data-cy="no-matched-facilities-message"]').should('contain', 'There are no results for the facility ID you entered');
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
@@ -43,8 +43,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
     cy.reload();
 
     feeRecords.forEach(({ id, facilityId }) => {
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('exist');
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('exist');
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
     });
   });
 
@@ -59,18 +59,18 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     cy.reload();
 
-    pages.utilisationReportsPage.getFacilityIdFilterInput().type('11111111');
-    pages.utilisationReportsPage.submitFacilityIdFilter();
+    pages.utilisationReportPage.getFacilityIdFilterInput().type('11111111');
+    pages.utilisationReportPage.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=11111111`));
 
     const [visibleFeeRecord, ...removedFeeRecords] = feeRecords;
 
-    pages.utilisationReportsPage.getPremiumPaymentsTableRow(visibleFeeRecord.id).should('exist');
-    pages.utilisationReportsPage.getPremiumPaymentsTableRow(visibleFeeRecord.id).should('contain', visibleFeeRecord.facilityId);
+    pages.utilisationReportPage.getPremiumPaymentsTableRow(visibleFeeRecord.id).should('exist');
+    pages.utilisationReportPage.getPremiumPaymentsTableRow(visibleFeeRecord.id).should('contain', visibleFeeRecord.facilityId);
 
     removedFeeRecords.forEach(({ id }) => {
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('not.exist');
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('not.exist');
     });
   });
 
@@ -85,41 +85,41 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     cy.reload();
 
-    pages.utilisationReportsPage.getFacilityIdFilterInput().type('1111');
-    pages.utilisationReportsPage.submitFacilityIdFilter();
+    pages.utilisationReportPage.getFacilityIdFilterInput().type('1111');
+    pages.utilisationReportPage.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=1111`));
 
     const [firstVisibleFeeRecord, secondVisibleFeeRecord, ...removedFeeRecords] = feeRecords;
 
-    pages.utilisationReportsPage.getPremiumPaymentsTableRow(firstVisibleFeeRecord.id).should('exist');
-    pages.utilisationReportsPage.getPremiumPaymentsTableRow(firstVisibleFeeRecord.id).should('contain', firstVisibleFeeRecord.facilityId);
+    pages.utilisationReportPage.getPremiumPaymentsTableRow(firstVisibleFeeRecord.id).should('exist');
+    pages.utilisationReportPage.getPremiumPaymentsTableRow(firstVisibleFeeRecord.id).should('contain', firstVisibleFeeRecord.facilityId);
 
-    pages.utilisationReportsPage.getPremiumPaymentsTableRow(secondVisibleFeeRecord.id).should('exist');
-    pages.utilisationReportsPage.getPremiumPaymentsTableRow(secondVisibleFeeRecord.id).should('contain', secondVisibleFeeRecord.facilityId);
+    pages.utilisationReportPage.getPremiumPaymentsTableRow(secondVisibleFeeRecord.id).should('exist');
+    pages.utilisationReportPage.getPremiumPaymentsTableRow(secondVisibleFeeRecord.id).should('contain', secondVisibleFeeRecord.facilityId);
 
     removedFeeRecords.forEach(({ id }) => {
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('not.exist');
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('not.exist');
     });
   });
 
   it('should display an error if the supplied facility id query is an invalid value and persist the inputted value', () => {
-    pages.utilisationReportsPage.getFacilityIdFilterInput().type('nonsense');
-    pages.utilisationReportsPage.submitFacilityIdFilter();
+    pages.utilisationReportPage.getFacilityIdFilterInput().type('nonsense');
+    pages.utilisationReportPage.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=nonsense`));
 
-    pages.utilisationReportsPage.getFacilityIdFilterInput().should('have.value', 'nonsense');
+    pages.utilisationReportPage.getFacilityIdFilterInput().should('have.value', 'nonsense');
 
     cy.get('a').should('contain', 'Enter 4-10 characters of a facility ID');
   });
 
   it('should display an error if the facility id is submitted with no value', () => {
-    pages.utilisationReportsPage.submitFacilityIdFilter();
+    pages.utilisationReportPage.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=`));
 
-    pages.utilisationReportsPage.getFacilityIdFilterInput().should('be.empty');
+    pages.utilisationReportPage.getFacilityIdFilterInput().should('be.empty');
 
     cy.get('a').should('contain', 'Enter 4-10 characters of a facility ID');
   });
@@ -147,25 +147,25 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
     cy.reload();
 
     allFeeRecords.forEach(({ id, facilityId }) => {
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('exist');
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('exist');
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
     });
 
-    pages.utilisationReportsPage.getPaymentLink(paymentId).should('exist');
+    pages.utilisationReportPage.getPaymentLink(paymentId).should('exist');
 
-    pages.utilisationReportsPage.getFacilityIdFilterInput().type('1111');
-    pages.utilisationReportsPage.submitFacilityIdFilter();
+    pages.utilisationReportPage.getFacilityIdFilterInput().type('1111');
+    pages.utilisationReportPage.submitFacilityIdFilter();
 
     toDoFeeRecords.forEach(({ id }) => {
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('not.exist');
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('not.exist');
     });
 
     groupedFeeRecords.forEach(({ id, facilityId }) => {
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('exist');
-      pages.utilisationReportsPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('exist');
+      pages.utilisationReportPage.getPremiumPaymentsTableRow(id).should('contain', facilityId);
     });
 
-    pages.utilisationReportsPage.getPaymentLink(paymentId).should('exist');
+    pages.utilisationReportPage.getPaymentLink(paymentId).should('exist');
   });
 
   it('displays a message when the supplied facility id matches no fee records', () => {
@@ -177,8 +177,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     cy.reload();
 
-    pages.utilisationReportsPage.getFacilityIdFilterInput().type('33333333');
-    pages.utilisationReportsPage.submitFacilityIdFilter();
+    pages.utilisationReportPage.getFacilityIdFilterInput().type('33333333');
+    pages.utilisationReportPage.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=33333333`));
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/mark-report-as-done.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/mark-report-as-done.spec.js
@@ -80,7 +80,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     pages.landingPage.visit();
     cy.login(USERS.PDC_RECONCILE);
 
-    pages.utilisationReportsPage.visit();
+    pages.utilisationReportsSummaryPage.visit();
   });
 
   it(`should only allow users to manually mark a report as completed/not completed if the report is not in the '${UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED}' state`, () => {
@@ -91,7 +91,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId, id, reportPeriod, status } = utilisationReport;
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -110,7 +110,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, notReceivedUtilisationReports).each((notReceivedReport) => {
       const { bankId, id, status } = notReceivedReport;
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -124,7 +124,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
       const { id, bankId, status } = utilisationReport;
       const displayStatus = getDisplayStatus(status);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -133,13 +133,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsCompletedButton(currentSubmissionMonth);
+    pages.utilisationReportsSummaryPage.clickMarkReportAsCompletedButton(currentSubmissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
       const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -153,7 +153,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
       const { id, bankId, status } = utilisationReport;
       const displayStatus = getDisplayStatus(status);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -162,7 +162,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsCompletedButton(currentSubmissionMonth);
+    pages.utilisationReportsSummaryPage.clickMarkReportAsCompletedButton(currentSubmissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId, id } = utilisationReport;
@@ -170,7 +170,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
       const completedStatus = UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED;
       const displayStatus = getDisplayStatus(completedStatus);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -179,13 +179,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsNotCompletedButton(currentSubmissionMonth);
+    pages.utilisationReportsSummaryPage.clickMarkReportAsNotCompletedButton(currentSubmissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
       const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -199,7 +199,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
       const { id, bankId, status } = utilisationReport;
       const displayStatus = getDisplayStatus(status);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -208,13 +208,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsNotCompletedButton(currentSubmissionMonth);
+    pages.utilisationReportsSummaryPage.clickMarkReportAsNotCompletedButton(currentSubmissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
       const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -250,7 +250,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
       const { bankId, id, status } = reconciliationCompletedReport;
       const displayStatus = getDisplayStatus(status);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -259,13 +259,13 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsCompletedButton(currentSubmissionMonth);
+    pages.utilisationReportsSummaryPage.clickMarkReportAsCompletedButton(currentSubmissionMonth);
 
     cy.get(aliasSelector(utilisationReportsAlias)).each((utilisationReport) => {
       const { bankId } = utilisationReport;
       const displayStatus = getDisplayStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, currentSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -298,7 +298,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
     cy.get(aliasSelector(previousUtilisationReportAlias)).then((utilisationReport) => {
       const { id, bankId, status } = utilisationReport;
 
-      pages.utilisationReportsPage
+      pages.utilisationReportsSummaryPage
         .tableRowSelector(bankId, previousSubmissionMonth)
         .should('exist')
         .within(($tableRow) => {
@@ -306,12 +306,12 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can mark reports as done and not done`
         });
     });
 
-    pages.utilisationReportsPage.clickMarkReportAsCompletedButton(previousSubmissionMonth);
+    pages.utilisationReportsSummaryPage.clickMarkReportAsCompletedButton(previousSubmissionMonth);
 
     cy.get(aliasSelector(previousUtilisationReportAlias)).then((utilisationReport) => {
       const { bankId } = utilisationReport;
 
-      pages.utilisationReportsPage.tableRowSelector(bankId, previousSubmissionMonth).should('not.exist');
+      pages.utilisationReportsSummaryPage.tableRowSelector(bankId, previousSubmissionMonth).should('not.exist');
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/navigating-to-utilisation-reports.spec.js
@@ -44,23 +44,23 @@ context('PDC_RECONCILE users can route to the payments page for a bank', () => {
     pages.landingPage.visit();
     cy.login(USERS.PDC_RECONCILE);
 
-    pages.utilisationReportsPage.visit();
+    pages.utilisationReportsSummaryPage.visit();
   });
 
   it('should only render a table row for the banks which should be visible', () => {
-    pages.utilisationReportsPage.heading(submissionMonth).should('exist');
+    pages.utilisationReportsSummaryPage.heading(submissionMonth).should('exist');
 
     cy.get(aliasSelector(allBanksAlias)).each((bank) => {
       const { id, isVisibleInTfmUtilisationReports } = bank;
 
       if (isVisibleInTfmUtilisationReports) {
         if (bank.id === '10') {
-          pages.utilisationReportsPage.tableRowSelector(id, latestQuarterlySubmissionMonth).should('exist');
+          pages.utilisationReportsSummaryPage.tableRowSelector(id, latestQuarterlySubmissionMonth).should('exist');
           return;
         }
-        pages.utilisationReportsPage.tableRowSelector(id, submissionMonth).should('exist');
+        pages.utilisationReportsSummaryPage.tableRowSelector(id, submissionMonth).should('exist');
       } else {
-        pages.utilisationReportsPage.tableRowSelector(id, submissionMonth).should('not.exist');
+        pages.utilisationReportsSummaryPage.tableRowSelector(id, submissionMonth).should('not.exist');
       }
     });
   });
@@ -68,7 +68,7 @@ context('PDC_RECONCILE users can route to the payments page for a bank', () => {
   it('should show the problem with service page if there are no reports in the database', () => {
     cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
 
-    pages.utilisationReportsPage.visit();
+    pages.utilisationReportsSummaryPage.visit();
 
     cy.get('.govuk-heading-xl')
       .should('exist')

--- a/e2e-tests/tfm/cypress/e2e/pages/index.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/index.js
@@ -26,7 +26,7 @@ import feedbackPage from './feedbackPage';
 import footer from './footer';
 import activitiesPage from './activities/activitiesPage';
 import { utilisationReportsSummaryPage } from './utilisationReportsSummaryPage';
-import { utilisationReportsPage } from './utilisationReportsPage';
+import { utilisationReportPage } from './utilisationReportPage';
 import { searchUtilisationReportsFormPage, searchUtilisationReportsResultsPage } from './searchUtilisationReportsPage';
 import { utilisationReportAddPaymentPage } from './utilisationReportAddPaymentPage';
 import { utilisationReportConfirmDeletePaymentPage } from './utilisationReportConfirmDeletePaymentPage';
@@ -61,7 +61,7 @@ export default {
   footer,
   activitiesPage,
   utilisationReportsSummaryPage,
-  utilisationReportsPage,
+  utilisationReportPage,
   searchUtilisationReportsFormPage,
   searchUtilisationReportsResultsPage,
   utilisationReportAddPaymentPage,

--- a/e2e-tests/tfm/cypress/e2e/pages/index.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/index.js
@@ -25,6 +25,7 @@ import amendmentsPage from './amendments/amendmentsPage';
 import feedbackPage from './feedbackPage';
 import footer from './footer';
 import activitiesPage from './activities/activitiesPage';
+import { utilisationReportsSummaryPage } from './utilisationReportsSummaryPage';
 import { utilisationReportsPage } from './utilisationReportsPage';
 import { searchUtilisationReportsFormPage, searchUtilisationReportsResultsPage } from './searchUtilisationReportsPage';
 import { utilisationReportAddPaymentPage } from './utilisationReportAddPaymentPage';
@@ -59,6 +60,7 @@ export default {
   amendmentsPage,
   footer,
   activitiesPage,
+  utilisationReportsSummaryPage,
   utilisationReportsPage,
   searchUtilisationReportsFormPage,
   searchUtilisationReportsResultsPage,

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportPage.js
@@ -1,4 +1,4 @@
-const utilisationReportsPage = {
+const utilisationReportPage = {
   getPaymentLink: (paymentId) => cy.get(`a[data-cy="edit-payment-link--paymentId-${paymentId}"]`),
   clickPaymentLink: (paymentId) => cy.get(`a[data-cy="edit-payment-link--paymentId-${paymentId}"]`).click(),
   getPremiumPaymentsTableRow: (feeRecordId) => cy.get(`tr[data-cy="premium-payments-table-row--feeRecordId-${feeRecordId}"]`),
@@ -6,4 +6,4 @@ const utilisationReportsPage = {
   submitFacilityIdFilter: () => cy.get('button[data-cy="facility-filter-submit-button"]').click(),
 };
 
-module.exports = { utilisationReportsPage };
+module.exports = { utilisationReportPage };

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportsPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportsPage.js
@@ -1,19 +1,9 @@
 const utilisationReportsPage = {
-  visit: () => cy.visit('/utilisation-reports'),
-  heading: (submissionMonth) => cy.get(`[data-cy="${submissionMonth}-submission-month-report-period-heading"]`),
-  dueDateText: (submissionMonth) => cy.get(`[data-cy="${submissionMonth}-submission-month-report-due-date-text"]`),
-  tableRowSelector: (bankId, submissionMonth) =>
-    cy.get(`[data-cy="utilisation-report-reconciliation-table-row-bank-${bankId}-submission-month-${submissionMonth}"]`),
-  clickMarkReportAsCompletedButton: (submissionMonth) =>
-    cy.get(`[data-cy="utilisation-reports-form--${submissionMonth}"]`).within(($form) => {
-      cy.wrap($form).get('[data-cy="mark-report-as-completed-button"]').click();
-    }),
-  clickMarkReportAsNotCompletedButton: (submissionMonth) =>
-    cy.get(`[data-cy="utilisation-reports-form--${submissionMonth}"]`).within(($form) => {
-      cy.wrap($form).get('[data-cy="mark-as-not-completed-button"]').click();
-    }),
   getPaymentLink: (paymentId) => cy.get(`a[data-cy="edit-payment-link--paymentId-${paymentId}"]`),
   clickPaymentLink: (paymentId) => cy.get(`a[data-cy="edit-payment-link--paymentId-${paymentId}"]`).click(),
+  getPremiumPaymentsTableRow: (feeRecordId) => cy.get(`tr[data-cy="premium-payments-table-row--feeRecordId-${feeRecordId}"]`),
+  getFacilityIdFilterInput: () => cy.getInputByLabelText('Filter by facility ID'),
+  submitFacilityIdFilter: () => cy.get('button[data-cy="facility-filter-submit-button"]').click(),
 };
 
 module.exports = { utilisationReportsPage };

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisationReportsSummaryPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisationReportsSummaryPage.js
@@ -1,0 +1,17 @@
+const utilisationReportsSummaryPage = {
+  visit: () => cy.visit('/utilisation-reports'),
+  heading: (submissionMonth) => cy.get(`[data-cy="${submissionMonth}-submission-month-report-period-heading"]`),
+  dueDateText: (submissionMonth) => cy.get(`[data-cy="${submissionMonth}-submission-month-report-due-date-text"]`),
+  tableRowSelector: (bankId, submissionMonth) =>
+    cy.get(`[data-cy="utilisation-report-reconciliation-table-row-bank-${bankId}-submission-month-${submissionMonth}"]`),
+  clickMarkReportAsCompletedButton: (submissionMonth) =>
+    cy.get(`[data-cy="utilisation-reports-form--${submissionMonth}"]`).within(($form) => {
+      cy.wrap($form).get('[data-cy="mark-report-as-completed-button"]').click();
+    }),
+  clickMarkReportAsNotCompletedButton: (submissionMonth) =>
+    cy.get(`[data-cy="utilisation-reports-form--${submissionMonth}"]`).within(($form) => {
+      cy.wrap($form).get('[data-cy="mark-as-not-completed-button"]').click();
+    }),
+};
+
+module.exports = { utilisationReportsSummaryPage };


### PR DESCRIPTION
## Introduction :pencil2:
We want to add e2e tests for filtering the premium payments table by facility id.

## Resolution :heavy_check_mark:
- Adds the e2e test
- Adds a new cypress task to insert payments

## Miscellaneous :heavy_plus_sign:
- Separates the constant for the utilisation reports summary page and the utilisation reports page
