### PR TITLE
feat(FN-2622): automatically match fee records with zero payments

### DIFF
--- a/dtfs-central-api/src/helpers/fee-record.helper.ts
+++ b/dtfs-central-api/src/helpers/fee-record.helper.ts
@@ -1,4 +1,4 @@
-import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, UTILISATION_REPORT_HEADERS } from '@ukef/dtfs2-common';
+import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, UTILISATION_REPORT_HEADERS, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { UtilisationReportRawCsvData } from '../types/utilisation-reports';
 
 type FeeRecordCsvRowToSqlEntityParams = {
@@ -20,8 +20,11 @@ const asNumberOrDefault = (maybeString: string | undefined, defaultNumber: numbe
  * @param param0 - The parameters required to create the SQL entity
  * @returns The SQL entity
  */
-export const feeRecordCsvRowToSqlEntity = ({ dataEntry, requestSource, report }: FeeRecordCsvRowToSqlEntityParams): FeeRecordEntity =>
-  FeeRecordEntity.create({
+export const feeRecordCsvRowToSqlEntity = ({ dataEntry, requestSource, report }: FeeRecordCsvRowToSqlEntityParams): FeeRecordEntity => {
+  const feesPaidToUkefForThePeriod = Number(dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD]);
+  const status: FeeRecordStatus = feesPaidToUkefForThePeriod === 0 ? 'MATCH' : 'TO_DO';
+
+  return FeeRecordEntity.create({
     facilityId: dataEntry[UTILISATION_REPORT_HEADERS.UKEF_FACILITY_ID],
     exporter: dataEntry[UTILISATION_REPORT_HEADERS.EXPORTER],
     baseCurrency: dataEntry[UTILISATION_REPORT_HEADERS.BASE_CURRENCY],
@@ -30,11 +33,12 @@ export const feeRecordCsvRowToSqlEntity = ({ dataEntry, requestSource, report }:
     totalFeesAccruedForThePeriodCurrency:
       dataEntry[UTILISATION_REPORT_HEADERS.TOTAL_FEES_ACCRUED_CURRENCY] ?? dataEntry[UTILISATION_REPORT_HEADERS.BASE_CURRENCY],
     totalFeesAccruedForThePeriodExchangeRate: asNumberOrDefault(dataEntry[UTILISATION_REPORT_HEADERS.TOTAL_FEES_ACCRUED_EXCHANGE_RATE], 1),
-    feesPaidToUkefForThePeriod: Number(dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD]),
+    feesPaidToUkefForThePeriod,
     feesPaidToUkefForThePeriodCurrency: dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD_CURRENCY],
     paymentCurrency: dataEntry[UTILISATION_REPORT_HEADERS.PAYMENT_CURRENCY] ?? dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD_CURRENCY],
     paymentExchangeRate: asNumberOrDefault(dataEntry[UTILISATION_REPORT_HEADERS.PAYMENT_EXCHANGE_RATE], 1),
-    status: 'TO_DO',
+    status,
     report,
     requestSource,
   });
+};

--- a/dtfs-central-api/test-helpers/test-data/index.ts
+++ b/dtfs-central-api/test-helpers/test-data/index.ts
@@ -5,3 +5,4 @@ export * from './portal-user';
 export * from './report-period';
 export * from './tfm-session-user';
 export * from './tfm-user';
+export * from './utilisation-report-raw-csv-data';

--- a/dtfs-central-api/test-helpers/test-data/utilisation-report-raw-csv-data.ts
+++ b/dtfs-central-api/test-helpers/test-data/utilisation-report-raw-csv-data.ts
@@ -1,0 +1,15 @@
+import { UtilisationReportRawCsvData } from '@ukef/dtfs2-common';
+
+export const aUtilisationReportRawCsvData = (): UtilisationReportRawCsvData => ({
+  'ukef facility id': '0123456789',
+  'base currency': 'GBP',
+  'facility utilisation': '100.00',
+  'total fees accrued for the period': '80.00',
+  'accrual currency': 'GBP',
+  'accrual exchange rate': '1',
+  'fees paid to ukef for the period': '80.00',
+  'fees paid to ukef currency': 'GBP',
+  exporter: 'test exporter',
+  'payment currency': 'GBP',
+  'payment exchange rate': '1',
+});


### PR DESCRIPTION
## Introduction :pencil2:
Fee records with zero payments should move to match status automatically when report is uploaded.

## Resolution :heavy_check_mark:
- When a fee record has 'fees paid to ukef for the period' equal to zero then the status of the created fee record should be 'MATCH'
- When a fee record has 'fees paid to ukef for the period' with a non-zero amount then the status of the created fee record should be 'TO_DO'

![image](https://github.com/UK-Export-Finance/dtfs2/assets/67907735/1862b8e4-1e32-44f8-938d-e84c3db81b62)