### PR TITLE
feat(DTFS2-NONE): reset process.env correctly in tests

### DIFF
--- a/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.test.ts
+++ b/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.test.ts
@@ -13,7 +13,7 @@ jest.mock('@ukef/dtfs2-common', () => ({
   getCurrentReportPeriodForBankSchedule: jest.fn(),
 }));
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('scheduler/jobs/create-utilisation-reports', () => {
   afterEach(() => {

--- a/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.test.ts
+++ b/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.test.ts
@@ -17,7 +17,7 @@ const originalProcessEnv = { ...process.env };
 
 describe('scheduler/jobs/create-utilisation-reports', () => {
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
   });
 
   describe('the task', () => {

--- a/dtfs-central-api/src/services/changeStream/changeStreamApi.test.ts
+++ b/dtfs-central-api/src/services/changeStream/changeStreamApi.test.ts
@@ -6,7 +6,7 @@ import { postAuditDetails, postDeletionAuditDetails } from './changeStreamApi';
 jest.mock('axios', () => jest.fn(() => Promise.resolve('mockResponse')));
 
 describe('changeStreamApi', () => {
-  const originalEnv = process.env;
+  const originalEnv = { ...process.env };
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = {

--- a/dtfs-central-api/src/services/changeStream/changeStreamApi.test.ts
+++ b/dtfs-central-api/src/services/changeStream/changeStreamApi.test.ts
@@ -6,11 +6,11 @@ import { postAuditDetails, postDeletionAuditDetails } from './changeStreamApi';
 jest.mock('axios', () => jest.fn(() => Promise.resolve('mockResponse')));
 
 describe('changeStreamApi', () => {
-  const originalEnv = { ...process.env };
+  const originalProcessEnv = { ...process.env };
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = {
-      ...originalEnv,
+      ...originalProcessEnv,
       AUDIT_API_URL: 'audit API url',
       AUDIT_API_USERNAME: 'audit API username',
       AUDIT_API_PASSWORD: 'audit API password',
@@ -18,7 +18,7 @@ describe('changeStreamApi', () => {
   });
 
   afterAll(() => {
-    process.env = originalEnv;
+    process.env = originalProcessEnv;
   });
 
   describe('postAuditDetails', () => {

--- a/libs/common/src/helpers/gef-deal-versioning.test.ts
+++ b/libs/common/src/helpers/gef-deal-versioning.test.ts
@@ -1,11 +1,11 @@
 import { ZodError } from 'zod';
 import { isFacilityEndDateEnabledOnGefVersion, getCurrentGefDealVersion } from './gef-deal-versioning';
 
-const originalEnv = { ...process.env };
+const originalProcessEnv = { ...process.env };
 
 describe('is-deal-feature-enabled helpers', () => {
   afterEach(() => {
-    process.env = originalEnv;
+    process.env = originalProcessEnv;
   });
 
   describe('getCurrentGefDealVersion', () => {

--- a/libs/common/src/helpers/gef-deal-versioning.test.ts
+++ b/libs/common/src/helpers/gef-deal-versioning.test.ts
@@ -1,11 +1,11 @@
 import { ZodError } from 'zod';
 import { isFacilityEndDateEnabledOnGefVersion, getCurrentGefDealVersion } from './gef-deal-versioning';
 
-const originalEnv = process.env;
+const originalEnv = { ...process.env };
 
 describe('is-deal-feature-enabled helpers', () => {
   afterEach(() => {
-    process.env = { ...originalEnv };
+    process.env = originalEnv;
   });
 
   describe('getCurrentGefDealVersion', () => {

--- a/libs/common/src/helpers/is-feature-flag-enabled.test.ts
+++ b/libs/common/src/helpers/is-feature-flag-enabled.test.ts
@@ -1,10 +1,10 @@
 import { FeatureFlag, isTfmPaymentReconciliationFeatureFlagEnabled } from './is-feature-flag-enabled';
 
-const originalEnv = process.env;
+const originalEnv = { ...process.env };
 
 describe('is-feature-flag-enabled helpers', () => {
   afterEach(() => {
-    process.env = { ...originalEnv };
+    process.env = originalEnv;
   });
 
   describe('isTfmPaymentReconciliationFeatureFlagEnabled', () => {

--- a/libs/common/src/helpers/is-feature-flag-enabled.test.ts
+++ b/libs/common/src/helpers/is-feature-flag-enabled.test.ts
@@ -1,10 +1,10 @@
 import { FeatureFlag, isTfmPaymentReconciliationFeatureFlagEnabled } from './is-feature-flag-enabled';
 
-const originalEnv = { ...process.env };
+const originalProcessEnv = { ...process.env };
 
 describe('is-feature-flag-enabled helpers', () => {
   afterEach(() => {
-    process.env = originalEnv;
+    process.env = originalProcessEnv;
   });
 
   describe('isTfmPaymentReconciliationFeatureFlagEnabled', () => {

--- a/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.test.ts
@@ -21,7 +21,7 @@ jest.mock('../../v1/api');
 console.error = jest.fn();
 console.info = jest.fn();
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('utilisation-report-helpers', () => {
   afterEach(() => {

--- a/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.test.ts
@@ -25,7 +25,7 @@ const originalProcessEnv = { ...process.env };
 
 describe('utilisation-report-helpers', () => {
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
     jest.resetAllMocks();
     jest.useRealTimers();
   });

--- a/portal-api/src/cron-scheduler-jobs/send-report-due-emails-job/index.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/send-report-due-emails-job/index.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../external-api/send-email', () => jest.fn());
 console.error = jest.fn();
 console.info = jest.fn();
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('sendReportDueEmailsJob', () => {
   const validBarclaysEmail = 'valid-barclays-email@example.com';

--- a/portal-api/src/cron-scheduler-jobs/send-report-due-emails-job/index.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/send-report-due-emails-job/index.test.ts
@@ -36,7 +36,7 @@ describe('sendReportDueEmailsJob', () => {
   });
 
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
     jest.resetAllMocks();
     jest.useRealTimers();
   });

--- a/portal-api/src/cron-scheduler-jobs/send-report-overdue-emails-job/index.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/send-report-overdue-emails-job/index.test.ts
@@ -36,7 +36,7 @@ describe('sendReportOverdueEmailsJob', () => {
   });
 
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
     jest.resetAllMocks();
     jest.useRealTimers();
   });

--- a/portal-api/src/cron-scheduler-jobs/send-report-overdue-emails-job/index.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/send-report-overdue-emails-job/index.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../external-api/send-email', () => jest.fn());
 console.error = jest.fn();
 console.info = jest.fn();
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('sendReportOverdueEmailsJob', () => {
   const validBarclaysEmail = 'valid-barclays-email@example.com';

--- a/portal-api/src/cron-scheduler-jobs/send-report-submission-period-start-emails-job/index.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/send-report-submission-period-start-emails-job/index.test.ts
@@ -19,7 +19,7 @@ const originalProcessEnv = { ...process.env };
 
 describe('sendReportSubmissionPeriodStartEmailsJob', () => {
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
     jest.resetAllMocks();
     jest.useRealTimers();
   });

--- a/portal-api/src/cron-scheduler-jobs/send-report-submission-period-start-emails-job/index.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/send-report-submission-period-start-emails-job/index.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../external-api/send-email', () => jest.fn());
 console.error = jest.fn();
 console.info = jest.fn();
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('sendReportSubmissionPeriodStartEmailsJob', () => {
   afterEach(() => {

--- a/portal-api/src/v1/services/utilisation-report/email-service.test.ts
+++ b/portal-api/src/v1/services/utilisation-report/email-service.test.ts
@@ -19,7 +19,7 @@ const originalProcessEnv = { ...process.env };
 describe('emailService', () => {
   afterEach(() => {
     jest.resetAllMocks();
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
   });
 
   describe('sendUtilisationReportUploadNotificationEmailToUkefGefReportingTeam', () => {

--- a/portal-api/src/v1/services/utilisation-report/email-service.test.ts
+++ b/portal-api/src/v1/services/utilisation-report/email-service.test.ts
@@ -14,7 +14,7 @@ console.info = jest.fn();
 jest.mock('../../api');
 jest.mock('../../email');
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('emailService', () => {
   afterEach(() => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/report-reconciliation-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/report-reconciliation-table.component-test.js
@@ -22,7 +22,7 @@ describe(component, () => {
   });
 
   afterAll(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
   });
 
   const getWrapper = async ({ userTeams, isTfmPaymentReconciliationFeatureFlagEnabled } = {}) => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/report-reconciliation-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/report-reconciliation-table.component-test.js
@@ -13,7 +13,7 @@ const tableSelector = '[data-cy="utilisation-report-reconciliation-table"]';
 
 const render = componentRenderer(component);
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe(component, () => {
   beforeAll(() => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/search-reports-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/search-reports-table.component-test.js
@@ -8,7 +8,7 @@ const tableSelector = '[data-cy="utilisation-reports-by-bank-and-year-table"]';
 
 const render = componentRenderer(component);
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 const mapReportToSummaryItem = (bank, report) => {
   const totalFeesReported = report.feeRecords.length;

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/search-reports-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/search-reports-table.component-test.js
@@ -38,7 +38,7 @@ const BANK = {
 
 describe(component, () => {
   afterAll(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
   });
 
   const getWrapper = ({ isTfmPaymentReconciliationFeatureFlagEnabled } = {}) => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-reports.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-reports.component-test.js
@@ -20,7 +20,7 @@ describe(page, () => {
   });
 
   afterAll(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
   });
 
   const getWrapper = async () => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-reports.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-reports.component-test.js
@@ -11,7 +11,7 @@ jest.mock('../../server/api');
 const page = '../templates/utilisation-reports/utilisation-reports.njk';
 const render = pageRenderer(page);
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe(page, () => {
   beforeAll(() => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../api');
 
 console.error = jest.fn();
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('controllers/utilisation-reports', () => {
   const isTfmPaymentReconciliationFeatureFlagEnabledSpy = jest.spyOn(dtfs2Common, 'isTfmPaymentReconciliationFeatureFlagEnabled');

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/index.test.ts
@@ -18,7 +18,7 @@ describe('controllers/utilisation-reports', () => {
   const isTfmPaymentReconciliationFeatureFlagEnabledSpy = jest.spyOn(dtfs2Common, 'isTfmPaymentReconciliationFeatureFlagEnabled');
 
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
     jest.resetAllMocks();
     jest.useRealTimers();
   });

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
@@ -4,7 +4,7 @@ const originalProcessEnv = { ...process.env };
 
 describe('utilisation-report-service', () => {
   afterEach(() => {
-    process.env = { ...originalProcessEnv };
+    process.env = originalProcessEnv;
   });
 
   describe('getReportDueDate', () => {

--- a/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
+++ b/trade-finance-manager-ui/server/services/utilisation-report-service.test.js
@@ -1,6 +1,6 @@
 const { getReportDueDate } = require('./utilisation-report-service');
 
-const originalProcessEnv = process.env;
+const originalProcessEnv = { ...process.env };
 
 describe('utilisation-report-service', () => {
   afterEach(() => {


### PR DESCRIPTION
## Introduction :pencil2:
When modifying the `process.env` file in tests, its not always correctly reset

## Resolution :heavy_check_mark:
Shallow clone the original process.env at the start of every test, so it's not reassigned unintentionally


