### PR TITLE
feat(FN-1617): update error messages and display next to input

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
@@ -111,7 +111,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     pages.utilisationReportPage.getFacilityIdFilterInput().should('have.value', 'nonsense');
 
-    cy.get('a').should('contain', 'Enter 4-10 characters of a facility ID');
+    cy.get('a').should('contain', 'Facility ID must be a number');
   });
 
   it('should display an error if the facility id is submitted with no value', () => {
@@ -121,7 +121,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     pages.utilisationReportPage.getFacilityIdFilterInput().should('be.empty');
 
-    cy.get('a').should('contain', 'Enter 4-10 characters of a facility ID');
+    cy.get('a').should('contain', 'Enter a facility ID');
   });
 
   it('should display the entire fee record payment group when only one of the fee records in the group has a matching facility id', () => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
@@ -120,6 +120,12 @@ describe(page, () => {
     wrapper.expectText('[data-cy="facility-filter-clear-button"]').toRead('Clear filter');
   });
 
+  it('renders error when facilityIdQueryError is provided', () => {
+    const wrapper = getWrapper({ ...params, facilityIdQueryError: { text: 'Oh no that is not correct', href: '#filter-component' } });
+    wrapper.expectText('[data-cy="facility-filter-form"]').toContain('Oh no that is not correct');
+    wrapper.expectLink('[data-cy="error-summary"] a').toLinkTo('#filter-component', 'Oh no that is not correct');
+  });
+
   it('should not render add payment button for PDC_READ user', () => {
     const wrapper = getWrapper({ ...params, user: aPdcReadUser() });
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
@@ -273,7 +273,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
       expect(viewModel.facilityIdQueryError).toBeDefined();
       expect(viewModel.facilityIdQueryError?.href).toBe('#facility-id-filter');
-      expect(viewModel.facilityIdQueryError?.text).toBe('Enter 4-10 characters of a facility ID');
+      expect(viewModel.facilityIdQueryError?.text).toBe('Facility ID must be a number');
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/validate-facility-id-query.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/validate-facility-id-query.test.ts
@@ -13,7 +13,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       expect(facilityIdQueryError).toEqual(undefined);
     });
 
-    it('returns no error when no facilityIdQuery but originalUrl has query param', () => {
+    it('returns no error when no facilityIdQuery but originalUrl has other query param', () => {
       // Arrange
       const facilityIdQuery = undefined;
 
@@ -24,21 +24,43 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       expect(facilityIdQueryError).toEqual(undefined);
     });
 
-    it.each(['abcd', '123', 'c3c3c', '?????', '12345678901'])(
-      'returns error when facilityIdQuery %p is invalid and originalUrl has query param',
-      (facilityIdQuery) => {
-        // Act
-        const facilityIdQueryError = validateFacilityIdQuery(facilityIdQuery, '?facilityIdQuery');
+    it('returns error when facilityIdQuery param provided with empty value', () => {
+      // Arrange
+      const facilityIdQuery = undefined;
 
-        // Assert
-        expect(facilityIdQueryError).toEqual({
-          text: 'Enter 4-10 characters of a facility ID',
-          href: '#facility-id-filter',
-        });
-      },
-    );
+      // Act
+      const facilityIdQueryError = validateFacilityIdQuery(facilityIdQuery, '?facilityIdQuery=');
 
-    it('returns no error with valid facilityIdQuery and originalUrl has query param', () => {
+      // Assert
+      expect(facilityIdQueryError).toEqual({
+        text: 'Enter a facility ID',
+        href: '#facility-id-filter',
+      });
+    });
+
+    it.each(['abcd', 'c3c3c', '?????'])('returns error when facilityIdQuery %p is not a number', (facilityIdQuery) => {
+      // Act
+      const facilityIdQueryError = validateFacilityIdQuery(facilityIdQuery, '?facilityIdQuery');
+
+      // Assert
+      expect(facilityIdQueryError).toEqual({
+        text: 'Facility ID must be a number',
+        href: '#facility-id-filter',
+      });
+    });
+
+    it.each(['123', '12345678901'])('returns error when facilityIdQuery %p is not within 4 and 10 characters', (facilityIdQuery) => {
+      // Act
+      const facilityIdQueryError = validateFacilityIdQuery(facilityIdQuery, '?facilityIdQuery');
+
+      // Assert
+      expect(facilityIdQueryError).toEqual({
+        text: 'Facility ID must be between 4 and 10 characters',
+        href: '#facility-id-filter',
+      });
+    });
+
+    it('returns no error with valid facilityIdQuery', () => {
       // Arrange
       const facilityIdQuery = '1234';
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/validate-facility-id-query.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/validate-facility-id-query.ts
@@ -2,16 +2,28 @@ import { isNonEmptyString } from '@ukef/dtfs2-common';
 import { ErrorSummaryViewModel } from '../../../types/view-models';
 import { REGEX } from '../../../constants';
 
+const FACILITY_ID_INPUT_ID = '#facility-id-filter';
+
 export const validateFacilityIdQuery = (facilityIdQuery: string | undefined, originalUrl: string): ErrorSummaryViewModel | undefined => {
-  if (
-    originalUrl.includes('?') &&
-    originalUrl.includes('facilityIdQuery') &&
-    (!isNonEmptyString(facilityIdQuery) || !REGEX.PARTIAL_FACILITY_ID.test(facilityIdQuery))
-  ) {
-    return {
-      text: 'Enter 4-10 characters of a facility ID',
-      href: '#facility-id-filter',
-    };
+  if (originalUrl.includes('?') && originalUrl.includes('facilityIdQuery')) {
+    if (!isNonEmptyString(facilityIdQuery)) {
+      return {
+        text: 'Enter a facility ID',
+        href: FACILITY_ID_INPUT_ID,
+      };
+    }
+    if (!REGEX.INT.test(facilityIdQuery)) {
+      return {
+        text: 'Facility ID must be a number',
+        href: FACILITY_ID_INPUT_ID,
+      };
+    }
+    if (!REGEX.PARTIAL_FACILITY_ID.test(facilityIdQuery)) {
+      return {
+        text: 'Facility ID must be between 4 and 10 characters',
+        href: FACILITY_ID_INPUT_ID,
+      };
+    }
   }
 
   return undefined;

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -50,27 +50,29 @@
               name: "facilityIdQuery",
               value: facilityIdQuery,
               errorMessage: facilityIdQueryError and {
-                text: facilityIdQueryError[0].text
+                text: facilityIdQueryError.text
               },
               attributes: {'data-cy': 'facility-filter-input'}
             }) }}
           </div>
           <div class="govuk-!-display-inline-block">
-            {{ govukButton({
-              text: "Filter",
-              classes: "govuk-button govuk-button--secondary govuk-!-margin-left-2 premium-payments-filter-control",
-              id: "facility-id-filter-button",
-              attributes: {'data-cy': 'facility-filter-submit-button'}
-            }) }}
-          </div>
-          <div class="govuk-!-display-inline-block">
-            {{ govukButton({
-              text: "Clear filter",
-              classes: "govuk-button govuk-button--secondary govuk-!-margin-left-2 premium-payments-filter-control",
-              id: "facility-id-clear-button",
-              href: clearButtonHref,
-              attributes: {'data-cy': 'facility-filter-clear-button'}
-            }) }}
+            <div class="govuk-!-display-inline-block">
+              {{ govukButton({
+                text: "Filter",
+                classes: "govuk-button govuk-button--secondary govuk-!-margin-left-2 premium-payments-filter-control",
+                id: "facility-id-filter-button",
+                attributes: {'data-cy': 'facility-filter-submit-button'}
+              }) }}
+            </div>
+            <div class="govuk-!-display-inline-block">
+              {{ govukButton({
+                text: "Clear filter",
+                classes: "govuk-button govuk-button--secondary govuk-!-margin-left-2 premium-payments-filter-control",
+                id: "facility-id-clear-button",
+                href: clearButtonHref,
+                attributes: {'data-cy': 'facility-filter-clear-button'}
+              }) }}
+            </div>
           </div>
         </form>
       </div>
@@ -119,7 +121,7 @@
   <p class="govuk-body">Select payments and mark as done when the adjustments have been keyed into ACBS.</p>
 
   <p class="govuk-body">Payments on the premium payments tab will show as reconciled when they have been marked as done here.</p>
-  
+
   <form method="post" data-cy="keying-sheet-form">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
@@ -133,7 +135,7 @@
             "data-cy": "keying-sheet-mark-as-done-button"
           }
         }) }}
-        
+
         {{ govukButton({
           text: "Mark as to do",
           href: '#',


### PR DESCRIPTION
## Introduction :pencil2:
The error messaging was not in line with GDS recommendations and was not showing next to the input due to a bug.

## Resolution :heavy_check_mark:
- Display error text next to input
- Update wording of existing error message
- Add two new cases
- Ensure buttons wrap in the most sensible way when error message is long

<img width="1573" alt="Screenshot 2024-07-12 at 16 29 41" src="https://github.com/user-attachments/assets/a351f4f2-d090-49c0-b583-2cc6c6ccded5">
<img width="1552" alt="Screenshot 2024-07-12 at 15 55 34" src="https://github.com/user-attachments/assets/90dfa2cd-4079-4d59-97f8-a0910fe6ca2d">
<img width="1546" alt="Screenshot 2024-07-12 at 15 55 26" src="https://github.com/user-attachments/assets/c373a50a-9035-4ad3-b572-fa4970e29ade">


