### PR TITLE
feat(FN-1725): add tfm facilities repo

### DIFF
--- a/dtfs-central-api/src/cron-scheduler-jobs/delete-acbs-durable-function-logs/index.test.ts
+++ b/dtfs-central-api/src/cron-scheduler-jobs/delete-acbs-durable-function-logs/index.test.ts
@@ -25,7 +25,7 @@ describe('scheduler/jobs/delete-acbs-durable-function-logs', () => {
 
     it('calls deleteAllCompleteAcbsDurableFunctionLogs from the durable functions repo', async () => {
       // Arrange
-      jest.mocked(deleteAllCompleteAcbsDurableFunctionLogs).mockResolvedValue({ acknowledged: true });
+      jest.mocked(deleteAllCompleteAcbsDurableFunctionLogs).mockResolvedValue({ acknowledged: true, deletedCount: 1 });
 
       // Act
       await deleteCompleteAcbsDurableFunctionLogsJob.task(new Date());
@@ -46,7 +46,7 @@ describe('scheduler/jobs/delete-acbs-durable-function-logs', () => {
 
     it('throws an error if deleteAllCompleteAcbsDurableFunctionLogs fails to write', async () => {
       // Arrange
-      jest.mocked(deleteAllCompleteAcbsDurableFunctionLogs).mockResolvedValue({ acknowledged: false });
+      jest.mocked(deleteAllCompleteAcbsDurableFunctionLogs).mockResolvedValue({ acknowledged: false, deletedCount: 1 });
 
       // Act
       await expect(deleteCompleteAcbsDurableFunctionLogsJob.task(new Date())).rejects.toThrow(WriteConcernError);
@@ -54,7 +54,7 @@ describe('scheduler/jobs/delete-acbs-durable-function-logs', () => {
 
     it('does not throw if deleteAllCompleteAcbsDurableFunctionLogs is acknowledged', async () => {
       // Arrange
-      jest.mocked(deleteAllCompleteAcbsDurableFunctionLogs).mockResolvedValue({ acknowledged: true });
+      jest.mocked(deleteAllCompleteAcbsDurableFunctionLogs).mockResolvedValue({ acknowledged: true, deletedCount: 1 });
 
       // Act
       const result = await deleteCompleteAcbsDurableFunctionLogsJob.task(new Date());

--- a/dtfs-central-api/src/repositories/durable-functions-repo.test.ts
+++ b/dtfs-central-api/src/repositories/durable-functions-repo.test.ts
@@ -1,4 +1,5 @@
 import { when } from 'jest-when';
+import { DeleteResult } from 'mongodb';
 import { AuditDetails, DURABLE_FUNCTIONS_LOG, MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
 import { deleteMany } from '@ukef/dtfs2-common/change-stream';
 import { mongoDbClient as db } from '../drivers/db-client';
@@ -41,7 +42,7 @@ describe('durable-functions-repo', () => {
     });
 
     it('returns the response from deleteMany', async () => {
-      const mockDeleteManyResponse = { acknowledged: true };
+      const mockDeleteManyResponse: DeleteResult = { acknowledged: true, deletedCount: 1 };
       when(deleteMany)
         .calledWith({
           filter: expectedDeleteManyCalledWith,

--- a/dtfs-central-api/src/repositories/durable-functions-repo.ts
+++ b/dtfs-central-api/src/repositories/durable-functions-repo.ts
@@ -1,8 +1,9 @@
+import { DeleteResult } from 'mongodb';
 import { AuditDetails, DURABLE_FUNCTIONS_LOG, MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
 import { deleteMany } from '@ukef/dtfs2-common/change-stream';
 import { mongoDbClient as db } from '../drivers/db-client';
 
-export const deleteAllDurableFunctionLogs = (auditDetails: AuditDetails): Promise<{ acknowledged: boolean }> => {
+export const deleteAllDurableFunctionLogs = (auditDetails: AuditDetails): Promise<DeleteResult> => {
   return deleteMany({
     filter: {},
     collectionName: MONGO_DB_COLLECTIONS.DURABLE_FUNCTIONS_LOG,
@@ -15,7 +16,7 @@ export const deleteAllDurableFunctionLogs = (auditDetails: AuditDetails): Promis
  * Deletes all durable function logs that have the type "ACBS" and status "Completed"
  * @returns The result of the deletion
  */
-export const deleteAllCompleteAcbsDurableFunctionLogs = (auditDetails: AuditDetails): Promise<{ acknowledged: boolean }> => {
+export const deleteAllCompleteAcbsDurableFunctionLogs = (auditDetails: AuditDetails): Promise<DeleteResult> => {
   return deleteMany({
     filter: {
       $and: [{ type: { $eq: DURABLE_FUNCTIONS_LOG.TYPE.ACBS } }, { status: { $eq: DURABLE_FUNCTIONS_LOG.STATUS.COMPLETED } }],

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/all-facilities-and-facility-count.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/all-facilities-and-facility-count.ts
@@ -1,0 +1,126 @@
+import { MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
+import { Document } from 'mongodb';
+
+export type AllFacilitiesAndFacilityCountAggregatePipelineOptions = {
+  searchStringEscaped: string;
+  fieldsToSortOn: Record<string, number>;
+  page: number;
+  pagesize: number;
+};
+
+export const allFacilitiesAndFacilityCount = ({
+  searchStringEscaped,
+  fieldsToSortOn,
+  page,
+  pagesize,
+}: AllFacilitiesAndFacilityCountAggregatePipelineOptions): Document[] => [
+  {
+    $lookup: {
+      from: MONGO_DB_COLLECTIONS.TFM_DEALS,
+      localField: 'facilitySnapshot.dealId',
+      foreignField: '_id',
+      as: 'tfmDeals',
+    },
+  },
+  {
+    $unwind: '$tfmDeals',
+  },
+  {
+    $project: {
+      _id: false,
+      companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+      ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
+      // amendments array for mapping completed amendments
+      amendments: '$amendments',
+      tfmFacilities: {
+        // create the `dealId` property
+        dealId: '$facilitySnapshot.dealId',
+        // create the `facilityId` property
+        facilityId: '$facilitySnapshot._id',
+        // create the `ukefFacilityId` property
+        ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
+        // create the `dealType` property - this is inside the `dealSnapshot` property, NOT `facilities` array
+        dealType: '$tfmDeals.dealSnapshot.dealType',
+        // create the `type` property
+        type: '$facilitySnapshot.type',
+        // create the `value` property - this is the facility value
+        value: '$facilitySnapshot.value',
+        // create the `currency` property
+        currency: '$facilitySnapshot.currency.id',
+        // create the `coverEndDate` property
+        // GEF already has this property, but BSS doesn't have it in this format, so we need to create it dynamically
+        coverEndDate: {
+          $switch: {
+            branches: [
+              {
+                case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'GEF'] },
+                then: '$facilitySnapshot.coverEndDate', // YYYY-MM-DD
+              },
+              {
+                case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'BSS/EWCS'] },
+                then: {
+                  $concat: ['$facilitySnapshot.coverEndDate-year', '-', '$facilitySnapshot.coverEndDate-month', '-', '$facilitySnapshot.coverEndDate-day'],
+                }, // YYYY-MM-DD
+              },
+            ],
+          },
+        },
+        // create the `companyName` property - this is inside the `dealSnapshot.exporter` property, NOT `facilities` array
+        companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+        // create the `hasBeenIssued` property
+        hasBeenIssued: '$facilitySnapshot.hasBeenIssued',
+      },
+    },
+  },
+  {
+    // search functionality based on ukefFacilityId property OR companyName
+    $match: {
+      $or: [
+        {
+          ukefFacilityId: {
+            $regex: searchStringEscaped,
+            $options: 'i',
+          },
+        },
+        {
+          companyName: {
+            $regex: searchStringEscaped,
+            $options: 'i',
+          },
+        },
+      ],
+    },
+  },
+  {
+    $addFields: {
+      facilityStage: {
+        $cond: {
+          if: '$tfmFacilities.hasBeenIssued',
+          then: 'Issued',
+          else: 'Unissued',
+        },
+      },
+    },
+  },
+  {
+    $sort: {
+      ...fieldsToSortOn,
+    },
+  },
+  {
+    $unset: 'facilityStage',
+  },
+  {
+    $facet: {
+      count: [{ $count: 'total' }],
+      facilities: [{ $skip: page * pagesize }, ...(pagesize ? [{ $limit: pagesize }] : [])],
+    },
+  },
+  { $unwind: '$count' },
+  {
+    $project: {
+      count: '$count.total',
+      facilities: true,
+    },
+  },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id-and-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id-and-status.ts
@@ -1,0 +1,15 @@
+import { ObjectId, Document } from 'mongodb';
+
+export const amendmentsByDealIdAndStatus = (dealId: string | ObjectId, status: string): Document[] => [
+  { $match: { 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } } },
+  {
+    $addFields: {
+      'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
+    },
+  },
+  { $unwind: '$amendments' },
+  { $match: { 'amendments.status': { $eq: status } } },
+  { $project: { _id: false, amendments: true } },
+  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+  { $project: { amendments: true, type: true, _id: false } },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id-and-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id-and-status.ts
@@ -9,6 +9,5 @@ export const amendmentsByDealIdAndStatus = (dealId: string | ObjectId, status: s
   },
   { $unwind: '$amendments' },
   { $match: { 'amendments.status': { $eq: status } } },
-  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
   { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id-and-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id-and-status.ts
@@ -9,7 +9,6 @@ export const amendmentsByDealIdAndStatus = (dealId: string | ObjectId, status: s
   },
   { $unwind: '$amendments' },
   { $match: { 'amendments.status': { $eq: status } } },
-  { $project: { _id: false, amendments: true } },
   { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-  { $project: { amendments: true, type: true, _id: false } },
+  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id.ts
@@ -2,11 +2,11 @@ import { ObjectId, Document } from 'mongodb';
 
 export const amendmentsByDealId = (dealId: string | ObjectId): Document[] => [
   { $match: { 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } } },
+  { $unwind: '$amendments' },
   {
     $addFields: {
       'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
     },
   },
-  { $unwind: '$amendments' },
   { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id.ts
@@ -1,0 +1,22 @@
+import { ObjectId, Document } from 'mongodb';
+import { AMENDMENT } from '../../../constants';
+
+export const amendmentsByDealId = (dealId: string | ObjectId): Document[] => [
+  { $match: { 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } } },
+  {
+    $addFields: {
+      'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
+    },
+  },
+  { $project: { _id: false, amendments: true } },
+  { $unwind: '$amendments' },
+  { $sort: { 'amendments.submittedAt': -1 } },
+  {
+    $match: {
+      'amendments.status': { $ne: AMENDMENT.AMENDMENT_STATUS.NOT_STARTED },
+      'amendments.submittedByPim': { $eq: true },
+    },
+  },
+  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+  { $project: { _id: false, amendments: true } },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-deal-id.ts
@@ -1,5 +1,4 @@
 import { ObjectId, Document } from 'mongodb';
-import { AMENDMENT } from '../../../constants';
 
 export const amendmentsByDealId = (dealId: string | ObjectId): Document[] => [
   { $match: { 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } } },
@@ -8,15 +7,6 @@ export const amendmentsByDealId = (dealId: string | ObjectId): Document[] => [
       'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
     },
   },
-  { $project: { _id: false, amendments: true } },
   { $unwind: '$amendments' },
-  { $sort: { 'amendments.submittedAt': -1 } },
-  {
-    $match: {
-      'amendments.status': { $ne: AMENDMENT.AMENDMENT_STATUS.NOT_STARTED },
-      'amendments.submittedByPim': { $eq: true },
-    },
-  },
-  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
   { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-amendment-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-amendment-id.ts
@@ -1,23 +1,13 @@
 import { ObjectId, Document } from 'mongodb';
 
 export const amendmentsByFacilityIdAndAmendmentId = (facilityId: string | ObjectId, amendmentId: string | ObjectId): Document[] => [
-  { $match: { _id: { $eq: new ObjectId(facilityId) }, 'amendments.amendmentId': { $eq: new ObjectId(amendmentId) } } },
+  { $match: { _id: { $eq: new ObjectId(facilityId) } } },
   {
     $addFields: {
       'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
     },
   },
-  {
-    $project: {
-      _id: false,
-      amendments: {
-        $filter: {
-          input: '$amendments',
-          as: 'amendment',
-          cond: { $eq: ['$$amendment.amendmentId', new ObjectId(amendmentId)] },
-        },
-      },
-    },
-  },
   { $unwind: '$amendments' },
+  { $match: { 'amendments.amendmentId': { $eq: new ObjectId(amendmentId) } } },
+  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-amendment-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-amendment-id.ts
@@ -1,0 +1,23 @@
+import { ObjectId, Document } from 'mongodb';
+
+export const amendmentsByFacilityIdAndAmendmentId = (facilityId: string | ObjectId, amendmentId: string | ObjectId): Document[] => [
+  { $match: { _id: { $eq: new ObjectId(facilityId) }, 'amendments.amendmentId': { $eq: new ObjectId(amendmentId) } } },
+  {
+    $addFields: {
+      'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
+    },
+  },
+  {
+    $project: {
+      _id: false,
+      amendments: {
+        $filter: {
+          input: '$amendments',
+          as: 'amendment',
+          cond: { $eq: ['$$amendment.amendmentId', new ObjectId(amendmentId)] },
+        },
+      },
+    },
+  },
+  { $unwind: '$amendments' },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-status.ts
@@ -1,0 +1,10 @@
+import { ObjectId, Document } from 'mongodb';
+
+export const amendmentsByFacilityIdAndStatus = (facilityId: string | ObjectId, status: string): Document[] => [
+  { $match: { _id: { $eq: new ObjectId(facilityId) } } },
+  { $unwind: '$amendments' },
+  { $match: { 'amendments.status': { $eq: status } } },
+  { $project: { _id: false, amendments: true } },
+  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+  { $project: { _id: false, amendments: true } },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-status.ts
@@ -4,5 +4,5 @@ export const amendmentsByFacilityIdAndStatus = (facilityId: string | ObjectId, s
   { $match: { _id: { $eq: new ObjectId(facilityId) } } },
   { $unwind: '$amendments' },
   { $match: { 'amendments.status': { $eq: status } } },
-  { $group: { _id: false, amendments: { $push: '$amendments' } } },
+  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id-and-status.ts
@@ -4,7 +4,5 @@ export const amendmentsByFacilityIdAndStatus = (facilityId: string | ObjectId, s
   { $match: { _id: { $eq: new ObjectId(facilityId) } } },
   { $unwind: '$amendments' },
   { $match: { 'amendments.status': { $eq: status } } },
-  { $project: { _id: false, amendments: true } },
-  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-  { $project: { _id: false, amendments: true } },
+  { $group: { _id: false, amendments: { $push: '$amendments' } } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id.ts
@@ -7,6 +7,4 @@ export const amendmentsByFacilityId = (facilityId: string | ObjectId): Document[
   { $unwind: '$amendments' },
   { $sort: { 'amendments.version': -1 } },
   { $match: { 'amendments.status': { $ne: AMENDMENT.AMENDMENT_STATUS.NOT_STARTED } } },
-  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id.ts
@@ -1,10 +1,8 @@
 import { Document, ObjectId } from 'mongodb';
-import { AMENDMENT } from '../../../constants';
 
 export const amendmentsByFacilityId = (facilityId: string | ObjectId): Document[] => [
   { $match: { _id: { $eq: new ObjectId(facilityId) } } },
   { $project: { _id: false, amendments: '$amendments' } },
   { $unwind: '$amendments' },
-  { $sort: { 'amendments.version': -1 } },
-  { $match: { 'amendments.status': { $ne: AMENDMENT.AMENDMENT_STATUS.NOT_STARTED } } },
+  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-facility-id.ts
@@ -1,0 +1,12 @@
+import { Document, ObjectId } from 'mongodb';
+import { AMENDMENT } from '../../../constants';
+
+export const amendmentsByFacilityId = (facilityId: string | ObjectId): Document[] => [
+  { $match: { _id: { $eq: new ObjectId(facilityId) } } },
+  { $project: { _id: false, amendments: '$amendments' } },
+  { $unwind: '$amendments' },
+  { $sort: { 'amendments.version': -1 } },
+  { $match: { 'amendments.status': { $ne: AMENDMENT.AMENDMENT_STATUS.NOT_STARTED } } },
+  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+  { $project: { _id: false, amendments: true } },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-status.ts
@@ -4,6 +4,4 @@ export const amendmentsByStatus = (status: string): Document[] => [
   { $project: { _id: false, amendments: '$amendments' } },
   { $unwind: '$amendments' },
   { $match: { 'amendments.status': { $eq: status } } },
-  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-status.ts
@@ -1,0 +1,9 @@
+import { Document } from 'mongodb';
+
+export const amendmentsByStatus = (status: string): Document[] => [
+  { $project: { _id: false, amendments: '$amendments' } },
+  { $unwind: '$amendments' },
+  { $match: { 'amendments.status': { $eq: status } } },
+  { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+  { $project: { _id: false, amendments: true } },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-status.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/amendments-by-status.ts
@@ -1,7 +1,7 @@
 import { Document } from 'mongodb';
 
 export const amendmentsByStatus = (status: string): Document[] => [
-  { $project: { _id: false, amendments: '$amendments' } },
   { $unwind: '$amendments' },
   { $match: { 'amendments.status': { $eq: status } } },
+  { $project: { _id: false, amendments: true } },
 ];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/index.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/index.ts
@@ -1,0 +1,23 @@
+import { amendmentsByStatus } from './amendments-by-status';
+import { amendmentsByFacilityId } from './amendments-by-facility-id';
+import { amendmentsByFacilityIdAndAmendmentId } from './amendments-by-facility-id-and-amendment-id';
+import { amendmentsByDealId } from './amendments-by-deal-id';
+import { amendmentsByFacilityIdAndStatus } from './amendments-by-facility-id-and-status';
+import { amendmentsByDealIdAndStatus } from './amendments-by-deal-id-and-status';
+import { latestCompletedAmendmentByFacilityId } from './latest-completed-amendment-by-facility-id';
+import { latestCompletedAmendmentByDealId } from './lastest-completed-amendment-by-deal-id';
+import { allFacilitiesAndFacilityCount } from './all-facilities-and-facility-count';
+
+export { AllFacilitiesAndFacilityCountAggregatePipelineOptions } from './all-facilities-and-facility-count';
+
+export const aggregatePipelines = {
+  amendmentsByStatus,
+  amendmentsByFacilityId,
+  amendmentsByFacilityIdAndAmendmentId,
+  amendmentsByDealId,
+  amendmentsByFacilityIdAndStatus,
+  amendmentsByDealIdAndStatus,
+  latestCompletedAmendmentByFacilityId,
+  latestCompletedAmendmentByDealId,
+  allFacilitiesAndFacilityCount,
+};

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/lastest-completed-amendment-by-deal-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/lastest-completed-amendment-by-deal-id.ts
@@ -1,0 +1,11 @@
+import { ObjectId, Document } from 'mongodb';
+import { AMENDMENT_STATUS } from '../../../constants/amendments';
+
+export const latestCompletedAmendmentByDealId = (dealId: string | ObjectId): Document[] => [
+  { $match: { 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } } },
+  { $unwind: '$amendments' },
+  { $match: { 'amendments.status': AMENDMENT_STATUS.COMPLETED } },
+  { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+  { $project: { _id: false, amendments: true } },
+  { $limit: 1 },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/latest-completed-amendment-by-facility-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/latest-completed-amendment-by-facility-id.ts
@@ -1,35 +1,10 @@
 import { ObjectId, Document } from 'mongodb';
-import { AMENDMENT_STATUS, AMENDMENT_BANK_DECISION, AMENDMENT_MANAGER_DECISIONS } from '../../../constants/amendments';
+import { AMENDMENT_STATUS } from '../../../constants/amendments';
 
 export const latestCompletedAmendmentByFacilityId = (facilityId: string | ObjectId): Document[] => [
   { $match: { _id: { $eq: new ObjectId(facilityId) } } },
   { $unwind: '$amendments' },
-  {
-    $match: {
-      $or: [
-        {
-          'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED },
-          'amendments.submittedByPim': { $eq: true },
-          'amendments.requireUkefApproval': { $eq: false },
-          'amendments.changeFacilityValue': { $eq: true },
-        },
-        {
-          'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED },
-          'amendments.bankDecision.decision': { $eq: AMENDMENT_BANK_DECISION.PROCEED },
-          'amendments.bankDecision.submitted': { $eq: true },
-          'amendments.ukefDecision.value': { $eq: AMENDMENT_MANAGER_DECISIONS.APPROVED_WITH_CONDITIONS },
-          'amendments.changeFacilityValue': { $eq: true },
-        },
-        {
-          'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED },
-          'amendments.bankDecision.decision': { $eq: AMENDMENT_BANK_DECISION.PROCEED },
-          'amendments.bankDecision.submitted': { $eq: true },
-          'amendments.ukefDecision.value': { $eq: AMENDMENT_MANAGER_DECISIONS.APPROVED_WITHOUT_CONDITIONS },
-          'amendments.changeFacilityValue': { $eq: true },
-        },
-      ],
-    },
-  },
+  { $match: { 'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED } } },
   { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
   { $project: { _id: false, amendments: true } },
   { $limit: 1 },

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/latest-completed-amendment-by-facility-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/latest-completed-amendment-by-facility-id.ts
@@ -1,0 +1,36 @@
+import { ObjectId, Document } from 'mongodb';
+import { AMENDMENT_STATUS, AMENDMENT_BANK_DECISION, AMENDMENT_MANAGER_DECISIONS } from '../../../constants/amendments';
+
+export const latestCompletedAmendmentByFacilityId = (facilityId: string | ObjectId): Document[] => [
+  { $match: { _id: { $eq: new ObjectId(facilityId) } } },
+  { $unwind: '$amendments' },
+  {
+    $match: {
+      $or: [
+        {
+          'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED },
+          'amendments.submittedByPim': { $eq: true },
+          'amendments.requireUkefApproval': { $eq: false },
+          'amendments.changeFacilityValue': { $eq: true },
+        },
+        {
+          'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED },
+          'amendments.bankDecision.decision': { $eq: AMENDMENT_BANK_DECISION.PROCEED },
+          'amendments.bankDecision.submitted': { $eq: true },
+          'amendments.ukefDecision.value': { $eq: AMENDMENT_MANAGER_DECISIONS.APPROVED_WITH_CONDITIONS },
+          'amendments.changeFacilityValue': { $eq: true },
+        },
+        {
+          'amendments.status': { $eq: AMENDMENT_STATUS.COMPLETED },
+          'amendments.bankDecision.decision': { $eq: AMENDMENT_BANK_DECISION.PROCEED },
+          'amendments.bankDecision.submitted': { $eq: true },
+          'amendments.ukefDecision.value': { $eq: AMENDMENT_MANAGER_DECISIONS.APPROVED_WITHOUT_CONDITIONS },
+          'amendments.changeFacilityValue': { $eq: true },
+        },
+      ],
+    },
+  },
+  { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+  { $project: { _id: false, amendments: true } },
+  { $limit: 1 },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/index.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/index.ts
@@ -1,0 +1,1 @@
+export { TfmFacilitiesRepo } from './tfm-facilities.repo';

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.test.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'mongodb';
+import { ZodError } from 'zod';
 import { ParsedTfmFacility, RawTfmFacility, TfmFacilitiesRepo } from './tfm-facilities.repo';
 
 describe('tfm-facilities-repo', () => {
@@ -33,7 +34,7 @@ describe('tfm-facilities-repo', () => {
       const input = {} as unknown as RawTfmFacility;
 
       // Act / Assert
-      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow(ZodError);
     });
 
     it("throws an error when the '_id' field is not a valid object id", () => {
@@ -41,7 +42,7 @@ describe('tfm-facilities-repo', () => {
       const input = { ...aValidTfmFacilityDocument(), _id: 123 } as unknown as RawTfmFacility;
 
       // Act / Assert
-      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow(ZodError);
     });
 
     it("throws an error when the 'facilitySnapshot' field is undefined", () => {
@@ -49,7 +50,7 @@ describe('tfm-facilities-repo', () => {
       const input = { ...aValidTfmFacilityDocument(), facilitySnapshot: undefined } as unknown as RawTfmFacility;
 
       // Act / Assert
-      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow(ZodError);
     });
 
     const REQUIRED_FACILITY_SNAPSHOT_FIELDS: (keyof ParsedTfmFacility['facilitySnapshot'])[] = [
@@ -82,7 +83,7 @@ describe('tfm-facilities-repo', () => {
       };
 
       // Act / Assert
-      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow(ZodError);
     });
 
     const NULLABLE_FACILITY_SNAPSHOT_FIELDS: (keyof ParsedTfmFacility['facilitySnapshot'])[] = ['coverStartDate', 'coverEndDate', 'issueDate', 'monthsOfCover'];
@@ -132,22 +133,6 @@ describe('tfm-facilities-repo', () => {
     });
 
     const FACILITY_SNAPSHOT_DATE_FIELDS: (keyof ParsedTfmFacility['facilitySnapshot'])[] = ['coverStartDate', 'coverEndDate', 'issueDate'];
-    it.each(FACILITY_SNAPSHOT_DATE_FIELDS)("coerces the 'facilitySnapshot.%s.$date' field to a Date object when the value is an ISO string", (field) => {
-      // Arrange
-      const date = new Date();
-      const input = {
-        ...aValidTfmFacilityDocument(),
-        facilitySnapshot: {
-          ...aValidTfmFacilityDocumentFacilitySnapshotResult(),
-          [field]: { $date: date.toISOString() },
-        },
-      };
-
-      // Act / Assert
-      const result = TfmFacilitiesRepo.validateAndParseFindOneResult(input);
-      expect(result.facilitySnapshot[field]).toEqual({ $date: date });
-    });
-
     it.each(FACILITY_SNAPSHOT_DATE_FIELDS)("coerces the 'facilitySnapshot.%s.$date' field to a Date object when the value is a timestamp", (field) => {
       // Arrange
       const date = new Date();

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.test.ts
@@ -1,0 +1,167 @@
+import { ObjectId } from 'mongodb';
+import { ParsedTfmFacility, RawTfmFacility, TfmFacilitiesRepo } from './tfm-facilities.repo';
+
+describe('tfm-facilities-repo', () => {
+  describe('TfmFacilitiesRepo.validateAndParseFindOneResult', () => {
+    const aValidTfmFacilityDocumentFacilitySnapshotResult = () => ({
+      _id: new ObjectId(),
+      dealId: new ObjectId(),
+      type: 'A type',
+      hasBeenIssued: true,
+      name: 'A name',
+      shouldCoverStartOnSubmission: true,
+      coverStartDate: null,
+      coverEndDate: null,
+      issueDate: null,
+      monthsOfCover: 12,
+      details: [],
+      detailsOther: '',
+      value: 9000,
+      coverPercentage: 12,
+      interestPercentage: 6,
+      ukefFacilityId: '12345678',
+      dayCountBasis: 365,
+    });
+
+    const aValidTfmFacilityDocument = () => ({
+      _id: new ObjectId(),
+      facilitySnapshot: aValidTfmFacilityDocumentFacilitySnapshotResult(),
+    });
+
+    it('throws an error when the input is an empty object', () => {
+      // Arrange
+      const input = {} as unknown as RawTfmFacility;
+
+      // Act / Assert
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+    });
+
+    it("throws an error when the '_id' field is not a valid object id", () => {
+      // Arrange
+      const input = { ...aValidTfmFacilityDocument(), _id: 123 } as unknown as RawTfmFacility;
+
+      // Act / Assert
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+    });
+
+    it("throws an error when the 'facilitySnapshot' field is undefined", () => {
+      // Arrange
+      const input = { ...aValidTfmFacilityDocument(), facilitySnapshot: undefined } as unknown as RawTfmFacility;
+
+      // Act / Assert
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+    });
+
+    const REQUIRED_FACILITY_SNAPSHOT_FIELDS: (keyof ParsedTfmFacility['facilitySnapshot'])[] = [
+      '_id',
+      'dealId',
+      'type',
+      'hasBeenIssued',
+      'name',
+      'shouldCoverStartOnSubmission',
+      'coverStartDate',
+      'coverEndDate',
+      'issueDate',
+      'monthsOfCover',
+      'details',
+      'detailsOther',
+      'value',
+      'coverPercentage',
+      'interestPercentage',
+      'ukefFacilityId',
+      'dayCountBasis',
+    ];
+    it.each(REQUIRED_FACILITY_SNAPSHOT_FIELDS)("throws an error when the 'facilitySnapshot.%s' field is missing", (field) => {
+      // Arrange
+      const input = {
+        ...aValidTfmFacilityDocument(),
+        facilitySnapshot: {
+          ...aValidTfmFacilityDocumentFacilitySnapshotResult(),
+          [field]: undefined,
+        },
+      };
+
+      // Act / Assert
+      expect(() => TfmFacilitiesRepo.validateAndParseFindOneResult(input)).toThrow();
+    });
+
+    const NULLABLE_FACILITY_SNAPSHOT_FIELDS: (keyof ParsedTfmFacility['facilitySnapshot'])[] = ['coverStartDate', 'coverEndDate', 'issueDate', 'monthsOfCover'];
+    it.each(NULLABLE_FACILITY_SNAPSHOT_FIELDS)(
+      "does not throw an error when the 'facilitySnapshot.%s' field is null and returns the object with the same field",
+      (field) => {
+        // Arrange
+        const input = {
+          ...aValidTfmFacilityDocument(),
+          facilitySnapshot: {
+            ...aValidTfmFacilityDocumentFacilitySnapshotResult(),
+            [field]: null,
+          },
+        };
+
+        // Act / Assert
+        const result = TfmFacilitiesRepo.validateAndParseFindOneResult(input);
+        expect(result.facilitySnapshot[field]).toBeNull();
+      },
+    );
+
+    it('does not throw an error when the input contains an extra field and does not return than field in the result', () => {
+      // Arrange
+      const input = {
+        ...aValidTfmFacilityDocument(),
+        someOtherField: 'Some other value',
+      };
+
+      // Act / Assert
+      const result = TfmFacilitiesRepo.validateAndParseFindOneResult(input);
+      expect(result).not.toHaveProperty('someOtherField');
+    });
+
+    it("does not throw an error when the 'facilitySnapshot' object contains an extra field and does not return than field in the result", () => {
+      // Arrange
+      const input = {
+        ...aValidTfmFacilityDocument(),
+        facilitySnapshot: {
+          ...aValidTfmFacilityDocumentFacilitySnapshotResult(),
+          someOtherField: 'Some other value',
+        },
+      };
+
+      // Act / Assert
+      const result = TfmFacilitiesRepo.validateAndParseFindOneResult(input);
+      expect(result.facilitySnapshot).not.toHaveProperty('someOtherField');
+    });
+
+    const FACILITY_SNAPSHOT_DATE_FIELDS: (keyof ParsedTfmFacility['facilitySnapshot'])[] = ['coverStartDate', 'coverEndDate', 'issueDate'];
+    it.each(FACILITY_SNAPSHOT_DATE_FIELDS)("coerces the 'facilitySnapshot.%s.$date' field to a Date object when the value is an ISO string", (field) => {
+      // Arrange
+      const date = new Date();
+      const input = {
+        ...aValidTfmFacilityDocument(),
+        facilitySnapshot: {
+          ...aValidTfmFacilityDocumentFacilitySnapshotResult(),
+          [field]: { $date: date.toISOString() },
+        },
+      };
+
+      // Act / Assert
+      const result = TfmFacilitiesRepo.validateAndParseFindOneResult(input);
+      expect(result.facilitySnapshot[field]).toEqual({ $date: date });
+    });
+
+    it.each(FACILITY_SNAPSHOT_DATE_FIELDS)("coerces the 'facilitySnapshot.%s.$date' field to a Date object when the value is a timestamp", (field) => {
+      // Arrange
+      const date = new Date();
+      const input = {
+        ...aValidTfmFacilityDocument(),
+        facilitySnapshot: {
+          ...aValidTfmFacilityDocumentFacilitySnapshotResult(),
+          [field]: { $date: date.getTime() },
+        },
+      };
+
+      // Act / Assert
+      const result = TfmFacilitiesRepo.validateAndParseFindOneResult(input);
+      expect(result.facilitySnapshot[field]).toEqual({ $date: date });
+    });
+  });
+});

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.test.ts
@@ -105,7 +105,7 @@ describe('tfm-facilities-repo', () => {
       },
     );
 
-    it('does not throw an error when the input contains an extra field and does not return than field in the result', () => {
+    it('does not throw an error when the input contains an extra field and does not return the extra field in the result', () => {
       // Arrange
       const input = {
         ...aValidTfmFacilityDocument(),
@@ -117,7 +117,7 @@ describe('tfm-facilities-repo', () => {
       expect(result).not.toHaveProperty('someOtherField');
     });
 
-    it("does not throw an error when the 'facilitySnapshot' object contains an extra field and does not return than field in the result", () => {
+    it("does not throw an error when the 'facilitySnapshot' object contains an extra field and does not return the extra field in the result", () => {
       // Arrange
       const input = {
         ...aValidTfmFacilityDocument(),

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -1,0 +1,80 @@
+import z from 'zod';
+import { ObjectId, UpdateFilter, WithoutId, WithId, FindOneAndUpdateOptions, Collection } from 'mongodb';
+import { TfmFacilitySchema } from './tfm-facility.schema';
+import { mongoDbClient } from '../../drivers/db-client';
+
+export type RawTfmFacility = WithId<object>;
+
+export type ParsedTfmFacility = z.infer<typeof TfmFacilitySchema>;
+
+export class TfmFacilitiesRepo {
+  /**
+   * Gets the TFM facilities collection
+   * @returns The TFM facilities collection
+   */
+  public static async getCollection(): Promise<Collection<WithoutId<RawTfmFacility>>> {
+    return await mongoDbClient.getCollection('tfm-facilities');
+  }
+
+  /**
+   * Validates and parses the result of a mongo `findOne` operation
+   * @param result - The result of any `findOne` operation
+   * @returns The parsed result
+   * @throws If the result does not match the TFM facilities schema
+   */
+  public static validateAndParseFindOneResult(result: RawTfmFacility): ParsedTfmFacility {
+    return TfmFacilitySchema.parse(result);
+  }
+
+  /**
+   * Validates and parses the result of a mongo `find` operation
+   * @param result - The result of any `find` operation
+   * @returns The parsed results
+   * @throws If the each item in the results array does not match the TFM facilities schema
+   */
+  public static validateAndParseFindResult(results: RawTfmFacility[]): ParsedTfmFacility[] {
+    return results.map((result) => this.validateAndParseFindOneResult(result));
+  }
+
+  /**
+   * Finds the tfm facilities by deal id
+   * @param dealId - The deal id
+   * @returns The found tfm facilities
+   */
+  public static async findByDealId(dealId: string | ObjectId): Promise<RawTfmFacility[]> {
+    const collection = await this.getCollection();
+    return await collection.find({ 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } }).toArray();
+  }
+
+  /**
+   * Finds the tfm facility with the supplied id
+   * @param id - The id of the facility
+   * @returns The found tfm facility
+   */
+  public static async findOneById(id: string | ObjectId): Promise<RawTfmFacility | null> {
+    const collection = await this.getCollection();
+    return await collection.findOne({ _id: { $eq: new ObjectId(id) } });
+  }
+
+  /**
+   * Updates the tfm facility with the supplied id
+   * @param id - The id to search by
+   * @param update - The update to apply
+   * @param [options] - Update options
+   * @returns The updated document
+   */
+  public static async findOneByIdAndUpdate(id: string | ObjectId, update: UpdateFilter<WithoutId<RawTfmFacility>>, options: FindOneAndUpdateOptions = {}) {
+    const collection = await this.getCollection();
+    return await collection.findOneAndUpdate({ _id: { $eq: new ObjectId(id) } }, update, options);
+  }
+
+  /**
+   * Finds the TFM facilities with the supplied ids
+   * @param ids - The facility ids
+   * @returns The found TFM facilities
+   */
+  public static async findByIds(ids: (string | ObjectId)[]): Promise<RawTfmFacility[]> {
+    const collection = await this.getCollection();
+    return await collection.find({ _id: { $in: ids } }).toArray();
+  }
+}

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -141,7 +141,7 @@ export class TfmFacilitiesRepo {
    * Method to execute an aggregate against the TFM facilities collection
    * @param pipeline - The aggregate pipeline
    * @param [options] - The aggregate options
-   * @returns The aggregation cursor
+   * @returns The aggregation cursor and array of aggregate results
    */
   public static async executeAggregate(pipeline: Document[], options?: AggregateOptions): Promise<ExecuteAggregateResult> {
     const collection = await this.getCollection();

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -57,11 +57,34 @@ export class TfmFacilitiesRepo {
    * @param id - The id to search by
    * @param update - The update to apply
    * @param [options] - Update options
-   * @returns The updated document
+   * @returns The document (returned after the update by default)
    */
-  public static async findOneByIdAndUpdate(id: string | ObjectId, update: UpdateFilter<WithoutId<RawTfmFacility>>, options: FindOneAndUpdateOptions = {}) {
+  public static async findOneByIdAndUpdate(
+    id: string | ObjectId,
+    update: UpdateFilter<WithoutId<RawTfmFacility>>,
+    options: FindOneAndUpdateOptions = { returnDocument: 'after' },
+  ) {
     const collection = await this.getCollection();
     return await collection.findOneAndUpdate({ _id: { $eq: new ObjectId(id) } }, update, options);
+  }
+
+  /**
+   * Updates the tfm facility with the supplied id
+   * and amendment id
+   * @param id - The facility id
+   * @param amendmentId - The amendment id
+   * @param update - The update to apply
+   * @returns The update result
+   */
+  public static async updateOneByIdAndAmendmentId(id: string | ObjectId, amendmentId: string | ObjectId, update: UpdateFilter<WithoutId<RawTfmFacility>>) {
+    const collection = await this.getCollection();
+    return await collection.updateOne(
+      {
+        _id: { $eq: new ObjectId(id) },
+        'amendments.amendmentId': { $eq: new ObjectId(amendmentId) },
+      },
+      update,
+    );
   }
 
   /**

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -8,11 +8,7 @@ export type RawTfmFacility = WithId<object>;
 export type ParsedTfmFacility = z.infer<typeof TfmFacilitySchema>;
 
 export class TfmFacilitiesRepo {
-  /**
-   * Gets the TFM facilities collection
-   * @returns The TFM facilities collection
-   */
-  public static async getCollection(): Promise<Collection<WithoutId<RawTfmFacility>>> {
+  private static async getCollection(): Promise<Collection<WithoutId<RawTfmFacility>>> {
     return await mongoDbClient.getCollection('tfm-facilities');
   }
 
@@ -20,7 +16,7 @@ export class TfmFacilitiesRepo {
    * Validates and parses the result of a mongo `findOne` operation
    * @param result - The result of any `findOne` operation
    * @returns The parsed result
-   * @throws If the result does not match the TFM facilities schema
+   * @throws {z.ZodError} If the result does not match the TFM facilities schema
    */
   public static validateAndParseFindOneResult(result: RawTfmFacility): ParsedTfmFacility {
     return TfmFacilitySchema.parse(result);
@@ -30,7 +26,7 @@ export class TfmFacilitiesRepo {
    * Validates and parses the result of a mongo `find` operation
    * @param result - The result of any `find` operation
    * @returns The parsed results
-   * @throws If the each item in the results array does not match the TFM facilities schema
+   * @throws {z.ZodError} If any item in the results array does not match the TFM facilities schema
    */
   public static validateAndParseFindResult(results: RawTfmFacility[]): ParsedTfmFacility[] {
     return results.map((result) => this.validateAndParseFindOneResult(result));
@@ -76,5 +72,16 @@ export class TfmFacilitiesRepo {
   public static async findByIds(ids: (string | ObjectId)[]): Promise<RawTfmFacility[]> {
     const collection = await this.getCollection();
     return await collection.find({ _id: { $in: ids } }).toArray();
+  }
+
+  /**
+   * Method to perform a custom operation on the TFM
+   * facilities collection
+   * @param operation - The database operation to perform
+   * @returns The result of the supplied operation
+   */
+  public static async custom<TReturn>(operation: (collection: Collection<WithoutId<RawTfmFacility>>) => TReturn | Promise<TReturn>): Promise<TReturn> {
+    const collection = await this.getCollection();
+    return await operation(collection);
   }
 }

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -10,7 +10,10 @@ import {
   AggregationCursor,
   AggregateOptions,
   UpdateResult,
+  Filter,
 } from 'mongodb';
+import { AuditDetails } from '@ukef/dtfs2-common';
+import { deleteMany } from '@ukef/dtfs2-common/change-stream';
 import { TfmFacilitySchema } from './tfm-facility.schema';
 import { mongoDbClient } from '../../drivers/db-client';
 
@@ -145,5 +148,23 @@ export class TfmFacilitiesRepo {
     const aggregationCursor = collection.aggregate(pipeline, options);
     const resultsArray = await aggregationCursor.toArray();
     return { aggregationCursor, resultsArray };
+  }
+
+  /**
+   * Delete many TFM facilities by the supplied deal id
+   * @param dealId - The deal id
+   * @param auditDetails - The audit details
+   * @returns The delete result
+   */
+  public static async deleteManyByDealId(dealId: string | ObjectId, auditDetails: AuditDetails): Promise<{ acknowledged: boolean }> {
+    const filter: Filter<RawTfmFacility> = {
+      'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) },
+    };
+    return await deleteMany({
+      filter,
+      collectionName: 'tfm-facilities',
+      db: mongoDbClient,
+      auditDetails,
+    });
   }
 }

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facility.schema.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facility.schema.ts
@@ -1,0 +1,36 @@
+import z from 'zod';
+import { MongoObjectIdSchema } from '../../v1/routes/middleware/payload-validation/schemas';
+
+const TfmFacilityDateFieldSchema = z
+  .object({
+    $date: z.coerce.date(),
+  })
+  .nullable();
+
+/**
+ * This schema is an incomplete schema for the TFM facilities
+ * collection which should be updated as and when new properties
+ * are needed.
+ */
+export const TfmFacilitySchema = z.object({
+  _id: MongoObjectIdSchema,
+  facilitySnapshot: z.object({
+    _id: MongoObjectIdSchema,
+    dealId: MongoObjectIdSchema,
+    type: z.string(),
+    hasBeenIssued: z.boolean(),
+    name: z.string(),
+    shouldCoverStartOnSubmission: z.boolean(), // boolean or string?
+    coverStartDate: TfmFacilityDateFieldSchema,
+    coverEndDate: TfmFacilityDateFieldSchema,
+    issueDate: TfmFacilityDateFieldSchema,
+    monthsOfCover: z.number().nullable(),
+    details: z.array(z.string()),
+    detailsOther: z.string(),
+    value: z.number(),
+    coverPercentage: z.number(),
+    interestPercentage: z.number(),
+    ukefFacilityId: z.string(),
+    dayCountBasis: z.number(),
+  }),
+});

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facility.schema.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facility.schema.ts
@@ -20,7 +20,7 @@ export const TfmFacilitySchema = z.object({
     type: z.string(),
     hasBeenIssued: z.boolean(),
     name: z.string(),
-    shouldCoverStartOnSubmission: z.boolean(), // boolean or string?
+    shouldCoverStartOnSubmission: z.boolean(),
     coverStartDate: TfmFacilityDateFieldSchema,
     coverEndDate: TfmFacilityDateFieldSchema,
     issueDate: TfmFacilityDateFieldSchema,

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -12,17 +12,16 @@ const CONSTANTS = require('../../../../constants');
  */
 const findAllAmendmentsByStatus = async (status) => {
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $project: { _id: false, amendments: '$amendments' } },
-            { $unwind: '$amendments' },
-            { $match: { 'amendments.status': { $eq: status } } },
-            { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-            { $project: { _id: false, amendments: true } },
-          ])
-          .toArray(),
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $project: { _id: false, amendments: '$amendments' } },
+          { $unwind: '$amendments' },
+          { $match: { 'amendments.status': { $eq: status } } },
+          { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+          { $project: { _id: false, amendments: true } },
+        ])
+        .toArray(),
     );
 
     // returns the amendment object for the given facilityId and amendmentId
@@ -52,19 +51,18 @@ const findAllAmendmentsByFacilityId = async (facilityId) => {
     if (!ObjectId.isValid(facilityId)) {
       throw new Error('Invalid facility Id');
     }
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { _id: { $eq: ObjectId(facilityId) } } },
-            { $project: { _id: false, amendments: '$amendments' } },
-            { $unwind: '$amendments' },
-            { $sort: { 'amendments.version': -1 } },
-            { $match: { 'amendments.status': { $ne: CONSTANTS.AMENDMENT.AMENDMENT_STATUS.NOT_STARTED } } },
-            { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-            { $project: { _id: false, amendments: true } },
-          ])
-          .toArray(),
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { _id: { $eq: ObjectId(facilityId) } } },
+          { $project: { _id: false, amendments: '$amendments' } },
+          { $unwind: '$amendments' },
+          { $sort: { 'amendments.version': -1 } },
+          { $match: { 'amendments.status': { $ne: CONSTANTS.AMENDMENT.AMENDMENT_STATUS.NOT_STARTED } } },
+          { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+          { $project: { _id: false, amendments: true } },
+        ])
+        .toArray(),
     );
 
     // returns the amendment object for the given facilityId and amendmentId
@@ -95,31 +93,30 @@ const findAmendmentById = async (facilityId, amendmentId) => {
   }
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { _id: { $eq: ObjectId(facilityId) }, 'amendments.amendmentId': { $eq: ObjectId(amendmentId) } } },
-            {
-              $addFields: {
-                'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
-              },
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { _id: { $eq: ObjectId(facilityId) }, 'amendments.amendmentId': { $eq: ObjectId(amendmentId) } } },
+          {
+            $addFields: {
+              'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
             },
-            {
-              $project: {
-                _id: false,
-                amendments: {
-                  $filter: {
-                    input: '$amendments',
-                    as: 'amendment',
-                    cond: { $eq: ['$$amendment.amendmentId', ObjectId(amendmentId)] },
-                  },
+          },
+          {
+            $project: {
+              _id: false,
+              amendments: {
+                $filter: {
+                  input: '$amendments',
+                  as: 'amendment',
+                  cond: { $eq: ['$$amendment.amendmentId', ObjectId(amendmentId)] },
                 },
               },
             },
-            { $unwind: '$amendments' },
-          ])
-          .toArray(),
+          },
+          { $unwind: '$amendments' },
+        ])
+        .toArray(),
     );
 
     // returns the amendment object for the given facilityId and amendmentId
@@ -147,29 +144,28 @@ const findAmendmentsByDealId = async (dealId) => {
   }
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
-            {
-              $addFields: {
-                'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
-              },
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
+          {
+            $addFields: {
+              'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
             },
-            { $project: { _id: false, amendments: true } },
-            { $unwind: '$amendments' },
-            { $sort: { 'amendments.submittedAt': -1 } },
-            {
-              $match: {
-                'amendments.status': { $ne: CONSTANTS.AMENDMENT.AMENDMENT_STATUS.NOT_STARTED },
-                'amendments.submittedByPim': { $eq: true },
-              },
+          },
+          { $project: { _id: false, amendments: true } },
+          { $unwind: '$amendments' },
+          { $sort: { 'amendments.submittedAt': -1 } },
+          {
+            $match: {
+              'amendments.status': { $ne: CONSTANTS.AMENDMENT.AMENDMENT_STATUS.NOT_STARTED },
+              'amendments.submittedByPim': { $eq: true },
             },
-            { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-            { $project: { _id: false, amendments: true } },
-          ])
-          .toArray(),
+          },
+          { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+          { $project: { _id: false, amendments: true } },
+        ])
+        .toArray(),
     );
     // returns the amendment object for the given dealId
     return amendment[0]?.amendments ?? null;
@@ -197,18 +193,17 @@ const findAmendmentByStatusAndFacilityId = async (facilityId, status) => {
   }
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { _id: { $eq: ObjectId(facilityId) } } },
-            { $unwind: '$amendments' },
-            { $match: { 'amendments.status': { $eq: status } } },
-            { $project: { _id: false, amendments: true } },
-            { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
-            { $project: { _id: false, amendments: true } },
-          ])
-          .toArray(),
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { _id: { $eq: ObjectId(facilityId) } } },
+          { $unwind: '$amendments' },
+          { $match: { 'amendments.status': { $eq: status } } },
+          { $project: { _id: false, amendments: true } },
+          { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+          { $project: { _id: false, amendments: true } },
+        ])
+        .toArray(),
     );
     // returns the amendment object for the given facilityId
     return amendment[0]?.amendments ?? null;
@@ -235,24 +230,23 @@ const findAmendmentByStatusAndDealId = async (dealId, status) => {
     return null;
   }
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
-            {
-              $addFields: {
-                'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
-              },
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
+          {
+            $addFields: {
+              'amendments.ukefFacilityId': '$facilitySnapshot.ukefFacilityId',
             },
-            { $unwind: '$amendments' },
-            { $match: { 'amendments.status': { $eq: status } } },
-            { $project: { _id: false, amendments: true } },
-            { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
+          },
+          { $unwind: '$amendments' },
+          { $match: { 'amendments.status': { $eq: status } } },
+          { $project: { _id: false, amendments: true } },
+          { $group: { _id: '$_id', amendments: { $push: '$amendments' } } },
 
-            { $project: { amendments: true, type: true, _id: false } },
-          ])
-          .toArray(),
+          { $project: { amendments: true, type: true, _id: false } },
+        ])
+        .toArray(),
     );
 
     // returns the amendment object for the given dealId
@@ -283,44 +277,43 @@ const findLatestCompletedValueAmendmentByFacilityId = async (facilityId) => {
   const { APPROVED_WITH_CONDITIONS, APPROVED_WITHOUT_CONDITIONS } = CONSTANTS.AMENDMENT.AMENDMENT_MANAGER_DECISIONS;
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { _id: { $eq: ObjectId(facilityId) } } },
-            { $unwind: '$amendments' },
-            {
-              $match: {
-                $or: [
-                  {
-                    'amendments.status': { $eq: COMPLETED },
-                    'amendments.submittedByPim': { $eq: true },
-                    'amendments.requireUkefApproval': { $eq: false },
-                    'amendments.changeFacilityValue': { $eq: true },
-                  },
-                  {
-                    'amendments.status': { $eq: COMPLETED },
-                    'amendments.bankDecision.decision': { $eq: PROCEED },
-                    'amendments.bankDecision.submitted': { $eq: true },
-                    'amendments.ukefDecision.value': { $eq: APPROVED_WITH_CONDITIONS },
-                    'amendments.changeFacilityValue': { $eq: true },
-                  },
-                  {
-                    'amendments.status': { $eq: COMPLETED },
-                    'amendments.bankDecision.decision': { $eq: PROCEED },
-                    'amendments.bankDecision.submitted': { $eq: true },
-                    'amendments.ukefDecision.value': { $eq: APPROVED_WITHOUT_CONDITIONS },
-                    'amendments.changeFacilityValue': { $eq: true },
-                  },
-                ],
-              },
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { _id: { $eq: ObjectId(facilityId) } } },
+          { $unwind: '$amendments' },
+          {
+            $match: {
+              $or: [
+                {
+                  'amendments.status': { $eq: COMPLETED },
+                  'amendments.submittedByPim': { $eq: true },
+                  'amendments.requireUkefApproval': { $eq: false },
+                  'amendments.changeFacilityValue': { $eq: true },
+                },
+                {
+                  'amendments.status': { $eq: COMPLETED },
+                  'amendments.bankDecision.decision': { $eq: PROCEED },
+                  'amendments.bankDecision.submitted': { $eq: true },
+                  'amendments.ukefDecision.value': { $eq: APPROVED_WITH_CONDITIONS },
+                  'amendments.changeFacilityValue': { $eq: true },
+                },
+                {
+                  'amendments.status': { $eq: COMPLETED },
+                  'amendments.bankDecision.decision': { $eq: PROCEED },
+                  'amendments.bankDecision.submitted': { $eq: true },
+                  'amendments.ukefDecision.value': { $eq: APPROVED_WITHOUT_CONDITIONS },
+                  'amendments.changeFacilityValue': { $eq: true },
+                },
+              ],
             },
-            { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+          },
+          { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
 
-            { $project: { _id: false, amendments: true } },
-            { $limit: 1 },
-          ])
-          .toArray(),
+          { $project: { _id: false, amendments: true } },
+          { $limit: 1 },
+        ])
+        .toArray(),
     );
 
     if (amendment[0]?.amendments?.value) {
@@ -357,44 +350,43 @@ const findLatestCompletedDateAmendmentByFacilityId = async (facilityId) => {
   const { APPROVED_WITH_CONDITIONS, APPROVED_WITHOUT_CONDITIONS } = CONSTANTS.AMENDMENT.AMENDMENT_MANAGER_DECISIONS;
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { _id: { $eq: ObjectId(facilityId) } } },
-            { $unwind: '$amendments' },
-            {
-              $match: {
-                $or: [
-                  {
-                    'amendments.status': { $eq: COMPLETED },
-                    'amendments.submittedByPim': { $eq: true },
-                    'amendments.requireUkefApproval': { $eq: false },
-                    'amendments.changeCoverEndDate': { $eq: true },
-                  },
-                  {
-                    'amendments.status': { $eq: COMPLETED },
-                    'amendments.bankDecision.decision': { $eq: PROCEED },
-                    'amendments.bankDecision.submitted': { $eq: true },
-                    'amendments.ukefDecision.coverEndDate': { $eq: APPROVED_WITH_CONDITIONS },
-                    'amendments.changeCoverEndDate': { $eq: true },
-                  },
-                  {
-                    'amendments.status': { $eq: COMPLETED },
-                    'amendments.bankDecision.decision': { $eq: PROCEED },
-                    'amendments.bankDecision.submitted': { $eq: true },
-                    'amendments.ukefDecision.coverEndDate': { $eq: APPROVED_WITHOUT_CONDITIONS },
-                    'amendments.changeCoverEndDate': { $eq: true },
-                  },
-                ],
-              },
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { _id: { $eq: ObjectId(facilityId) } } },
+          { $unwind: '$amendments' },
+          {
+            $match: {
+              $or: [
+                {
+                  'amendments.status': { $eq: COMPLETED },
+                  'amendments.submittedByPim': { $eq: true },
+                  'amendments.requireUkefApproval': { $eq: false },
+                  'amendments.changeCoverEndDate': { $eq: true },
+                },
+                {
+                  'amendments.status': { $eq: COMPLETED },
+                  'amendments.bankDecision.decision': { $eq: PROCEED },
+                  'amendments.bankDecision.submitted': { $eq: true },
+                  'amendments.ukefDecision.coverEndDate': { $eq: APPROVED_WITH_CONDITIONS },
+                  'amendments.changeCoverEndDate': { $eq: true },
+                },
+                {
+                  'amendments.status': { $eq: COMPLETED },
+                  'amendments.bankDecision.decision': { $eq: PROCEED },
+                  'amendments.bankDecision.submitted': { $eq: true },
+                  'amendments.ukefDecision.coverEndDate': { $eq: APPROVED_WITHOUT_CONDITIONS },
+                  'amendments.changeCoverEndDate': { $eq: true },
+                },
+              ],
             },
-            { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+          },
+          { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
 
-            { $project: { _id: false, amendments: true } },
-            { $limit: 1 },
-          ])
-          .toArray(),
+          { $project: { _id: false, amendments: true } },
+          { $limit: 1 },
+        ])
+        .toArray(),
     );
 
     if (amendment[0]?.amendments?.coverEndDate) {
@@ -420,18 +412,17 @@ const findLatestCompletedAmendmentByFacilityIdVersion = async (facilityId) => {
   const { COMPLETED } = CONSTANTS.AMENDMENT.AMENDMENT_STATUS;
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { _id: { $eq: ObjectId(facilityId) } } },
-            { $unwind: '$amendments' },
-            { $match: { 'amendments.status': { $eq: COMPLETED } } },
-            { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
-            { $project: { _id: false, amendments: true } },
-            { $limit: 1 },
-          ])
-          .toArray(),
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { _id: { $eq: ObjectId(facilityId) } } },
+          { $unwind: '$amendments' },
+          { $match: { 'amendments.status': { $eq: COMPLETED } } },
+          { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+          { $project: { _id: false, amendments: true } },
+          { $limit: 1 },
+        ])
+        .toArray(),
     );
     return amendment[0]?.amendments?.version ?? null;
   } catch (error) {
@@ -458,18 +449,17 @@ const findLatestCompletedAmendmentByDealId = async (dealId) => {
   }
 
   try {
-    const amendment = await TfmFacilitiesRepo.custom(
-      async (collection) =>
-        await collection
-          .aggregate([
-            { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
-            { $unwind: '$amendments' },
-            { $match: { 'amendments.status': CONSTANTS.AMENDMENT.AMENDMENT_STATUS.COMPLETED } },
-            { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
-            { $project: { _id: false, amendments: true } },
-            { $limit: 1 },
-          ])
-          .toArray(),
+    const amendment = await TfmFacilitiesRepo.custom((collection) =>
+      collection
+        .aggregate([
+          { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
+          { $unwind: '$amendments' },
+          { $match: { 'amendments.status': CONSTANTS.AMENDMENT.AMENDMENT_STATUS.COMPLETED } },
+          { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+          { $project: { _id: false, amendments: true } },
+          { $limit: 1 },
+        ])
+        .toArray(),
     );
     return amendment[0]?.amendments ?? null;
   } catch (error) {

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -1,6 +1,5 @@
-const { MONGO_DB_COLLECTIONS } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
-const { mongoDbClient: db } = require('../../../../drivers/db-client');
+const { TfmFacilitiesRepo } = require('../../../../repositories/tfm-facilities-repo');
 const CONSTANTS = require('../../../../constants');
 
 /* returns an array of object containing all amendments in progress
@@ -13,7 +12,7 @@ const CONSTANTS = require('../../../../constants');
  */
 const findAllAmendmentsByStatus = async (status) => {
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $project: { _id: false, amendments: '$amendments' } },
@@ -51,7 +50,7 @@ const findAllAmendmentsByFacilityId = async (facilityId) => {
     if (!ObjectId.isValid(facilityId)) {
       throw new Error('Invalid facility Id');
     }
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { _id: { $eq: ObjectId(facilityId) } } },
@@ -92,7 +91,7 @@ const findAmendmentById = async (facilityId, amendmentId) => {
   }
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { _id: { $eq: ObjectId(facilityId) }, 'amendments.amendmentId': { $eq: ObjectId(amendmentId) } } },
@@ -142,7 +141,7 @@ const findAmendmentsByDealId = async (dealId) => {
   }
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
@@ -190,7 +189,7 @@ const findAmendmentByStatusAndFacilityId = async (facilityId, status) => {
   }
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { _id: { $eq: ObjectId(facilityId) } } },
@@ -226,7 +225,7 @@ const findAmendmentByStatusAndDealId = async (dealId, status) => {
     return null;
   }
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },
@@ -272,7 +271,7 @@ const findLatestCompletedValueAmendmentByFacilityId = async (facilityId) => {
   const { APPROVED_WITH_CONDITIONS, APPROVED_WITHOUT_CONDITIONS } = CONSTANTS.AMENDMENT.AMENDMENT_MANAGER_DECISIONS;
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { _id: { $eq: ObjectId(facilityId) } } },
@@ -344,7 +343,7 @@ const findLatestCompletedDateAmendmentByFacilityId = async (facilityId) => {
   const { APPROVED_WITH_CONDITIONS, APPROVED_WITHOUT_CONDITIONS } = CONSTANTS.AMENDMENT.AMENDMENT_MANAGER_DECISIONS;
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { _id: { $eq: ObjectId(facilityId) } } },
@@ -405,7 +404,7 @@ const findLatestCompletedAmendmentByFacilityIdVersion = async (facilityId) => {
   const { COMPLETED } = CONSTANTS.AMENDMENT.AMENDMENT_STATUS;
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { _id: { $eq: ObjectId(facilityId) } } },
@@ -441,7 +440,7 @@ const findLatestCompletedAmendmentByDealId = async (dealId) => {
   }
 
   try {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    const collection = await TfmFacilitiesRepo.getCollection();
     const amendment = await collection
       .aggregate([
         { $match: { 'facilitySnapshot.dealId': { $eq: ObjectId(dealId) } } },

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -14,8 +14,8 @@ const findAllAmendmentsByStatus = async (status) => {
   try {
     const amendmentsWithStatus = await TfmFacilitiesRepo.findAmendmentsByStatus(status);
 
-    // returns the amendment object for the given status
-    return amendmentsWithStatus.at(0) ?? null;
+    // returns the amendments for the given status
+    return amendmentsWithStatus;
   } catch (error) {
     console.error('Unable to find amendments object %o', error);
     return null;
@@ -23,9 +23,9 @@ const findAllAmendmentsByStatus = async (status) => {
 };
 
 exports.getAllAmendmentsInProgress = async (req, res) => {
-  const amendment = (await findAllAmendmentsByStatus(CONSTANTS.AMENDMENT.AMENDMENT_STATUS.IN_PROGRESS)) ?? [];
+  const amendments = await findAllAmendmentsByStatus(CONSTANTS.AMENDMENT.AMENDMENT_STATUS.IN_PROGRESS);
 
-  return res.status(200).send(amendment);
+  return res.status(200).send(amendments);
 };
 
 /* returns an array of object containing all properties for a given facilityId:
@@ -44,7 +44,7 @@ const findAllAmendmentsByFacilityId = async (facilityId) => {
     const amendmentsForFacility = await TfmFacilitiesRepo.findAmendmentsByFacilityId(facilityId);
 
     // returns the amendment object for the given facilityId
-    return amendmentsForFacility.at(0) ?? null;
+    return amendmentsForFacility;
   } catch (error) {
     console.error('Unable to find amendments object %o', error);
     return null;
@@ -101,7 +101,7 @@ const findAmendmentsByDealId = async (dealId) => {
     const amendments = await TfmFacilitiesRepo.findAmendmentsByDealId(dealId);
 
     // returns the amendment object for the given dealId
-    return amendments.at(0) ?? null;
+    return amendments;
   } catch (error) {
     console.error('Unable to find the amendments object by Deal Id %o', error);
     return null;

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.js
@@ -281,8 +281,7 @@ exports.getAmendmentsByFacilityId = async (req, res) => {
   let amendment;
   switch (amendmentIdOrStatus) {
     case CONSTANTS.AMENDMENT.AMENDMENT_QUERY_STATUSES.IN_PROGRESS: {
-      const amendmentsInProgress = (await findAmendmentByStatusAndFacilityId(facilityId, CONSTANTS.AMENDMENT.AMENDMENT_STATUS.IN_PROGRESS)) ?? [];
-      amendment = amendmentsInProgress[0] ?? {};
+      amendment = (await findAmendmentByStatusAndFacilityId(facilityId, CONSTANTS.AMENDMENT.AMENDMENT_STATUS.IN_PROGRESS)) ?? {};
       break;
     }
     case CONSTANTS.AMENDMENT.AMENDMENT_QUERY_STATUSES.COMPLETED:
@@ -291,7 +290,7 @@ exports.getAmendmentsByFacilityId = async (req, res) => {
       } else if (type === CONSTANTS.AMENDMENT.AMENDMENT_QUERIES.LATEST_COVER_END_DATE) {
         amendment = (await findLatestCompletedDateAmendmentByFacilityId(facilityId)) ?? {};
       } else {
-        amendment = (await findAmendmentByStatusAndFacilityId(facilityId, CONSTANTS.AMENDMENT.AMENDMENT_STATUS.COMPLETED)) ?? [];
+        amendment = await TfmFacilitiesRepo.findAmendmentsByFacilityIdAndStatus(facilityId, CONSTANTS.AMENDMENT.AMENDMENT_STATUS.COMPLETED);
       }
       break;
     default:
@@ -325,7 +324,7 @@ exports.getAmendmentsByDealId = async (req, res) => {
       }
       break;
     default:
-      amendment = (await findAmendmentsByDealId(dealId)) ?? [];
+      amendment = await findAmendmentsByDealId(dealId);
   }
   return res.status(200).send(amendment);
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
@@ -1,12 +1,11 @@
 const { InvalidAuditDetailsError, AUDIT_USER_TYPES } = require('@ukef/dtfs2-common');
-const { MONGO_DB_COLLECTIONS } = require('@ukef/dtfs2-common');
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetailsAndUserType } = require('@ukef/dtfs2-common/change-stream');
 const { ObjectId } = require('mongodb');
 const { getUnixTime } = require('date-fns');
-const { mongoDbClient: db } = require('../../../../drivers/db-client');
 const CONSTANTS = require('../../../../constants');
 const { findAmendmentByStatusAndFacilityId, findLatestCompletedAmendmentByFacilityIdVersion } = require('./tfm-get-amendments.controller');
 const { findOneFacility } = require('../facility/tfm-get-facility.controller');
+const { TfmFacilitiesRepo } = require('../../../../repositories/tfm-facilities-repo');
 
 exports.postTfmAmendment = async (req, res) => {
   const { facilityId } = req.params;
@@ -55,7 +54,7 @@ exports.postTfmAmendment = async (req, res) => {
   if (latestCompletedAmendmentVersion) {
     amendment.version = latestCompletedAmendmentVersion + 1;
   }
-  const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+  const collection = await TfmFacilitiesRepo.getCollection();
   await collection.updateOne(
     { _id: { $eq: ObjectId(facilityId) } },
     {

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
@@ -54,8 +54,8 @@ exports.postTfmAmendment = async (req, res) => {
   if (latestCompletedAmendmentVersion) {
     amendment.version = latestCompletedAmendmentVersion + 1;
   }
-  await TfmFacilitiesRepo.custom(async (collection) => {
-    await collection.updateOne(
+  await TfmFacilitiesRepo.custom((collection) => {
+    collection.updateOne(
       { _id: { $eq: ObjectId(facilityId) } },
       {
         $push: { amendments: amendment },

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
@@ -54,14 +54,9 @@ exports.postTfmAmendment = async (req, res) => {
   if (latestCompletedAmendmentVersion) {
     amendment.version = latestCompletedAmendmentVersion + 1;
   }
-  await TfmFacilitiesRepo.custom((collection) => {
-    collection.updateOne(
-      { _id: { $eq: ObjectId(facilityId) } },
-      {
-        $push: { amendments: amendment },
-        $set: { auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) },
-      },
-    );
+  await TfmFacilitiesRepo.updateOneById(facilityId, {
+    $push: { amendments: amendment },
+    $set: { auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) },
   });
 
   return res.status(200).json({ amendmentId: amendment.amendmentId.toHexString() });

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
@@ -49,11 +49,8 @@ exports.postTfmAmendment = async (req, res) => {
     createdAt: getUnixTime(new Date()),
     updatedAt: getUnixTime(new Date()),
     status: CONSTANTS.AMENDMENT.AMENDMENT_STATUS.NOT_STARTED,
-    version: 1,
+    version: latestCompletedAmendmentVersion ? latestCompletedAmendmentVersion + 1 : 1,
   };
-  if (latestCompletedAmendmentVersion) {
-    amendment.version = latestCompletedAmendmentVersion + 1;
-  }
   await TfmFacilitiesRepo.updateOneById(facilityId, {
     $push: { amendments: amendment },
     $set: { auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) },

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-post-amendments.controller.js
@@ -54,14 +54,15 @@ exports.postTfmAmendment = async (req, res) => {
   if (latestCompletedAmendmentVersion) {
     amendment.version = latestCompletedAmendmentVersion + 1;
   }
-  const collection = await TfmFacilitiesRepo.getCollection();
-  await collection.updateOne(
-    { _id: { $eq: ObjectId(facilityId) } },
-    {
-      $push: { amendments: amendment },
-      $set: { auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) },
-    },
-  );
+  await TfmFacilitiesRepo.custom(async (collection) => {
+    await collection.updateOne(
+      { _id: { $eq: ObjectId(facilityId) } },
+      {
+        $push: { amendments: amendment },
+        $set: { auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) },
+      },
+    );
+  });
 
   return res.status(200).json({ amendmentId: amendment.amendmentId.toHexString() });
 };

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-put-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-put-amendments.controller.js
@@ -1,11 +1,11 @@
-const { MONGO_DB_COLLECTIONS, AUDIT_USER_TYPES } = require('@ukef/dtfs2-common');
+const { AUDIT_USER_TYPES } = require('@ukef/dtfs2-common');
 const { InvalidAuditDetailsError } = require('@ukef/dtfs2-common');
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetailsAndUserType } = require('@ukef/dtfs2-common/change-stream');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { getUnixTime } = require('date-fns');
-const { mongoDbClient: db } = require('../../../../drivers/db-client');
 const { findAmendmentById } = require('./tfm-get-amendments.controller');
+const { TfmFacilitiesRepo } = require('../../../../repositories/tfm-facilities-repo');
 
 exports.updateTfmAmendment = async (req, res) => {
   const { payload, auditDetails } = req.body;
@@ -32,7 +32,7 @@ exports.updateTfmAmendment = async (req, res) => {
     return res.status(404).send({ status: 404, message: 'The amendment does not exist' });
   }
 
-  const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+  const collection = await TfmFacilitiesRepo.getCollection();
   const protectedProperties = ['_id', 'amendmentId', 'facilityId', 'dealId', 'createdAt', 'updatedAt', 'version'];
 
   for (const property of protectedProperties) {

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-put-amendments.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-put-amendments.controller.js
@@ -40,12 +40,14 @@ exports.updateTfmAmendment = async (req, res) => {
 
   const update = { ...payload, updatedAt: getUnixTime(new Date()) };
 
-  await TfmFacilitiesRepo.custom(async (collection) => {
-    await collection.updateOne(
-      { _id: { $eq: ObjectId(facilityId) }, 'amendments.amendmentId': { $eq: ObjectId(amendmentId) } },
-      $.flatten({ 'amendments.$': update, auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails) }),
-    );
-  });
+  await TfmFacilitiesRepo.updateOneByIdAndAmendmentId(
+    facilityId,
+    amendmentId,
+    $.flatten({
+      'amendments.$': update,
+      auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
+    }),
+  );
 
   const updatedAmendment = await findAmendmentById(facilityId, amendmentId);
   return res.status(200).json({ ...updatedAmendment });

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-delete-deal.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-delete-deal.controller.ts
@@ -1,10 +1,11 @@
 import { Response } from 'express';
 import { ObjectId } from 'mongodb';
 import { AuditDetails, MONGO_DB_COLLECTIONS, InvalidAuditDetailsError, DocumentNotDeletedError, DocumentNotFoundError } from '@ukef/dtfs2-common';
-import { deleteMany, deleteOne, validateAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { deleteOne, validateAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { findOneDeal } from './tfm-get-deal.controller';
 import { mongoDbClient } from '../../../../drivers/db-client';
 import { CustomExpressRequest } from '../../../../types/custom-express-request';
+import { TfmFacilitiesRepo } from '../../../../repositories/tfm-facilities-repo';
 
 export const deleteDeal = async (req: CustomExpressRequest<{ reqBody: { auditDetails: AuditDetails } }>, res: Response) => {
   const { id } = req.params;
@@ -40,12 +41,7 @@ export const deleteDeal = async (req: CustomExpressRequest<{ reqBody: { auditDet
       auditDetails,
     });
 
-    await deleteMany({
-      filter: { 'facilitySnapshot.dealId': { $eq: deal._id } },
-      collectionName: MONGO_DB_COLLECTIONS.TFM_FACILITIES,
-      db: mongoDbClient,
-      auditDetails,
-    });
+    await TfmFacilitiesRepo.deleteManyByDealId(deal._id, auditDetails);
 
     return res.status(200).send(deleteResult);
   } catch (error) {

--- a/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deal.controller.js
+++ b/dtfs-central-api/src/v1/controllers/tfm/deal/tfm-get-deal.controller.js
@@ -1,7 +1,8 @@
-const { MONGO_DB_COLLECTIONS } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
+const { MONGO_DB_COLLECTIONS } = require('@ukef/dtfs2-common');
 const { mongoDbClient: db } = require('../../../../drivers/db-client');
 const CONSTANTS = require('../../../../constants');
+const { TfmFacilitiesRepo } = require('../../../../repositories/tfm-facilities-repo');
 
 const findOneDeal = async (_id, callback) => {
   if (!ObjectId.isValid(_id)) {
@@ -9,7 +10,6 @@ const findOneDeal = async (_id, callback) => {
   }
 
   const dealsCollection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_DEALS);
-  const facilitiesCollection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
 
   const deal = await dealsCollection.findOne({ _id: { $eq: ObjectId(_id) } });
   let returnDeal = deal;
@@ -27,13 +27,7 @@ const findOneDeal = async (_id, callback) => {
         const mappedDeal = deal.dealSnapshot;
         const mappedBonds = [];
         const mappedLoans = [];
-        const facilities = await facilitiesCollection
-          .find({
-            _id: {
-              $in: facilityIds,
-            },
-          })
-          .toArray();
+        const facilities = await TfmFacilitiesRepo.findByIds(facilityIds);
 
         facilityIds.forEach((id) => {
           const { facilitySnapshot } = facilities.find((f) => f._id.toHexString() === id.toHexString());

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.ts
@@ -66,127 +66,117 @@ export const getAllFacilities = async (req: GetAllFacilitiesRequest, res: Respon
    *     }
    * }]
    */
-  const doc = await TfmFacilitiesRepo.custom((facilitiesCollection) =>
-    facilitiesCollection
-      .aggregate([
-        {
-          $lookup: {
-            from: MONGO_DB_COLLECTIONS.TFM_DEALS,
-            localField: 'facilitySnapshot.dealId',
-            foreignField: '_id',
-            as: 'tfmDeals',
-          },
-        },
-        {
-          $unwind: '$tfmDeals',
-        },
-        {
-          $project: {
-            _id: false,
-            companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
-            ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
-            // amendments array for mapping completed amendments
-            amendments: '$amendments',
-            tfmFacilities: {
-              // create the `dealId` property
-              dealId: '$facilitySnapshot.dealId',
-              // create the `facilityId` property
-              facilityId: '$facilitySnapshot._id',
-              // create the `ukefFacilityId` property
-              ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
-              // create the `dealType` property - this is inside the `dealSnapshot` property, NOT `facilities` array
-              dealType: '$tfmDeals.dealSnapshot.dealType',
-              // create the `type` property
-              type: '$facilitySnapshot.type',
-              // create the `value` property - this is the facility value
-              value: '$facilitySnapshot.value',
-              // create the `currency` property
-              currency: '$facilitySnapshot.currency.id',
-              // create the `coverEndDate` property
-              // GEF already has this property, but BSS doesn't have it in this format, so we need to create it dynamically
-              coverEndDate: {
-                $switch: {
-                  branches: [
-                    {
-                      case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'GEF'] },
-                      then: '$facilitySnapshot.coverEndDate', // YYYY-MM-DD
-                    },
-                    {
-                      case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'BSS/EWCS'] },
-                      then: {
-                        $concat: [
-                          '$facilitySnapshot.coverEndDate-year',
-                          '-',
-                          '$facilitySnapshot.coverEndDate-month',
-                          '-',
-                          '$facilitySnapshot.coverEndDate-day',
-                        ],
-                      }, // YYYY-MM-DD
-                    },
-                  ],
+  const { resultsArray: doc } = await TfmFacilitiesRepo.executeAggregate([
+    {
+      $lookup: {
+        from: MONGO_DB_COLLECTIONS.TFM_DEALS,
+        localField: 'facilitySnapshot.dealId',
+        foreignField: '_id',
+        as: 'tfmDeals',
+      },
+    },
+    {
+      $unwind: '$tfmDeals',
+    },
+    {
+      $project: {
+        _id: false,
+        companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+        ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
+        // amendments array for mapping completed amendments
+        amendments: '$amendments',
+        tfmFacilities: {
+          // create the `dealId` property
+          dealId: '$facilitySnapshot.dealId',
+          // create the `facilityId` property
+          facilityId: '$facilitySnapshot._id',
+          // create the `ukefFacilityId` property
+          ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
+          // create the `dealType` property - this is inside the `dealSnapshot` property, NOT `facilities` array
+          dealType: '$tfmDeals.dealSnapshot.dealType',
+          // create the `type` property
+          type: '$facilitySnapshot.type',
+          // create the `value` property - this is the facility value
+          value: '$facilitySnapshot.value',
+          // create the `currency` property
+          currency: '$facilitySnapshot.currency.id',
+          // create the `coverEndDate` property
+          // GEF already has this property, but BSS doesn't have it in this format, so we need to create it dynamically
+          coverEndDate: {
+            $switch: {
+              branches: [
+                {
+                  case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'GEF'] },
+                  then: '$facilitySnapshot.coverEndDate', // YYYY-MM-DD
                 },
-              },
-              // create the `companyName` property - this is inside the `dealSnapshot.exporter` property, NOT `facilities` array
-              companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
-              // create the `hasBeenIssued` property
-              hasBeenIssued: '$facilitySnapshot.hasBeenIssued',
+                {
+                  case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'BSS/EWCS'] },
+                  then: {
+                    $concat: ['$facilitySnapshot.coverEndDate-year', '-', '$facilitySnapshot.coverEndDate-month', '-', '$facilitySnapshot.coverEndDate-day'],
+                  }, // YYYY-MM-DD
+                },
+              ],
             },
           },
+          // create the `companyName` property - this is inside the `dealSnapshot.exporter` property, NOT `facilities` array
+          companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+          // create the `hasBeenIssued` property
+          hasBeenIssued: '$facilitySnapshot.hasBeenIssued',
         },
-        {
-          // search functionality based on ukefFacilityId property OR companyName
-          $match: {
-            $or: [
-              {
-                ukefFacilityId: {
-                  $regex: searchStringEscaped,
-                  $options: 'i',
-                },
-              },
-              {
-                companyName: {
-                  $regex: searchStringEscaped,
-                  $options: 'i',
-                },
-              },
-            ],
-          },
-        },
-        {
-          $addFields: {
-            facilityStage: {
-              $cond: {
-                if: '$tfmFacilities.hasBeenIssued',
-                then: 'Issued',
-                else: 'Unissued',
-              },
+      },
+    },
+    {
+      // search functionality based on ukefFacilityId property OR companyName
+      $match: {
+        $or: [
+          {
+            ukefFacilityId: {
+              $regex: searchStringEscaped,
+              $options: 'i',
             },
           },
-        },
-        {
-          $sort: {
-            ...fieldsToSortOn,
+          {
+            companyName: {
+              $regex: searchStringEscaped,
+              $options: 'i',
+            },
+          },
+        ],
+      },
+    },
+    {
+      $addFields: {
+        facilityStage: {
+          $cond: {
+            if: '$tfmFacilities.hasBeenIssued',
+            then: 'Issued',
+            else: 'Unissued',
           },
         },
-        {
-          $unset: 'facilityStage',
-        },
-        {
-          $facet: {
-            count: [{ $count: 'total' }],
-            facilities: [{ $skip: pageNumber * pagesizeNumber }, ...(pagesize ? [{ $limit: pagesizeNumber }] : [])],
-          },
-        },
-        { $unwind: '$count' },
-        {
-          $project: {
-            count: '$count.total',
-            facilities: true,
-          },
-        },
-      ])
-      .toArray(),
-  );
+      },
+    },
+    {
+      $sort: {
+        ...fieldsToSortOn,
+      },
+    },
+    {
+      $unset: 'facilityStage',
+    },
+    {
+      $facet: {
+        count: [{ $count: 'total' }],
+        facilities: [{ $skip: pageNumber * pagesizeNumber }, ...(pagesize ? [{ $limit: pagesizeNumber }] : [])],
+      },
+    },
+    { $unwind: '$count' },
+    {
+      $project: {
+        count: '$count.total',
+        facilities: true,
+      },
+    },
+  ]);
 
   if (!doc.length) {
     const pagination = {

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facilities.controller.ts
@@ -66,127 +66,126 @@ export const getAllFacilities = async (req: GetAllFacilitiesRequest, res: Respon
    *     }
    * }]
    */
-  const doc = await TfmFacilitiesRepo.custom(
-    async (facilitiesCollection) =>
-      await facilitiesCollection
-        .aggregate([
-          {
-            $lookup: {
-              from: MONGO_DB_COLLECTIONS.TFM_DEALS,
-              localField: 'facilitySnapshot.dealId',
-              foreignField: '_id',
-              as: 'tfmDeals',
-            },
+  const doc = await TfmFacilitiesRepo.custom((facilitiesCollection) =>
+    facilitiesCollection
+      .aggregate([
+        {
+          $lookup: {
+            from: MONGO_DB_COLLECTIONS.TFM_DEALS,
+            localField: 'facilitySnapshot.dealId',
+            foreignField: '_id',
+            as: 'tfmDeals',
           },
-          {
-            $unwind: '$tfmDeals',
-          },
-          {
-            $project: {
-              _id: false,
-              companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+        },
+        {
+          $unwind: '$tfmDeals',
+        },
+        {
+          $project: {
+            _id: false,
+            companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+            ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
+            // amendments array for mapping completed amendments
+            amendments: '$amendments',
+            tfmFacilities: {
+              // create the `dealId` property
+              dealId: '$facilitySnapshot.dealId',
+              // create the `facilityId` property
+              facilityId: '$facilitySnapshot._id',
+              // create the `ukefFacilityId` property
               ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
-              // amendments array for mapping completed amendments
-              amendments: '$amendments',
-              tfmFacilities: {
-                // create the `dealId` property
-                dealId: '$facilitySnapshot.dealId',
-                // create the `facilityId` property
-                facilityId: '$facilitySnapshot._id',
-                // create the `ukefFacilityId` property
-                ukefFacilityId: '$facilitySnapshot.ukefFacilityId',
-                // create the `dealType` property - this is inside the `dealSnapshot` property, NOT `facilities` array
-                dealType: '$tfmDeals.dealSnapshot.dealType',
-                // create the `type` property
-                type: '$facilitySnapshot.type',
-                // create the `value` property - this is the facility value
-                value: '$facilitySnapshot.value',
-                // create the `currency` property
-                currency: '$facilitySnapshot.currency.id',
-                // create the `coverEndDate` property
-                // GEF already has this property, but BSS doesn't have it in this format, so we need to create it dynamically
-                coverEndDate: {
-                  $switch: {
-                    branches: [
-                      {
-                        case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'GEF'] },
-                        then: '$facilitySnapshot.coverEndDate', // YYYY-MM-DD
-                      },
-                      {
-                        case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'BSS/EWCS'] },
-                        then: {
-                          $concat: [
-                            '$facilitySnapshot.coverEndDate-year',
-                            '-',
-                            '$facilitySnapshot.coverEndDate-month',
-                            '-',
-                            '$facilitySnapshot.coverEndDate-day',
-                          ],
-                        }, // YYYY-MM-DD
-                      },
-                    ],
-                  },
+              // create the `dealType` property - this is inside the `dealSnapshot` property, NOT `facilities` array
+              dealType: '$tfmDeals.dealSnapshot.dealType',
+              // create the `type` property
+              type: '$facilitySnapshot.type',
+              // create the `value` property - this is the facility value
+              value: '$facilitySnapshot.value',
+              // create the `currency` property
+              currency: '$facilitySnapshot.currency.id',
+              // create the `coverEndDate` property
+              // GEF already has this property, but BSS doesn't have it in this format, so we need to create it dynamically
+              coverEndDate: {
+                $switch: {
+                  branches: [
+                    {
+                      case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'GEF'] },
+                      then: '$facilitySnapshot.coverEndDate', // YYYY-MM-DD
+                    },
+                    {
+                      case: { $eq: ['$tfmDeals.dealSnapshot.dealType', 'BSS/EWCS'] },
+                      then: {
+                        $concat: [
+                          '$facilitySnapshot.coverEndDate-year',
+                          '-',
+                          '$facilitySnapshot.coverEndDate-month',
+                          '-',
+                          '$facilitySnapshot.coverEndDate-day',
+                        ],
+                      }, // YYYY-MM-DD
+                    },
+                  ],
                 },
-                // create the `companyName` property - this is inside the `dealSnapshot.exporter` property, NOT `facilities` array
-                companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
-                // create the `hasBeenIssued` property
-                hasBeenIssued: '$facilitySnapshot.hasBeenIssued',
+              },
+              // create the `companyName` property - this is inside the `dealSnapshot.exporter` property, NOT `facilities` array
+              companyName: '$tfmDeals.dealSnapshot.exporter.companyName',
+              // create the `hasBeenIssued` property
+              hasBeenIssued: '$facilitySnapshot.hasBeenIssued',
+            },
+          },
+        },
+        {
+          // search functionality based on ukefFacilityId property OR companyName
+          $match: {
+            $or: [
+              {
+                ukefFacilityId: {
+                  $regex: searchStringEscaped,
+                  $options: 'i',
+                },
+              },
+              {
+                companyName: {
+                  $regex: searchStringEscaped,
+                  $options: 'i',
+                },
+              },
+            ],
+          },
+        },
+        {
+          $addFields: {
+            facilityStage: {
+              $cond: {
+                if: '$tfmFacilities.hasBeenIssued',
+                then: 'Issued',
+                else: 'Unissued',
               },
             },
           },
-          {
-            // search functionality based on ukefFacilityId property OR companyName
-            $match: {
-              $or: [
-                {
-                  ukefFacilityId: {
-                    $regex: searchStringEscaped,
-                    $options: 'i',
-                  },
-                },
-                {
-                  companyName: {
-                    $regex: searchStringEscaped,
-                    $options: 'i',
-                  },
-                },
-              ],
-            },
+        },
+        {
+          $sort: {
+            ...fieldsToSortOn,
           },
-          {
-            $addFields: {
-              facilityStage: {
-                $cond: {
-                  if: '$tfmFacilities.hasBeenIssued',
-                  then: 'Issued',
-                  else: 'Unissued',
-                },
-              },
-            },
+        },
+        {
+          $unset: 'facilityStage',
+        },
+        {
+          $facet: {
+            count: [{ $count: 'total' }],
+            facilities: [{ $skip: pageNumber * pagesizeNumber }, ...(pagesize ? [{ $limit: pagesizeNumber }] : [])],
           },
-          {
-            $sort: {
-              ...fieldsToSortOn,
-            },
+        },
+        { $unwind: '$count' },
+        {
+          $project: {
+            count: '$count.total',
+            facilities: true,
           },
-          {
-            $unset: 'facilityStage',
-          },
-          {
-            $facet: {
-              count: [{ $count: 'total' }],
-              facilities: [{ $skip: pageNumber * pagesizeNumber }, ...(pagesize ? [{ $limit: pagesizeNumber }] : [])],
-            },
-          },
-          { $unwind: '$count' },
-          {
-            $project: {
-              count: '$count.total',
-              facilities: true,
-            },
-          },
-        ])
-        .toArray(),
+        },
+      ])
+      .toArray(),
   );
 
   if (!doc.length) {

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facility.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-get-facility.controller.ts
@@ -1,14 +1,13 @@
-const { MONGO_DB_COLLECTIONS } = require('@ukef/dtfs2-common');
-const { ObjectId } = require('mongodb');
-const { mongoDbClient: db } = require('../../../../drivers/db-client');
+import { Request, Response } from 'express';
+import { ObjectId } from 'mongodb';
+import { TfmFacilitiesRepo } from '../../../../repositories/tfm-facilities-repo';
 
-const findOneFacility = async (_id, callback) => {
+export const findOneFacility = async (_id: string | ObjectId, callback?: (facility: object | null) => unknown) => {
   if (!ObjectId.isValid(_id)) {
     return { status: 400, message: 'Invalid Facility Id' };
   }
 
-  const collection = await db.getCollection(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
-  const facility = await collection.findOne({ _id: { $eq: ObjectId(_id) } });
+  const facility = await TfmFacilitiesRepo.findOneById(_id);
 
   if (callback) {
     callback(facility);
@@ -16,9 +15,8 @@ const findOneFacility = async (_id, callback) => {
 
   return facility;
 };
-exports.findOneFacility = findOneFacility;
 
-exports.findOneFacilityGet = async (req, res) => {
+export const findOneFacilityGet = async (req: Request, res: Response) => {
   if (ObjectId.isValid(req.params.id)) {
     const facility = await findOneFacility(req.params.id);
 

--- a/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/facility/tfm-update-facility.controller.ts
@@ -13,12 +13,10 @@ const updateFacility = async ({ facilityId, tfmUpdate, auditDetails }: { facilit
     auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
   };
 
-  const findAndUpdateResponse = await TfmFacilitiesRepo.findOneByIdAndUpdate(facilityId, flatten(update), {
+  const updatedFacility = await TfmFacilitiesRepo.findOneByIdAndUpdate(facilityId, flatten(update), {
     returnDocument: 'after',
     upsert: true,
   });
-
-  const { value: updatedFacility } = findAndUpdateResponse;
 
   return updatedFacility;
 };

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-amendment-request-check-previous.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-amendment-request-check-previous.spec.js
@@ -230,9 +230,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     amendmentsPage.continueAmendment().click();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeDaysDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeDaysMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeDaysYear);
+    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeYearsDay);
+    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeYearsMonth);
+    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeYearsYear);
     amendmentsPage.continueAmendment().click();
 
     cy.url().should('contain', 'facility-value');
@@ -335,7 +335,7 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
 
     cy.url().should('contain', 'facility-value');
 
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('12345');
+    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234');
 
     amendmentsPage.continueAmendment().click();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-proceed.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-proceed.spec.js
@@ -20,6 +20,7 @@ context('Amendments underwriting - add banks decision - proceed', () => {
   const todayIsEndOfMonth = add(new Date(), { days: 1 }).getDate() === 1;
   const aMonthFromNowIsEndOfMonth = add(new Date(), { months: 1, days: 1 }).getDate() === 1;
   const facilityTenor = todayIsEndOfMonth && !aMonthFromNowIsEndOfMonth ? '25 months' : '26 months';
+  const updatedFacilityTenor = '25 months';
 
   let dealId;
   const dealFacilities = [];
@@ -505,8 +506,8 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     const facilityId = dealFacilities[0]._id;
 
     cy.visit(relative(`/case/${dealId}/deal`));
-    caseDealPage.dealFacilitiesTable.row(facilityId).facilityTenor().contains(facilityTenor);
-    caseDealPage.dealFacilitiesTable.row(facilityId).facilityEndDate().contains(dateConstants.oneMonthFormattedTable);
+    caseDealPage.dealFacilitiesTable.row(facilityId).facilityTenor().contains(updatedFacilityTenor);
+    caseDealPage.dealFacilitiesTable.row(facilityId).facilityEndDate().contains(dateConstants.tomorrowFormattedFull);
     caseDealPage.dealFacilitiesTable.row(facilityId).exportCurrency().contains(`${CURRENCY.GBP} 123.00`);
     caseDealPage.dealFacilitiesTable.row(facilityId).valueGBP().contains(`${CURRENCY.GBP} 123.00`);
     caseDealPage.dealFacilitiesTable.row(facilityId).exposure().contains(`${CURRENCY.GBP} 24.60`);
@@ -517,7 +518,7 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     facilityPage.facilityValueGbp().contains(`${CURRENCY.GBP} 123.00`);
     facilityPage.facilityMaximumUkefExposure().contains(`${CURRENCY.GBP} 24.60 as at 5 June 2022`);
 
-    facilityPage.facilityCoverEndDate().contains(dateConstants.oneMonthFormattedTable);
-    facilityPage.facilityTenor().contains(facilityTenor);
+    facilityPage.facilityCoverEndDate().contains(dateConstants.tomorrowFormattedFull);
+    facilityPage.facilityTenor().contains(updatedFacilityTenor);
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendments-version-order.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendments-version-order.spec.js
@@ -286,9 +286,9 @@ context('Amendments underwriting - amendments should be in correct order of vers
     amendmentsPage.continueAmendment().click();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeMonthsDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeMonthsMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeMonthsYear);
+    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeYearsDay);
+    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeYearsMonth);
+    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeYearsYear);
     amendmentsPage.continueAmendment().click();
 
     cy.url().should('contain', 'facility-value');

--- a/libs/common/src/change-stream/delete-many.ts
+++ b/libs/common/src/change-stream/delete-many.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config.js';
-import { DeleteResult, Filter, ObjectId, OptionalId, TransactionOptions, WithoutId } from 'mongodb';
+import { DeleteResult, Filter, ObjectId, TransactionOptions, WithoutId } from 'mongodb';
 import { add } from 'date-fns';
 import { AuditDetails, DbModel, DeletionAuditLog, MongoDbCollectionName } from '../types';
 import { MongoDbClient } from '../mongo-db-client';
@@ -10,7 +10,7 @@ import { DocumentNotFoundError, WriteConcernError } from '../errors';
 const { DELETION_AUDIT_LOGS_TTL_SECONDS } = changeStreamConfig;
 
 type DeleteManyParams<CollectionName extends MongoDbCollectionName> = {
-  filter: Filter<OptionalId<DbModel<CollectionName>>>;
+  filter: Filter<WithoutId<DbModel<CollectionName>>>;
   collectionName: CollectionName;
   db: MongoDbClient;
   auditDetails: AuditDetails;
@@ -63,7 +63,7 @@ const deleteManyWithAuditLogs = async <CollectionName extends MongoDbCollectionN
 
       const deleteManyFilter = {
         _id: { $in: documentsToDeleteIds },
-      } as unknown as Filter<OptionalId<DbModel<CollectionName>>>;
+      } as unknown as Filter<WithoutId<DbModel<CollectionName>>>;
       const deleteResult = await collection.deleteMany(deleteManyFilter, { session });
       if (!(deleteResult.acknowledged && deleteResult.deletedCount === documentsToDeleteIds.length)) {
         throw new WriteConcernError();

--- a/libs/common/src/mongo-db-client/index.ts
+++ b/libs/common/src/mongo-db-client/index.ts
@@ -1,4 +1,4 @@
-import { Collection, Db as DbConnection, MongoClient, OptionalId } from 'mongodb';
+import { Collection, Db as DbConnection, MongoClient, WithoutId } from 'mongodb';
 import { MongoDbCollectionName } from '../types/mongo-db-models/mongo-db-collection-name';
 import { DbModel } from '../types/mongo-db-models/db-model';
 
@@ -65,7 +65,7 @@ export class MongoDbClient {
    */
   public async getCollection<CollectionName extends MongoDbCollectionName>(
     collectionName: CollectionName,
-  ): Promise<Collection<OptionalId<DbModel<CollectionName>>>> {
+  ): Promise<Collection<WithoutId<DbModel<CollectionName>>>> {
     return (await this.getOrInitialiseClient()).connection.collection(collectionName);
   }
 

--- a/libs/common/src/mongo-db-client/index.ts
+++ b/libs/common/src/mongo-db-client/index.ts
@@ -1,4 +1,4 @@
-import { Collection, Db as DbConnection, MongoClient, WithoutId } from 'mongodb';
+import { Collection, Db as DbConnection, MongoClient, OptionalId } from 'mongodb';
 import { MongoDbCollectionName } from '../types/mongo-db-models/mongo-db-collection-name';
 import { DbModel } from '../types/mongo-db-models/db-model';
 
@@ -65,7 +65,7 @@ export class MongoDbClient {
    */
   public async getCollection<CollectionName extends MongoDbCollectionName>(
     collectionName: CollectionName,
-  ): Promise<Collection<WithoutId<DbModel<CollectionName>>>> {
+  ): Promise<Collection<OptionalId<DbModel<CollectionName>>>> {
     return (await this.getOrInitialiseClient()).connection.collection(collectionName);
   }
 

--- a/libs/common/src/schemas/index.ts
+++ b/libs/common/src/schemas/index.ts
@@ -1,4 +1,4 @@
 export * as PORTAL_USER from './portal-user';
 export * as AUDIT_DATABASE_RECORD from './audit-database-record';
 export * as ISO_DATE_TIME_STAMP from './iso-date-time-stamp';
-export * as OBJECT_ID from './object-id';
+export { OBJECT_ID } from './object-id';

--- a/libs/common/src/types/mongo-db-models/tfm-teams.ts
+++ b/libs/common/src/types/mongo-db-models/tfm-teams.ts
@@ -1,7 +1,8 @@
+import { WithId } from 'mongodb';
 import { TeamId } from '../tfm/team-id';
 
-export type TfmTeam = {
+export type TfmTeam = WithId<{
   id: TeamId;
   name: string;
   email: string;
-};
+}>;

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -949,7 +949,7 @@ const amendACBSfacility = async (amendments, facility, deal) => {
       return null;
     });
 
-    if (response.data) {
+    if (response?.data) {
       return response.data;
     }
   }

--- a/trade-finance-manager-api/src/v1/controllers/facility.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/facility.controller.js
@@ -45,7 +45,7 @@ const getFacilities = async (req, res) => {
         facility.ukefFacilityId = '-';
       }
 
-      const latestCompletedAmendment = findLatestCompletedAmendment(dbFacility?.amendments);
+      const { value: latestAmendmentValue, coverEndDate: latestAmendmentCoverEndDate } = findLatestCompletedAmendment(dbFacility?.amendments);
       let facilityCoverEndDate = '';
       let facilityCoverEndDateEpoch = '';
 
@@ -58,18 +58,17 @@ const getFacilities = async (req, res) => {
       let facilityCurrencyAndValue = `${facility.currency} ${commaNumber(facility.value)}`;
       let facilityValue = parseInt(facility.value, 10);
 
-      if (latestCompletedAmendment?.value) {
-        const { value, currency } = latestCompletedAmendment.value;
+      if (latestAmendmentValue) {
+        const { value, currency } = latestAmendmentValue;
         const formattedFacilityValue = formatFacilityValue(value);
         facilityCurrencyAndValue = `${currency} ${commaNumber(formattedFacilityValue)}`;
         facilityValue = parseInt(value, 10);
       }
 
-      if (latestCompletedAmendment?.coverEndDate) {
-        const { coverEndDate } = latestCompletedAmendment;
+      if (latestAmendmentCoverEndDate) {
         // * 1000 to convert to ms epoch time format so can be correctly formatted by template
-        facilityCoverEndDate = format(new Date(coverEndDate * 1000), 'dd MMM yyyy');
-        facilityCoverEndDateEpoch = coverEndDate;
+        facilityCoverEndDate = format(new Date(latestAmendmentCoverEndDate * 1000), 'dd MMM yyyy');
+        facilityCoverEndDateEpoch = latestAmendmentCoverEndDate;
       }
 
       facility.coverEndDate = facilityCoverEndDate;

--- a/trade-finance-manager-api/src/v1/rest-mappings/deal-with-amendment-bss.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/deal-with-amendment-bss.api-test.js
@@ -3,7 +3,7 @@ const { CURRENCY } = require('@ukef/dtfs2-common');
 const dealReducer = require('./deal');
 const mapDealSnapshot = require('./mappings/deal/mapDealSnapshot');
 const mapDealTfm = require('./mappings/deal/dealTfm/mapDealTfm');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../constants/deals');
+const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION, AMENDMENT_STATUS } = require('../../constants/deals');
 
 const MOCK_DEAL_AIN_SUBMITTED = require('../__mocks__/mock-deal-AIN-submitted');
 
@@ -11,17 +11,20 @@ describe('gef deal with amendments', () => {
   const coverEndDateUnix = 1658403289;
 
   const mockAmendmentValueResponse = {
+    status: AMENDMENT_STATUS.COMPLETED,
     value: 5000,
     currency: CURRENCY.GBP,
     amendmentId: '1234',
   };
 
   const mockAmendmentDateResponse = {
+    status: AMENDMENT_STATUS.COMPLETED,
     coverEndDate: coverEndDateUnix,
     amendmentId: '1234',
   };
 
   const mockAmendment = {
+    status: AMENDMENT_STATUS.COMPLETED,
     coverEndDate: coverEndDateUnix,
     value: 5000,
     currency: CURRENCY.GBP,

--- a/trade-finance-manager-api/src/v1/rest-mappings/deal-with-amendment-gef.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/deal-with-amendment-gef.api-test.js
@@ -5,17 +5,20 @@ const mapGefDeal = require('./mappings/gef-deal/mapGefDeal');
 
 const MOCK_GEF_DEAL = require('../__mocks__/mock-gef-deal');
 const MOCK_CASH_CONTINGENT_FACILITIES = require('../__mocks__/mock-cash-contingent-facilities');
+const { AMENDMENT_STATUS } = require('../../constants/deals');
 
 describe('gef deal with amendments', () => {
   const coverEndDateUnix = 1658403289;
 
   const mockAmendmentValueResponse = {
+    status: AMENDMENT_STATUS.COMPLETED,
     value: 5000,
     currency: CURRENCY.GBP,
     amendmentId: '1234',
   };
 
   const mockAmendmentDateResponse = {
+    status: AMENDMENT_STATUS.COMPLETED,
     coverEndDate: coverEndDateUnix,
     amendmentId: '1234',
   };

--- a/trade-finance-manager-api/src/v1/rest-mappings/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/helpers/amendment.helpers.js
@@ -1,7 +1,9 @@
 const { CURRENCY } = require('@ukef/dtfs2-common');
+const { orderBy } = require('lodash');
 const { formattedNumber } = require('../../../utils/number');
 const { decimalsCount, roundNumber } = require('../../helpers/number');
 const isValidFacility = require('./isValidFacility.helper');
+const { AMENDMENT_STATUS } = require('../../../constants/deals');
 
 // returns the formatted amendment value and currency (without conversion)
 const amendmentChangeValueExportCurrency = (amendment) => {
@@ -62,21 +64,33 @@ const calculateUkefExposure = (facilityValueInGBP, coverPercentage) => {
   return null;
 };
 
-// returns tfm object from latest amendment if it exists or null
+/**
+ * @typedef {object} LatestCompletedAmendment
+ * @property {{ currency: import('@ukef/dtfs2-common').Currency, value: number }} [value]
+ * @property {import('@ukef/dtfs2-common').UnixTimestamp} [coverEndDate]
+ * @property {number} [amendmentExposurePeriodInMonths]
+ * @property {{ exposure: number, timestamp: import('@ukef/dtfs2-common').UnixTimestamp }} [exposure]
+ */
+
+/**
+ * Get the latest completed amendment values
+ * @param {Record<string, unknown>[]} amendments
+ * @returns {LatestCompletedAmendment}
+ */
 const findLatestCompletedAmendment = (amendments) => {
   if (!amendments) {
-    return null;
-  }
-  // array reversed to get the latest amendment
-  const amendmentsReversed = [...amendments].reverse();
-  // reversed array checked for first tfm object and is returned
-  const tfmAmendmentObject = amendmentsReversed.find((amendment) => amendment.tfm);
-
-  if (tfmAmendmentObject) {
-    return tfmAmendmentObject.tfm;
+    return {};
   }
 
-  return null;
+  const completedAmendments = amendments.filter(({ status }) => status === AMENDMENT_STATUS.COMPLETED);
+  const sortedAmendments = orderBy(completedAmendments, ['updatedAt', 'version'], ['desc', 'asc']);
+  const foundAmendment = sortedAmendments.find((amendment) => amendment.tfm)?.tfm ?? {};
+  if (!foundAmendment.coverEndDate) {
+    foundAmendment.coverEndDate = sortedAmendments.find((amendment) => amendment.coverEndDate)?.coverEndDate;
+  }
+
+  const { value, amendmentExposurePeriodInMonths, exposure, coverEndDate } = foundAmendment;
+  return { value, coverEndDate, amendmentExposurePeriodInMonths, exposure };
 };
 
 // calculates the value for total exposure to return for a single amendment

--- a/trade-finance-manager-api/src/v1/rest-mappings/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/helpers/amendment.helpers.js
@@ -84,13 +84,47 @@ const findLatestCompletedAmendment = (amendments) => {
 
   const completedAmendments = amendments.filter(({ status }) => status === AMENDMENT_STATUS.COMPLETED);
   const sortedAmendments = orderBy(completedAmendments, ['updatedAt', 'version'], ['desc', 'asc']);
-  const foundAmendment = sortedAmendments.find((amendment) => amendment.tfm)?.tfm ?? {};
-  if (!foundAmendment.coverEndDate) {
-    foundAmendment.coverEndDate = sortedAmendments.find((amendment) => amendment.coverEndDate)?.coverEndDate;
-  }
 
-  const { value, amendmentExposurePeriodInMonths, exposure, coverEndDate } = foundAmendment;
-  return { value, coverEndDate, amendmentExposurePeriodInMonths, exposure };
+  /**
+   * The amended coverEndDate can come both from 'amendment' or
+   * 'amendment.tfm'. Preference is given to the value coming from
+   * 'amendment.tfm', but it is set to the value from 'amendment'
+   * if any amendment 'tfm' object does not contain a coverEndDate
+   */
+  let amendmentTfmCoverEndDate;
+  let amendmentCoverEndDate;
+
+  /**
+   * @type {LatestCompletedAmendment}
+   */
+  const latestAmendmentValues = sortedAmendments.reduce((updatedFields, amendment) => {
+    if (!amendment.tfm) {
+      return updatedFields;
+    }
+
+    const existingUpdatedFields = { ...updatedFields };
+
+    if (!updatedFields.value) {
+      existingUpdatedFields.value = amendment.tfm.value;
+    }
+    if (!updatedFields.amendmentExposurePeriodInMonths) {
+      existingUpdatedFields.amendmentExposurePeriodInMonths = amendment.tfm.amendmentExposurePeriodInMonths;
+    }
+    if (!updatedFields.exposure) {
+      existingUpdatedFields.exposure = amendment.tfm.exposure;
+    }
+
+    if (!amendmentTfmCoverEndDate) {
+      amendmentTfmCoverEndDate = amendment.tfm.coverEndDate;
+    }
+    if (!amendmentCoverEndDate) {
+      amendmentCoverEndDate = amendment.coverEndDate;
+    }
+
+    return existingUpdatedFields;
+  }, {});
+  latestAmendmentValues.coverEndDate = amendmentTfmCoverEndDate ?? amendmentCoverEndDate;
+  return latestAmendmentValues;
 };
 
 // calculates the value for total exposure to return for a single amendment

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/deal/mapTotals.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/deal/mapTotals.api-test.js
@@ -1,6 +1,7 @@
 const { CURRENCY } = require('@ukef/dtfs2-common');
 const mapTotals = require('./mapTotals');
 const { formattedNumber } = require('../../../../utils/number');
+const { AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapTotals', () => {
   const mockAmendmentValueResponse = {
@@ -130,8 +131,11 @@ describe('mapTotals', () => {
       mockBondAndLoanFacilities.map((facility) => {
         const facilityMapped = { ...facility };
 
-        facilityMapped.amendments[0].tfm = {
-          value: { ...mockAmendmentValueResponse },
+        facilityMapped.amendments[0] = {
+          status: AMENDMENT_STATUS.COMPLETED,
+          tfm: {
+            value: { ...mockAmendmentValueResponse },
+          },
         };
         return facilityMapped;
       });
@@ -182,8 +186,11 @@ describe('mapTotals', () => {
       mockCashAndContingentFacilities.map((facility) => {
         const facilityMapped = { ...facility };
 
-        facilityMapped.amendments[0].tfm = {
-          value: { ...mockAmendmentValueResponse },
+        facilityMapped.amendments[0] = {
+          status: AMENDMENT_STATUS.COMPLETED,
+          tfm: {
+            value: { ...mockAmendmentValueResponse },
+          },
         };
         return facilityMapped;
       });

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/deal/mapTotals.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/deal/mapTotals.js
@@ -16,10 +16,10 @@ const mapTotals = (facilities) => {
           // if latest amendment then returns value of new amendment
           if (facility?.amendments?.length) {
             const { exchangeRate } = tfm;
-            const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
+            const { value: latestAmendmentValue } = findLatestCompletedAmendment(facility.amendments);
 
-            if (latestAmendmentTFM?.value) {
-              const valueInGBP = calculateNewFacilityValue(exchangeRate, latestAmendmentTFM.value);
+            if (latestAmendmentValue) {
+              const valueInGBP = calculateNewFacilityValue(exchangeRate, latestAmendmentValue);
               return Number(valueInGBP);
             }
           }

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.api-test.js
@@ -1,6 +1,7 @@
 const { format, fromUnixTime, set } = require('date-fns');
 const mapCoverEndDate = require('./mapCoverEndDate');
 const { formatYear } = require('../../../../utils/date');
+const { AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapCoverEndDate', () => {
   it('should return formatted cover end date', () => {
@@ -93,6 +94,7 @@ describe('mapCoverEndDate', () => {
       const mockFacility = {
         amendments: [
           {
+            status: AMENDMENT_STATUS.COMPLETED,
             tfm: {
               coverEndDate: coverEndDateUnix,
             },

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapCoverEndDate.js
@@ -13,15 +13,13 @@ const mapCoverEndDate = (day, month, year, facility) => {
     // if there are amendments present
     if (facility?.amendments?.length) {
       // returns latest completed tfm object from amendment
-      const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
+      const { coverEndDate: latestAmendmentCoverEndDate } = findLatestCompletedAmendment(facility.amendments);
       // if coverEndDate as part of amendment changes
-      if (latestAmendmentTFM?.coverEndDate) {
-        const { coverEndDate } = latestAmendmentTFM;
-
+      if (latestAmendmentCoverEndDate) {
         // maps new coverEndDate from unix timestamp in amendment
-        dayToUse = format(fromUnixTime(coverEndDate), 'dd');
-        monthToUse = format(fromUnixTime(coverEndDate), 'MM');
-        yearToUse = format(fromUnixTime(coverEndDate), 'yyyy');
+        dayToUse = format(fromUnixTime(latestAmendmentCoverEndDate), 'dd');
+        monthToUse = format(fromUnixTime(latestAmendmentCoverEndDate), 'MM');
+        yearToUse = format(fromUnixTime(latestAmendmentCoverEndDate), 'yyyy');
       }
     }
 

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapDates.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapDates.api-test.js
@@ -3,6 +3,7 @@ const mapDates = require('./mapDates');
 const mapCoverEndDate = require('./mapCoverEndDate');
 const mapTenorDate = require('./mapTenorDate');
 const { FACILITIES } = require('../../../../constants');
+const { AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapDates', () => {
   const mockCoverEndDate = {
@@ -114,6 +115,7 @@ describe('mapDates', () => {
 
     mockFacility.amendments = [
       {
+        status: AMENDMENT_STATUS.COMPLETED,
         tfm: {
           coverEndDate: coverEndDateUnix,
           amendmentExposurePeriodInMonths: amendmentTenorPeriod,

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValue.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValue.api-test.js
@@ -1,6 +1,7 @@
 const { CURRENCY } = require('@ukef/dtfs2-common');
 const mapFacilityValue = require('./mapFacilityValue');
 const { formattedNumber } = require('../../../../utils/number');
+const { AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapFacilityValue', () => {
   describe('when no facility provided', () => {
@@ -81,12 +82,16 @@ describe('mapFacilityValue', () => {
     it('should add amendment facility value when amendment complete', () => {
       const amendmentValue = 2000;
 
-      mockFacility.amendments[0].tfm = {
-        value: {
-          value: amendmentValue,
-          currency: CURRENCY.GBP,
+      mockFacility.amendments[0] = {
+        status: AMENDMENT_STATUS.COMPLETED,
+        tfm: {
+          value: {
+            value: amendmentValue,
+            currency: CURRENCY.GBP,
+          },
         },
       };
+
       const result = mapFacilityValue(mockFacility.currency.id, mockFacility.value, mockFacility);
 
       const expected = `${CURRENCY.GBP} ${formattedNumber(amendmentValue)}`;

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValue.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValue.js
@@ -9,10 +9,10 @@ const mapFacilityValue = (currencyId, value, facility) => {
     // if there are amendments in facility
     if (facility?.amendments?.length) {
       const { exchangeRate } = facilityTfm;
-      const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
+      const { value: latestAmendmentValue } = findLatestCompletedAmendment(facility.amendments);
       // if latest completed amendment contains value
-      if (latestAmendmentTFM?.value) {
-        const valueInGBP = calculateNewFacilityValue(exchangeRate, latestAmendmentTFM.value);
+      if (latestAmendmentValue) {
+        const valueInGBP = calculateNewFacilityValue(exchangeRate, latestAmendmentValue);
         return `${CURRENCY.GBP} ${formattedNumber(valueInGBP)}`;
       }
     }

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValueExportCurrency.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValueExportCurrency.js
@@ -9,11 +9,11 @@ const mapFacilityValueExportCurrency = (facility) => {
     const { currency, value } = facilitySnapshot;
     // if amendments in facility
     if (facility?.amendments?.length) {
-      const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
+      const { value: latestAmendmentValue } = findLatestCompletedAmendment(facility.amendments);
 
       // if latest completed amendment contains value
-      if (latestAmendmentTFM?.value) {
-        return amendmentChangeValueExportCurrency(latestAmendmentTFM.value);
+      if (latestAmendmentValue) {
+        return amendmentChangeValueExportCurrency(latestAmendmentValue);
       }
     }
     const formattedFacilityValue = formattedNumber(value);

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValueExporterCurrency.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapFacilityValueExporterCurrency.api-test.js
@@ -1,5 +1,6 @@
 const { CURRENCY } = require('@ukef/dtfs2-common');
 const mapFacilityValueExportCurrency = require('./mapFacilityValueExportCurrency');
+const { AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapFacilityValueExportCurrency()', () => {
   const mockFacility = {
@@ -33,6 +34,7 @@ describe('mapFacilityValueExportCurrency()', () => {
   it('should return the new amendment value when latest amendment is complete', () => {
     mockFacility.amendments = [
       {
+        status: AMENDMENT_STATUS.COMPLETED,
         tfm: {
           value: { ...mockAmendmentValueResponse },
         },

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapTenor.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapTenor.api-test.js
@@ -1,5 +1,6 @@
 const mapTenor = require('./mapTenor');
 const { FACILITY_TYPE } = require('../../../../constants/facilities');
+const { AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapTenor()', () => {
   const coverEndDateUnix = 1658403289;
@@ -91,6 +92,7 @@ describe('mapTenor()', () => {
 
   it('should return tenor from GEF amendment when completed amendment exists', () => {
     mockGefFacility.amendments[0] = {
+      status: AMENDMENT_STATUS.COMPLETED,
       tfm: {
         ...mockAmendmentDateResponse,
       },

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapTenor.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapTenor.js
@@ -14,12 +14,12 @@ const mapTenor = (facilitySnapshot, facilityTfm, facility) => {
 
   // if amendments
   if (facility?.amendments?.length) {
-    const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
+    const { amendmentExposurePeriodInMonths } = findLatestCompletedAmendment(facility.amendments);
 
     // checks if exposure period in months is latest completed amendment
-    if (latestAmendmentTFM?.amendmentExposurePeriodInMonths) {
+    if (amendmentExposurePeriodInMonths) {
       // sets updatedExposurePeriodInMonths as amendment exposure period
-      exposurePeriod = latestAmendmentTFM.amendmentExposurePeriodInMonths;
+      exposurePeriod = amendmentExposurePeriodInMonths;
     }
   }
 

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapUkefExposure.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapUkefExposure.api-test.js
@@ -1,7 +1,7 @@
 const { CURRENCY } = require('@ukef/dtfs2-common');
 const mapUkefExposure = require('./mapUkefExposure');
 const { formattedNumber } = require('../../../../utils/number');
-const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../../../constants/deals');
+const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION, AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapUkefExposure()', () => {
   const mockAmendment = {
@@ -91,8 +91,11 @@ describe('mapUkefExposure()', () => {
       amendments: [{ ...mockAmendment }],
     };
 
-    mockFacility.amendments[0].tfm = {
-      exposure: { ...mockAmendmentValueResponse },
+    mockFacility.amendments[0] = {
+      status: AMENDMENT_STATUS.COMPLETED,
+      tfm: {
+        exposure: { ...mockAmendmentValueResponse },
+      },
     };
 
     const result = mapUkefExposure(mockFacilityTfm, mockFacility);

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapUkefExposure.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapUkefExposure.js
@@ -12,10 +12,10 @@ const mapUkefExposure = (facilityTfm, facility) => {
     let ukefExposureCalculationTimestampValue = ukefExposureCalculationTimestamp;
     // if amendment in facility
     if (facility?.amendments?.length) {
-      const latestAmendmentTFM = findLatestCompletedAmendment(facility.amendments);
+      const { exposure: amendmentExposure } = findLatestCompletedAmendment(facility.amendments);
       // if exposure part of latest tfm object
-      if (latestAmendmentTFM?.exposure) {
-        const { exposure, timestamp } = latestAmendmentTFM.exposure;
+      if (amendmentExposure) {
+        const { exposure, timestamp } = amendmentExposure;
         // sets new exposure value based on amendment value
         formattedUkefExposure = exposure;
         // sets timestamp from amendment exposure timestamp

--- a/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapUkefExposureValue.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/mappings/facilities/mapUkefExposureValue.api-test.js
@@ -1,7 +1,7 @@
 const { CURRENCY } = require('@ukef/dtfs2-common');
 const mapUkefExposureValue = require('./mapUkefExposureValue');
 const { formattedNumber } = require('../../../../utils/number');
-const { AMENDMENT_UW_DECISION } = require('../../../../constants/deals');
+const { AMENDMENT_UW_DECISION, AMENDMENT_STATUS } = require('../../../../constants/deals');
 
 describe('mapUkefExposureValue()', () => {
   const mockAmendmentValueResponse = {
@@ -46,8 +46,11 @@ describe('mapUkefExposureValue()', () => {
   });
 
   it('should return exposure from amendment if amendment completed', () => {
-    mockFacility.amendments[0].tfm = {
-      exposure: { ...mockAmendmentValueResponse },
+    mockFacility.amendments[0] = {
+      status: AMENDMENT_STATUS.COMPLETED,
+      tfm: {
+        exposure: { ...mockAmendmentValueResponse },
+      },
     };
     const result = mapUkefExposureValue(mockFacilityTfm, mockFacility);
 

--- a/trade-finance-manager-ui/server/controllers/case/amendments/amendCoverEndDate.controller.js
+++ b/trade-finance-manager-ui/server/controllers/case/amendments/amendCoverEndDate.controller.js
@@ -25,7 +25,7 @@ const getAmendCoverEndDate = async (req, res) => {
   }
 
   const facility = await api.getFacility(facilityId, userToken);
-  const { data: latestAmendmentCoverEndDate } = await api.getLatestCompletedAmendmentDate(facilityId, amendmentId, userToken);
+  const { data: latestAmendmentCoverEndDate } = await api.getLatestCompletedAmendmentDate(facilityId, userToken);
 
   let currentCoverEndDate = format(new Date(facility.facilitySnapshot.dates.coverEndDate), 'dd MMMM yyyy');
 
@@ -51,7 +51,7 @@ const postAmendCoverEndDate = async (req, res) => {
   const { data: amendment } = await api.getAmendmentById(facilityId, amendmentId, userToken);
   const { dealId } = amendment;
   const facility = await api.getFacility(facilityId, userToken);
-  const { data: latestAmendmentCoverEndDate } = await api.getLatestCompletedAmendmentDate(facilityId, amendmentId, userToken);
+  const { data: latestAmendmentCoverEndDate } = await api.getLatestCompletedAmendmentDate(facilityId, userToken);
 
   let currentCoverEndDate = format(new Date(facility.facilitySnapshot.dates.coverEndDate), 'dd MMMM yyyy');
 


### PR DESCRIPTION
## Introduction :pencil2:
We want a repo for the mongo tfm facilities collection.

## Resolution :heavy_check_mark:
- Adds a new `TfmFacilitiesRepo` class
- Updates the existing tfm-facilities controller to be typescript and use the new repo
- Adds static helpers to the `TfmFacilitiesRepo` which parses a found mongo collection item*

*the type of the tfm-facilities collection is not always consistent and is hard to document. In order to reach a compromise between overly strict type checking and no type information at all, we introduce a set of methods on the `TfmFacilitiesRepo` to parse any result from a call to the repo. The parser uses a `zod` schema to validate the information that we expect to exist on the document and, if valid, returns the parsed data. The schema which is used to parse this data should be extended with new fields as and when they are needed.

## Miscellaneous :heavy_plus_sign:
- Adds generic to audit logs delete many method added by @MarRobSoftwire which allows for type inference on the filter
