### PR TITLE
feat(FN-1728): mark keying data as done/to do buttons

### DIFF
--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -286,68 +286,6 @@ utilisationReportsRouter
 
 /**
  * @openapi
- * /utilisation-reports/:reportId/keying-data/mark-as-done:
- *   put:
- *     summary: Put keying sheet data status to DONE for multiple fee records
- *     tags: [Utilisation Report]
- *     description: Mark multiple fee records within a keying sheet as keying sheet row status DONE
- *     requestBody:
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               feeRecordIds:
- *                 type: array
- *                 items:
- *                   type: number
- *               user:
- *                 $ref: '#/definitions/TFMUser'
- *     responses:
- *       200:
- *         description: OK
- *       400:
- *         description: Bad request
- *       500:
- *         description: Internal Server Error
- */
-utilisationReportsRouter
-  .route('/:reportId/keying-data/mark-as-done')
-  .put(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, validatePutKeyingDataMarkAsPayload, putKeyingDataMarkAsDone);
-
-/**
- * @openapi
- * /utilisation-reports/:reportId/keying-data/mark-as-to-do:
- *   put:
- *     summary: Put keying sheet data status to TO DO for multiple fee records
- *     tags: [Utilisation Report]
- *     description: Mark multiple fee records within a keying sheet as keying sheet row status TO DO
- *     requestBody:
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               feeRecordIds:
- *                 type: array
- *                 items:
- *                   type: number
- *               user:
- *                 $ref: '#/definitions/TFMUser'
- *     responses:
- *       200:
- *         description: OK
- *       400:
- *         description: Bad request
- *       500:
- *         description: Internal Server Error
- */
-utilisationReportsRouter
-  .route('/:reportId/keying-data/mark-as-to-do')
-  .put(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, validatePutKeyingDataMarkAsPayload, putKeyingDataMarkAsToDo);
-
-/**
- * @openapi
  * /utilisation-reports/:reportId/keying-data:
  *   post:
  *     summary: Generate keying data for a utilisation report
@@ -447,7 +385,7 @@ utilisationReportsRouter
 
 /**
  * @openapi
- * /utilisation-reports/:reportId/keying-data/mark-as-done:
+ * /utilisation-reports/:reportId/keying-data/mark-as-to-do:
  *   put:
  *     summary: Put keying sheet data status to TO DO for multiple fee records
  *     tags: [Utilisation Report]

--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -286,6 +286,68 @@ utilisationReportsRouter
 
 /**
  * @openapi
+ * /utilisation-reports/:reportId/keying-data/mark-as-done:
+ *   put:
+ *     summary: Put keying sheet data status to DONE for multiple fee records
+ *     tags: [Utilisation Report]
+ *     description: Mark multiple fee records within a keying sheet as keying sheet row status DONE
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               feeRecordIds:
+ *                 type: array
+ *                 items:
+ *                   type: number
+ *               user:
+ *                 $ref: '#/definitions/TFMUser'
+ *     responses:
+ *       200:
+ *         description: OK
+ *       400:
+ *         description: Bad request
+ *       500:
+ *         description: Internal Server Error
+ */
+utilisationReportsRouter
+  .route('/:reportId/keying-data/mark-as-done')
+  .put(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, validatePutKeyingDataMarkAsPayload, putKeyingDataMarkAsDone);
+
+/**
+ * @openapi
+ * /utilisation-reports/:reportId/keying-data/mark-as-to-do:
+ *   put:
+ *     summary: Put keying sheet data status to TO DO for multiple fee records
+ *     tags: [Utilisation Report]
+ *     description: Mark multiple fee records within a keying sheet as keying sheet row status TO DO
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               feeRecordIds:
+ *                 type: array
+ *                 items:
+ *                   type: number
+ *               user:
+ *                 $ref: '#/definitions/TFMUser'
+ *     responses:
+ *       200:
+ *         description: OK
+ *       400:
+ *         description: Bad request
+ *       500:
+ *         description: Internal Server Error
+ */
+utilisationReportsRouter
+  .route('/:reportId/keying-data/mark-as-to-do')
+  .put(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, validatePutKeyingDataMarkAsPayload, putKeyingDataMarkAsToDo);
+
+/**
+ * @openapi
  * /utilisation-reports/:reportId/keying-data:
  *   post:
  *     summary: Generate keying data for a utilisation report
@@ -385,7 +447,7 @@ utilisationReportsRouter
 
 /**
  * @openapi
- * /utilisation-reports/:reportId/keying-data/mark-as-to-do:
+ * /utilisation-reports/:reportId/keying-data/mark-as-done:
  *   put:
  *     summary: Put keying sheet data status to TO DO for multiple fee records
  *     tags: [Utilisation Report]

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -241,6 +241,8 @@ module.exports = {
   getUtilisationReportReconciliationDetailsById: jest.fn(),
   addPaymentToFeeRecords: jest.fn(),
   generateKeyingData: jest.fn(),
+  markKeyingDataAsDone: jest.fn(),
+  markKeyingDataAsToDo: jest.fn(),
   getUtilisationReportWithFeeRecordsToKey: jest.fn(),
   getPaymentDetails: jest.fn(),
   deletePaymentById: jest.fn(),

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -1357,6 +1357,44 @@ const generateKeyingData = async (reportId, user) => {
 };
 
 /**
+ * Updates keying sheet fee records with supplied ids to DONE
+ * @param {string} reportId - The report id
+ * @param {number[]} feeRecordIds - The ids of the fee records to mark as DONE
+ * @param {import('./types/tfm-session-user').TfmSessionUser} user - The session user
+ * @returns {Promise<{}>}
+ */
+const markKeyingDataAsDone = async (reportId, feeRecordIds, user) => {
+  await axios({
+    method: 'put',
+    url: `${DTFS_CENTRAL_API_URL}/v1/utilisation-reports/${reportId}/keying-data/mark-as-done`,
+    headers: headers.central,
+    data: {
+      user,
+      feeRecordIds,
+    },
+  });
+};
+
+/**
+ * Updates keying sheet fee records with supplied ids to TO_DO
+ * @param {string} reportId - The report id
+ * @param {number[]} feeRecordIds - The ids of the fee records to mark as TO_DO
+ * @param {import('./types/tfm-session-user').TfmSessionUser} user - The session user
+ * @returns {Promise<{}>}
+ */
+const markKeyingDataAsToDo = async (reportId, feeRecordIds, user) => {
+  await axios({
+    method: 'put',
+    url: `${DTFS_CENTRAL_API_URL}/v1/utilisation-reports/${reportId}/keying-data/mark-as-to-do`,
+    headers: headers.central,
+    data: {
+      user,
+      feeRecordIds,
+    },
+  });
+};
+
+/**
  * Gets the utilisation report with the supplied id and the
  * fee records to key
  * @param {string} reportId - The report id
@@ -1508,6 +1546,8 @@ module.exports = {
   getUtilisationReportSummariesByBankIdAndYear,
   addPaymentToFeeRecords,
   generateKeyingData,
+  markKeyingDataAsDone,
+  markKeyingDataAsToDo,
   getUtilisationReportWithFeeRecordsToKey,
   getPaymentDetails,
   deletePaymentById,

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/index.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/index.ts
@@ -11,3 +11,5 @@ export { getPaymentDetailsById } from './get-payment-details-by-id.controller';
 export { deletePayment } from './delete-payment.controller';
 export { patchPayment } from './patch-payment.controller';
 export { postRemoveFeesFromPayment } from './post-remove-fees-from-payment.controller';
+export { putKeyingDataMarkAsDone } from './put-keying-data-mark-as-done.controller';
+export { putKeyingDataMarkAsToDo } from './put-keying-data-mark-as-to-do.controller';

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-done.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-done.controller.test.ts
@@ -1,0 +1,88 @@
+import httpMocks from 'node-mocks-http';
+import { AxiosResponse, HttpStatusCode, AxiosError } from 'axios';
+import api from '../../api';
+import { aTfmSessionUser } from '../../../../test-helpers';
+import { putKeyingDataMarkAsDone } from './put-keying-data-mark-as-done.controller';
+
+console.error = jest.fn();
+
+jest.mock('../../api');
+
+describe('put-keying-data-mark-as-done.controller', () => {
+  describe('putKeyingDataMarkAsDone', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    const reportId = '12';
+    const feeRecordIds = [1, 2];
+    const user = aTfmSessionUser();
+
+    const getHttpMocks = () =>
+      httpMocks.createMocks({
+        params: { reportId },
+        body: {
+          user,
+          feeRecordIds,
+        },
+      });
+
+    it('marks keying data as DONE and responds with a 200', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await putKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(api.markKeyingDataAsDone).toHaveBeenCalledWith(reportId, feeRecordIds, user);
+      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with a 500 if an unknown error occurs', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.markKeyingDataAsDone).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await putKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with a specific error code if an axios error is thrown', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const errorStatus = HttpStatusCode.BadRequest;
+      const axiosError = new AxiosError(undefined, undefined, undefined, undefined, { status: errorStatus } as AxiosResponse);
+
+      jest.mocked(api.markKeyingDataAsDone).mockRejectedValue(axiosError);
+
+      // Act
+      await putKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with an error message', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.markKeyingDataAsDone).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await putKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(res._getData()).toBe('Failed to mark keying data as done');
+      expect(res._isEndCalled()).toBe(true);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-done.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-done.controller.ts
@@ -1,0 +1,28 @@
+import { HttpStatusCode, isAxiosError } from 'axios';
+import { Response } from 'express';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import api from '../../api';
+import { TfmSessionUser } from '../../../types/tfm-session-user';
+
+type PutKeyingDataMarkAsDoneRequest = CustomExpressRequest<{
+  reqBody: {
+    user: TfmSessionUser;
+    feeRecordIds: number[];
+  };
+}>;
+
+export const putKeyingDataMarkAsDone = async (req: PutKeyingDataMarkAsDoneRequest, res: Response) => {
+  const { reportId } = req.params;
+  const { feeRecordIds, user } = req.body;
+
+  try {
+    await api.markKeyingDataAsDone(reportId, feeRecordIds, user);
+
+    return res.sendStatus(HttpStatusCode.Ok);
+  } catch (error) {
+    const errorMessage = 'Failed to mark keying data as done';
+    console.error(errorMessage, error);
+    const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
+    return res.status(errorStatus).send(errorMessage);
+  }
+};

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.test.ts
@@ -27,7 +27,7 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
         },
       });
 
-    it('marks keying data as DONE and responds with a 200', async () => {
+    it('marks keying data as TO_DO and responds with a 200', async () => {
       // Arrange
       const { req, res } = getHttpMocks();
 

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.test.ts
@@ -1,0 +1,88 @@
+import httpMocks from 'node-mocks-http';
+import { AxiosResponse, HttpStatusCode, AxiosError } from 'axios';
+import api from '../../api';
+import { aTfmSessionUser } from '../../../../test-helpers';
+import { putKeyingDataMarkAsToDo } from './put-keying-data-mark-as-to-do.controller';
+
+console.error = jest.fn();
+
+jest.mock('../../api');
+
+describe('put-keying-data-mark-as-to-do.controller', () => {
+  describe('putKeyingDataMarkAsToDo', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    const reportId = '12';
+    const feeRecordIds = [1, 2];
+    const user = aTfmSessionUser();
+
+    const getHttpMocks = () =>
+      httpMocks.createMocks({
+        params: { reportId },
+        body: {
+          user,
+          feeRecordIds,
+        },
+      });
+
+    it('marks keying data as DONE and responds with a 200', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await putKeyingDataMarkAsToDo(req, res);
+
+      // Assert
+      expect(api.markKeyingDataAsToDo).toHaveBeenCalledWith(reportId, feeRecordIds, user);
+      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with a 500 if an unknown error occurs', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.markKeyingDataAsToDo).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await putKeyingDataMarkAsToDo(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with a specific error code if an axios error is thrown', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      const errorStatus = HttpStatusCode.BadRequest;
+      const axiosError = new AxiosError(undefined, undefined, undefined, undefined, { status: errorStatus } as AxiosResponse);
+
+      jest.mocked(api.markKeyingDataAsToDo).mockRejectedValue(axiosError);
+
+      // Act
+      await putKeyingDataMarkAsToDo(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('responds with an error message', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.markKeyingDataAsToDo).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await putKeyingDataMarkAsToDo(req, res);
+
+      // Assert
+      expect(res._getData()).toBe('Failed to mark keying data as to do');
+      expect(res._isEndCalled()).toBe(true);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.ts
@@ -1,0 +1,28 @@
+import { HttpStatusCode, isAxiosError } from 'axios';
+import { Response } from 'express';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import api from '../../api';
+import { TfmSessionUser } from '../../../types/tfm-session-user';
+
+type PutKeyingDataMarkAsToDoRequest = CustomExpressRequest<{
+  reqBody: {
+    user: TfmSessionUser;
+    feeRecordIds: number[];
+  };
+}>;
+
+export const putKeyingDataMarkAsToDo = async (req: PutKeyingDataMarkAsToDoRequest, res: Response) => {
+  const { reportId } = req.params;
+  const { feeRecordIds, user } = req.body;
+
+  try {
+    await api.markKeyingDataAsToDo(reportId, feeRecordIds, user);
+
+    return res.sendStatus(HttpStatusCode.Ok);
+  } catch (error) {
+    const errorMessage = 'Failed to mark keying data as to do';
+    console.error(errorMessage, error);
+    const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
+    return res.status(errorStatus).send(errorMessage);
+  }
+};

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -162,6 +162,14 @@ authRouter
   );
 
 authRouter
+  .route('/utilisation-reports/:reportId/keying-data/mark-as-done')
+  .put(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, utilisationReportsController.putKeyingDataMarkAsDone);
+
+authRouter
+  .route('/utilisation-reports/:reportId/keying-data/mark-as-to-do')
+  .put(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, utilisationReportsController.putKeyingDataMarkAsToDo);
+
+authRouter
   .route('/utilisation-reports/:reportId/keying-data')
   .post(validation.sqlIdValidation('reportId'), handleExpressValidatorResult, utilisationReportsController.postKeyingData);
 

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
@@ -32,7 +32,7 @@ describe(component, () => {
       amount: '100',
       change: 'INCREASE',
     },
-    checkboxId: 'feeRecordId-1',
+    checkboxId: 'feeRecordId-1-status-TO_DO',
     isChecked: false,
   });
 
@@ -205,10 +205,10 @@ describe(component, () => {
     const userCanEdit = true;
 
     it('renders the select fee record checkbox with the supplied checkbox id', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), checkboxId: 'feeRecordId-123' };
+      const KeyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), checkboxId: 'feeRecordId-123-status-DONE' };
       const wrapper = getWrapper({ userCanEdit, KeyingSheetRow });
 
-      wrapper.expectElement('tr input[type="checkbox"]#feeRecordId-123').toExist();
+      wrapper.expectElement('tr input[type="checkbox"]#feeRecordId-123-status-DONE').toExist();
     });
 
     it('renders the select fee record checkbox as checked when isChecked is set to true', () => {
@@ -262,7 +262,7 @@ describe(component, () => {
         status: 'TO_DO',
         displayStatus: 'TO DO',
         baseCurrency: 'EUR',
-        checkboxId: 'feeRecordId-123',
+        checkboxId: 'feeRecordId-123-status-TO_DO',
         fixedFeeAdjustment: { change: 'NONE', amount: '0' },
         premiumAccrualBalanceAdjustment: { change: 'NONE', amount: '0' },
         principalBalanceAdjustment: { change: 'NONE', amount: '0' },

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
@@ -36,11 +36,11 @@ describe(component, () => {
     isChecked: false,
   });
 
-  const getWrapper = ({ KeyingSheetRow, userCanEdit }: { KeyingSheetRow?: KeyingSheetTableRow; userCanEdit?: boolean } = {}) =>
-    render({ KeyingSheetRow: KeyingSheetRow ?? aKeyingSheetTableRow(), userCanEdit: userCanEdit ?? true });
+  const getWrapper = ({ keyingSheetRow, userCanEdit }: { keyingSheetRow?: KeyingSheetTableRow; userCanEdit?: boolean } = {}) =>
+    render({ keyingSheetRow: keyingSheetRow ?? aKeyingSheetTableRow(), userCanEdit: userCanEdit ?? true });
 
   it('renders the keying sheet status, facility id, exporter, base currency and fee payment in the table row', () => {
-    const KeyingSheetRow: KeyingSheetTableRow = {
+    const keyingSheetRow: KeyingSheetTableRow = {
       ...aKeyingSheetTableRow(),
       status: 'TO_DO',
       displayStatus: 'TO DO',
@@ -48,7 +48,7 @@ describe(component, () => {
       exporter: 'some exporter',
       baseCurrency: 'EUR',
     };
-    const wrapper = getWrapper({ KeyingSheetRow });
+    const wrapper = getWrapper({ keyingSheetRow });
 
     wrapper.expectElement(`tr td:contains("TO DO")`).toExist();
     wrapper.expectElement(`tr td:contains("some facility id")`).toExist();
@@ -57,7 +57,7 @@ describe(component, () => {
   });
 
   it('renders the fee payment column with the numeric cell class and date received column', () => {
-    const KeyingSheetRow: KeyingSheetTableRow = {
+    const keyingSheetRow: KeyingSheetTableRow = {
       ...aKeyingSheetTableRow(),
       feePayments: [
         {
@@ -66,7 +66,7 @@ describe(component, () => {
         },
       ],
     };
-    const wrapper = getWrapper({ KeyingSheetRow });
+    const wrapper = getWrapper({ keyingSheetRow });
 
     wrapper.expectElement('tr td:contains("GBP 111.11")').toExist();
     wrapper.expectElement('tr td:contains("GBP 111.11")').hasClass('govuk-table__cell--numeric');
@@ -82,13 +82,13 @@ describe(component, () => {
 
   it("renders the '-' in all the increase and decrease adjustment cells when the adjustment change is 'NONE'", () => {
     const change = 'NONE';
-    const KeyingSheetRow: KeyingSheetTableRow = {
+    const keyingSheetRow: KeyingSheetTableRow = {
       ...aKeyingSheetTableRow(),
       fixedFeeAdjustment: { change, amount: '111.11' },
       premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
       principalBalanceAdjustment: { change, amount: '333.33' },
     };
-    const wrapper = getWrapper({ KeyingSheetRow });
+    const wrapper = getWrapper({ keyingSheetRow });
 
     wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).toHaveCount(3);
     wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).toHaveCount(3);
@@ -103,46 +103,46 @@ describe(component, () => {
     const increaseColumnSelector = 'tr td[data-cy="keying-sheet-adjustment--increase"]';
 
     it('renders the fixed fee adjustment amount in the increase column with the numeric cell class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`${increaseColumnSelector}:contains("111.11")`).toExist();
       wrapper.expectElement(`${increaseColumnSelector}:contains("111.11")`).hasClass('govuk-table__cell--numeric');
     });
 
     it('renders the premium accrual balance adjustment in the increase column with the numeric cell class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`${increaseColumnSelector}:contains("222.22")`).toExist();
       wrapper.expectElement(`${increaseColumnSelector}:contains("222.22")`).hasClass('govuk-table__cell--numeric');
     });
 
     it('renders the principal balance adjustment in the increase column with the numeric cell class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         principalBalanceAdjustment: { change, amount: '333.33' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`${increaseColumnSelector}:contains("333.33")`).toExist();
       wrapper.expectElement(`${increaseColumnSelector}:contains("333.33")`).hasClass('govuk-table__cell--numeric');
     });
 
     it("sets all the decrease columns to the '-' character and does not use the numeric cell class", () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
         premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
         principalBalanceAdjustment: { change, amount: '333.33' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).toHaveCount(3);
       wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
@@ -155,46 +155,46 @@ describe(component, () => {
     const decreaseColumnSelector = 'tr td[data-cy="keying-sheet-adjustment--decrease"]';
 
     it('renders the fixed fee adjustment amount in the decrease column with the numeric cell class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`${decreaseColumnSelector}:contains("111.11")`).toExist();
       wrapper.expectElement(`${decreaseColumnSelector}:contains("111.11")`).hasClass('govuk-table__cell--numeric');
     });
 
     it('renders the premium accrual balance adjustment in the decrease column with the numeric cell class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`${decreaseColumnSelector}:contains("222.22")`).toExist();
       wrapper.expectElement(`${decreaseColumnSelector}:contains("222.22")`).hasClass('govuk-table__cell--numeric');
     });
 
     it('renders the principal balance adjustment in the decrease column with the numeric cell class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         principalBalanceAdjustment: { change, amount: '333.33' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`${decreaseColumnSelector}:contains("333.33")`).toExist();
       wrapper.expectElement(`${decreaseColumnSelector}:contains("333.33")`).hasClass('govuk-table__cell--numeric');
     });
 
     it("sets all the increase columns to the '-' character and does not use the numeric cell class", () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
         premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
         principalBalanceAdjustment: { change, amount: '333.33' },
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).toHaveCount(3);
       wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
@@ -205,23 +205,23 @@ describe(component, () => {
     const userCanEdit = true;
 
     it('renders the select fee record checkbox with the supplied checkbox id', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), checkboxId: 'feeRecordId-123-status-DONE' };
-      const wrapper = getWrapper({ userCanEdit, KeyingSheetRow });
+      const keyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), checkboxId: 'feeRecordId-123-status-DONE' };
+      const wrapper = getWrapper({ userCanEdit, keyingSheetRow });
 
       wrapper.expectElement('tr input[type="checkbox"]#feeRecordId-123-status-DONE').toExist();
     });
 
     it('renders the select fee record checkbox as checked when isChecked is set to true', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), isChecked: true };
-      const wrapper = getWrapper({ userCanEdit, KeyingSheetRow });
+      const keyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), isChecked: true };
+      const wrapper = getWrapper({ userCanEdit, keyingSheetRow });
 
       wrapper.expectElement('tr input[type="checkbox"]').toHaveCount(1);
       wrapper.expectInput('tr input[type="checkbox"]').toBeChecked();
     });
 
     it('renders the select fee record checkbox as not checked when isChecked is set to false', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), isChecked: false };
-      const wrapper = getWrapper({ userCanEdit, KeyingSheetRow });
+      const keyingSheetRow: KeyingSheetTableRow = { ...aKeyingSheetTableRow(), isChecked: false };
+      const wrapper = getWrapper({ userCanEdit, keyingSheetRow });
 
       wrapper.expectElement('tr input[type="checkbox"]').toHaveCount(1);
       wrapper.expectInput('tr input[type="checkbox"]').notToBeChecked();
@@ -245,17 +245,17 @@ describe(component, () => {
     });
 
     it('renders as many rows as there are fee payments', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         feePayments: [aFeePayment(), aFeePayment(), aFeePayment()],
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement('tr').toHaveCount(3);
     });
 
     it('renders the none-fee payment keying sheet data and checkbox only in the first row', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         facilityId: '12345678',
         exporter: 'Test exporter 1',
@@ -268,7 +268,7 @@ describe(component, () => {
         principalBalanceAdjustment: { change: 'NONE', amount: '0' },
         feePayments: [aFeePayment(), aFeePayment(), aFeePayment()],
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement('tr').toHaveCount(3);
 
@@ -298,7 +298,7 @@ describe(component, () => {
     });
 
     it('sets the data sort value for each row to match the value in the first row for the status, facility id and exporter', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         status: 'TO_DO',
         displayStatus: 'TO DO',
@@ -306,7 +306,7 @@ describe(component, () => {
         exporter: 'Test exporter 1',
         feePayments: [aFeePayment(), aFeePayment(), aFeePayment()],
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement('tr').toHaveCount(3);
 
@@ -324,11 +324,11 @@ describe(component, () => {
     });
 
     it('renders every cell except those in the last row using the no border class', () => {
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         feePayments: [aFeePayment(), aFeePayment(), aFeePayment()],
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement('tr:eq(0) td.no-border').toHaveCount(13);
       wrapper.expectElement('tr:eq(1) td.no-border').toHaveCount(13);
@@ -341,11 +341,11 @@ describe(component, () => {
         { formattedCurrencyAndAmount: 'GBP 222.22', formattedDateReceived: 'February 2' },
         { formattedCurrencyAndAmount: 'GBP 333.33', formattedDateReceived: 'March 3' },
       ];
-      const KeyingSheetRow: KeyingSheetTableRow = {
+      const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         feePayments,
       };
-      const wrapper = getWrapper({ KeyingSheetRow });
+      const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement('tr').toHaveCount(3);
 

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table.component-test.ts
@@ -38,7 +38,7 @@ describe(component, () => {
           amount: '100',
           change: 'INCREASE',
         },
-        checkboxId: 'feeRecordId-1',
+        checkboxId: 'feeRecordId-1-status-TO_DO',
         isChecked: false,
       },
     ],

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table.component-test.ts
@@ -110,7 +110,7 @@ describe(component, () => {
       const wrapper = getWrapper({ ...aKeyingSheetTableViewModel(), userCanEdit });
 
       wrapper.expectElement('thead input#select-all-checkbox').toExist();
-      wrapper.expectElement('thead th:has(input#select-all-checkbox)').toHaveAttribute('rowspan', '2');
+      wrapper.expectElement('thead td:has(input#select-all-checkbox)').toHaveAttribute('rowspan', '2');
     });
   });
 

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
@@ -180,10 +180,12 @@ describe(page, () => {
     const markAsDoneButtonSelector = `${keyingSheetTabSelector} [data-cy="keying-sheet-mark-as-done-button"]`;
     wrapper.expectInput(markAsDoneButtonSelector).toHaveValue('Mark as done');
     wrapper.expectElement(markAsDoneButtonSelector).toHaveAttribute('formaction', `/utilisation-reports/${reportId}/keying-data/mark-as-done`);
+    wrapper.expectElement(markAsDoneButtonSelector).doesNotHaveClass('govuk-button--secondary');
 
     const markAsToDoButtonSelector = `${keyingSheetTabSelector} [data-cy="keying-sheet-mark-as-to-do-button"]`;
     wrapper.expectInput(markAsToDoButtonSelector).toHaveValue('Mark as to do');
     wrapper.expectElement(markAsToDoButtonSelector).toHaveAttribute('formaction', `/utilisation-reports/${reportId}/keying-data/mark-as-to-do`);
+    wrapper.expectElement(markAsToDoButtonSelector).hasClass('govuk-button--secondary');
 
     wrapper.expectElement(`${keyingSheetTabSelector} table[data-cy="keying-sheet-table"]`).toExist();
   });

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
@@ -177,9 +177,13 @@ describe(page, () => {
 
     wrapper.expectElement(`${keyingSheetTabSelector} div.govuk-button-group`).toExist();
 
-    wrapper.expectPrimaryButton(`${keyingSheetTabSelector} [data-cy="keying-sheet-mark-as-done-button"]`).toLinkTo('#', 'Mark as done');
+    const markAsDoneButtonSelector = `${keyingSheetTabSelector} [data-cy="keying-sheet-mark-as-done-button"]`;
+    wrapper.expectInput(markAsDoneButtonSelector).toHaveValue('Mark as done');
+    wrapper.expectElement(markAsDoneButtonSelector).toHaveAttribute('formaction', `/utilisation-reports/${reportId}/keying-data/mark-as-done`);
 
-    wrapper.expectSecondaryButton(`${keyingSheetTabSelector} [data-cy="keying-sheet-mark-as-to-do-button"]`).toLinkTo('#', 'Mark as to do');
+    const markAsToDoButtonSelector = `${keyingSheetTabSelector} [data-cy="keying-sheet-mark-as-to-do-button"]`;
+    wrapper.expectInput(markAsToDoButtonSelector).toHaveValue('Mark as to do');
+    wrapper.expectElement(markAsToDoButtonSelector).toHaveAttribute('formaction', `/utilisation-reports/${reportId}/keying-data/mark-as-to-do`);
 
     wrapper.expectElement(`${keyingSheetTabSelector} table[data-cy="keying-sheet-table"]`).toExist();
   });

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -987,6 +987,48 @@ const generateKeyingData = async (reportId, user, userToken) => {
 };
 
 /**
+ * Updates keying sheet fee records with supplied ids to DONE
+ * @param {string} reportId - The report id
+ * @param {number[]} feeRecordIds - The ids of the fee records to mark as DONE
+ * @param {import('./types/tfm-session-user').TfmSessionUser} user - The session user
+ * @param {string} userToken - The user token
+ * @returns {Promise<{}>}
+ */
+const markKeyingDataAsDone = async (reportId, feeRecordIds, user, userToken) => {
+  const response = await axios({
+    method: 'put',
+    url: `${TFM_API_URL}/v1/utilisation-reports/${reportId}/keying-data/mark-as-done`,
+    headers: generateHeaders(userToken),
+    data: {
+      user,
+      feeRecordIds,
+    },
+  });
+  return response.data;
+};
+
+/**
+ * Updates keying sheet fee records with supplied ids to TO_DO
+ * @param {string} reportId - The report id
+ * @param {number[]} feeRecordIds - The ids of the fee records to mark as TO_DO
+ * @param {import('./types/tfm-session-user').TfmSessionUser} user - The session user
+ * @param {string} userToken - The user token
+ * @returns {Promise<{}>}
+ */
+const markKeyingDataAsToDo = async (reportId, feeRecordIds, user, userToken) => {
+  const response = await axios({
+    method: 'put',
+    url: `${TFM_API_URL}/v1/utilisation-reports/${reportId}/keying-data/mark-as-to-do`,
+    headers: generateHeaders(userToken),
+    data: {
+      user,
+      feeRecordIds,
+    },
+  });
+  return response.data;
+};
+
+/**
  * Gets the utilisation report with the fee
  * records to key
  * @param {string} reportId - The report id
@@ -1138,6 +1180,8 @@ module.exports = {
   getReportSummariesByBankAndYear,
   addPaymentToFeeRecords,
   generateKeyingData,
+  markKeyingDataAsDone,
+  markKeyingDataAsToDo,
   getUtilisationReportWithFeeRecordsToKey,
   getPaymentDetailsWithFeeRecords,
   getPaymentDetailsWithoutFeeRecords,

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -654,16 +654,16 @@ describe('reconciliation-for-report-helper', () => {
       },
     );
 
-    it('sets the keying sheet view model checkbox id using the keying sheet fee record id', () => {
+    it('sets the keying sheet view model checkbox id using the keying sheet fee record id and status', () => {
       // Arrange
-      const keyingSheet: KeyingSheet = [{ ...aKeyingSheetRow(), feeRecordId: 123 }];
+      const keyingSheet: KeyingSheet = [{ ...aKeyingSheetRow(), feeRecordId: 123, status: 'TO_DO' }];
 
       // Act
       const result = mapKeyingSheetToKeyingSheetViewModel(keyingSheet);
 
       // Assert
       expect(result).toHaveLength(1);
-      expect(result[0].checkboxId).toBe('feeRecordId-123');
+      expect(result[0].checkboxId).toBe('feeRecordId-123-status-TO_DO');
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
@@ -13,6 +13,7 @@ import { getKeyToCurrencyAndAmountSortValueMap } from './get-key-to-currency-and
 import { PremiumPaymentsTableCheckboxId } from '../../../types/premium-payments-table-checkbox-id';
 import { getFeeRecordDisplayStatus } from './get-fee-record-display-status';
 import { getKeyingSheetDisplayStatus } from './get-keying-sheet-display-status';
+import { KeyingSheetCheckboxId } from '../../../types/keying-sheet-checkbox-id';
 
 const sortFeeRecordsByReportedPayments = (feeRecords: FeeRecord[]): FeeRecord[] =>
   orderBy(feeRecords, [({ reportedPayments }) => reportedPayments.currency, ({ reportedPayments }) => reportedPayments.amount], ['asc']);
@@ -126,6 +127,9 @@ const mapKeyingSheetFeePaymentsToKeyingSheetFeePaymentsViewModel = (feePayments:
     formattedDateReceived: format(new Date(dateReceived), 'd MMM yyyy'),
   }));
 
+const getKeyingSheetRowCheckboxId = (keyingSheetRow: KeyingSheetRow): KeyingSheetCheckboxId =>
+  `feeRecordId-${keyingSheetRow.feeRecordId}-status-${keyingSheetRow.status}`;
+
 /**
  * Maps the keying sheet to the keying sheet view model
  * @param keyingSheet - The keying sheet
@@ -142,6 +146,6 @@ export const mapKeyingSheetToKeyingSheetViewModel = (keyingSheet: KeyingSheet): 
     fixedFeeAdjustment: getKeyingSheetAdjustmentViewModel(keyingSheetRow.fixedFeeAdjustment),
     premiumAccrualBalanceAdjustment: getKeyingSheetAdjustmentViewModel(keyingSheetRow.premiumAccrualBalanceAdjustment),
     principalBalanceAdjustment: getKeyingSheetAdjustmentViewModel(keyingSheetRow.principalBalanceAdjustment),
-    checkboxId: `feeRecordId-${keyingSheetRow.feeRecordId}`,
+    checkboxId: getKeyingSheetRowCheckboxId(keyingSheetRow),
     isChecked: false,
   }));

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/index.test.ts
@@ -1,5 +1,5 @@
 import httpMocks from 'node-mocks-http';
-import { postKeyingData } from '.';
+import { postKeyingData, postKeyingDataMarkAsDone, postKeyingDataMarkAsToDo } from '.';
 import { aTfmSessionUser } from '../../../../test-helpers/test-data/tfm-session-user';
 import api from '../../../api';
 
@@ -66,6 +66,148 @@ describe('controllers/utilisation-reports/keying-data', () => {
 
       // Act
       await postKeyingData(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderData()).toEqual({ user: requestSession.user });
+    });
+  });
+
+  describe('postKeyingDataMarkAsDone', () => {
+    const userToken = 'abc123';
+    const user = aTfmSessionUser();
+    const requestSession = {
+      user,
+      userToken,
+    };
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('marks selected fee record ids for rows with status TO_DO as done and redirects to keying sheet', async () => {
+      // Arrange
+      const reportId = '15';
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId },
+        body: {
+          'feeRecordId-123-status-TO_DO': 'on',
+          'feeRecordId-456-status-TO_DO': 'on',
+          'feeRecordId-789-status-DONE': 'on',
+        },
+      });
+
+      // Act
+      await postKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(api.markKeyingDataAsDone).toHaveBeenCalledWith(reportId, [123, 456], user, userToken);
+      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('does not mark any fees as done and redirects to keying sheet when none of the selected checkboxes are for rows with status TO_DO', async () => {
+      // Arrange
+      const reportId = '15';
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId },
+        body: { 'feeRecordId-789-status-DONE': 'on' },
+      });
+
+      // Act
+      await postKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(api.markKeyingDataAsDone).not.toHaveBeenCalled();
+      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('renders the problem-with-service page when an error occurs', async () => {
+      // Arrange
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId: '1' },
+        body: { 'feeRecordId-123-status-TO_DO': 'on' },
+      });
+
+      jest.mocked(api.markKeyingDataAsDone).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await postKeyingDataMarkAsDone(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderData()).toEqual({ user: requestSession.user });
+    });
+  });
+
+  describe('postKeyingDataMarkAsToDo', () => {
+    const userToken = 'abc123';
+    const user = aTfmSessionUser();
+    const requestSession = {
+      user,
+      userToken,
+    };
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('marks selected fee record ids for rows with status DONE as to do and redirects to keying sheet', async () => {
+      // Arrange
+      const reportId = '15';
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId },
+        body: {
+          'feeRecordId-123-status-DONE': 'on',
+          'feeRecordId-456-status-TO_DO': 'on',
+          'feeRecordId-789-status-DONE': 'on',
+        },
+      });
+
+      // Act
+      await postKeyingDataMarkAsToDo(req, res);
+
+      // Assert
+      expect(api.markKeyingDataAsToDo).toHaveBeenCalledWith(reportId, [123, 789], user, userToken);
+      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('does not mark any fees as to do and redirects to keying sheet when none of the selected checkboxes are for rows with status DONE', async () => {
+      // Arrange
+      const reportId = '15';
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId },
+        body: { 'feeRecordId-789-status-TO_DO': 'on' },
+      });
+
+      // Act
+      await postKeyingDataMarkAsToDo(req, res);
+
+      // Assert
+      expect(api.markKeyingDataAsToDo).not.toHaveBeenCalled();
+      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toBe(true);
+    });
+
+    it('renders the problem-with-service page when an error occurs', async () => {
+      // Arrange
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId: '1' },
+        body: { 'feeRecordId-123-status-DONE': 'on' },
+      });
+
+      jest.mocked(api.markKeyingDataAsToDo).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await postKeyingDataMarkAsToDo(req, res);
 
       // Assert
       expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/index.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
 import api from '../../../api';
 import { asUserSession } from '../../../helpers/express-session';
+import { getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys } from './keying-sheet-checkbox-id-helpers';
+import { KeyingSheetCheckboxId } from '../../../types/keying-sheet-checkbox-id';
 
 export const postKeyingData = async (req: Request, res: Response) => {
   const { user, userToken } = asUserSession(req.session);
@@ -12,6 +15,46 @@ export const postKeyingData = async (req: Request, res: Response) => {
     return res.redirect(`/utilisation-reports/${reportId}#keying-sheet`);
   } catch (error) {
     console.error('Failed to add payment', error);
+    return res.render('_partials/problem-with-service.njk', { user });
+  }
+};
+
+export type PostKeyingDataMarkAsRequest = CustomExpressRequest<{
+  reqBody: Record<KeyingSheetCheckboxId, 'on'>;
+}>;
+
+export const postKeyingDataMarkAsDone = async (req: PostKeyingDataMarkAsRequest, res: Response) => {
+  const { user, userToken } = asUserSession(req.session);
+  const { reportId } = req.params;
+
+  try {
+    const feeRecordsIdsToMarkAsDone = getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys(req.body, 'TO_DO');
+
+    if (feeRecordsIdsToMarkAsDone.length > 0) {
+      await api.markKeyingDataAsDone(reportId, feeRecordsIdsToMarkAsDone, user, userToken);
+    }
+
+    return res.redirect(`/utilisation-reports/${reportId}#keying-sheet`);
+  } catch (error) {
+    console.error('Failed to mark keying data as done', error);
+    return res.render('_partials/problem-with-service.njk', { user });
+  }
+};
+
+export const postKeyingDataMarkAsToDo = async (req: PostKeyingDataMarkAsRequest, res: Response) => {
+  const { user, userToken } = asUserSession(req.session);
+  const { reportId } = req.params;
+
+  try {
+    const feeRecordsIdsToMarkAsToDo = getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys(req.body, 'DONE');
+
+    if (feeRecordsIdsToMarkAsToDo.length > 0) {
+      await api.markKeyingDataAsToDo(reportId, feeRecordsIdsToMarkAsToDo, user, userToken);
+    }
+
+    return res.redirect(`/utilisation-reports/${reportId}#keying-sheet`);
+  } catch (error) {
+    console.error('Failed to mark keying data as to do', error);
     return res.render('_partials/problem-with-service.njk', { user });
   }
 };

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/keying-sheet-checkbox-id-helpers.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/keying-sheet-checkbox-id-helpers.test.ts
@@ -1,0 +1,37 @@
+import { getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys } from './keying-sheet-checkbox-id-helpers';
+
+describe('keying-sheet-checkbox-id-helpers', () => {
+  describe('getFeeRecordIdsForRowsWithStatusFromObjectKeys', () => {
+    it('returns all fee record ids of fee records with status TO_DO from the object keys', () => {
+      // Arrange
+      const object = {
+        'feeRecordId-123-status-TO_DO': 'on',
+        'feeRecordId-45678-status-TO_DO': 13,
+        'feeRecordId-999-status-DONE': 'on',
+        'other-key': 'value',
+      };
+
+      // Act
+      const feeRecordIds = getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys(object, 'TO_DO');
+
+      // Assert
+      expect(feeRecordIds).toEqual([123, 45678]);
+    });
+
+    it('returns all fee record ids of fee records with status DONE from the object keys', () => {
+      // Arrange
+      const object = {
+        'feeRecordId-123-status-TO_DO': 'on',
+        'feeRecordId-45678-status-DONE': 13,
+        'feeRecordId-999-status-DONE': 'on',
+        'other-key': 'value',
+      };
+
+      // Act
+      const feeRecordIds = getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys(object, 'DONE');
+
+      // Assert
+      expect(feeRecordIds).toEqual([45678, 999]);
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/keying-sheet-checkbox-id-helpers.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/keying-sheet-checkbox-id-helpers.ts
@@ -1,0 +1,21 @@
+import { KEYING_SHEET_ROW_STATUS, KeyingSheetRowStatus } from '@ukef/dtfs2-common';
+import { KeyingSheetCheckboxId } from '../../../types/keying-sheet-checkbox-id';
+
+const KEYING_SHEET_ROW_STATUS_GROUP = `(?<status>${Object.values(KEYING_SHEET_ROW_STATUS).join('|')})`;
+
+const KEYING_SHEET_ROW_CHECKBOX_ID_REGEX = new RegExp(`feeRecordId-(?<id>\\d+,?)-status-${KEYING_SHEET_ROW_STATUS_GROUP}`);
+
+const getKeyingSheetCheckboxIdsFromObjectKeys = (object: object): KeyingSheetCheckboxId[] =>
+  Object.keys(object).filter((key) => KEYING_SHEET_ROW_CHECKBOX_ID_REGEX.test(key)) as KeyingSheetCheckboxId[];
+
+const getFeeRecordIdsAndStatusesFromKeyingSheetCheckboxIds = (checkboxIds: KeyingSheetCheckboxId[]): { id: number; status: KeyingSheetRowStatus }[] =>
+  checkboxIds.map((checkboxId) => {
+    const { id, status } = KEYING_SHEET_ROW_CHECKBOX_ID_REGEX.exec(checkboxId)!.groups!;
+    return { id: Number(id), status: status as KeyingSheetRowStatus };
+  });
+
+export const getFeeRecordIdsForKeyingSheetRowsWithStatusFromObjectKeys = (object: object, status: KeyingSheetRowStatus) => {
+  const checkboxIds = getKeyingSheetCheckboxIdsFromObjectKeys(object);
+  const feeRecordIdsWithStatuses = getFeeRecordIdsAndStatusesFromKeyingSheetCheckboxIds(checkboxIds);
+  return feeRecordIdsWithStatuses.filter((feeRecordIdWithStatus) => feeRecordIdWithStatus.status === status).map(({ id }) => id);
+};

--- a/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
+++ b/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
@@ -15,7 +15,7 @@ import { getReportDownload } from '../../controllers/utilisation-reports/report-
 import { getUtilisationReportReconciliationByReportId } from '../../controllers/utilisation-reports/utilisation-report-reconciliation-for-report';
 import { getFindReportsByYear } from '../../controllers/utilisation-reports/find-reports-by-year';
 import { addPayment } from '../../controllers/utilisation-reports/add-payment';
-import { postKeyingData } from '../../controllers/utilisation-reports/keying-data';
+import { postKeyingData, postKeyingDataMarkAsDone, postKeyingDataMarkAsToDo } from '../../controllers/utilisation-reports/keying-data';
 import { postCheckKeyingData } from '../../controllers/utilisation-reports/check-keying-data';
 import { getEditPayment, postEditPayment } from '../../controllers/utilisation-reports/edit-payment';
 import { getConfirmDeletePayment, postConfirmDeletePayment } from '../../controllers/utilisation-reports/confirm-delete-payment';
@@ -65,6 +65,22 @@ utilisationReportsRoutes.post(
   validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
   validateSqlId('reportId'),
   postCheckKeyingData,
+);
+
+utilisationReportsRoutes.post(
+  '/:reportId/keying-data/mark-as-done',
+  validateTfmPaymentReconciliationFeatureFlagIsEnabled,
+  validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
+  validateSqlId('reportId'),
+  postKeyingDataMarkAsDone,
+);
+
+utilisationReportsRoutes.post(
+  '/:reportId/keying-data/mark-as-to-do',
+  validateTfmPaymentReconciliationFeatureFlagIsEnabled,
+  validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
+  validateSqlId('reportId'),
+  postKeyingDataMarkAsToDo,
 );
 
 utilisationReportsRoutes.post(

--- a/trade-finance-manager-ui/server/types/keying-sheet-checkbox-id.ts
+++ b/trade-finance-manager-ui/server/types/keying-sheet-checkbox-id.ts
@@ -1,0 +1,3 @@
+import { KeyingSheetRowStatus } from '@ukef/dtfs2-common';
+
+export type KeyingSheetCheckboxId = `feeRecordId-${string}-status-${KeyingSheetRowStatus}`;

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -2,6 +2,7 @@ import { Currency, CurrencyAndAmountString, FeeRecordStatus, KeyingSheetAdjustme
 import { ErrorSummaryViewModel } from './error-summary-view-model';
 import { PremiumPaymentsTableCheckboxId } from '../premium-payments-table-checkbox-id';
 import { BaseViewModel } from './base-view-model';
+import { KeyingSheetCheckboxId } from '../keying-sheet-checkbox-id';
 
 export type SortedAndFormattedCurrencyAndAmount = {
   formattedCurrencyAndAmount: CurrencyAndAmountString | undefined;
@@ -43,7 +44,7 @@ export type KeyingSheetViewModel = {
   fixedFeeAdjustment: KeyingSheetAdjustmentViewModel;
   premiumAccrualBalanceAdjustment: KeyingSheetAdjustmentViewModel;
   principalBalanceAdjustment: KeyingSheetAdjustmentViewModel;
-  checkboxId: `feeRecordId-${number}`;
+  checkboxId: KeyingSheetCheckboxId;
   isChecked: boolean;
 }[];
 

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table-row.njk
@@ -14,17 +14,17 @@
     </td>
   {% endmacro %}
   {% set userCanEdit = params.userCanEdit %}
-  {% set status = params.KeyingSheetRow.status %}
-  {% set displayStatus = params.KeyingSheetRow.displayStatus %}
-  {% set facilityId = params.KeyingSheetRow.facilityId %}
-  {% set exporter = params.KeyingSheetRow.exporter %}
-  {% set feePayments = params.KeyingSheetRow.feePayments %}
-  {% set baseCurrency = params.KeyingSheetRow.baseCurrency %}
-  {% set fixedFeeAdjustment = params.KeyingSheetRow.fixedFeeAdjustment %}
-  {% set premiumAccrualBalanceAdjustment = params.KeyingSheetRow.premiumAccrualBalanceAdjustment %}
-  {% set principalBalanceAdjustment = params.KeyingSheetRow.principalBalanceAdjustment %}
-  {% set checkboxId = params.KeyingSheetRow.checkboxId %}
-  {% set isChecked = params.KeyingSheetRow.isChecked %}
+  {% set status = params.keyingSheetRow.status %}
+  {% set displayStatus = params.keyingSheetRow.displayStatus %}
+  {% set facilityId = params.keyingSheetRow.facilityId %}
+  {% set exporter = params.keyingSheetRow.exporter %}
+  {% set feePayments = params.keyingSheetRow.feePayments %}
+  {% set baseCurrency = params.keyingSheetRow.baseCurrency %}
+  {% set fixedFeeAdjustment = params.keyingSheetRow.fixedFeeAdjustment %}
+  {% set premiumAccrualBalanceAdjustment = params.keyingSheetRow.premiumAccrualBalanceAdjustment %}
+  {% set principalBalanceAdjustment = params.keyingSheetRow.principalBalanceAdjustment %}
+  {% set checkboxId = params.keyingSheetRow.checkboxId %}
+  {% set isChecked = params.keyingSheetRow.isChecked %}
   {% for feePayment in feePayments %}
     {% set isFirstLineOfRow = loop.index === 1 %}
     {% set isLastLineOfRow = loop.index === feePayments.length %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table.njk
@@ -17,9 +17,9 @@
         <th scope="colgroup" class="govuk-table__header" colspan="2">Premium accrual balance adjustment</th>
         <th scope="colgroup" class="govuk-table__header" colspan="2">Principal balance adjustment</th>
         {% if userCanEdit %}
-          <th scope="col" class="govuk-table__header" rowspan="2">
+          <td class="govuk-table__header" rowspan="2">
             {{ selectAllTableCellCheckbox.render() }}
-          </th>
+          </td>
         {% endif %}
       </tr>
       <tr class="govuk-table__row">
@@ -32,9 +32,9 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      {% for KeyingSheetRow in keyingSheet %}
+      {% for keyingSheetRow in keyingSheet %}
         {{ keyingSheetTableRow.render({
-          KeyingSheetRow: KeyingSheetRow,
+          keyingSheetRow: keyingSheetRow,
           userCanEdit: userCanEdit
         }) }}
       {% endfor %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
@@ -37,7 +37,7 @@
         {{ tableHeader({ headerText: 'Total payments received', isNumericColumn: true, enableSorting: enablePaymentsReceivedSorting, ariaSort: 'none' }) }}
         {{ tableHeader({ headerText: 'Status', isNumericColumn: false, enableSorting: true, ariaSort: 'none' }) }}
         {% if userCanEdit %}
-          <td scope="col" class="govuk-table__header">
+          <td class="govuk-table__header">
             {{ selectAllTableCellCheckbox.render() }}
           </td>
         {% endif %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -127,23 +127,20 @@
 
     {% if userCanEdit %}
       <div class="govuk-button-group">
-        {{ govukButton({
-          text: "Mark as done",
-          href: '#',
-          classes: "govuk-!-margin-right-3",
-          attributes: {
-            "data-cy": "keying-sheet-mark-as-done-button"
-          }
-        }) }}
-
-        {{ govukButton({
-          text: "Mark as to do",
-          href: '#',
-          classes: "govuk-button--secondary",
-          attributes: {
-            "data-cy": "keying-sheet-mark-as-to-do-button"
-          }
-        }) }}
+        <input
+          class="govuk-button govuk-!-margin-right-3"
+          formaction="/utilisation-reports/{{ reportId }}/keying-data/mark-as-done"
+          value="Mark as done"
+          data-module="govuk-button"
+          type="submit"
+          data-cy="keying-sheet-mark-as-done-button"/>
+        <input
+          class="govuk-button govuk-button--secondary"
+          formaction="/utilisation-reports/{{ reportId }}/keying-data/mark-as-to-do"
+          value="Mark as to do"
+          data-module="govuk-button"
+          type="submit"
+          data-cy="keying-sheet-mark-as-to-do-button"/>
       </div>
     {% endif %}
 


### PR DESCRIPTION
## Introduction :pencil2:
We need to be able to mark keying sheet rows as DONE and as TO DO

## Resolution :heavy_check_mark:
- Make respective api calls when mark as done and mark as to do buttons are clicked
- Ignore any selected checkboxes for rows already at the status we are moving to

<img width="1568" alt="Screenshot 2024-07-17 at 15 25 20" src="https://github.com/user-attachments/assets/2e54b6e7-0516-4285-9237-5fc17786bdca">


