### PR TITLE
feat(FN-3202): use feature GitHub env for feature deploy

### DIFF
--- a/.github/workflows/feature_deploy.yml
+++ b/.github/workflows/feature_deploy.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - feat/FN-3202/use-feature-github-env-for-feature-deploy
     paths:
       - "portal/**"
       - "portal-api/**"
@@ -19,11 +20,11 @@ on:
 
 env:
   environment: feature
-  credentials: ${{ secrets.AZURE_DIGITAL_DEV }}
+  credentials: ${{ secrets.AZURE_CREDENTIALS }}
   from: latest
-  acr: ${{ secrets.ACR_REGISTRY_FEATURE }}
-  acr_username: ${{ secrets.ACR_USERNAME_FEATURE }}
-  acr_password: ${{ secrets.ACR_PASSWORD_FEATURE }}
+  acr: ${{ secrets.ACR_REGISTRY }}
+  acr_username: ${{ secrets.ACR_USERNAME }}
+  acr_password: ${{ secrets.ACR_PASSWORD }}
   # TODO: FN-1077 NOTE: While we are using the dev GH environment, we can't use the RESOURCE_GROUP secret
   # (It doesn't need to be a secret anyway.) So we define our resource group in an environment variable
   # here and use that. The Azure region is the same so I've left that as using the secret.
@@ -43,7 +44,8 @@ jobs:
     needs: deployment-environment
     name: Run SQL Migrations
     runs-on: [self-hosted, linux, deployment]
-    environment: dev
+    environment:
+      name: ${{ needs.deployment-environment.outputs.environment }}
     env:
       SQL_DB_HOST: ${{ secrets.SQL_DB_HOST }}
       SQL_DB_PORT: ${{ secrets.SQL_DB_PORT }}
@@ -75,9 +77,9 @@ jobs:
     runs-on: [self-hosted, linux, deployment]
     # TODO: FN-1077 NOTE: we don't currently have a `feature` GitHub environment yet so use the `dev` one while we're not doing much.
     # Restore the parameterised version throughout!
-    environment: dev
-    # environment:
-    #   name: ${{ needs.deployment-environment.outputs.environment }}
+    # environment: feature
+    environment:
+      name: ${{ needs.deployment-environment.outputs.environment }}
     strategy:
       max-parallel: 1
       matrix:
@@ -158,9 +160,9 @@ jobs:
     runs-on: [self-hosted, linux, deployment]
     # TODO: FN-1077 NOTE: we don't currently have a `feature` GitHub environment yet so use the `dev` one while we're not doing much.
     # Restore the parameterised version throughout!
-    environment: dev
-    # environment:
-    #   name: ${{ needs.deployment-environment.outputs.environment }}
+    # environment: dev
+    environment:
+      name: ${{ needs.deployment-environment.outputs.environment }}
     strategy:
       matrix:
         repository:

--- a/.github/workflows/feature_deploy.yml
+++ b/.github/workflows/feature_deploy.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - feat/FN-3202/use-feature-github-env-for-feature-deploy
     paths:
       - "portal/**"
       - "portal-api/**"

--- a/.github/workflows/feature_deploy.yml
+++ b/.github/workflows/feature_deploy.yml
@@ -17,6 +17,7 @@ on:
       - "external-api/**"
       - "azure-functions/acbs-function/**"
       - "libs/common/**"
+      - ".github/**"
 
 env:
   environment: feature

--- a/.github/workflows/feature_deploy.yml
+++ b/.github/workflows/feature_deploy.yml
@@ -77,7 +77,6 @@ jobs:
     runs-on: [self-hosted, linux, deployment]
     # TODO: FN-1077 NOTE: we don't currently have a `feature` GitHub environment yet so use the `dev` one while we're not doing much.
     # Restore the parameterised version throughout!
-    # environment: feature
     environment:
       name: ${{ needs.deployment-environment.outputs.environment }}
     strategy:
@@ -160,7 +159,6 @@ jobs:
     runs-on: [self-hosted, linux, deployment]
     # TODO: FN-1077 NOTE: we don't currently have a `feature` GitHub environment yet so use the `dev` one while we're not doing much.
     # Restore the parameterised version throughout!
-    # environment: dev
     environment:
       name: ${{ needs.deployment-environment.outputs.environment }}
     strategy:


### PR DESCRIPTION
## Introduction :pencil2:
We want to have a new feature environment in github so that we can control deployments to the feature env separately to deployments to dev and enable SQL to be deployed to without overlapping variable/secret names

## Resolution :heavy_check_mark:
Point feature_deploy at feature environment now instead of dev environment so it doesn't use the dev variables/secrets. Behind the scenes we also populated the feature env in github

## Miscellaneous :heavy_plus_sign:
Note this makes it much easier to combine the feature_deploy and deployment.yml files now, however I'm holding off doing this until branching/release strategy talks are finished as we might be refactoring parts anyway!

