### PR TITLE
feat(FN-1728): display fee record group status correctly for ready to key data

### DIFF
--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-fee-record-payment-groups.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-fee-record-payment-groups.ts
@@ -1,7 +1,16 @@
+import { FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { FeeRecordPaymentEntityGroup, calculateTotalCurrencyAndAmount } from '../../../../../helpers';
 import { mapPaymentEntityToPayment } from '../../../../../mapping/payment-mapper';
 import { mapFeeRecordEntityToFeeRecord } from '../../../../../mapping/fee-record-mapper';
 import { FeeRecordPaymentGroup } from '../../../../../types/utilisation-reports';
+
+const getStatusForGroupOfFeeRecords = (feeRecordEntitiesInGroup: FeeRecordEntity[]): FeeRecordStatus => {
+  if (feeRecordEntitiesInGroup.some((feeRecordEntity) => feeRecordEntity.status === 'READY_TO_KEY')) {
+    return 'READY_TO_KEY';
+  }
+
+  return feeRecordEntitiesInGroup[0].status;
+};
 
 /**
  * Maps the fee record payment entity groups to the fee record payment groups
@@ -12,7 +21,7 @@ export const mapFeeRecordPaymentEntityGroupsToFeeRecordPaymentGroups = (
   feeRecordPaymentEntityGroups: FeeRecordPaymentEntityGroup[],
 ): FeeRecordPaymentGroup[] => {
   return feeRecordPaymentEntityGroups.map(({ feeRecords: feeRecordEntitiesInGroup, payments }) => {
-    const { status } = feeRecordEntitiesInGroup[0];
+    const status = getStatusForGroupOfFeeRecords(feeRecordEntitiesInGroup);
 
     if (payments.length === 0) {
       // If there are no payments, there is only one fee record in the group


### PR DESCRIPTION
## Introduction :pencil2:
Fee records in a group which have had their keying sheet generated can have different statuses to each other.

## Resolution :heavy_check_mark:
- Display the status 'READY TO KEY' when any fee record in a group has status `READY_TO_KEY`
- Use the status of the first record in the group otherwise (since all fee records will have the same status)
- Change to test set up to allow easily testing with different combinations of statuses

Group in premium payments tab:
<img width="1613" alt="Screenshot 2024-07-18 at 15 21 14" src="https://github.com/user-attachments/assets/774732d1-b0bb-413c-97c5-c6011cc04eeb">
Corresponding keying sheet tab rows for some of the fee records in group:
<img width="1567" alt="Screenshot 2024-07-18 at 15 21 43" src="https://github.com/user-attachments/assets/a3364d9b-68c0-4337-8ea4-1f3d1f79a82e">
<img width="1570" alt="Screenshot 2024-07-18 at 15 21 59" src="https://github.com/user-attachments/assets/5036ce0e-6021-4810-b98b-316d623d4cee">
