### PR TITLE
feat(DTFS2-7288): allow release branches to deploy to staging env

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -57,7 +57,7 @@ on:
 
 env:
   PRODUCT: dtfs
-  ENVIRONMENT: ${{  github.event.workflow_run.head_branch == 'release-*' && 'dev' || github.event.workflow_run.head_branch }}
+  ENVIRONMENT: ${{ github.event.workflow_run.head_branch == 'release-*' && 'staging' || github.event.workflow_run.head_branch }}
   TIMEZONE: "Europe/London"
   # Base artifact
   FROM: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ on:
       - release-*
 
     paths:
-      - ".github/workflows/deployment.yml"
+      - ".github/**"
       - "portal/**"
       - "gef-ui/**"
       - "trade-finance-manager-ui/**"


### PR DESCRIPTION
## Introduction :pencil2:
We need to allow release branches to deploy to the staging environment

## Extra thoughts
I've specifically done this as a tiny change to just support what we need for release-2.3 rather than doing an overhaul.
In an ideal world I would:
 - trigger deployments from pushing to the branch and get rid of the test.yml step for deployments
 - delete references to staging branch
 - delete references to dev branch
 - add a manual github action (workflow_dispatch) to allow main to deploy to dev (or automatic main -> dev deployment and refactor the deployment pipeline to reduce downtime, e.g. get all slots ready then swap them together rather than in serial build an image, create a slot then slot swap for each service)





