### PR TITLE
fix(DTFS2-7292): downgraded MSSQL to 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ coverage
 .idea
 
 # DB
-dtfs-submissions-data-volume*
+dtfs-mongo-volume*
 dtfs-sql-volume*
 **/temp/*
 utils/**/actionsheets/*

--- a/docker-compose.gha.yml
+++ b/docker-compose.gha.yml
@@ -19,8 +19,14 @@ services:
       - '1433:1433'
     volumes:
       - ./dtfs-sql-volume-dtfs-submissions:/data/db
+    healthcheck:
+      test: ['CMD', '/opt/mssql-tools18/bin/sqlcmd', '-C -S', 'localhost', '-U', 'sa', '-P', MSSQL_SA_PASSWORD, '-Q', 'SELECT 1;']
+      retries: 3
+      interval: 60s
+      timeout: 10s
+      start_period: 60s
 
-  dtfs-submissions-data:
+  dtfs-mongo:
     build:
       context: ./mongodb
       dockerfile: Dockerfile
@@ -38,7 +44,7 @@ services:
       start_period: 30s
     command: "--bind_ip_all --keyFile /mongo-keyfile --replSet rs0"
     volumes:
-      - ./dtfs-submissions-data-volume-dtfs-submissions:/data/db
+      - ./dtfs-mongo-volume-dtfs-submissions:/data/db
 
   dtfs-central-api:
     build:
@@ -48,7 +54,7 @@ services:
     restart: always
     depends_on:
       - dtfs-sql
-      - dtfs-submissions-data
+      - dtfs-mongo
       - external-api
     ports:
       - '5005:5005'
@@ -262,7 +268,7 @@ services:
     image: dtfs/external-api
     restart: always
     depends_on:
-      - dtfs-submissions-data
+      - dtfs-mongo
     ports:
       - '5002:5002'
     volumes:

--- a/docker-compose.replica-set.yml
+++ b/docker-compose.replica-set.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./dtfs-sql-volume-dtfs-submissions:/data/db
 
-  dtfs-submissions-data:
+  dtfs-mongo:
     build:
       context: ./mongodb
       dockerfile: Dockerfile
@@ -38,7 +38,7 @@ services:
       start_period: 30s
     command: "--bind_ip_all --keyFile /mongo-keyfile --replSet rs0"
     volumes:
-      - ./dtfs-submissions-data-volume-dtfs-submissions:/data/db
+      - ./dtfs-mongo-volume-dtfs-submissions:/data/db
 
   dtfs-central-api:
     build:
@@ -48,7 +48,7 @@ services:
     restart: always
     depends_on:
       - dtfs-sql
-      - dtfs-submissions-data
+      - dtfs-mongo
       - external-api
     ports:
       - '5005:5005' # http
@@ -257,7 +257,7 @@ services:
     image: dtfs/external-api
     restart: always
     depends_on:
-      - dtfs-submissions-data
+      - dtfs-mongo
     ports:
       - '5002:5002' # http
       - '9228:9228' # debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./dtfs-sql-volume-dtfs-submissions:/data/db
 
-  dtfs-submissions-data:
+  dtfs-mongo:
     image: mongo:5.0.5
     restart: always
     environment:
@@ -30,7 +30,7 @@ services:
     ports:
       - '27017-27019:27017-27019'
     volumes:
-      - ./dtfs-submissions-data-volume-dtfs-submissions:/data/db
+      - ./dtfs-mongo-volume-dtfs-submissions:/data/db
 
   dtfs-central-api:
     build:
@@ -40,7 +40,7 @@ services:
     restart: always
     depends_on:
       - dtfs-sql
-      - dtfs-submissions-data
+      - dtfs-mongo
       - external-api
     ports:
       - '5005:5005' # http
@@ -248,7 +248,7 @@ services:
     image: dtfs/external-api
     restart: always
     depends_on:
-      - dtfs-submissions-data
+      - dtfs-mongo
     ports:
       - '5002:5002' # http
       - '9228:9228' # debug

--- a/libs/common/src/sql-db-connection/Dockerfile
+++ b/libs/common/src/sql-db-connection/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM mcr.microsoft.com/mssql/server:2019-latest
+FROM mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
 
 # Setup
 COPY init.sh /

--- a/libs/common/src/sql-db-connection/Dockerfile
+++ b/libs/common/src/sql-db-connection/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM mcr.microsoft.com/mssql/server
+FROM mcr.microsoft.com/mssql/server:2019-latest
 
 # Setup
 COPY init.sh /

--- a/libs/common/src/sql-db-connection/init.sh
+++ b/libs/common/src/sql-db-connection/init.sh
@@ -1,54 +1,42 @@
 #!/bin/bash
 set -m
-
-execute_sql_command() {
-  /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -Q "$1" > /dev/null
-  return $?
-}
-
-get_now_unix_timestamp() {
-  echo $(date +%s)
-}
-
 /opt/mssql/bin/sqlservr &
-
-readonly time_limit_seconds=60
-readonly interval_seconds=5
-readonly start_time=$(get_now_unix_timestamp)
 
 echo "⚡ Initialising MSSQL Server"
 
-# Wait for SQL Server to start
-while ! execute_sql_command "SELECT 1;"
-do
-  current_time=$(get_now_unix_timestamp)
-  elapsed_seconds=$((current_time - start_time))
+# Executes SQL query
+query() {
+  /opt/mssql-tools/bin/sqlcmd -C -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -Q "$1" >/dev/null
+  return $?
+}
 
-  if [ $elapsed_seconds -gt $time_limit_seconds ]; then
-    echo "❌ Error: Failed to create database '$SQL_DB_NAME' - SQL Server did not start within $time_limit_seconds seconds."
-    exit 1
-  fi
+# Initial DB setup
+initialise() {
+  # 1. Database
+  query "CREATE DATABASE [$SQL_DB_NAME];"
+  query "USE [$SQL_DB_NAME];"
 
-  echo "❌ MSSQL failed to start after $elapsed_seconds seconds. Waiting for $interval_seconds more seconds."
-  sleep $interval_seconds
+  # 2. User
+  query "CREATE LOGIN $SQL_DB_USERNAME WITH PASSWORD = '$SQL_DB_PASSWORD';"
+  query "CREATE USER $SQL_DB_USERNAME FOR LOGIN $SQL_DB_USERNAME;"
+
+  # 3. Permissions
+  query "ALTER ROLE db_datareader ADD MEMBER $SQL_DB_USERNAME;"
+  query "ALTER ROLE db_datawriter ADD MEMBER $SQL_DB_USERNAME;"
+  query "ALTER ROLE db_ddladmin ADD MEMBER $SQL_DB_USERNAME;"
+}
+
+# Boot check
+while ! query "SELECT 1;"; do
+  echo "❌ MSSQL boot has failed, retrying..."
+  sleep 3
 done
 
-echo "✅ MSSQL initialised, creating database '$SQL_DB_NAME'..."
+echo "⚠️ MSSQL is now running."
 
-# Create the database
-execute_sql_command "CREATE DATABASE [$SQL_DB_NAME];"
+initialise
 
-echo "⚡Creating user '$SQL_DB_USERNAME'..."
+echo "✅ MSSQL has been initialised."
 
-# Create a new login
-execute_sql_command "CREATE LOGIN $SQL_DB_USERNAME WITH PASSWORD = '$SQL_DB_PASSWORD';"
-
-# Create a new user in the database and map it to the login
-execute_sql_command "USE [$SQL_DB_NAME]; CREATE USER $SQL_DB_USERNAME FOR LOGIN $SQL_DB_USERNAME;"
-
-# Grant the new user required permissions
-execute_sql_command "USE [$SQL_DB_NAME]; ALTER ROLE db_datareader ADD MEMBER $SQL_DB_USERNAME;"
-execute_sql_command "USE [$SQL_DB_NAME]; ALTER ROLE db_datawriter ADD MEMBER $SQL_DB_USERNAME;"
-execute_sql_command "USE [$SQL_DB_NAME]; ALTER ROLE db_ddladmin ADD MEMBER $SQL_DB_USERNAME;"
-
+# Run process in the foreground
 fg

--- a/libs/common/src/sql-db-connection/init.sh
+++ b/libs/common/src/sql-db-connection/init.sh
@@ -12,18 +12,19 @@ query() {
 
 # Initial DB setup
 initialise() {
+  readonly DB="USE [$SQL_DB_NAME];"
+
   # 1. Database
   query "CREATE DATABASE [$SQL_DB_NAME];"
-  query "USE [$SQL_DB_NAME];"
 
   # 2. User
   query "CREATE LOGIN $SQL_DB_USERNAME WITH PASSWORD = '$SQL_DB_PASSWORD';"
-  query "CREATE USER $SQL_DB_USERNAME FOR LOGIN $SQL_DB_USERNAME;"
+  query "$DB CREATE USER $SQL_DB_USERNAME FOR LOGIN $SQL_DB_USERNAME;"
 
   # 3. Permissions
-  query "ALTER ROLE db_datareader ADD MEMBER $SQL_DB_USERNAME;"
-  query "ALTER ROLE db_datawriter ADD MEMBER $SQL_DB_USERNAME;"
-  query "ALTER ROLE db_ddladmin ADD MEMBER $SQL_DB_USERNAME;"
+  query "$DB ALTER ROLE db_datareader ADD MEMBER $SQL_DB_USERNAME;"
+  query "$DB ALTER ROLE db_datawriter ADD MEMBER $SQL_DB_USERNAME;"
+  query "$DB ALTER ROLE db_ddladmin ADD MEMBER $SQL_DB_USERNAME;"
 }
 
 # Boot check

--- a/utils/copy-env-vars/index.ts
+++ b/utils/copy-env-vars/index.ts
@@ -25,8 +25,8 @@ const baseEnvFilePath = path.join(basePath, '.env');
  * This function updates the .env file to apply these rules
  */
 const updateEnvVars = (fileData: string): string => {
-  const MONGODB_URI_REGEX = /(MONGODB_URI=.*)(dtfs-submissions-data)/g;
-  const MONGODB_URI_QA_REGEX = /(MONGODB_URI_QA=.*)(dtfs-submissions-data)/g;
+  const MONGODB_URI_REGEX = /(MONGODB_URI=.*)(dtfs-mongo)/g;
+  const MONGODB_URI_QA_REGEX = /(MONGODB_URI_QA=.*)(dtfs-mongo)/g;
   const SQL_DB_HOST_REGEX = /(SQL_DB_HOST=.*)(dtfs-sql)/g;
 
   const replacePattern = '$1localhost';


### PR DESCRIPTION
## Introduction :pencil2:
A recent update on Microsoft MSSQL version especially `2022` have path and driver updates.
This has broken the pipeline due to absence of any health check for `dtfs-sql` container pipeline debugging has been inaccurate.

This PR aims to mitigate both the issues.

## Resolution :heavy_check_mark:
* Downgraded MSSQL docker image to explicit version `mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04`
* Refactored `init.sh` for MSSQL server boot.
* Added health check to `dtfs-sql` container.

## Miscellaneous :heavy_plus_sign:
* Renamed `dtfs-submissions-data` to `dtfs-mongo` for consistent naming convention.

