### PR TITLE
feat(DTFS2-7232): add current facility end date to amendments

### DIFF
--- a/dtfs-central-api/src/constants/amendments.ts
+++ b/dtfs-central-api/src/constants/amendments.ts
@@ -15,10 +15,3 @@ export const AMENDMENT_QUERY_STATUSES = {
   IN_PROGRESS: 'in-progress',
   COMPLETED: 'completed',
 } as const;
-
-export const AMENDMENT_QUERIES = {
-  LATEST_VALUE: 'latest-value',
-  LATEST_COVER_END_DATE: 'latest-cover-end-date',
-  LATEST_FACILITY_END_DATE: 'latest-facility-end-date',
-  LATEST: 'latest',
-} as const;

--- a/dtfs-central-api/src/constants/amendments.ts
+++ b/dtfs-central-api/src/constants/amendments.ts
@@ -19,5 +19,6 @@ export const AMENDMENT_QUERY_STATUSES = {
 export const AMENDMENT_QUERIES = {
   LATEST_VALUE: 'latest-value',
   LATEST_COVER_END_DATE: 'latest-cover-end-date',
+  LATEST_FACILITY_END_DATE: 'latest-facility-end-date',
   LATEST: 'latest',
 } as const;

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.ts
@@ -1,9 +1,9 @@
 import { ObjectId, Document } from 'mongodb';
 import { HttpStatusCode } from 'axios';
 import { Request, Response } from 'express';
-import { Currency, TfmFacilityAmendment, AMENDMENT_STATUS, ApiError, API_ERROR_CODE } from '@ukef/dtfs2-common';
+import { Currency, TfmFacilityAmendment, AMENDMENT_STATUS, AMENDMENT_QUERIES, ApiError, API_ERROR_CODE } from '@ukef/dtfs2-common';
 import { TfmFacilitiesRepo } from '../../../../repositories/tfm-facilities-repo';
-import { AMENDMENT_QUERIES, AMENDMENT_QUERY_STATUSES } from '../../../../constants';
+import { AMENDMENT_QUERY_STATUSES } from '../../../../constants';
 
 export const getAllAmendmentsInProgress = async (_req: Request, res: Response) => {
   try {

--- a/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/tfm/amendments/tfm-get-amendments.controller.ts
@@ -48,6 +48,22 @@ const mapAmendmentToLatestCompletedDate = (
   };
 };
 
+const mapAmendmentToLatestCompletedFacilityEndDate = (
+  amendment: TfmFacilityAmendment,
+): {
+  amendmentId: string;
+  facilityEndDate: string;
+} => {
+  const { amendmentId, facilityEndDate } = amendment;
+  if (!facilityEndDate) {
+    throw new Error('Found amendment does not have a defined facilityEndDate');
+  }
+  return {
+    amendmentId: amendmentId.toString(),
+    facilityEndDate,
+  };
+};
+
 export const getAmendmentsByFacilityId = async (req: Request, res: Response) => {
   const { facilityId, amendmentIdOrStatus, type } = req.params;
 
@@ -65,6 +81,9 @@ export const getAmendmentsByFacilityId = async (req: Request, res: Response) => 
         } else if (type === AMENDMENT_QUERIES.LATEST_COVER_END_DATE) {
           const latestAmendment = await TfmFacilitiesRepo.findLatestCompletedAmendmentByFacilityId(facilityId);
           amendment = latestAmendment ? mapAmendmentToLatestCompletedDate(latestAmendment) : {};
+        } else if (type === AMENDMENT_QUERIES.LATEST_FACILITY_END_DATE) {
+          const latestAmendment = await TfmFacilitiesRepo.findLatestCompletedAmendmentByFacilityId(facilityId);
+          amendment = latestAmendment ? mapAmendmentToLatestCompletedFacilityEndDate(latestAmendment) : {};
         } else {
           amendment = await TfmFacilitiesRepo.findAmendmentsByFacilityIdAndStatus(facilityId, AMENDMENT_STATUS.COMPLETED);
         }

--- a/libs/common/src/constants/amendment-status.ts
+++ b/libs/common/src/constants/amendment-status.ts
@@ -1,5 +1,0 @@
-export const AMENDMENT_STATUS = {
-  NOT_STARTED: 'Not started',
-  IN_PROGRESS: 'In progress',
-  COMPLETED: 'Completed',
-} as const;

--- a/libs/common/src/constants/amendments.ts
+++ b/libs/common/src/constants/amendments.ts
@@ -1,0 +1,12 @@
+export const AMENDMENT_STATUS = {
+  NOT_STARTED: 'Not started',
+  IN_PROGRESS: 'In progress',
+  COMPLETED: 'Completed',
+} as const;
+
+export const AMENDMENT_QUERIES = {
+  LATEST_VALUE: 'latest-value',
+  LATEST_COVER_END_DATE: 'latest-cover-end-date',
+  LATEST_FACILITY_END_DATE: 'latest-facility-end-date',
+  LATEST: 'latest',
+} as const;

--- a/libs/common/src/constants/index.ts
+++ b/libs/common/src/constants/index.ts
@@ -11,7 +11,7 @@ export * from './fee-record-status';
 export * from './audit-user-types';
 export * from './company-registration-number';
 export * from './keying-sheet-row-status';
-export * from './amendment-status';
+export * from './amendments';
 export * from './api-error-code';
 export * from './facility-type';
 export * from './facility-provided-details';

--- a/libs/common/src/types/amendment-status.ts
+++ b/libs/common/src/types/amendment-status.ts
@@ -1,4 +1,4 @@
-import { AMENDMENT_STATUS } from '../constants/amendment-status';
+import { AMENDMENT_STATUS } from '../constants/amendments';
 import { ValuesOf } from './types-helper';
 
 export type AmendmentStatus = ValuesOf<typeof AMENDMENT_STATUS>;

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -505,11 +505,38 @@ describe('API is protected against SSRF attacks', () => {
     });
   });
 
-  describe('getCompletedAmendment', () => {
+  const getAmendmentDetailsByFacilityIdFunctionsToTest = [
+    {
+      description: 'getCompletedAmendment',
+      apiFunction: api.getCompletedAmendment,
+      url: /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed$/,
+    },
+    {
+      description: 'getLatestCompletedAmendmentValue',
+      apiFunction: api.getLatestCompletedAmendmentValue,
+      url: /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed\/latest-value$/,
+    },
+    {
+      description: 'getLatestCompletedAmendmentDate',
+      apiFunction: api.getLatestCompletedAmendmentDate,
+      url: /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed\/latest-cover-end-date$/,
+    },
+    {
+      description: 'getLatestCompletedAmendmentFacilityEndDate',
+      apiFunction: api.getLatestCompletedAmendmentFacilityEndDate,
+      url: /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed\/latest-facility-end-date$/,
+    },
+    {
+      description: 'getAmendmentByFacilityId',
+      apiFunction: api.getAmendmentByFacilityId,
+      url: /^.*\/v1\/tfm\/facilities\/.*\/amendments$/,
+    },
+  ];
+
+  describe.each(getAmendmentDetailsByFacilityIdFunctionsToTest)('$description', ({ apiFunction, url }) => {
     const mockResponse = 'Mock amendment';
     beforeAll(() => {
       mockAxios.reset();
-      const url = /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed$/;
       mockAxios.onGet(url).reply(200, mockResponse);
     });
 
@@ -517,7 +544,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
 
-      const response = await api.getCompletedAmendment(urlTraversal);
+      const response = await apiFunction(urlTraversal);
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -526,7 +553,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
 
-      const response = await api.getCompletedAmendment(localIp);
+      const response = await apiFunction(localIp);
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -534,81 +561,12 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.getCompletedAmendment(validFacilityId);
+      const response = await apiFunction(validFacilityId);
 
       expect(response).toEqual(mockResponse);
     });
   });
 
-  describe('getLatestCompletedAmendmentValue', () => {
-    const mockResponse = 'Mock value';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed\/latest-value$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
-
-      const response = await api.getLatestCompletedAmendmentValue(urlTraversal);
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
-
-      const response = await api.getLatestCompletedAmendmentValue(localIp);
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getLatestCompletedAmendmentValue(validFacilityId);
-
-      expect(response).toEqual(mockResponse);
-    });
-  });
-
-  describe('getLatestCompletedAmendmentDate', () => {
-    const mockResponse = 'Mock date';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/tfm\/facilities\/.*\/amendments\/completed\/latest-cover-end-date$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
-
-      const response = await api.getLatestCompletedAmendmentDate(urlTraversal);
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
-
-      const response = await api.getLatestCompletedAmendmentDate(localIp);
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getLatestCompletedAmendmentDate(validFacilityId);
-
-      expect(response).toEqual(mockResponse);
-    });
-  });
 
   describe('getAmendmentById', () => {
     const mockResponse = 'Mock amendment';
@@ -643,41 +601,6 @@ describe('API is protected against SSRF attacks', () => {
       const validAmendmentId = '5ce819935e539c343f141ece';
 
       const response = await api.getAmendmentById(validFacilityId, validAmendmentId);
-
-      expect(response).toEqual(mockResponse);
-    });
-  });
-
-  describe('getAmendmentByFacilityId', () => {
-    const mockResponse = 'Mock amendment';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/tfm\/facilities\/.*\/amendments$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
-
-      const response = await api.getAmendmentByFacilityId(urlTraversal);
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility Id provided' };
-
-      const response = await api.getAmendmentByFacilityId(localIp);
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getAmendmentByFacilityId(validFacilityId);
 
       expect(response).toEqual(mockResponse);
     });

--- a/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
+++ b/trade-finance-manager-api/api-tests/api-ssrf.api-test.js
@@ -567,7 +567,6 @@ describe('API is protected against SSRF attacks', () => {
     });
   });
 
-
   describe('getAmendmentById', () => {
     const mockResponse = 'Mock amendment';
     beforeAll(() => {

--- a/trade-finance-manager-api/api-tests/v1/amendments/create-amendment-tfm-object-on-amendment-completion.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/amendments/create-amendment-tfm-object-on-amendment-completion.api-test.js
@@ -1,10 +1,16 @@
-const { CURRENCY, AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
+const { CURRENCY, AMENDMENT_STATUS, isTfmFacilityEndDateFeatureFlagEnabled } = require('@ukef/dtfs2-common');
 const amendmentController = require('../../../src/v1/controllers/amendment.controller');
 const externalApis = require('../../../src/v1/api');
 const MOCK_GEF_AIN_DEAL = require('../../../src/v1/__mocks__/mock-TFM-deal-AIN-submitted');
 
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  isTfmFacilityEndDateFeatureFlagEnabled: jest.fn(),
+}));
+
 describe('update amendment-tfm on amendment completion', () => {
   const unixTime = 1658403289;
+  const isoString = '2024-02-14T00:00:00.000+00:00';
 
   const mockAmendment = {
     dealId: '123',
@@ -21,7 +27,7 @@ describe('update amendment-tfm on amendment completion', () => {
     },
   };
 
-  const updateDealSpy = jest.fn(() => Promise.resolve(mockDeal));
+  const updateDealSpy = jest.fn().mockResolvedValue(mockDeal);
 
   const valueChange = {
     value: 5000,
@@ -33,108 +39,203 @@ describe('update amendment-tfm on amendment completion', () => {
     coverEndDate: unixTime,
   };
 
+  const facilityEndDateChange = {
+    facilityEndDate: isoString,
+  };
+
   const mockFacility = {
     facilitySnapshot: { ...MOCK_GEF_AIN_DEAL.dealSnapshot.facilities[0] },
   };
 
   beforeEach(() => {
     updateDealSpy.mockClear();
-    externalApis.getAmendmentById = jest.fn(() => Promise.resolve(mockAmendment));
-    externalApis.getLatestCompletedAmendmentValue = jest.fn(() => Promise.resolve(valueChange));
-    externalApis.getLatestCompletedAmendmentDate = jest.fn(() => Promise.resolve(dateChange));
+    externalApis.getAmendmentById = jest.fn().mockResolvedValue(mockAmendment);
+    externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue(valueChange);
+    externalApis.getLatestCompletedAmendmentDate = jest.fn().mockResolvedValue(dateChange);
+    externalApis.getLatestCompletedAmendmentFacilityEndDate = jest.fn().mockResolvedValue(facilityEndDateChange);
 
-    externalApis.updateFacilityAmendment = jest.fn(() => Promise.resolve(mockAmendment));
-    externalApis.findOneDeal = jest.fn(() => Promise.resolve(MOCK_GEF_AIN_DEAL));
-    externalApis.findOneFacility = jest.fn(() => Promise.resolve(mockFacility));
+    externalApis.updateFacilityAmendment = jest.fn().mockResolvedValue(mockAmendment);
+    externalApis.findOneDeal = jest.fn().mockResolvedValue(MOCK_GEF_AIN_DEAL);
+    externalApis.findOneFacility = jest.fn().mockResolvedValue(mockFacility);
   });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  it('createAmendmentTFMObject() - should not create tfm object when no getLatestCompletedAmendmentValue or getLatestCompletedAmendmentDate', async () => {
-    externalApis.getLatestCompletedAmendmentValue = jest.fn(() => Promise.resolve({}));
-    externalApis.getLatestCompletedAmendmentDate = jest.fn(() => Promise.resolve({}));
-    const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+  describe('createAmendmentTFMObject', () => {
+    describe('when TFM Facility end date feature flag disabled', () => {
+      beforeEach(() => {
+        jest.mocked(isTfmFacilityEndDateFeatureFlagEnabled).mockReturnValue(false);
+      });
 
-    expect(result).toEqual({});
-  });
+      it('should not create tfm object when no getLatestCompletedAmendmentValue or getLatestCompletedAmendmentDate', async () => {
+        externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue({});
+        externalApis.getLatestCompletedAmendmentDate = jest.fn().mockResolvedValue({});
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
 
-  it('createAmendmentTFMObject() - should create tfm object when getLatestCompletedAmendmentValue and getLatestCompletedAmendmentDate', async () => {
-    externalApis.getFacilityExposurePeriod = jest.fn(() => Promise.resolve({ exposurePeriodInMonths: 5 }));
+        expect(result).toEqual({});
+      });
 
-    const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+      it('should create tfm object when getLatestCompletedAmendmentValue and getLatestCompletedAmendmentDate', async () => {
+        externalApis.getFacilityExposurePeriod = jest.fn().mockResolvedValue({ exposurePeriodInMonths: 5 });
 
-    const expected = {
-      amendmentExposurePeriodInMonths: 5,
-      coverEndDate: unixTime,
-      exposure: {
-        exposure: '4,000.00',
-        timestamp: expect.any(Number),
-        ukefExposureValue: 4000,
-      },
-      value: {
-        currency: CURRENCY.GBP,
-        value: 5000,
-      },
-    };
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
 
-    expect(result).toEqual(expected);
-  });
+        const expected = {
+          amendmentExposurePeriodInMonths: 5,
+          coverEndDate: unixTime,
+          exposure: {
+            exposure: '4,000.00',
+            timestamp: expect.any(Number),
+            ukefExposureValue: 4000,
+          },
+          value: {
+            currency: CURRENCY.GBP,
+            value: 5000,
+          },
+        };
 
-  it('createAmendmentTFMObject() - should create tfm object when getLatestCompletedAmendmentValue and getLatestCompletedAmendmentDate', async () => {
-    externalApis.getFacilityExposurePeriod = jest.fn(() => Promise.resolve({ exposurePeriodInMonths: 5 }));
+        expect(result).toEqual(expected);
+      });
 
-    const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+      it('should create tfm object when getLatestCompletedAmendmentValue only', async () => {
+        externalApis.getLatestCompletedAmendmentDate = jest.fn().mockResolvedValue({});
 
-    const expected = {
-      amendmentExposurePeriodInMonths: 5,
-      coverEndDate: unixTime,
-      exposure: {
-        exposure: '4,000.00',
-        timestamp: expect.any(Number),
-        ukefExposureValue: 4000,
-      },
-      value: {
-        currency: CURRENCY.GBP,
-        value: 5000,
-      },
-    };
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
 
-    expect(result).toEqual(expected);
-  });
+        const expected = {
+          exposure: {
+            exposure: '4,000.00',
+            timestamp: expect.any(Number),
+            ukefExposureValue: 4000,
+          },
+          value: {
+            currency: CURRENCY.GBP,
+            value: 5000,
+          },
+        };
 
-  it('createAmendmentTFMObject() - should create tfm object when getLatestCompletedAmendmentValue only', async () => {
-    externalApis.getLatestCompletedAmendmentDate = jest.fn(() => Promise.resolve({}));
+        expect(result).toEqual(expected);
+      });
 
-    const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+      it('should create tfm object when only getLatestCompletedAmendmentDate', async () => {
+        externalApis.getFacilityExposurePeriod = jest.fn().mockResolvedValue({ exposurePeriodInMonths: 5 });
+        externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue({});
 
-    const expected = {
-      exposure: {
-        exposure: '4,000.00',
-        timestamp: expect.any(Number),
-        ukefExposureValue: 4000,
-      },
-      value: {
-        currency: CURRENCY.GBP,
-        value: 5000,
-      },
-    };
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
 
-    expect(result).toEqual(expected);
-  });
+        const expected = {
+          amendmentExposurePeriodInMonths: 5,
+          coverEndDate: unixTime,
+        };
 
-  it('createAmendmentTFMObject() - should create tfm object when only getLatestCompletedAmendmentDate', async () => {
-    externalApis.getFacilityExposurePeriod = jest.fn(() => Promise.resolve({ exposurePeriodInMonths: 5 }));
-    externalApis.getLatestCompletedAmendmentValue = jest.fn(() => Promise.resolve({}));
+        expect(result).toEqual(expected);
+      });
+    });
 
-    const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+    describe('when TFM Facility end date feature flag enabled', () => {
+      beforeEach(() => {
+        jest.mocked(isTfmFacilityEndDateFeatureFlagEnabled).mockReturnValue(true);
+      });
 
-    const expected = {
-      amendmentExposurePeriodInMonths: 5,
-      coverEndDate: unixTime,
-    };
+      it('should not create tfm object when no getLatestCompletedAmendmentValue, getLatestCompletedAmendmentDate or getLatestFacilityEndDate', async () => {
+        externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue({});
+        externalApis.getLatestCompletedAmendmentDate = jest.fn().mockResolvedValue({});
+        externalApis.getLatestCompletedAmendmentFacilityEndDate = jest.fn().mockResolvedValue({});
 
-    expect(result).toEqual(expected);
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+
+        expect(result).toEqual({});
+      });
+
+      it('should create tfm object when getLatestCompletedAmendmentValue, getLatestCompletedAmendmentDate and getLatestFacilityEndDate', async () => {
+        externalApis.getFacilityExposurePeriod = jest.fn().mockResolvedValue({ exposurePeriodInMonths: 5 });
+
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+
+        const expected = {
+          amendmentExposurePeriodInMonths: 5,
+          coverEndDate: unixTime,
+          facilityEndDate: isoString,
+          exposure: {
+            exposure: '4,000.00',
+            timestamp: expect.any(Number),
+            ukefExposureValue: 4000,
+          },
+          value: {
+            currency: CURRENCY.GBP,
+            value: 5000,
+          },
+        };
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should create tfm object when getLatestCompletedAmendmentValue only', async () => {
+        externalApis.getLatestCompletedAmendmentDate = jest.fn().mockResolvedValue({});
+        externalApis.getLatestCompletedAmendmentFacilityEndDate = jest.fn().mockResolvedValue({});
+
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+
+        const expected = {
+          exposure: {
+            exposure: '4,000.00',
+            timestamp: expect.any(Number),
+            ukefExposureValue: 4000,
+          },
+          value: {
+            currency: CURRENCY.GBP,
+            value: 5000,
+          },
+        };
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should create tfm object when only getLatestCompletedAmendmentDate', async () => {
+        externalApis.getFacilityExposurePeriod = jest.fn().mockResolvedValue({ exposurePeriodInMonths: 5 });
+        externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue({});
+        externalApis.getLatestCompletedAmendmentFacilityEndDate = jest.fn().mockResolvedValue({});
+
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+
+        const expected = {
+          amendmentExposurePeriodInMonths: 5,
+          coverEndDate: unixTime,
+        };
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should create tfm object when only getLatestCompletedAmendmentFacilityEndDate', async () => {
+        externalApis.getFacilityExposurePeriod = jest.fn().mockResolvedValue({ exposurePeriodInMonths: 5 });
+        externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue({});
+        externalApis.getLatestCompletedAmendmentDate = jest.fn().mockResolvedValue({});
+
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+
+        const expected = {
+          facilityEndDate: isoString,
+        };
+
+        expect(result).toEqual(expected);
+      });
+
+      it('should create tfm object when getLatestCompletedAmendmentFacilityEndDate and getLatestCompletedAmendmentDate', async () => {
+        externalApis.getFacilityExposurePeriod = jest.fn().mockResolvedValue({ exposurePeriodInMonths: 5 });
+        externalApis.getLatestCompletedAmendmentValue = jest.fn().mockResolvedValue({});
+
+        const result = await amendmentController.createAmendmentTFMObject(mockAmendment.amendmentId, mockAmendment.facilityId);
+
+        const expected = {
+          amendmentExposurePeriodInMonths: 5,
+          coverEndDate: unixTime,
+          facilityEndDate: isoString,
+        };
+
+        expect(result).toEqual(expected);
+      });
+    });
   });
 });

--- a/trade-finance-manager-api/src/constants/amendments.js
+++ b/trade-finance-manager-api/src/constants/amendments.js
@@ -15,6 +15,7 @@ const AMENDMENT_QUERY_STATUSES = {
 const AMENDMENT_QUERIES = {
   LATEST_VALUE: 'latest-value',
   LATEST_COVER_END_DATE: 'latest-cover-end-date',
+  LATEST_FACILITY_END_DATE: 'latest-facility-end-date',
   LATEST: 'latest',
 };
 

--- a/trade-finance-manager-api/src/constants/amendments.js
+++ b/trade-finance-manager-api/src/constants/amendments.js
@@ -12,15 +12,7 @@ const AMENDMENT_QUERY_STATUSES = {
   COMPLETED: 'completed',
 };
 
-const AMENDMENT_QUERIES = {
-  LATEST_VALUE: 'latest-value',
-  LATEST_COVER_END_DATE: 'latest-cover-end-date',
-  LATEST_FACILITY_END_DATE: 'latest-facility-end-date',
-  LATEST: 'latest',
-};
-
 module.exports = {
   UNDERWRITER_MANAGER_DECISIONS,
   AMENDMENT_QUERY_STATUSES,
-  AMENDMENT_QUERIES,
 };

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -473,6 +473,28 @@ const getLatestCompletedAmendmentDate = async (facilityId) => {
   }
 };
 
+const getLatestCompletedAmendmentFacilityEndDate = async (facilityId) => {
+  if (!isValidMongoId(facilityId)) {
+    console.error('Invalid facility Id %s', facilityId);
+    return {  status: 400, message: 'Invalid facility id provided' };
+  }
+  try {
+    const response = await axios({
+      method: 'get',
+      url: `${DTFS_CENTRAL_API_URL}/v1/tfm/facilities/${facilityId}/amendments/completed/latest-facility-end-date`,
+      headers: headers.central,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Unable to get the latest completed facilityEndDate amendment %o', error);
+    return {
+      status: error?.response?.status || 500,
+      data: 'Failed to get the latest completed facilityEndDate amendment',
+    };
+  }
+};
+
 const getAmendmentById = async (facilityId, amendmentId) => {
   const isValid = isValidMongoId(facilityId) && isValidMongoId(amendmentId) && hasValidUri(DTFS_CENTRAL_API_URL);
   if (isValid) {
@@ -1507,6 +1529,7 @@ module.exports = {
   getCompletedAmendment,
   getLatestCompletedAmendmentValue,
   getLatestCompletedAmendmentDate,
+  getLatestCompletedAmendmentFacilityEndDate,
   getAmendmentById,
   getAmendmentByFacilityId,
   getAmendmentsByDealId,

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -474,9 +474,10 @@ const getLatestCompletedAmendmentDate = async (facilityId) => {
 };
 
 const getLatestCompletedAmendmentFacilityEndDate = async (facilityId) => {
-  if (!isValidMongoId(facilityId)) {
+  const isValid = isValidMongoId(facilityId) && hasValidUri(DTFS_CENTRAL_API_URL);
+  if (!isValid) {
     console.error('Invalid facility Id %s', facilityId);
-    return {  status: 400, message: 'Invalid facility id provided' };
+    return { status: 400, data: 'Invalid facility Id provided' };
   }
   try {
     const response = await axios({
@@ -490,7 +491,7 @@ const getLatestCompletedAmendmentFacilityEndDate = async (facilityId) => {
     console.error('Unable to get the latest completed facilityEndDate amendment %o', error);
     return {
       status: error?.response?.status || 500,
-      data: 'Failed to get the latest completed facilityEndDate amendment',
+      data: 'Failed to get the latest completed coverEndDate amendment',
     };
   }
 };

--- a/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/amendment.controller.js
@@ -1,6 +1,6 @@
 const { ObjectId } = require('mongodb');
 const { generateTfmAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { isTfmFacilityEndDateFeatureFlagEnabled } = require('@ukef/dtfs2-common');
+const { isTfmFacilityEndDateFeatureFlagEnabled, AMENDMENT_QUERIES } = require('@ukef/dtfs2-common');
 const api = require('../api');
 const acbs = require('./acbs.controller');
 const { amendIssuedFacility } = require('./amend-issued-facility');
@@ -127,11 +127,11 @@ const getAmendmentByFacilityId = async (req, res) => {
       amendment = (await api.getAmendmentInProgress(facilityId)).data;
       break;
     case CONSTANTS.AMENDMENTS.AMENDMENT_QUERY_STATUSES.COMPLETED:
-      if (type === CONSTANTS.AMENDMENTS.AMENDMENT_QUERIES.LATEST_COVER_END_DATE) {
+      if (type === AMENDMENT_QUERIES.LATEST_COVER_END_DATE) {
         amendment = await api.getLatestCompletedAmendmentDate(facilityId);
-      } else if (type === CONSTANTS.AMENDMENTS.AMENDMENT_QUERIES.LATEST_VALUE) {
+      } else if (type === AMENDMENT_QUERIES.LATEST_VALUE) {
         amendment = await api.getLatestCompletedAmendmentValue(facilityId);
-      } else if (type === CONSTANTS.AMENDMENTS.AMENDMENT_QUERIES.LATEST_FACILITY_END_DATE) {
+      } else if (type === AMENDMENT_QUERIES.LATEST_FACILITY_END_DATE) {
         amendment = await api.getLatestCompletedAmendmentFacilityEndDate(facilityId);
       } else {
         amendment = await api.getCompletedAmendment(facilityId);
@@ -158,7 +158,7 @@ const getAmendmentsByDealId = async (req, res) => {
       amendment = await api.getAmendmentInProgressByDealId(dealId);
       break;
     case CONSTANTS.AMENDMENTS.AMENDMENT_QUERY_STATUSES.COMPLETED:
-      if (type === CONSTANTS.AMENDMENTS.AMENDMENT_QUERIES.LATEST) {
+      if (type === AMENDMENT_QUERIES.LATEST) {
         amendment = await api.getLatestCompletedAmendmentByDealId(dealId);
       } else {
         amendment = await api.getCompletedAmendmentByDealId(dealId);

--- a/trade-finance-manager-api/src/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/src/v1/helpers/amendment.helpers.js
@@ -498,26 +498,41 @@ const calculateAmendmentDateTenor = async (coverEndDate, existingFacility) => {
   }
 };
 
-// populates tfmObject with date values
-const addLatestAmendmentDates = async (tfmObject, latestDate, facilityId) => {
-  // if there is a latest coverEndDate
-  if (latestDate?.coverEndDate) {
-    const { coverEndDate } = latestDate;
-    const existingFacility = await api.findOneFacility(facilityId);
+/**
+ * Populates the tfmObject with date values
+ * @param {}tfmObject
+ * @param latestCoverEndDateResponse
+ * @param latestFacilityEndDateDataResponse
+ * @param facilityId
+ * @returns {Object}
+ */
+const addLatestAmendmentDates = async (tfmObject, latestCoverEndDateResponse, latestFacilityEndDateDataResponse, facilityId) => {
+  const existingFacility = await api.findOneFacility(facilityId);
 
-    if (!existingFacility) {
-      return tfmObject;
-    }
-    // populates with coverEndDate and exposurePeriod
-    const newTfmObject = {
-      ...tfmObject,
-      coverEndDate: latestDate.coverEndDate,
+  if (!existingFacility) {
+    return tfmObject;
+  }
+
+  let newTfmObject = tfmObject;
+
+  if (latestCoverEndDateResponse?.coverEndDate) {
+    const { coverEndDate } = latestCoverEndDateResponse;
+    newTfmObject = {
+      ...newTfmObject,
+      coverEndDate,
       amendmentExposurePeriodInMonths: await calculateAmendmentDateTenor(coverEndDate, existingFacility),
     };
-
-    return newTfmObject;
   }
-  return tfmObject;
+
+  if (latestFacilityEndDateDataResponse?.facilityEndDate) {
+    const { facilityEndDate } = latestFacilityEndDateDataResponse;
+    newTfmObject = {
+      ...newTfmObject,
+      facilityEndDate,
+    };
+  }
+
+  return newTfmObject;
 };
 
 /**

--- a/trade-finance-manager-api/src/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/src/v1/helpers/amendment.helpers.js
@@ -500,11 +500,11 @@ const calculateAmendmentDateTenor = async (coverEndDate, existingFacility) => {
 
 /**
  * Populates the tfmObject with date values
- * @param {}tfmObject
- * @param latestCoverEndDateResponse
- * @param latestFacilityEndDateDataResponse
- * @param facilityId
- * @returns {Object}
+ * @param {import('@ukef/dtfs2-common').TfmFacility} tfmObject
+ * @param {{ coverEndDate?: number } | undefined} latestCoverEndDateResponse
+ * @param {{ facilityEndDate?: string } | undefined} latestFacilityEndDateDataResponse
+ * @param {string} facilityId
+ * @returns {import('@ukef/dtfs2-common').TfmFacility & { coverEndDate?: string, amendmentExposurePeriodInMonths?: number, facilityEndDate?: string }}
  */
 const addLatestAmendmentDates = async (tfmObject, latestCoverEndDateResponse, latestFacilityEndDateDataResponse, facilityId) => {
   const existingFacility = await api.findOneFacility(facilityId);
@@ -513,26 +513,16 @@ const addLatestAmendmentDates = async (tfmObject, latestCoverEndDateResponse, la
     return tfmObject;
   }
 
-  let newTfmObject = tfmObject;
+  const coverEndDate = latestCoverEndDateResponse?.coverEndDate;
+  const amendmentExposurePeriodInMonths = coverEndDate ? await calculateAmendmentDateTenor(coverEndDate, existingFacility) : undefined;
+  const facilityEndDate = latestFacilityEndDateDataResponse?.facilityEndDate;
 
-  if (latestCoverEndDateResponse?.coverEndDate) {
-    const { coverEndDate } = latestCoverEndDateResponse;
-    newTfmObject = {
-      ...newTfmObject,
-      coverEndDate,
-      amendmentExposurePeriodInMonths: await calculateAmendmentDateTenor(coverEndDate, existingFacility),
-    };
-  }
-
-  if (latestFacilityEndDateDataResponse?.facilityEndDate) {
-    const { facilityEndDate } = latestFacilityEndDateDataResponse;
-    newTfmObject = {
-      ...newTfmObject,
-      facilityEndDate,
-    };
-  }
-
-  return newTfmObject;
+  return {
+    ...tfmObject,
+    coverEndDate,
+    amendmentExposurePeriodInMonths,
+    facilityEndDate,
+  };
 };
 
 /**

--- a/trade-finance-manager-api/src/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/src/v1/helpers/amendment.helpers.test.js
@@ -853,8 +853,13 @@ describe('addLatestAmendmentDates', () => {
   };
 
   describe('when TFM Facility end date feature flag disabled', () => {
+    const FACILITY_END_DATE = undefined;
+    const EMPTY_TFM_OBJECT = {};
+
     it('should return an empty object when the amendment contains no cover end date data', async () => {
-      const response = await addLatestAmendmentDates({}, {}, undefined, '123');
+      const latestCoverEndDateResponseWithoutCoverEndDate = {};
+
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, latestCoverEndDateResponseWithoutCoverEndDate, FACILITY_END_DATE, '123');
 
       expect(response).toEqual({});
     });
@@ -863,16 +868,16 @@ describe('addLatestAmendmentDates', () => {
       api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
       api.findOneFacility = () => Promise.resolve(null);
 
-      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, undefined, '123');
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, latestCoverEndDateResponse, FACILITY_END_DATE, '123');
 
       expect(response).toEqual({});
     });
 
-    it('should return an object containing coverEndDate and amendmentExposurePeriodInMonths when the amendment contains cover end date data and the api calls are succesfully made', async () => {
+    it('should return an object containing coverEndDate and amendmentExposurePeriodInMonths when the amendment contains cover end date data and the api calls are successfully made', async () => {
       api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
       api.findOneFacility = () => Promise.resolve(mockFacility);
 
-      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, undefined, '123');
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, latestCoverEndDateResponse, FACILITY_END_DATE, '123');
 
       const expected = {
         coverEndDate: latestCoverEndDateResponse.coverEndDate,
@@ -884,8 +889,18 @@ describe('addLatestAmendmentDates', () => {
   });
 
   describe('when TFM Facility end date feature flag enabled', () => {
+    const EMPTY_TFM_OBJECT = {};
+
     it('should return empty object when no coverEndDate and no facilityEndDate', async () => {
-      const response = await addLatestAmendmentDates({}, {}, {}, '123');
+      const latestCoverEndDateResponseWithoutCoverEndDate = {};
+      const latestFacilityEndDateResponseWithoutFacilityEndDate = {};
+
+      const response = await addLatestAmendmentDates(
+        EMPTY_TFM_OBJECT,
+        latestCoverEndDateResponseWithoutCoverEndDate,
+        latestFacilityEndDateResponseWithoutFacilityEndDate,
+        '123',
+      );
 
       expect(response).toEqual({});
     });
@@ -894,7 +909,7 @@ describe('addLatestAmendmentDates', () => {
       api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
       api.findOneFacility = () => Promise.resolve(null);
 
-      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, latestFacilityEndDateResponse, '123');
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, latestCoverEndDateResponse, latestFacilityEndDateResponse, '123');
 
       expect(response).toEqual({});
     });
@@ -903,7 +918,7 @@ describe('addLatestAmendmentDates', () => {
       api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
       api.findOneFacility = () => Promise.resolve(mockFacility);
 
-      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, {}, '123');
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, latestCoverEndDateResponse, {}, '123');
 
       const expected = {
         coverEndDate: latestCoverEndDateResponse.coverEndDate,
@@ -917,7 +932,7 @@ describe('addLatestAmendmentDates', () => {
       api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
       api.findOneFacility = () => Promise.resolve(mockFacility);
 
-      const response = await addLatestAmendmentDates({}, {}, latestFacilityEndDateResponse, '123');
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, {}, latestFacilityEndDateResponse, '123');
 
       const expected = {
         facilityEndDate: latestFacilityEndDateResponse.facilityEndDate,
@@ -930,7 +945,7 @@ describe('addLatestAmendmentDates', () => {
       api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
       api.findOneFacility = () => Promise.resolve(mockFacility);
 
-      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, latestFacilityEndDateResponse, '123');
+      const response = await addLatestAmendmentDates(EMPTY_TFM_OBJECT, latestCoverEndDateResponse, latestFacilityEndDateResponse, '123');
 
       const expected = {
         coverEndDate: latestCoverEndDateResponse.coverEndDate,

--- a/trade-finance-manager-api/src/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/src/v1/helpers/amendment.helpers.test.js
@@ -819,8 +819,11 @@ describe('calculateAmendmentDateTenor()', () => {
 });
 
 describe('addLatestAmendmentDates', () => {
-  const latestDateResponse = {
+  const latestCoverEndDateResponse = {
     coverEndDate: 1658403289,
+  };
+  const latestFacilityEndDateResponse = {
+    facilityEndDate: '2024-02-14T00:00:00.000+00:00',
   };
   const mockCoverEndDate = {
     'coverEndDate-day': '01',
@@ -849,33 +852,94 @@ describe('addLatestAmendmentDates', () => {
     },
   };
 
-  it('should return empty object when no coverEndDate', async () => {
-    const response = await addLatestAmendmentDates({}, {}, '123');
+  describe('when TFM Facility end date feature flag disabled', () => {
+    it('should return an empty object when the amendment contains no cover end date data', async () => {
+      const response = await addLatestAmendmentDates({}, {}, undefined, '123');
 
-    expect(response).toEqual({});
+      expect(response).toEqual({});
+    });
+
+    it('should return an empty object when there is no matching facility found', async () => {
+      api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
+      api.findOneFacility = () => Promise.resolve(null);
+
+      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, undefined, '123');
+
+      expect(response).toEqual({});
+    });
+
+    it('should return an object containing coverEndDate and amendmentExposurePeriodInMonths when the amendment contains cover end date data and the api calls are succesfully made', async () => {
+      api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
+      api.findOneFacility = () => Promise.resolve(mockFacility);
+
+      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, undefined, '123');
+
+      const expected = {
+        coverEndDate: latestCoverEndDateResponse.coverEndDate,
+        amendmentExposurePeriodInMonths: 2,
+      };
+
+      expect(response).toEqual(expected);
+    });
   });
 
-  it('should return empty object when no facility response', async () => {
-    api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
-    api.findOneFacility = () => Promise.resolve(null);
+  describe('when TFM Facility end date feature flag enabled', () => {
+    it('should return empty object when no coverEndDate and no facilityEndDate', async () => {
+      const response = await addLatestAmendmentDates({}, {}, {}, '123');
 
-    const response = await addLatestAmendmentDates({}, latestDateResponse, '123');
+      expect(response).toEqual({});
+    });
 
-    expect(response).toEqual({});
-  });
+    it('should return an empty object when there is no matching facility found', async () => {
+      api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
+      api.findOneFacility = () => Promise.resolve(null);
 
-  it('should return populated object correct parameters and api calls are made', async () => {
-    api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
-    api.findOneFacility = () => Promise.resolve(mockFacility);
+      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, latestFacilityEndDateResponse, '123');
 
-    const response = await addLatestAmendmentDates({}, latestDateResponse, '123');
+      expect(response).toEqual({});
+    });
 
-    const expected = {
-      coverEndDate: latestDateResponse.coverEndDate,
-      amendmentExposurePeriodInMonths: 2,
-    };
+    it('should return an object containing coverEndDate and amendmentExposurePeriodInMonths when the amendment contains only cover end date data', async () => {
+      api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
+      api.findOneFacility = () => Promise.resolve(mockFacility);
 
-    expect(response).toEqual(expected);
+      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, {}, '123');
+
+      const expected = {
+        coverEndDate: latestCoverEndDateResponse.coverEndDate,
+        amendmentExposurePeriodInMonths: 2,
+      };
+
+      expect(response).toEqual(expected);
+    });
+
+    it('should return an object containing facilityEndDate when the amendment contains only facility end date data', async () => {
+      api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
+      api.findOneFacility = () => Promise.resolve(mockFacility);
+
+      const response = await addLatestAmendmentDates({}, {}, latestFacilityEndDateResponse, '123');
+
+      const expected = {
+        facilityEndDate: latestFacilityEndDateResponse.facilityEndDate,
+      };
+
+      expect(response).toEqual(expected);
+    });
+
+    it('should return an object containing coverEndDate, amendmentExposurePeriodInMonths and facilityEndDate when the amendment contains both cover end date and facility end date data', async () => {
+      api.getFacilityExposurePeriod = () => Promise.resolve({ exposurePeriodInMonths: 2 });
+      api.findOneFacility = () => Promise.resolve(mockFacility);
+
+      const response = await addLatestAmendmentDates({}, latestCoverEndDateResponse, latestFacilityEndDateResponse, '123');
+
+      const expected = {
+        coverEndDate: latestCoverEndDateResponse.coverEndDate,
+        amendmentExposurePeriodInMonths: 2,
+        facilityEndDate: latestFacilityEndDateResponse.facilityEndDate,
+      };
+
+      expect(response).toEqual(expected);
+    });
   });
 });
 

--- a/trade-finance-manager-ui/server/api-response-types/amendments.ts
+++ b/trade-finance-manager-ui/server/api-response-types/amendments.ts
@@ -1,0 +1,10 @@
+type ErrorResponse = {
+  status: number;
+  data: string;
+};
+
+type FacilityEndDateResponse = {
+  facilityEndDate: string;
+};
+
+export type GetLatestCompletedAmendmentFacilityEndDateResponse = ErrorResponse | FacilityEndDateResponse;

--- a/trade-finance-manager-ui/server/api-response-types/index.ts
+++ b/trade-finance-manager-ui/server/api-response-types/index.ts
@@ -1,5 +1,6 @@
 export * from './fee-record';
 export * from './payment';
+export * from './amendments';
 export * from './selected-reported-fees-details-response';
 export * from './utilisation-report-reconciliation-details-response-body';
 export * from './fee-records-to-key-response-body';

--- a/trade-finance-manager-ui/server/api-ssrf.test.js
+++ b/trade-finance-manager-ui/server/api-ssrf.test.js
@@ -148,11 +148,48 @@ describe('API is protected against SSRF attacks', () => {
     });
   });
 
-  describe('getAmendmentInProgress', () => {
+  const getAmendmentDetailsByFacilityIdFunctionsToTest = [
+    {
+      description: 'getAmendmentInProgress',
+      apiFunction: api.getAmendmentInProgress,
+      url: /^.*\/v1\/facilities\/.*\/amendments\/in-progress$/,
+    },
+    {
+      description: 'getCompletedAmendment',
+      apiFunction: api.getCompletedAmendment,
+      url: /^.*\/v1\/facilities\/.*\/amendments\/completed$/,
+    },
+    {
+      description: 'getLatestCompletedAmendmentValue',
+      apiFunction: api.getLatestCompletedAmendmentValue,
+      url: /^.*\/v1\/facilities\/.*\/amendments\/completed\/latest-value$/,
+    },
+    {
+      description: 'getLatestCompletedAmendmentDate',
+      apiFunction: api.getLatestCompletedAmendmentDate,
+      url: /^.*\/v1\/facilities\/.*\/amendments\/completed\/latest-cover-end-date$/,
+    },
+    {
+      description: 'getLatestCompletedAmendmentFacilityEndDate',
+      apiFunction: api.getLatestCompletedAmendmentFacilityEndDate,
+      url: /^.*\/v1\/facilities\/.*\/amendments\/completed\/latest-facility-end-date$/,
+    },
+    {
+      description: 'getAmendmentsByFacilityId',
+      apiFunction: api.getAmendmentsByFacilityId,
+      url: /^.*\/v1\/facilities\/.*\/amendments$/,
+    },
+    {
+      description: 'getAmendmentsByFacilityId',
+      apiFunction: api.getAmendmentsByFacilityId,
+      url: /^.*\/v1\/facilities\/.*\/amendments$/,
+    },
+  ];
+
+  describe.each(getAmendmentDetailsByFacilityIdFunctionsToTest)('$description', ({ apiFunction, url }) => {
     const mockResponse = 'Mock amendment';
     beforeAll(() => {
       mockAxios.reset();
-      const url = /^.*\/v1\/facilities\/.*\/amendments\/in-progress$/;
       mockAxios.onGet(url).reply(200, mockResponse);
     });
 
@@ -160,7 +197,7 @@ describe('API is protected against SSRF attacks', () => {
       const urlTraversal = '../../../etc/stealpassword';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.getAmendmentInProgress(urlTraversal, 'mock token');
+      const response = await apiFunction(urlTraversal, 'mock token');
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -169,7 +206,7 @@ describe('API is protected against SSRF attacks', () => {
       const localIp = '127.0.0.1';
       const expectedResponse = { status: 400, data: 'Invalid facility id' };
 
-      const response = await api.getAmendmentInProgress(localIp, 'mock token');
+      const response = await apiFunction(localIp, 'mock token');
 
       expect(response).toMatchObject(expectedResponse);
     });
@@ -177,112 +214,7 @@ describe('API is protected against SSRF attacks', () => {
     it('Makes an axios request when the facility id is valid', async () => {
       const validFacilityId = '5ce819935e539c343f141ece';
 
-      const response = await api.getAmendmentInProgress(validFacilityId, 'mock token');
-
-      expect(response.data).toEqual(mockResponse);
-    });
-  });
-
-  describe('getCompletedAmendment', () => {
-    const mockResponse = 'Mock amendment';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/facilities\/.*\/amendments\/completed$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getCompletedAmendment(urlTraversal, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getCompletedAmendment(localIp, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getCompletedAmendment(validFacilityId, 'mock token');
-
-      expect(response.data).toEqual(mockResponse);
-    });
-  });
-
-  describe('getLatestCompletedAmendmentValue', () => {
-    const mockResponse = 'Mock amendment';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/facilities\/.*\/amendments\/completed\/latest-value$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getLatestCompletedAmendmentValue(urlTraversal, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getLatestCompletedAmendmentValue(localIp, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getLatestCompletedAmendmentValue(validFacilityId, 'mock token');
-
-      expect(response.data).toEqual(mockResponse);
-    });
-  });
-
-  describe('getLatestCompletedAmendmentDate', () => {
-    const mockResponse = 'Mock amendment';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/facilities\/.*\/amendments\/completed\/latest-cover-end-date$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getLatestCompletedAmendmentDate(urlTraversal, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getLatestCompletedAmendmentDate(localIp, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getLatestCompletedAmendmentDate(validFacilityId, 'mock token');
+      const response = await apiFunction(validFacilityId, 'mock token');
 
       expect(response.data).toEqual(mockResponse);
     });
@@ -321,41 +253,6 @@ describe('API is protected against SSRF attacks', () => {
       const validAmendmentId = '5ce819935e539c343f141ece';
 
       const response = await api.getAmendmentById(validFacilityId, validAmendmentId, 'mock token');
-
-      expect(response.data).toEqual(mockResponse);
-    });
-  });
-
-  describe('getAmendmentsByFacilityId', () => {
-    const mockResponse = 'Mock amendments';
-    beforeAll(() => {
-      mockAxios.reset();
-      const url = /^.*\/v1\/facilities\/.*\/amendments$/;
-      mockAxios.onGet(url).reply(200, mockResponse);
-    });
-
-    it('Returns an error when a url traversal is supplied', async () => {
-      const urlTraversal = '../../../etc/stealpassword';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getAmendmentsByFacilityId(urlTraversal, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Returns an error when a local IP is supplied', async () => {
-      const localIp = '127.0.0.1';
-      const expectedResponse = { status: 400, data: 'Invalid facility id' };
-
-      const response = await api.getAmendmentsByFacilityId(localIp, 'mock token');
-
-      expect(response).toMatchObject(expectedResponse);
-    });
-
-    it('Makes an axios request when the facility id is valid', async () => {
-      const validFacilityId = '5ce819935e539c343f141ece';
-
-      const response = await api.getAmendmentsByFacilityId(validFacilityId, 'mock token');
 
       expect(response.data).toEqual(mockResponse);
     });

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -629,7 +629,7 @@ const getLatestCompletedAmendmentDate = async (facilityId, token) => {
 /**
  * @param {string} facilityId - The facility ID
  * @param {string} token - The user token
- * @returns {Promise<{ status: number, data: string | {facilityEndDate: string} }>}
+ * @returns {Promise<import('./api-response-types').GetLatestCompletedAmendmentFacilityEndDateResponse>}
  */
 const getLatestCompletedAmendmentFacilityEndDate = async (facilityId, token) => {
   try {

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -626,6 +626,33 @@ const getLatestCompletedAmendmentDate = async (facilityId, token) => {
   }
 };
 
+/**
+ * @param {string} facilityId - The facility ID
+ * @param {string} token - The user token
+ * @returns {Promise<{ status: number, data: string | {facilityEndDate: string} }>}
+ */
+const getLatestCompletedAmendmentFacilityEndDate = async (facilityId, token) => {
+  try {
+    const isValidFacilityId = isValidMongoId(facilityId);
+
+    if (!isValidFacilityId) {
+      console.error('getLatestCompletedAmendmentFacilityEndDate: Invalid facility id provided %s', facilityId);
+      return { status: 400, data: 'Invalid facility id' };
+    }
+
+    const response = await axios({
+      method: 'get',
+      url: `${TFM_API_URL}/v1/facilities/${facilityId}/amendments/completed/latest-facility-end-date`,
+      headers: generateHeaders(token),
+    });
+
+    return { status: 200, data: response.data };
+  } catch (error) {
+    console.error('Unable to get the latest completed facilityEndDate amendment %o', error);
+    return { status: error?.response?.status || 500, data: 'Failed to get latest completed facility end date amendment' };
+  }
+};
+
 const getAmendmentById = async (facilityId, amendmentId, token) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
@@ -1196,6 +1223,7 @@ module.exports = {
   getAllAmendmentsInProgress,
   getLatestCompletedAmendmentValue,
   getLatestCompletedAmendmentDate,
+  getLatestCompletedAmendmentFacilityEndDate,
   getParty,
   getUkBankHolidays,
   getUtilisationReportsReconciliationSummary,

--- a/trade-finance-manager-ui/server/controllers/case/amendments/amendmentFacilityEndDate.post.api-test.js
+++ b/trade-finance-manager-ui/server/controllers/case/amendments/amendmentFacilityEndDate.post.api-test.js
@@ -40,173 +40,319 @@ describe('amendmentFacilityEndDate routes', () => {
       jest.mocked(isTfmFacilityEndDateFeatureFlagEnabled).mockReturnValue(true);
     });
 
-    it('should render the template with errors if the entered facility end date is before the cover start date', async () => {
-      const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 11, 11).valueOf().toString() } } };
+    describe('incorrect facility end date entered', () => {
+      it('should render the template with errors if the entered facility end date is before the cover start date', async () => {
+        const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 11, 11).valueOf().toString() } } };
 
-      api.getAmendmentById.mockResolvedValueOnce({ status: 200, data: MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE });
-      api.updateAmendment.mockResolvedValueOnce({ status: 200 });
-      api.getFacility.mockResolvedValueOnce(mockFacility);
+        api.getAmendmentById.mockResolvedValueOnce({ status: 200, data: MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE });
+        api.updateAmendment.mockResolvedValueOnce({ status: 200 });
+        api.getFacility.mockResolvedValueOnce(mockFacility);
 
-      const req = {
-        params: {
-          _id: dealId,
-          amendmentId,
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': '12',
+            'facility-end-date-month': '11',
+            'facility-end-date-year': '2024',
+          },
+          session,
+        };
+
+        await postAmendmentFacilityEndDate(req, res);
+        expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
+          dealId,
+          isEditable: true,
           facilityId,
-        },
-        body: {
-          'facility-end-date-day': '12',
-          'facility-end-date-month': '11',
-          'facility-end-date-year': '2024',
-        },
-        session,
-      };
+          facilityEndDateDay: '12',
+          facilityEndDateMonth: '11',
+          facilityEndDateYear: '2024',
+          error: {
+            summary: [
+              {
+                text: 'The facility end date cannot be before the cover start date',
+              },
+            ],
+            fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
+          },
+          user: req.session.user,
+        });
+      });
 
-      await postAmendmentFacilityEndDate(req, res);
-      expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
-        dealId,
-        isEditable: true,
-        facilityId,
-        facilityEndDateDay: '12',
-        facilityEndDateMonth: '11',
-        facilityEndDateYear: '2024',
-        error: {
-          summary: [
-            {
-              text: 'The facility end date cannot be before the cover start date',
-            },
-          ],
-          fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
-        },
-        user: req.session.user,
+      it('should render the template with errors if the entered facility end date is greater than 6 years in the future', async () => {
+        const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2021, 11, 11).valueOf().toString() } } };
+
+        api.getAmendmentById.mockResolvedValueOnce({ status: 200, data: MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE });
+        api.updateAmendment.mockResolvedValueOnce({ status: 200 });
+        api.getFacility.mockResolvedValueOnce(mockFacility);
+
+        const now = new Date();
+        const sixYearsFromNowPlusDay = add(now, { years: 6, days: 1 });
+
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': sixYearsFromNowPlusDay.getDate().toString(),
+            'facility-end-date-month': (sixYearsFromNowPlusDay.getMonth() + 1).toString(),
+            'facility-end-date-year': sixYearsFromNowPlusDay.getFullYear().toString(),
+          },
+          session,
+        };
+
+        await postAmendmentFacilityEndDate(req, res);
+        expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
+          dealId,
+          isEditable: true,
+          facilityId,
+          facilityEndDateDay: sixYearsFromNowPlusDay.getDate().toString(),
+          facilityEndDateMonth: (sixYearsFromNowPlusDay.getMonth() + 1).toString(),
+          facilityEndDateYear: sixYearsFromNowPlusDay.getFullYear().toString(),
+          error: {
+            summary: [
+              {
+                text: 'Facility end date cannot be greater than 6 years in the future',
+              },
+            ],
+            fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
+          },
+          user: req.session.user,
+        });
+      });
+
+      it("should render the template with the current facility date as undefined if facility end date is not in the facility snapshot and there hasn't yet been an amendment to it", async () => {
+        api.getAmendmentById.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE,
+          },
+        });
+        api.getLatestCompletedAmendmentFacilityEndDate = jest.fn().mockResolvedValueOnce({ status: 200, data: {} });
+        api.getFacility = jest.fn().mockResolvedValueOnce({ facilitySnapshot: { dates: {} } });
+
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': '',
+            'facility-end-date-month': '',
+            'facility-end-date-year': '',
+          },
+          session,
+        };
+        await postAmendmentFacilityEndDate(req, res);
+
+        expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
+          dealId,
+          facilityId,
+          facilityEndDateDay: '',
+          facilityEndDateMonth: '',
+          facilityEndDateYear: '',
+          currentFacilityEndDate: undefined,
+          error: {
+            summary: [
+              {
+                text: 'Enter the facility end date',
+              },
+            ],
+            fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
+          },
+          isEditable: true,
+          user,
+        });
+      });
+
+      it('should render the template with the current facility end date from the facility snapshot if it exists and this is the first amendment to it', async () => {
+        api.getAmendmentById.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE,
+          },
+        });
+        api.getLatestCompletedAmendmentFacilityEndDate = jest.fn().mockResolvedValueOnce({ status: 200, data: {} });
+        api.getFacility = jest
+          .fn()
+          .mockResolvedValueOnce({ facilitySnapshot: { dates: { isUsingFacilityEndDate: true, facilityEndDate: new Date(2025, 11, 11).toISOString() } } });
+
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': '',
+            'facility-end-date-month': '',
+            'facility-end-date-year': '',
+          },
+          session,
+        };
+        await postAmendmentFacilityEndDate(req, res);
+
+        expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
+          dealId,
+          facilityId,
+          facilityEndDateDay: '',
+          facilityEndDateMonth: '',
+          facilityEndDateYear: '',
+          currentFacilityEndDate: '11 December 2025',
+          error: {
+            summary: [
+              {
+                text: 'Enter the facility end date',
+              },
+            ],
+            fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
+          },
+          isEditable: true,
+          user,
+        });
+      });
+
+      it('should render the template with the most recent amended facility end date value if a previous amendment to it has been made', async () => {
+        api.getAmendmentById.mockResolvedValueOnce({
+          status: 200,
+          data: {
+            ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE,
+          },
+        });
+        api.getLatestCompletedAmendmentFacilityEndDate = jest
+          .fn()
+          .mockResolvedValueOnce({ status: 200, data: { facilityEndDate: new Date(2028, 1, 1).toISOString() } });
+        api.getFacility = jest
+          .fn()
+          .mockResolvedValueOnce({ facilitySnapshot: { dates: { isUsingFacilityEndDate: true, facilityEndDate: new Date(2025, 11, 11).toISOString() } } });
+
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          session,
+          body: {
+            'facility-end-date-day': '',
+            'facility-end-date-month': '',
+            'facility-end-date-year': '',
+          },
+        };
+        await postAmendmentFacilityEndDate(req, res);
+
+        expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
+          dealId,
+          facilityId,
+          facilityEndDateDay: '',
+          facilityEndDateMonth: '',
+          facilityEndDateYear: '',
+          currentFacilityEndDate: '01 February 2028',
+          error: {
+            summary: [
+              {
+                text: 'Enter the facility end date',
+              },
+            ],
+            fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
+          },
+
+          isEditable: true,
+          user,
+        });
       });
     });
 
-    it('should render the template with errors if the entered facility end date is greater than 6 years in the future', async () => {
-      const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2021, 11, 11).valueOf().toString() } } };
+    describe('correct facility end date entered', () => {
+      it('should redirect to the check answers page when only the cover end date is being amended and there are no errors', async () => {
+        const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 1, 1).valueOf().toString() } } };
 
-      api.getAmendmentById.mockResolvedValueOnce({ status: 200, data: MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE });
-      api.updateAmendment.mockResolvedValueOnce({ status: 200 });
-      api.getFacility.mockResolvedValueOnce(mockFacility);
+        api.getAmendmentById.mockResolvedValueOnce({ status: 200, data: MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE });
+        api.updateAmendment.mockResolvedValueOnce({ status: 200 });
+        api.getFacility.mockResolvedValueOnce(mockFacility);
 
-      const now = new Date();
-      const sixYearsFromNowPlusDay = add(now, { years: 6, days: 1 });
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': '12',
+            'facility-end-date-month': '11',
+            'facility-end-date-year': '2025',
+          },
+          session,
+        };
 
-      const req = {
-        params: {
-          _id: dealId,
-          amendmentId,
-          facilityId,
-        },
-        body: {
-          'facility-end-date-day': sixYearsFromNowPlusDay.getDate().toString(),
-          'facility-end-date-month': (sixYearsFromNowPlusDay.getMonth() + 1).toString(),
-          'facility-end-date-year': sixYearsFromNowPlusDay.getFullYear().toString(),
-        },
-        session,
-      };
+        await postAmendmentFacilityEndDate(req, res);
 
-      await postAmendmentFacilityEndDate(req, res);
-      expect(res.render).toHaveBeenCalledWith('case/amendments/amendment-facility-end-date.njk', {
-        dealId,
-        isEditable: true,
-        facilityId,
-        facilityEndDateDay: sixYearsFromNowPlusDay.getDate().toString(),
-        facilityEndDateMonth: (sixYearsFromNowPlusDay.getMonth() + 1).toString(),
-        facilityEndDateYear: sixYearsFromNowPlusDay.getFullYear().toString(),
-        error: {
-          summary: [
-            {
-              text: 'Facility end date cannot be greater than 6 years in the future',
-            },
-          ],
-          fields: ['facility-end-date-day', 'facility-end-date-month', 'facility-end-date-year'],
-        },
-        user: req.session.user,
+        expect(res.redirect).toHaveBeenCalledWith(`/case/${dealId}/facility/${facilityId}/amendment/${amendmentId}/check-answers`);
       });
-    });
 
-    it('should redirect to the check answers page when only the cover end date is being amended and there are no errors', async () => {
-      const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 1, 1).valueOf().toString() } } };
+      it('should redirect to the update facility value page when the facility value also needs amending and there are no errors', async () => {
+        const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 1, 1).valueOf().toString() } } };
 
-      api.getAmendmentById.mockResolvedValueOnce({ status: 200, data: MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE });
-      api.updateAmendment.mockResolvedValueOnce({ status: 200 });
-      api.getFacility.mockResolvedValueOnce(mockFacility);
+        api.getAmendmentById.mockResolvedValueOnce({
+          status: 200,
+          data: { ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE, changeFacilityValue: true },
+        });
+        api.updateAmendment.mockResolvedValueOnce({ status: 200 });
+        api.getFacility.mockResolvedValueOnce(mockFacility);
 
-      const req = {
-        params: {
-          _id: dealId,
-          amendmentId,
-          facilityId,
-        },
-        body: {
-          'facility-end-date-day': '12',
-          'facility-end-date-month': '11',
-          'facility-end-date-year': '2025',
-        },
-        session,
-      };
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': '12',
+            'facility-end-date-month': '11',
+            'facility-end-date-year': '2025',
+          },
+          session,
+        };
 
-      await postAmendmentFacilityEndDate(req, res);
+        await postAmendmentFacilityEndDate(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(`/case/${dealId}/facility/${facilityId}/amendment/${amendmentId}/check-answers`);
-    });
-
-    it('should redirect to the update facility value page when the facility value also needs amending and there are no errors', async () => {
-      const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 1, 1).valueOf().toString() } } };
-
-      api.getAmendmentById.mockResolvedValueOnce({
-        status: 200,
-        data: { ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE, changeFacilityValue: true },
+        expect(res.redirect).toHaveBeenCalledWith(`/case/${dealId}/facility/${facilityId}/amendment/${amendmentId}/facility-value`);
       });
-      api.updateAmendment.mockResolvedValueOnce({ status: 200 });
-      api.getFacility.mockResolvedValueOnce(mockFacility);
 
-      const req = {
-        params: {
-          _id: dealId,
-          amendmentId,
-          facilityId,
-        },
-        body: {
-          'facility-end-date-day': '12',
-          'facility-end-date-month': '11',
-          'facility-end-date-year': '2025',
-        },
-        session,
-      };
+      it("should redirect to the amendments summary page if there's an error updating the amendment", async () => {
+        const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 1, 1).valueOf().toString() } } };
 
-      await postAmendmentFacilityEndDate(req, res);
+        api.getAmendmentById.mockResolvedValueOnce({
+          status: 200,
+          data: { ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE, changeFacilityValue: true },
+        });
+        api.updateAmendment.mockResolvedValueOnce({ status: 400 });
+        api.getFacility.mockResolvedValueOnce(mockFacility);
 
-      expect(res.redirect).toHaveBeenCalledWith(`/case/${dealId}/facility/${facilityId}/amendment/${amendmentId}/facility-value`);
-    });
+        const req = {
+          params: {
+            _id: dealId,
+            amendmentId,
+            facilityId,
+          },
+          body: {
+            'facility-end-date-day': '12',
+            'facility-end-date-month': '11',
+            'facility-end-date-year': '2025',
+          },
+          session,
+        };
 
-    it("should redirect to the amendments summary page if there's an error updating the amendment", async () => {
-      const mockFacility = { facilitySnapshot: { dates: { coverStartDate: new Date(2024, 1, 1).valueOf().toString() } } };
+        await postAmendmentFacilityEndDate(req, res);
 
-      api.getAmendmentById.mockResolvedValueOnce({
-        status: 200,
-        data: { ...MOCK_AMENDMENT_COVERENDDATE_CHANGE_USING_FACILITY_ENDDATE, changeFacilityValue: true },
+        expect(res.redirect).toHaveBeenCalledWith(`/case/${dealId}/facility/${facilityId}#amendments`);
       });
-      api.updateAmendment.mockResolvedValueOnce({ status: 400 });
-      api.getFacility.mockResolvedValueOnce(mockFacility);
-
-      const req = {
-        params: {
-          _id: dealId,
-          amendmentId,
-          facilityId,
-        },
-        body: {
-          'facility-end-date-day': '12',
-          'facility-end-date-month': '11',
-          'facility-end-date-year': '2025',
-        },
-        session,
-      };
-
-      await postAmendmentFacilityEndDate(req, res);
-
-      expect(res.redirect).toHaveBeenCalledWith(`/case/${dealId}/facility/${facilityId}#amendments`);
     });
   });
 });

--- a/trade-finance-manager-ui/templates/case/amendments/amendment-facility-end-date.njk
+++ b/trade-finance-manager-ui/templates/case/amendments/amendment-facility-end-date.njk
@@ -23,61 +23,66 @@
   }) }}
  {% endif %}
 
-<form method="POST" autocomplete="off" class="govuk-!-margin-top-4">
+<form method="POST" autocomplete="off">
   <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-  {{ govukDateInput({
-    id: "facilityEndDate",
-    fieldset: {
-        legend: {
-          text: "Enter the new facility end date",
-          isPageHeading: true,
-          classes: "govuk-fieldset__legend--l govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-2"
+  <fieldset class="govuk-fieldset" role="group" aria-describedby="coverEndDate-hint">
+
+    <legend class="govuk-fieldset__legend">
+      <h1 class="govuk-heading-l govuk-!-margin-top-4 govuk-!-margin-bottom-0" data-cy="amendment--facility-end-date-heading">Enter the new facility end date</h1>
+    </legend>
+
+    <dl class="govuk-body govuk-!-margin-bottom-4" data-cy="amendment--current-facility-end-date">
+      <dt class="govuk-body govuk-!-margin-bottom-0 govuk-!-font-weight-bold">Current facility end date</dt>
+      <dd>{{ ( currentFacilityEndDate if currentFacilityEndDate else "Not provided") }}</dd>
+    </dl>
+
+    {{ govukDateInput({
+      id: "facilityEndDate",
+      namePrefix: "facility-end-date",
+      hint: {
+        text: "For example, 31 3 2022",
+        attributes: {
+          "data-cy": "facility-end-date-hint"
         }
       },
-    namePrefix: "facility-end-date",
-    hint: {
-      text: "For example, 31 3 2022",
-      attributes: {
-        "data-cy": "facility-end-date-hint"
-      }
-    },
-    errorMessage: error and {
-      text: error.summary[0].text,
-      attributes: {
-        'data-cy': 'amendment--inline-error'
-      }
-    },
-    items: [
-      {
-        label: "Day",
-        classes: (error and 'facility-end-date-day' in error.fields) and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
-        name: "day",
-        value: facilityEndDateDay,
+      errorMessage: error and {
+        text: error.summary[0].text,
         attributes: {
-          'data-cy': "amendment--facility-end-date-day"
+          'data-cy': 'amendment--inline-error'
         }
       },
-      {
-        label: "Month",
-        classes: (error and 'facility-end-date-month' in error.fields) and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
-        name: "month",
-        value: facilityEndDateMonth,
-        attributes: {
-          'data-cy': "amendment--facility-end-date-month"
+      items: [
+        {
+          label: "Day",
+          classes: (error and 'facility-end-date-day' in error.fields) and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+          name: "day",
+          value: facilityEndDateDay,
+          attributes: {
+            'data-cy': "amendment--facility-end-date-day"
+          }
+        },
+        {
+          label: "Month",
+          classes: (error and 'facility-end-date-month' in error.fields) and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+          name: "month",
+          value: facilityEndDateMonth,
+          attributes: {
+            'data-cy': "amendment--facility-end-date-month"
+          }
+        },
+        {
+          label: "Year",
+          classes: (error and 'facility-end-date-year' in error.fields) and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
+          name: "year",
+          value: facilityEndDateYear,
+          attributes: {
+            'data-cy': "amendment--facility-end-date-year"
+          }
         }
-      },
-      {
-        label: "Year",
-        classes: (error and 'facility-end-date-year' in error.fields) and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
-        name: "year",
-        value: facilityEndDateYear,
-        attributes: {
-          'data-cy': "amendment--facility-end-date-year"
-        }
-      }
-    ]
-  }) }}
+      ]
+    }) }}
+  </fieldset>
 
   <div class="govuk-button-group">
     {% if isEditable %}


### PR DESCRIPTION
## Introduction :pencil2:
When adding a new facility end date to an amendment, it should show the current facility end date if either: 
- this is the first amendment, and the facility snapshot when received into tfm contains a facility end date OR
- this an additional amendment, and a previous amendment has already updated the facility end date to a value in which case it should display the FED of the most recent amendment that updated the FED. 

## Resolution :heavy_check_mark:
- Added the current facility end date section to the nunjucks file
- retrieve the latest amendment FED submitted from the API

## Miscellaneous :heavy_plus_sign:
- Reduces some repetition in test files

## Screenshots
<img src="https://github.com/user-attachments/assets/e27f607d-e990-4bc1-933a-47134e79c7a7" width="400" >
<img src="https://github.com/user-attachments/assets/7fea8189-995c-45f2-87af-67fa633c5169" width="400">


