### PR TITLE
feat(FN-3289): remove the keying sheet accruals columns

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -256,7 +256,6 @@ describe('POST /v1/utilisation-reports/:reportId/keying-data', () => {
         where: {
           status: 'READY_TO_KEY',
           fixedFeeAdjustment: Not(IsNull()),
-          premiumAccrualBalanceAdjustment: Not(IsNull()),
           principalBalanceAdjustment: Not(IsNull()),
         },
       });
@@ -266,7 +265,6 @@ describe('POST /v1/utilisation-reports/:reportId/keying-data', () => {
         where: {
           status: 'READY_TO_KEY',
           fixedFeeAdjustment: IsNull(),
-          premiumAccrualBalanceAdjustment: IsNull(),
           principalBalanceAdjustment: IsNull(),
         },
       });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -116,21 +116,6 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       expect(feeRecord.fixedFeeAdjustment).toBe(10);
     });
 
-    it('sets the fee record premiumAccrualBalanceAdjustment to 10', async () => {
-      // Arrange
-      const feeRecord = aMatchingFeeRecord();
-
-      // Act
-      await handleFeeRecordGenerateKeyingDataEvent(feeRecord, {
-        transactionEntityManager: mockEntityManager,
-        isFinalFeeRecordForFacility,
-        requestSource,
-      });
-
-      // Assert
-      expect(feeRecord.premiumAccrualBalanceAdjustment).toBe(10);
-    });
-
     it('sets the fee record principalBalanceAdjustment to the difference between the fee record utilisation and the facility utilisation data utilisation', async () => {
       // Arrange
       const feeRecord = aMatchingFeeRecord();
@@ -165,21 +150,6 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
       // Assert
       expect(feeRecord.fixedFeeAdjustment).toBeNull();
-    });
-
-    it('does not set the fee record premiumAccrualBalanceAdjustment', async () => {
-      // Arrange
-      const feeRecord = aMatchingFeeRecord();
-
-      // Act
-      await handleFeeRecordGenerateKeyingDataEvent(feeRecord, {
-        transactionEntityManager: mockEntityManager,
-        isFinalFeeRecordForFacility,
-        requestSource,
-      });
-
-      // Assert
-      expect(feeRecord.premiumAccrualBalanceAdjustment).toBeNull();
     });
 
     it('does not set the fee record principalBalanceAdjustment', async () => {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -23,7 +23,6 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
   const principalBalanceAdjustment = calculatePrincipalBalanceAdjustment(feeRecord, feeRecord.facilityUtilisationData);
   feeRecord.updateWithKeyingData({
     fixedFeeAdjustment: 10,
-    premiumAccrualBalanceAdjustment: 10,
     principalBalanceAdjustment,
     requestSource,
   });

--- a/dtfs-central-api/src/types/fee-records.ts
+++ b/dtfs-central-api/src/types/fee-records.ts
@@ -40,7 +40,6 @@ export type KeyingSheetRow = {
   }[];
   baseCurrency: Currency;
   fixedFeeAdjustment: KeyingSheetAdjustment | null;
-  premiumAccrualBalanceAdjustment: KeyingSheetAdjustment | null;
   principalBalanceAdjustment: KeyingSheetAdjustment | null;
 };
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-keying-sheet.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-keying-sheet.test.ts
@@ -113,30 +113,6 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
       { condition: 'is positive', value: 100, expectedMappedValue: { amount: 100, change: 'INCREASE' } },
       { condition: 'is negative', value: -100, expectedMappedValue: { amount: 100, change: 'DECREASE' } },
     ])(
-      'sets the keying sheet premiumAccrualBalanceAdjustment to $expectedMappedValue when the fee record entity premiumAccrualBalanceAdjustment $condition',
-      ({ value, expectedMappedValue }) => {
-        // Arrange
-        const feeRecords = [
-          FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withPremiumAccrualBalanceAdjustment(value).build(),
-        ];
-
-        const feeRecordPaymentGroups: FeeRecordPaymentEntityGroup[] = [{ feeRecords, payments: [aPayment()] }];
-
-        // Act
-        const result = mapFeeRecordPaymentEntityGroupsToKeyingSheet(feeRecordPaymentGroups);
-
-        // Assert
-        expect(result).toHaveLength(1);
-        expect(result[0].premiumAccrualBalanceAdjustment).toEqual(expectedMappedValue);
-      },
-    );
-
-    it.each([
-      { condition: 'is null', value: null, expectedMappedValue: null },
-      { condition: 'is zero', value: 0, expectedMappedValue: { amount: 0, change: 'NONE' } },
-      { condition: 'is positive', value: 100, expectedMappedValue: { amount: 100, change: 'INCREASE' } },
-      { condition: 'is negative', value: -100, expectedMappedValue: { amount: 100, change: 'DECREASE' } },
-    ])(
       'sets the keying sheet principalBalanceAdjustment to $expectedMappedValue when the fee record entity principalBalanceAdjustment $condition',
       ({ value, expectedMappedValue }) => {
         // Arrange

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-keying-sheet.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-keying-sheet.ts
@@ -30,7 +30,6 @@ const mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments = (feeRecordEntity: F
   exporter: feeRecordEntity.exporter,
   baseCurrency: feeRecordEntity.baseCurrency,
   fixedFeeAdjustment: getKeyingSheetAdjustmentForAmount(feeRecordEntity.fixedFeeAdjustment),
-  premiumAccrualBalanceAdjustment: getKeyingSheetAdjustmentForAmount(feeRecordEntity.premiumAccrualBalanceAdjustment),
   principalBalanceAdjustment: getKeyingSheetAdjustmentForAmount(feeRecordEntity.principalBalanceAdjustment),
 });
 

--- a/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/keying-sheet.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/keying-sheet.js
@@ -41,9 +41,6 @@
  *       fixedFeeAdjustment:
  *         $ref: '#/definitions/KeyingSheetAdjustment'
  *         nullable: true
- *       premiumAccrualBalanceAdjustment:
- *         $ref: '#/definitions/KeyingSheetAdjustment'
- *         nullable: true
  *       principalBalanceAdjustment:
  *         $ref: '#/definitions/KeyingSheetAdjustment'
  *         nullable: true

--- a/libs/common/src/sql-db-connection/migrations/1722868553795-RemoveFeeRecordAccrualsColumn.ts
+++ b/libs/common/src/sql-db-connection/migrations/1722868553795-RemoveFeeRecordAccrualsColumn.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveFeeRecordAccrualsColumn1722868553795 implements MigrationInterface {
+  name = 'RemoveFeeRecordAccrualsColumn1722868553795';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord" DROP COLUMN "premiumAccrualBalanceAdjustment"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FeeRecord"
+            ADD "premiumAccrualBalanceAdjustment" decimal(14, 2)
+        `);
+  }
+}

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -127,12 +127,6 @@ export class FeeRecordEntity extends AuditableBaseEntity {
   fixedFeeAdjustment!: number | null;
 
   /**
-   * The keying sheet premium accrual balance adjustment
-   */
-  @MonetaryColumn({ nullable: true })
-  premiumAccrualBalanceAdjustment!: number | null;
-
-  /**
    * The keying sheet principal balance adjustment
    */
   @MonetaryColumn({ nullable: true })
@@ -172,7 +166,6 @@ export class FeeRecordEntity extends AuditableBaseEntity {
     feeRecord.updateLastUpdatedBy(requestSource);
     feeRecord.payments = [];
     feeRecord.fixedFeeAdjustment = null;
-    feeRecord.premiumAccrualBalanceAdjustment = null;
     feeRecord.principalBalanceAdjustment = null;
     return feeRecord;
   }
@@ -193,15 +186,9 @@ export class FeeRecordEntity extends AuditableBaseEntity {
     this.updateLastUpdatedBy(requestSource);
   }
 
-  public updateWithKeyingData({
-    fixedFeeAdjustment,
-    premiumAccrualBalanceAdjustment,
-    principalBalanceAdjustment,
-    requestSource,
-  }: UpdateWithKeyingDataParams): void {
+  public updateWithKeyingData({ fixedFeeAdjustment, principalBalanceAdjustment, requestSource }: UpdateWithKeyingDataParams): void {
     this.status = 'READY_TO_KEY';
     this.fixedFeeAdjustment = fixedFeeAdjustment;
-    this.premiumAccrualBalanceAdjustment = premiumAccrualBalanceAdjustment;
     this.principalBalanceAdjustment = principalBalanceAdjustment;
     this.updateLastUpdatedBy(requestSource);
   }

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.types.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.types.ts
@@ -25,7 +25,6 @@ export type UpdateWithStatusParams = {
 
 export type UpdateWithKeyingDataParams = {
   fixedFeeAdjustment: number;
-  premiumAccrualBalanceAdjustment: number;
   principalBalanceAdjustment: number;
   requestSource: DbRequestSource;
 };

--- a/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
@@ -34,7 +34,6 @@ export class FeeRecordEntityMockBuilder {
     data.status = 'TO_DO';
     data.payments = [];
     data.fixedFeeAdjustment = null;
-    data.premiumAccrualBalanceAdjustment = null;
     data.principalBalanceAdjustment = null;
     data.updateLastUpdatedBy(requestSource);
     return new FeeRecordEntityMockBuilder(data);
@@ -119,11 +118,6 @@ export class FeeRecordEntityMockBuilder {
 
   public withFixedFeeAdjustment(fixedFeeAdjustment: number | null): FeeRecordEntityMockBuilder {
     this.feeRecord.fixedFeeAdjustment = fixedFeeAdjustment;
-    return this;
-  }
-
-  public withPremiumAccrualBalanceAdjustment(premiumAccrualBalanceAdjustment: number | null): FeeRecordEntityMockBuilder {
-    this.feeRecord.premiumAccrualBalanceAdjustment = premiumAccrualBalanceAdjustment;
     return this;
   }
 

--- a/trade-finance-manager-api/src/v1/api-response-types/utilisation-report-reconciliation-details-response-body.ts
+++ b/trade-finance-manager-api/src/v1/api-response-types/utilisation-report-reconciliation-details-response-body.ts
@@ -32,7 +32,6 @@ type KeyingSheet = {
   }[];
   baseCurrency: Currency;
   fixedFeeAdjustment: KeyingSheetAdjustment | null;
-  premiumAccrualBalanceAdjustment: KeyingSheetAdjustment | null;
   principalBalanceAdjustment: KeyingSheetAdjustment | null;
 }[];
 

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
@@ -25,10 +25,6 @@ describe(component, () => {
       amount: '100',
       change: 'INCREASE',
     },
-    premiumAccrualBalanceAdjustment: {
-      amount: '100',
-      change: 'INCREASE',
-    },
     principalBalanceAdjustment: {
       amount: '100',
       change: 'INCREASE',
@@ -112,8 +108,8 @@ describe(component, () => {
   it('renders the keying sheet adjustment increase and decrease columns', () => {
     const wrapper = getWrapper();
 
-    wrapper.expectElement('tr td[data-cy="keying-sheet-adjustment--increase"]').toHaveCount(3);
-    wrapper.expectElement('tr td[data-cy="keying-sheet-adjustment--decrease"]').toHaveCount(3);
+    wrapper.expectElement('tr td[data-cy="keying-sheet-adjustment--increase"]').toHaveCount(2);
+    wrapper.expectElement('tr td[data-cy="keying-sheet-adjustment--decrease"]').toHaveCount(2);
   });
 
   it("renders the '-' in all the increase and decrease adjustment cells when the adjustment change is 'NONE'", () => {
@@ -121,13 +117,12 @@ describe(component, () => {
     const keyingSheetRow: KeyingSheetTableRow = {
       ...aKeyingSheetTableRow(),
       fixedFeeAdjustment: { change, amount: '111.11' },
-      premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
       principalBalanceAdjustment: { change, amount: '333.33' },
     };
     const wrapper = getWrapper({ keyingSheetRow });
 
-    wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).toHaveCount(3);
-    wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).toHaveCount(3);
+    wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).toHaveCount(2);
+    wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).toHaveCount(2);
     wrapper.expectElement('tr td:contains("111.11")').notToExist();
     wrapper.expectElement('tr td:contains("222.22")').notToExist();
     wrapper.expectElement('tr td:contains("333.33")').notToExist();
@@ -149,17 +144,6 @@ describe(component, () => {
       wrapper.expectElement(`${increaseColumnSelector}:contains("111.11")`).hasClass('govuk-table__cell--numeric');
     });
 
-    it('renders the premium accrual balance adjustment in the increase column with the numeric cell class', () => {
-      const keyingSheetRow: KeyingSheetTableRow = {
-        ...aKeyingSheetTableRow(),
-        premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
-      };
-      const wrapper = getWrapper({ keyingSheetRow });
-
-      wrapper.expectElement(`${increaseColumnSelector}:contains("222.22")`).toExist();
-      wrapper.expectElement(`${increaseColumnSelector}:contains("222.22")`).hasClass('govuk-table__cell--numeric');
-    });
-
     it('renders the principal balance adjustment in the increase column with the numeric cell class', () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
@@ -175,12 +159,11 @@ describe(component, () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
-        premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
         principalBalanceAdjustment: { change, amount: '333.33' },
       };
       const wrapper = getWrapper({ keyingSheetRow });
 
-      wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).toHaveCount(3);
+      wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).toHaveCount(2);
       wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--decrease"]:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
     });
   });
@@ -201,17 +184,6 @@ describe(component, () => {
       wrapper.expectElement(`${decreaseColumnSelector}:contains("111.11")`).hasClass('govuk-table__cell--numeric');
     });
 
-    it('renders the premium accrual balance adjustment in the decrease column with the numeric cell class', () => {
-      const keyingSheetRow: KeyingSheetTableRow = {
-        ...aKeyingSheetTableRow(),
-        premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
-      };
-      const wrapper = getWrapper({ keyingSheetRow });
-
-      wrapper.expectElement(`${decreaseColumnSelector}:contains("222.22")`).toExist();
-      wrapper.expectElement(`${decreaseColumnSelector}:contains("222.22")`).hasClass('govuk-table__cell--numeric');
-    });
-
     it('renders the principal balance adjustment in the decrease column with the numeric cell class', () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
@@ -227,12 +199,11 @@ describe(component, () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
-        premiumAccrualBalanceAdjustment: { change, amount: '222.22' },
         principalBalanceAdjustment: { change, amount: '333.33' },
       };
       const wrapper = getWrapper({ keyingSheetRow });
 
-      wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).toHaveCount(3);
+      wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).toHaveCount(2);
       wrapper.expectElement(`tr td[data-cy="keying-sheet-adjustment--increase"]:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
     });
   });
@@ -300,7 +271,6 @@ describe(component, () => {
         baseCurrency: 'EUR',
         checkboxId: 'feeRecordId-123-status-TO_DO',
         fixedFeeAdjustment: { change: 'NONE', amount: '0' },
-        premiumAccrualBalanceAdjustment: { change: 'NONE', amount: '0' },
         principalBalanceAdjustment: { change: 'NONE', amount: '0' },
         feePayments: [aFeePayment(), aFeePayment(), aFeePayment()],
       };
@@ -324,7 +294,7 @@ describe(component, () => {
       wrapper.expectElement('tr:eq(1) td:contains("EUR")').notToExist();
       wrapper.expectElement('tr:eq(2) td:contains("EUR")').notToExist();
 
-      wrapper.expectElement('tr:eq(0) td:contains("-")').toHaveCount(6);
+      wrapper.expectElement('tr:eq(0) td:contains("-")').toHaveCount(4);
       wrapper.expectElement('tr:eq(1) td:contains("-")').notToExist();
       wrapper.expectElement('tr:eq(2) td:contains("-")').notToExist();
 
@@ -366,8 +336,8 @@ describe(component, () => {
       };
       const wrapper = getWrapper({ keyingSheetRow });
 
-      wrapper.expectElement('tr:eq(0) td.no-border').toHaveCount(13);
-      wrapper.expectElement('tr:eq(1) td.no-border').toHaveCount(13);
+      wrapper.expectElement('tr:eq(0) td.no-border').toHaveCount(11);
+      wrapper.expectElement('tr:eq(1) td.no-border').toHaveCount(11);
       wrapper.expectElement('tr:eq(2) td.no-border').notToExist();
     });
 

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table.component-test.ts
@@ -31,10 +31,6 @@ describe(component, () => {
           amount: '100',
           change: 'INCREASE',
         },
-        premiumAccrualBalanceAdjustment: {
-          amount: '100',
-          change: 'INCREASE',
-        },
         principalBalanceAdjustment: {
           amount: '100',
           change: 'INCREASE',
@@ -84,24 +80,21 @@ describe(component, () => {
     wrapper.expectElement(tableHeaderSelector('Fee payment')).hasClass('govuk-table__header--numeric');
   });
 
-  it('renders the fixed fee adjustment, premium accrual balance adjustment and principal balance adjustment headers with a colspan of 2', () => {
+  it('renders the fixed fee adjustment and principal balance adjustment headers with a colspan of 2', () => {
     const wrapper = getWrapper(aKeyingSheetTableViewModel());
 
     wrapper.expectElement(tableHeaderSelector('Fixed fee adjustment')).toExist();
     wrapper.expectElement(tableHeaderSelector('Fixed fee adjustment')).toHaveAttribute('colspan', '2');
 
-    wrapper.expectElement(tableHeaderSelector('Premium accrual balance adjustment')).toExist();
-    wrapper.expectElement(tableHeaderSelector('Premium accrual balance adjustment')).toHaveAttribute('colspan', '2');
-
     wrapper.expectElement(tableHeaderSelector('Principal balance adjustment')).toExist();
     wrapper.expectElement(tableHeaderSelector('Principal balance adjustment')).toHaveAttribute('colspan', '2');
   });
 
-  it('renders 3 increase and 3 decrease columns in the table headers', () => {
+  it('renders 2 increase and 2 decrease columns in the table headers', () => {
     const wrapper = getWrapper(aKeyingSheetTableViewModel());
 
-    wrapper.expectElement(tableHeaderSelector('Increase')).toHaveCount(3);
-    wrapper.expectElement(tableHeaderSelector('Decrease')).toHaveCount(3);
+    wrapper.expectElement(tableHeaderSelector('Increase')).toHaveCount(2);
+    wrapper.expectElement(tableHeaderSelector('Decrease')).toHaveCount(2);
   });
 
   describe('when userCanEdit is set to true', () => {

--- a/trade-finance-manager-ui/server/api-response-types/utilisation-report-reconciliation-details-response-body.ts
+++ b/trade-finance-manager-ui/server/api-response-types/utilisation-report-reconciliation-details-response-body.ts
@@ -31,7 +31,6 @@ export type KeyingSheetRow = {
   }[];
   baseCurrency: Currency;
   fixedFeeAdjustment: KeyingSheetAdjustment | null;
-  premiumAccrualBalanceAdjustment: KeyingSheetAdjustment | null;
   principalBalanceAdjustment: KeyingSheetAdjustment | null;
 };
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -483,7 +483,6 @@ describe('reconciliation-for-report-helper', () => {
       feePayments: [],
       baseCurrency: 'GBP',
       fixedFeeAdjustment: null,
-      premiumAccrualBalanceAdjustment: null,
       principalBalanceAdjustment: null,
     });
 
@@ -590,39 +589,6 @@ describe('reconciliation-for-report-helper', () => {
         // Assert
         expect(result).toHaveLength(1);
         expect(result[0].fixedFeeAdjustment).toEqual(expectedMappedValue);
-      },
-    );
-
-    it.each([
-      { condition: 'is null', value: null, expectedMappedValue: { amount: undefined, change: 'NONE' } },
-      { condition: 'has zero amount (no change)', value: { amount: 0, change: 'NONE' }, expectedMappedValue: { amount: '0.00', change: 'NONE' } },
-      {
-        condition: 'has a positive amount (increase)',
-        value: { amount: 100, change: 'INCREASE' },
-        expectedMappedValue: { amount: '100.00', change: 'INCREASE' },
-      },
-      {
-        condition: 'has a negative amount (decrease)',
-        value: { amount: 100, change: 'DECREASE' },
-        expectedMappedValue: { amount: '100.00', change: 'DECREASE' },
-      },
-    ] as const)(
-      'sets the view model premiumAccrualBalanceAdjustment to $expectedMappedValue when the fee record entity premiumAccrualBalanceAdjustment $condition',
-      ({ value, expectedMappedValue }) => {
-        // Arrange
-        const keyingSheet: KeyingSheet = [
-          {
-            ...aKeyingSheetRow(),
-            premiumAccrualBalanceAdjustment: value,
-          },
-        ];
-
-        // Act
-        const result = mapKeyingSheetToKeyingSheetViewModel(keyingSheet);
-
-        // Assert
-        expect(result).toHaveLength(1);
-        expect(result[0].premiumAccrualBalanceAdjustment).toEqual(expectedMappedValue);
       },
     );
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
@@ -145,7 +145,6 @@ export const mapKeyingSheetToKeyingSheetViewModel = (keyingSheet: KeyingSheet): 
     baseCurrency: keyingSheetRow.baseCurrency,
     feePayments: mapKeyingSheetFeePaymentsToKeyingSheetFeePaymentsViewModel(keyingSheetRow.feePayments),
     fixedFeeAdjustment: getKeyingSheetAdjustmentViewModel(keyingSheetRow.fixedFeeAdjustment),
-    premiumAccrualBalanceAdjustment: getKeyingSheetAdjustmentViewModel(keyingSheetRow.premiumAccrualBalanceAdjustment),
     principalBalanceAdjustment: getKeyingSheetAdjustmentViewModel(keyingSheetRow.principalBalanceAdjustment),
     checkboxId: getKeyingSheetRowCheckboxId(keyingSheetRow),
     isChecked: false,

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -43,7 +43,6 @@ export type KeyingSheetViewModel = {
     formattedDateReceived: string | undefined;
   }[];
   fixedFeeAdjustment: KeyingSheetAdjustmentViewModel;
-  premiumAccrualBalanceAdjustment: KeyingSheetAdjustmentViewModel;
   principalBalanceAdjustment: KeyingSheetAdjustmentViewModel;
   checkboxId: KeyingSheetCheckboxId;
   isChecked: boolean;

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table-row.njk
@@ -22,7 +22,6 @@
   {% set feePayments = params.keyingSheetRow.feePayments if params.keyingSheetRow.feePayments.length > 0 else [{}] %}
   {% set baseCurrency = params.keyingSheetRow.baseCurrency %}
   {% set fixedFeeAdjustment = params.keyingSheetRow.fixedFeeAdjustment %}
-  {% set premiumAccrualBalanceAdjustment = params.keyingSheetRow.premiumAccrualBalanceAdjustment %}
   {% set principalBalanceAdjustment = params.keyingSheetRow.principalBalanceAdjustment %}
   {% set checkboxId = params.keyingSheetRow.checkboxId %}
   {% set isChecked = params.keyingSheetRow.isChecked %}
@@ -44,7 +43,6 @@
       </td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}">{{ baseCurrency if isFirstLineOfRow }}</td>
       {{ adjustmentColumns(fixedFeeAdjustment, { showBottomBorder: isLastLineOfRow, showValues: isFirstLineOfRow }) }}
-      {{ adjustmentColumns(premiumAccrualBalanceAdjustment, { showBottomBorder: isLastLineOfRow, showValues: isFirstLineOfRow }) }}
       {{ adjustmentColumns(principalBalanceAdjustment, { showBottomBorder: isLastLineOfRow, showValues: isFirstLineOfRow }) }}
       {% if userCanEdit %}
         <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}">

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table.njk
@@ -14,7 +14,6 @@
         <th scope="col" class="govuk-table__header govuk-table__header--numeric" rowspan="2">Fee payment</th>
         <th scope="col" class="govuk-table__header" rowspan="2">Base currency</th>
         <th scope="colgroup" class="govuk-table__header" colspan="2">Fixed fee adjustment</th>
-        <th scope="colgroup" class="govuk-table__header" colspan="2">Premium accrual balance adjustment</th>
         <th scope="colgroup" class="govuk-table__header" colspan="2">Principal balance adjustment</th>
         {% if userCanEdit %}
           <td class="govuk-table__header" rowspan="2">
@@ -23,8 +22,6 @@
         {% endif %}
       </tr>
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Increase</th>
-        <th scope="col" class="govuk-table__header">Decrease</th>
         <th scope="col" class="govuk-table__header">Increase</th>
         <th scope="col" class="govuk-table__header">Decrease</th>
         <th scope="col" class="govuk-table__header">Increase</th>

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
@@ -42,7 +42,6 @@ export const createRandomFeeRecordForReport = (report: UtilisationReportEntity, 
   });
 
   feeRecord.fixedFeeAdjustment = null;
-  feeRecord.premiumAccrualBalanceAdjustment = null;
   feeRecord.principalBalanceAdjustment = null;
 
   feeRecord.updateLastUpdatedBy({ platform: 'SYSTEM' });
@@ -80,7 +79,6 @@ export const createAutoMatchedZeroPaymentFeeRecordForReport = (report: Utilisati
   });
 
   feeRecord.fixedFeeAdjustment = null;
-  feeRecord.premiumAccrualBalanceAdjustment = null;
   feeRecord.principalBalanceAdjustment = null;
 
   feeRecord.updateLastUpdatedBy({ platform: 'SYSTEM' });


### PR DESCRIPTION
## Introduction :pencil2:
We want to remove the keying sheet columns related to accruals.

## Resolution :heavy_check_mark:
- Removes the fee record column with a new migration
- Remove all references to the premium accrual balance adjustment

### Screenshot 📷 
![image](https://github.com/user-attachments/assets/37c0f81e-8a67-4448-bb10-28dca9620716)

## Miscellaneous :heavy_plus_sign:

