### PR TITLE
fix(dtfs2-7311): update integer in jsdocs when incorrect

### DIFF
--- a/azure-functions/acbs-function/mappings/facility/helpers/get-facility-currency-exchange-rate.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-facility-currency-exchange-rate.js
@@ -2,7 +2,7 @@
  * Return facility's curency exchange rate when facility
  * currency is not in GBP
  * @param {Object} facility Facility object
- * @returns {Integer} Facility exchange rate
+ * @returns {number} Facility exchange rate
  */
 const getCurrencyExchangeRate = (facility) => Number(facility.tfm.exchangeRate.toFixed(4));
 

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-fee-amount.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-fee-amount.js
@@ -5,7 +5,7 @@ const CONSTANTS = require('../../../constants');
  * @param {Object} facility Facility object
  * @param {String} dealType Deal type i.e. GEF, BSS, EWCS
  * @param {Integer} premiumScheduleIndex Premium schedule index
- * @returns {Integer} Fee record amount
+ * @returns {number} Fee record amount
  */
 
 const getFeeAmount = (facility, dealType, premiumScheduleIndex) => {

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-interest-or-fee-rate.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-interest-or-fee-rate.js
@@ -2,8 +2,8 @@ const CONSTANTS = require('../../../constants');
 
 /**
  * Formats an amount with trailing two decimal points integer
- * @param {Integer} amount Amount with or without decimal points integers
- * @returns {Integer} Two decimal points formatted integer
+ * @param {number} amount Amount with or without decimal points integers
+ * @returns {number} Two decimal points formatted integer
  */
 const decimalPoint = (amount) => {
   if (amount) {

--- a/azure-functions/acbs-function/mappings/facility/helpers/get-loan-amount-difference.js
+++ b/azure-functions/acbs-function/mappings/facility/helpers/get-loan-amount-difference.js
@@ -10,10 +10,10 @@ const { FACILITY } = CONSTANTS;
  *
  * `GEF` facilities type will return 10% of the difference.
  * `Bond` facility type will return the full difference.
- * @param {Integer} ukefExposure UKEF Exposure
+ * @param {number} ukefExposure UKEF Exposure
  * @param {String} type Facility Type
  * @param {Object} facilityMasterRecord Facility master record object
- * @returns {Integer} Loan amount difference, if null argument then returns `0`
+ * @returns {number} Loan amount difference, if null argument then returns `0`
  */
 const getLoanAmountDifference = (ukefExposure, type, facilityMasterRecord) => {
   if (ukefExposure && facilityMasterRecord) {

--- a/utils/data-migration/helpers/format.js
+++ b/utils/data-migration/helpers/format.js
@@ -7,7 +7,7 @@
  * as number.
  * @param {String} string Raw string with commas
  * @param {Boolean} Number Whether output should be a `Number`
- * @returns {Integer} Formatted value
+ * @returns {number} Formatted value
  */
 const stripCommas = (string, number = false) => {
   if (string) {
@@ -19,7 +19,7 @@ const stripCommas = (string, number = false) => {
 /**
  * Returns deal's total maximum liability in GBP.
  * @param {Array} facilities Array of facilities
- * @returns {Integer} Total of deal's maximum liability in GBP
+ * @returns {number} Total of deal's maximum liability in GBP
  */
 const getMaximumLiability = (facilities) => {
   if (facilities) {


### PR DESCRIPTION
## Introduction :pencil2:
We incorrectly use `Integer` to refer to numbers which are not ints.

## Resolution :heavy_check_mark:
Update these to number

## Miscellaneous :heavy_plus_sign:
I know that `Integer` does not exist in JS -- To avoid this being a contentious PR, I've left `Integer` in where it makes sense (`months` etc), as JSDocs do not care this isn't a real type
