### PR TITLE
feat(FN-1725): util to create keying sheet tfm facilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,10 +211,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common
@@ -404,10 +404,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common
@@ -478,10 +478,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common
@@ -540,10 +540,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common
@@ -612,10 +612,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common
@@ -673,10 +673,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common
@@ -754,10 +754,10 @@ jobs:
         run: docker compose -f docker-compose.gha.yml up --build -d
 
       - name: Initialise
-        working-directory: ./
+        working-directory: ./utils
         run: |
           sleep 100s
-          npm run load
+          npm run mock-data-loader
 
       - name: SQL
         working-directory: ./libs/common

--- a/e2e-tests/gef/cypress/support/commands/loadData.js
+++ b/e2e-tests/gef/cypress/support/commands/loadData.js
@@ -8,7 +8,7 @@ const loadData = () => {
   // Ensure project root directory
   cy.exec('if [ -d "dtfs2" ]; then cd dtfs2; fi');
   // Load mock data
-  cy.exec('cd ../../ && npm run load');
+  cy.exec('cd ../../utils && npm run mock-data-loader');
 };
 
 export default loadData;

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
   ],
   "scripts": {
     "audit:fix:all": "npm audit --fix --if-present",
-    "db:seed": "(cd utils && npm run db:seed)",
-    "db:seed:reset": "(cd utils && npm run db:seed:reset)",
     "env:copy": "(cd utils && npm run env:copy)",
     "housekeeping": "npm update --save && npm i && npm run prettier:fix:all && npm run lint:fix:all && npm run validate:yml && npm run audit:fix:all && npm run spellcheck",
     "lint:all": "npm run lint --workspaces --if-present",

--- a/utils/README.md
+++ b/utils/README.md
@@ -8,6 +8,60 @@ The `data-migration` directory contains scripts designed to facilitate the migra
 
 ## Mock Data Loader :page_with_curl:
 
-The `mock-data-loader` directory contains mock data that can be used for local development and in non-production environments. To learn more about how to use this mock data, please refer to the [mock-data-loader/README.md](mock-data-loader/README.md) file.
+The `mock-data-loader` directory contains mock data that can be used for local development and in non-production environments.
+
+You can run mock data loader directly using
+
+```shell
+npm run mock-data-loader
+```
+
+or as part of the all-purpose
+
+```shell
+npm run load
+```
+
+command.
+
+## SQL DB Seeder
+
+The `sql-db-seeder` directory contains a script which seeds random data into the SQL database for utilisation reports.
+
+You can run the SQL seeder directly using
+
+```shell
+npm run db:seed
+```
+
+or as part of the all-purpose
+
+```shell
+npm run load
+```
+
+command.
+
+## Create Keying Sheet TFM Facilities
+
+The `create-keying-sheet-tfm-facilities` directory contains a script which inserts data into the Mongo DB database to line up with the data inserted by the `sql-db-seeder`. This is needed as the "keying sheet" related functionality requires that the `FeeRecord` facility ids which are inserted correspond the UKEF facility ids in the Mongo DB `facilities` and `tfm-facilities` colletion.
+
+You can run this script directly using
+
+```shell
+npm run create-keying-sheet-tfm-facilities
+```
+
+or indirectly via both
+
+```shell
+npm run db:seed
+```
+
+or
+
+```shell
+npm run load
+```
 
 ---

--- a/utils/create-keying-sheet-tfm-facilities/database-client/facility-client.ts
+++ b/utils/create-keying-sheet-tfm-facilities/database-client/facility-client.ts
@@ -1,0 +1,28 @@
+import { Collection, WithoutId } from 'mongodb';
+import { Facility } from '@ukef/dtfs2-common';
+import { mongoDbClient } from './mongo-db-client';
+
+export class FacilityClient {
+  private static collection?: Collection<WithoutId<Facility>>;
+
+  public static async init(): Promise<void> {
+    this.collection = await mongoDbClient.getCollection('facilities');
+  }
+
+  public static async insertIfNotExists(facility: Facility): Promise<void> {
+    if (!this.collection) {
+      throw new Error('Facility client has not yet been initialised');
+    }
+
+    const { ukefFacilityId } = facility;
+
+    const numberOfFacilities = await this.collection.count({ ukefFacilityId: { $eq: ukefFacilityId } });
+    if (numberOfFacilities !== 0) {
+      console.info(`Facility with UKEF facility id '${ukefFacilityId}' already exists`);
+      return;
+    }
+
+    console.info(`Inserting facility with UKEF facility id '${ukefFacilityId}'`);
+    await this.collection.insertOne(facility);
+  }
+}

--- a/utils/create-keying-sheet-tfm-facilities/database-client/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/database-client/index.ts
@@ -1,0 +1,3 @@
+export * from './mongo-db-client';
+export * from './facility-client';
+export * from './tfm-facility-client';

--- a/utils/create-keying-sheet-tfm-facilities/database-client/mongo-db-client.ts
+++ b/utils/create-keying-sheet-tfm-facilities/database-client/mongo-db-client.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { MongoDbClient } from '@ukef/dtfs2-common/mongo-db-client';
 
 const mongoDbConfigSchema = z.object({
-  MONGODB_URI: z.string(),
+  MONGODB_URI_QA: z.string(),
   MONGO_INITDB_DATABASE: z.string(),
 });
 
@@ -10,7 +10,7 @@ const getMongoDbClient = (): MongoDbClient => {
   const mongoDbConfig = mongoDbConfigSchema.parse(process.env);
   return new MongoDbClient({
     dbName: mongoDbConfig.MONGO_INITDB_DATABASE,
-    dbConnectionString: mongoDbConfig.MONGODB_URI,
+    dbConnectionString: mongoDbConfig.MONGODB_URI_QA,
   });
 };
 

--- a/utils/create-keying-sheet-tfm-facilities/database-client/mongo-db-client.ts
+++ b/utils/create-keying-sheet-tfm-facilities/database-client/mongo-db-client.ts
@@ -1,0 +1,17 @@
+import z from 'zod';
+import { MongoDbClient } from '@ukef/dtfs2-common/mongo-db-client';
+
+const mongoDbConfigSchema = z.object({
+  MONGODB_URI: z.string(),
+  MONGO_INITDB_DATABASE: z.string(),
+});
+
+const getMongoDbClient = (): MongoDbClient => {
+  const mongoDbConfig = mongoDbConfigSchema.parse(process.env);
+  return new MongoDbClient({
+    dbName: mongoDbConfig.MONGO_INITDB_DATABASE,
+    dbConnectionString: mongoDbConfig.MONGODB_URI,
+  });
+};
+
+export const mongoDbClient = getMongoDbClient();

--- a/utils/create-keying-sheet-tfm-facilities/database-client/tfm-facility-client.ts
+++ b/utils/create-keying-sheet-tfm-facilities/database-client/tfm-facility-client.ts
@@ -1,0 +1,28 @@
+import { Collection, WithoutId } from 'mongodb';
+import { TfmFacility } from '@ukef/dtfs2-common';
+import { mongoDbClient } from './mongo-db-client';
+
+export class TfmFacilityClient {
+  private static collection?: Collection<WithoutId<TfmFacility>>;
+
+  public static async init(): Promise<void> {
+    this.collection = await mongoDbClient.getCollection('tfm-facilities');
+  }
+
+  public static async insertIfNotExists(tfmFacility: WithoutId<TfmFacility>): Promise<void> {
+    if (!this.collection) {
+      throw new Error('TFM facility client has not yet been initialised');
+    }
+
+    const { ukefFacilityId } = tfmFacility.facilitySnapshot;
+
+    const numberOfFacilities = await this.collection.count({ 'facilitySnapshot.ukefFacilityId': { $eq: ukefFacilityId } });
+    if (numberOfFacilities !== 0) {
+      console.info(`TFM facility with UKEF facility id '${ukefFacilityId}' already exists`);
+      return;
+    }
+
+    console.info(`Inserting TFM facility with UKEF facility id '${ukefFacilityId}'`);
+    await this.collection.insertOne(tfmFacility);
+  }
+}

--- a/utils/create-keying-sheet-tfm-facilities/helpers/generate-random-tfm-facility-for-facility.ts
+++ b/utils/create-keying-sheet-tfm-facilities/helpers/generate-random-tfm-facility-for-facility.ts
@@ -1,0 +1,28 @@
+import { WithoutId } from 'mongodb';
+import { faker } from '@faker-js/faker';
+import { Facility, TfmFacility, TfmFacilityAmendment } from '@ukef/dtfs2-common';
+import { aTfmFacilityAmendmentWithFacilityIdAndDealId } from '../mock-data';
+
+const generateRandomTfmFacilityAmendmentsForFacility = (facility: Facility): TfmFacilityAmendment[] | undefined => {
+  const numberToGenerate = faker.number.int({ min: 0, max: 3 });
+  if (numberToGenerate === 0) {
+    return undefined;
+  }
+
+  const amendments: TfmFacilityAmendment[] = [];
+  while (amendments.length < numberToGenerate) {
+    amendments.push(aTfmFacilityAmendmentWithFacilityIdAndDealId(facility._id, facility.dealId));
+  }
+  return amendments;
+};
+
+export const generateRandomTfmFacilityForFacility = (facility: Facility): WithoutId<TfmFacility> => {
+  const tfmFacility: WithoutId<TfmFacility> = { facilitySnapshot: facility };
+
+  const amendments = generateRandomTfmFacilityAmendmentsForFacility(facility);
+  if (amendments) {
+    return { ...tfmFacility, amendments };
+  }
+
+  return tfmFacility;
+};

--- a/utils/create-keying-sheet-tfm-facilities/helpers/get-sql-facility-ids.ts
+++ b/utils/create-keying-sheet-tfm-facilities/helpers/get-sql-facility-ids.ts
@@ -1,0 +1,7 @@
+import { FacilityUtilisationDataEntity } from '@ukef/dtfs2-common';
+import { DataSource } from 'typeorm';
+
+export const getSqlFacilityIds = async (dataSource: DataSource): Promise<string[]> => {
+  const facilityUtilisationDataRows = await dataSource.manager.find(FacilityUtilisationDataEntity, { select: ['id'] });
+  return facilityUtilisationDataRows.map(({ id }) => id);
+};

--- a/utils/create-keying-sheet-tfm-facilities/helpers/get-valid-gef-deal-id-generator.ts
+++ b/utils/create-keying-sheet-tfm-facilities/helpers/get-valid-gef-deal-id-generator.ts
@@ -1,0 +1,23 @@
+import { Collection } from 'mongodb';
+import { faker } from '@faker-js/faker';
+import { mongoDbClient } from '../database-client/mongo-db-client';
+
+/**
+ * TFM facilities should have a deal id which is linked to
+ * a GEF Mongo DB deal. This function gets those valid ids
+ * in the form of a generator so that each facility is
+ * randomly linked to a specific deal
+ */
+export const getValidGefDealIdGenerator = async () => {
+  const dealsCollection = (await mongoDbClient.getCollection('deals')) as Collection;
+  const dealIds = await dealsCollection
+    .find({ dealType: { $eq: 'GEF' } }, { projection: { _id: 1 } })
+    .map(({ _id }) => _id)
+    .toArray();
+
+  if (dealIds.length === 0) {
+    throw new Error('Failed to find any GEF deals');
+  }
+
+  return () => faker.helpers.arrayElement(dealIds);
+};

--- a/utils/create-keying-sheet-tfm-facilities/helpers/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './get-valid-gef-deal-id-generator';
 export * from './get-sql-facility-ids';
+export * from './generate-random-tfm-facility-for-facility';

--- a/utils/create-keying-sheet-tfm-facilities/helpers/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './get-valid-gef-deal-id-generator';
+export * from './get-sql-facility-ids';

--- a/utils/create-keying-sheet-tfm-facilities/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/index.ts
@@ -1,0 +1,38 @@
+import { WithoutId } from 'mongodb';
+import { SqlDbDataSource } from '@ukef/dtfs2-common/sql-db-connection';
+import { Facility, TfmFacility } from '@ukef/dtfs2-common';
+import { FacilityClient, mongoDbClient, TfmFacilityClient } from './database-client';
+import { getSqlFacilityIds, getValidGefDealIdGenerator } from './helpers';
+import { aFacilityWithoutDealId } from './mock-data';
+
+const run = async () => {
+  const dataSource = await SqlDbDataSource.initialize();
+
+  await FacilityClient.init();
+  await TfmFacilityClient.init();
+
+  try {
+    const facilityIdsToInsert = await getSqlFacilityIds(dataSource);
+
+    const validGefDealIdGenerator = await getValidGefDealIdGenerator();
+
+    const facilities: Facility[] = facilityIdsToInsert.map((ukefFacilityId) => ({
+      ...aFacilityWithoutDealId(),
+      ukefFacilityId,
+      dealId: validGefDealIdGenerator(),
+    }));
+    await Promise.all(facilities.map((facility) => FacilityClient.insertIfNotExists(facility)));
+
+    const tfmFacilities: WithoutId<TfmFacility>[] = facilities.map((facilitySnapshot) => ({ facilitySnapshot }));
+    await Promise.all(tfmFacilities.map((tfmFacility) => TfmFacilityClient.insertIfNotExists(tfmFacility)));
+  } catch (error) {
+    console.error('Failed to create tfm facilities:', error);
+  } finally {
+    await dataSource.destroy();
+    await mongoDbClient.close();
+  }
+};
+
+(async () => {
+  await run();
+})();

--- a/utils/create-keying-sheet-tfm-facilities/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/index.ts
@@ -2,7 +2,7 @@ import { WithoutId } from 'mongodb';
 import { SqlDbDataSource } from '@ukef/dtfs2-common/sql-db-connection';
 import { Facility, TfmFacility } from '@ukef/dtfs2-common';
 import { FacilityClient, mongoDbClient, TfmFacilityClient } from './database-client';
-import { getSqlFacilityIds, getValidGefDealIdGenerator } from './helpers';
+import { generateRandomTfmFacilityForFacility, getSqlFacilityIds, getValidGefDealIdGenerator } from './helpers';
 import { aFacilityWithoutDealId } from './mock-data';
 
 const run = async () => {
@@ -23,7 +23,7 @@ const run = async () => {
     }));
     await Promise.all(facilities.map((facility) => FacilityClient.insertIfNotExists(facility)));
 
-    const tfmFacilities: WithoutId<TfmFacility>[] = facilities.map((facilitySnapshot) => ({ facilitySnapshot }));
+    const tfmFacilities: WithoutId<TfmFacility>[] = facilities.map(generateRandomTfmFacilityForFacility);
     await Promise.all(tfmFacilities.map((tfmFacility) => TfmFacilityClient.insertIfNotExists(tfmFacility)));
   } catch (error) {
     console.error('Failed to create tfm facilities:', error);

--- a/utils/create-keying-sheet-tfm-facilities/mock-data/facility.ts
+++ b/utils/create-keying-sheet-tfm-facilities/mock-data/facility.ts
@@ -1,0 +1,46 @@
+import { faker } from '@faker-js/faker';
+import { ObjectId } from 'mongodb';
+import { addMonths, subMonths } from 'date-fns';
+import { Facility, UnixTimestampString } from '@ukef/dtfs2-common';
+
+const TODAY = new Date();
+
+const LATEST_COVER_START_DATE = subMonths(TODAY, 1);
+const getRandomCoverStartDateTimestamp = (): UnixTimestampString => faker.date.past({ years: 1, refDate: LATEST_COVER_START_DATE }).getTime().toString();
+
+const EARLIEST_COVER_END_DATE = addMonths(TODAY, 12);
+const getRandomCoverEndDateTimestamp = (): UnixTimestampString => faker.date.future({ years: 2, refDate: EARLIEST_COVER_END_DATE }).getTime().toString();
+
+export const aFacilityWithoutDealId = (): Omit<Facility, 'dealId'> => ({
+  _id: new ObjectId(),
+  type: 'Cash',
+  hasBeenIssued: true,
+  name: 'facilityName',
+  shouldCoverStartOnSubmission: true,
+  coverStartDate: getRandomCoverStartDateTimestamp(),
+  coverEndDate: getRandomCoverEndDateTimestamp(),
+  issueDate: null,
+  monthsOfCover: 12,
+  details: [],
+  detailsOther: '',
+  currency: {
+    id: 'GBP',
+  },
+  value: 100000,
+  coverPercentage: 80,
+  interestPercentage: 5,
+  paymentType: 'cash',
+  createdAt: TODAY.getTime(),
+  updatedAt: TODAY.getTime(),
+  ukefExposure: 80000,
+  guaranteeFee: 10,
+  submittedAsIssuedDate: null,
+  ukefFacilityId: '12345678',
+  feeType: 'cash',
+  feeFrequency: 'Monthly',
+  dayCountBasis: 365,
+  coverDateConfirmed: null,
+  hasBeenIssuedAndAcknowledged: null,
+  canResubmitIssuedFacilities: null,
+  unissuedToIssuedByMaker: {},
+});

--- a/utils/create-keying-sheet-tfm-facilities/mock-data/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/mock-data/index.ts
@@ -1,0 +1,1 @@
+export * from './facility';

--- a/utils/create-keying-sheet-tfm-facilities/mock-data/index.ts
+++ b/utils/create-keying-sheet-tfm-facilities/mock-data/index.ts
@@ -1,1 +1,2 @@
 export * from './facility';
+export * from './tfm-facility-amendment';

--- a/utils/create-keying-sheet-tfm-facilities/mock-data/tfm-facility-amendment.ts
+++ b/utils/create-keying-sheet-tfm-facilities/mock-data/tfm-facility-amendment.ts
@@ -1,0 +1,30 @@
+import { ObjectId } from 'mongodb';
+import { faker } from '@faker-js/faker';
+import { addMonths } from 'date-fns';
+import { AMENDMENT_STATUS, TfmFacilityAmendment, UnixTimestamp } from '@ukef/dtfs2-common';
+
+const TODAY = new Date();
+
+const EARLIEST_COVER_END_DATE = addMonths(TODAY, 12);
+const getRandomCoverEndDateTimestamp = (): UnixTimestamp => faker.date.future({ years: 2, refDate: EARLIEST_COVER_END_DATE }).getTime();
+
+const getRandomAmendmentStatus = () => faker.helpers.arrayElement(Object.values(AMENDMENT_STATUS));
+
+export const aTfmFacilityAmendmentWithFacilityIdAndDealId = (facilityId: ObjectId, dealId: ObjectId): TfmFacilityAmendment => {
+  const amendment: TfmFacilityAmendment = {
+    facilityId,
+    dealId,
+    amendmentId: new ObjectId(),
+    createdAt: TODAY.getTime(),
+    updatedAt: TODAY.getTime(),
+    status: getRandomAmendmentStatus(),
+    version: 0,
+  };
+
+  amendment.changeCoverEndDate = faker.helpers.arrayElement([true, false]);
+  if (amendment.changeCoverEndDate) {
+    amendment.coverEndDate = getRandomCoverEndDateTimestamp();
+  }
+
+  return amendment;
+};

--- a/utils/mock-data-loader/tfm/clean-all-tables-tfm.js
+++ b/utils/mock-data-loader/tfm/clean-all-tables-tfm.js
@@ -1,4 +1,5 @@
 const { logger } = require('../helpers/logger.helper');
+const { mongoDbClient } = require('../database/database-client');
 const api = require('./api');
 
 const cleanTeams = async () => {
@@ -20,7 +21,7 @@ const cleanUsers = async () => {
 };
 
 const cleanTfmDeals = async () => {
-  logger.info('cleaning TFM deals and facilities', { depth: 1 });
+  logger.info('cleaning TFM deals', { depth: 1 });
 
   const tfmDeals = await api.listDeals();
 
@@ -31,11 +32,19 @@ const cleanTfmDeals = async () => {
   }
 };
 
+const cleanTfmFacilities = async () => {
+  logger.info('cleaning TFM facilities', { depth: 1 });
+
+  const tfmFacilitiesCollection = await mongoDbClient.getCollection('tfm-facilities');
+  await tfmFacilitiesCollection.deleteMany({});
+};
+
 const cleanAllTables = async () => {
   logger.info('cleaning TFM tables');
   await cleanTeams();
   await cleanUsers();
   await cleanTfmDeals();
+  await cleanTfmFacilities();
 };
 
 module.exports = cleanAllTables;

--- a/utils/package.json
+++ b/utils/package.json
@@ -6,11 +6,13 @@
     "license": "MIT",
     "author": "UK Export Finance",
     "scripts": {
-        "db:seed": "npx ts-node sql-db-seeder/src/index.ts",
+        "create-keying-sheet-tfm-facilities": "npx ts-node create-keying-sheet-tfm-facilities/index.ts",
+        "db:seed": "npx ts-node sql-db-seeder/src/index.ts && npm run create-keying-sheet-tfm-facilities",
         "env:copy": "ts-node copy-env-vars/index.ts",
         "lint": "eslint --color **/*.{ts,js} --ignore-path ../.eslintignore",
         "lint:fix": "eslint --fix --color **/*.{ts,js}",
-        "load": "ts-node mock-data-loader/re-insert-mocks.js",
+        "load": "npm run mock-data-loader && npm run db:seed",
+        "mock-data-loader": "ts-node mock-data-loader/re-insert-mocks.js",
         "prettier": "prettier --no-error-on-unmatched-pattern --check **/*.{ts,js} --ignore-path ../.prettierignore",
         "prettier:fix": "prettier --write **/*.{ts,js} --ignore-path ../.prettierignore",
         "type-check": "tsc --noEmit --pretty"


### PR DESCRIPTION
## Introduction :pencil2:
The SQL seeder inserts entries in the `FacilityUtilisationData` table, where the `id` column of this table should correspond to a Mongo DB facility `ukefFacilityId`. This PR adds a new util script which inserts these entries after the seeder is run so that the keying sheet functionality works without error.

## Resolution :heavy_check_mark:
- Adds a new util
- Makes the `npm run load` command run all the local data-loading related scripts
- Updates the test pipeline so that only the mock data loader gets run before each test step

## Miscellaneous :heavy_plus_sign:
- Fix a bug where mock data loader doesn't actually clear the `tfm facilities` collection
- Updates the utils `README.md`

