### PR TITLE
feat(FN-3267): update facility utilisation data with keying data

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -84,18 +84,7 @@ describe(`POST ${BASE_URL}`, () => {
     makeRequest: (url) => testApi.post(aValidRequestBody()).to(url),
   });
 
-  it('returns a 400 when the report id is not a valid id', async () => {
-    // Arrange
-    const requestBody = aValidRequestBody();
-
-    // Act
-    const response = await testApi.post(requestBody).to(getUrl('invalid-id'));
-
-    // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
-  });
-
-  it("returns a 400 when the payload 'user' is an empty object", async () => {
+  it("returns a 400 (Bad Request) when the payload 'user' is an empty object", async () => {
     // Arrange
     const requestBody = {
       ...aValidRequestBody(),
@@ -109,7 +98,7 @@ describe(`POST ${BASE_URL}`, () => {
     expect(response.status).toBe(HttpStatusCode.BadRequest);
   });
 
-  it('returns a 404 when there are no fee records at the MATCH state attached to the report with the supplied id', async () => {
+  it('returns a 404 (Not Found) when there are no fee records at the MATCH state attached to the report with the supplied id', async () => {
     // Arrange
     const report = anUploadedReconciliationInProgressUtilisationReport();
     const toDoFeeRecords = [
@@ -126,7 +115,7 @@ describe(`POST ${BASE_URL}`, () => {
     expect(response.status).toBe(HttpStatusCode.NotFound);
   });
 
-  it('returns a 200 when request has a valid body and there are fee records at the MATCH status', async () => {
+  it('returns a 200 (Ok) when request has a valid body and there are fee records at the MATCH status', async () => {
     // Arrange
     const report = anUploadedReconciliationInProgressUtilisationReport();
     const feeRecords = [

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -59,7 +59,7 @@ describe(`POST ${BASE_URL}`, () => {
 
   beforeAll(async () => {
     await SqlDbHelper.initialize();
-    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAll();
 
     await wipe(['users', 'tfm-users', 'tfm-facilities']);
 
@@ -71,7 +71,7 @@ describe(`POST ${BASE_URL}`, () => {
   });
 
   afterEach(async () => {
-    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAll();
     await wipe(['tfm-facilities']);
   });
 

--- a/dtfs-central-api/src/errors/transaction-failed.error.ts
+++ b/dtfs-central-api/src/errors/transaction-failed.error.ts
@@ -1,13 +1,34 @@
 import { HttpStatusCode } from 'axios';
 import { ApiError } from '.';
 
+type CreateTransactionFailedErrorParams = {
+  message: string;
+  status: number;
+};
+
 export class TransactionFailedError extends ApiError {
-  constructor(apiError?: ApiError) {
-    const errorMessage = apiError?.message ?? 'Unknown error';
-    const errorStatus = apiError?.status ?? HttpStatusCode.InternalServerError;
-    super({
-      message: errorMessage,
-      status: errorStatus,
+  private constructor({ message, status }: CreateTransactionFailedErrorParams) {
+    super({ message, status });
+  }
+
+  public static forApiError(apiError: ApiError): TransactionFailedError {
+    return new TransactionFailedError({
+      message: apiError.message,
+      status: apiError.status,
+    });
+  }
+
+  public static forError(error: Error): TransactionFailedError {
+    return new TransactionFailedError({
+      message: error.message,
+      status: HttpStatusCode.InternalServerError,
+    });
+  }
+
+  public static forUnknownError(): TransactionFailedError {
+    return new TransactionFailedError({
+      message: 'An unknown error occurred',
+      status: HttpStatusCode.InternalServerError,
     });
   }
 }

--- a/dtfs-central-api/src/helpers/execute-with-sql-transaction.test.ts
+++ b/dtfs-central-api/src/helpers/execute-with-sql-transaction.test.ts
@@ -125,12 +125,21 @@ describe('executeWithSqlTransaction', () => {
     expect(mockRelease).toHaveBeenCalled();
   });
 
-  it("throws a generic 'TransactionFailedError' if the supplied function throws a generic error", async () => {
+  it("throws a generic 'TransactionFailedError' if the supplied function throws an unexpected error", async () => {
     // Arrange
-    const functionToExecute = jest.fn().mockRejectedValue(new Error('Some error'));
+    const functionToExecute = jest.fn().mockRejectedValue('Some rejected value');
 
     // Act / Assert
-    await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(new TransactionFailedError());
+    await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(TransactionFailedError.forUnknownError());
+  });
+
+  it("throws a specific 'TransactionFailedError' if the supplied function throws an 'Error'", async () => {
+    // Arrange
+    const error = new Error('Some error');
+    const functionToExecute = jest.fn().mockRejectedValue(error);
+
+    // Act / Assert
+    await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(TransactionFailedError.forError(error));
   });
 
   it("throws a specific 'TransactionFailedError' if the supplied function throws an 'ApiError'", async () => {
@@ -143,7 +152,7 @@ describe('executeWithSqlTransaction', () => {
     const functionToExecute = jest.fn().mockRejectedValue(customError);
 
     // Act / Assert
-    await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(new TransactionFailedError(customError));
+    await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(TransactionFailedError.forApiError(customError));
   });
 
   it('returns the return value of the supplied function', async () => {

--- a/dtfs-central-api/src/helpers/execute-with-sql-transaction.ts
+++ b/dtfs-central-api/src/helpers/execute-with-sql-transaction.ts
@@ -73,9 +73,12 @@ export const executeWithSqlTransaction = async <ReturnValue>(functionToExecute: 
   } catch (error) {
     await queryRunner.rollbackTransaction();
     if (error instanceof ApiError) {
-      throw new TransactionFailedError(error);
+      throw TransactionFailedError.forApiError(error);
     }
-    throw new TransactionFailedError();
+    if (error instanceof Error) {
+      throw TransactionFailedError.forError(error);
+    }
+    throw TransactionFailedError.forUnknownError();
   } finally {
     await queryRunner.release();
   }

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -10,12 +10,13 @@ import {
 } from '@ukef/dtfs2-common';
 import { handleFeeRecordGenerateKeyingDataEvent } from './generate-keying-data.event-handler';
 import { aReportPeriod } from '../../../../../../test-helpers/test-data';
-import { calculateFixedFeeAdjustment, calculatePrincipalBalanceAdjustment } from '../helpers';
+import { calculateFixedFeeAdjustment, calculatePrincipalBalanceAdjustment, updateFacilityUtilisationData } from '../helpers';
 
 jest.mock<unknown>('../helpers', () => ({
   ...jest.requireActual('../helpers'),
   calculateFixedFeeAdjustment: jest.fn(),
   calculatePrincipalBalanceAdjustment: jest.fn(),
+  updateFacilityUtilisationData: jest.fn(),
 }));
 
 describe('handleFeeRecordGenerateKeyingDataEvent', () => {
@@ -35,6 +36,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
   beforeEach(() => {
     jest.mocked(calculateFixedFeeAdjustment).mockResolvedValue(10);
     jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(20);
+    jest.mocked(updateFacilityUtilisationData).mockResolvedValue(aFacilityUtilisationDataEntity());
   });
 
   afterEach(() => {
@@ -263,6 +265,35 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       // Assert
       expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
     });
+
+    it('updates the facility utilisation data entity attached to the fee record', async () => {
+      // Arrange
+      const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('11111111').build();
+      const feeRecord = aMatchingFeeRecord();
+      feeRecord.facilityUtilisationData = facilityUtilisationDataEntity;
+      feeRecord.facilityUtilisation = 9876543.21;
+
+      const reportPeriod: ReportPeriod = {
+        start: { month: 4, year: 2024 },
+        end: { month: 5, year: 2025 },
+      };
+
+      // Act
+      await handleFeeRecordGenerateKeyingDataEvent(feeRecord, {
+        transactionEntityManager: mockEntityManager,
+        isFinalFeeRecordForFacility,
+        reportPeriod,
+        requestSource,
+      });
+
+      // Assert
+      expect(updateFacilityUtilisationData).toHaveBeenCalledWith(facilityUtilisationDataEntity, {
+        reportPeriod,
+        utilisation: 9876543.21,
+        requestSource,
+        entityManager: mockEntityManager,
+      });
+    });
   });
 
   describe('when isFinalFeeRecordForFacility is set to false', () => {
@@ -398,9 +429,29 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       // Assert
       expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
     });
+
+    it('does not update the facility utilisation data entity attached to the fee record', async () => {
+      // Arrange
+      const feeRecord = aMatchingFeeRecord();
+
+      // Act
+      await handleFeeRecordGenerateKeyingDataEvent(feeRecord, {
+        transactionEntityManager: mockEntityManager,
+        isFinalFeeRecordForFacility,
+        reportPeriod: aReportPeriod(),
+        requestSource,
+      });
+
+      // Assert
+      expect(updateFacilityUtilisationData).not.toHaveBeenCalled();
+    });
   });
 
   function aReconciliationInProgressReport() {
     return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
+  }
+
+  function aFacilityUtilisationDataEntity() {
+    return FacilityUtilisationDataEntityMockBuilder.forId('12345678').build();
   }
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -22,13 +22,6 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
     return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
   }
 
-  await updateFacilityUtilisationData(feeRecord.facilityUtilisationData, {
-    reportPeriod,
-    utilisation: feeRecord.facilityUtilisation,
-    requestSource,
-    entityManager: transactionEntityManager,
-  });
-
   const fixedFeeAdjustment = await calculateFixedFeeAdjustment(feeRecord, feeRecord.facilityUtilisationData, reportPeriod);
   const principalBalanceAdjustment = calculatePrincipalBalanceAdjustment(feeRecord, feeRecord.facilityUtilisationData);
   const statusToUpdateTo = getStatusToUpdateTo(feeRecord.feesPaidToUkefForThePeriod, fixedFeeAdjustment, principalBalanceAdjustment);
@@ -38,7 +31,16 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
     principalBalanceAdjustment,
     requestSource,
   });
-  return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
+  await transactionEntityManager.save(FeeRecordEntity, feeRecord);
+
+  await updateFacilityUtilisationData(feeRecord.facilityUtilisationData, {
+    reportPeriod,
+    utilisation: feeRecord.facilityUtilisation,
+    requestSource,
+    entityManager: transactionEntityManager,
+  });
+
+  return feeRecord;
 };
 
 function getStatusToUpdateTo(feesPaidToUkefForThePeriod: number, fixedFeeAdjustment: number = 0, principalBalanceAdjustment: number = 0): FeeRecordStatus {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from 'typeorm';
 import { DbRequestSource, FeeRecordEntity, FeeRecordStatus, ReportPeriod } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
-import { calculatePrincipalBalanceAdjustment, calculateFixedFeeAdjustment } from '../helpers';
+import { calculatePrincipalBalanceAdjustment, calculateFixedFeeAdjustment, updateFacilityUtilisationData } from '../helpers';
 
 type GenerateKeyingDataEventPayload = {
   transactionEntityManager: EntityManager;
@@ -21,6 +21,13 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
     feeRecord.updateWithStatus({ status: statusToUpdateTo, requestSource });
     return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
   }
+
+  await updateFacilityUtilisationData(feeRecord.facilityUtilisationData, {
+    reportPeriod,
+    utilisation: feeRecord.facilityUtilisation,
+    requestSource,
+    entityManager: transactionEntityManager,
+  });
 
   const fixedFeeAdjustment = await calculateFixedFeeAdjustment(feeRecord, feeRecord.facilityUtilisationData, reportPeriod);
   const principalBalanceAdjustment = calculatePrincipalBalanceAdjustment(feeRecord, feeRecord.facilityUtilisationData);

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
@@ -35,7 +35,7 @@ describe('calculateFixedFeeAdjustment', () => {
 
     // Act / Assert
     await expect(calculateFixedFeeAdjustment(feeRecord, facilityUtilisationData, reportPeriod)).rejects.toThrow(
-      new Error('Fee record report period cannot be the same as the facility utilisation data report period'),
+      new Error('Fixed fee adjustment must be calculated before the facility utilisation data has been updated'),
     );
   });
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
@@ -1,5 +1,5 @@
 import { when } from 'jest-when';
-import { FacilityUtilisationDataEntityMockBuilder, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FacilityUtilisationDataEntityMockBuilder, FeeRecordEntityMockBuilder, ReportPeriod, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { calculateFixedFeeAdjustment } from './calculate-fixed-fee-adjustment';
 import { aReportPeriod } from '../../../../../../test-helpers/test-data';
 import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
@@ -19,6 +19,23 @@ describe('calculateFixedFeeAdjustment', () => {
     // Act / Assert
     await expect(calculateFixedFeeAdjustment(feeRecord, facilityUtilisationData, aReportPeriod())).rejects.toThrow(
       new Error('Fee record facility id does not match the facility utilisation id'),
+    );
+  });
+
+  it('throws an error if the facility utilisation data report period is the same as the supplied report period', async () => {
+    // Arrange
+    const reportPeriod: ReportPeriod = {
+      start: { month: 1, year: 2024 },
+      end: { month: 1, year: 2024 },
+    };
+    const report = aUtilisationReport();
+    report.reportPeriod = reportPeriod;
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('11111111').build();
+    const facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId('11111111').withReportPeriod(reportPeriod).build();
+
+    // Act / Assert
+    await expect(calculateFixedFeeAdjustment(feeRecord, facilityUtilisationData, reportPeriod)).rejects.toThrow(
+      new Error('Fee record report period cannot be the same as the facility utilisation data report period'),
     );
   });
 
@@ -42,10 +59,10 @@ describe('calculateFixedFeeAdjustment', () => {
       when(getFixedFeeForFacility).calledWith(facilityId, currentFacilityUtilisation, reportPeriod).mockResolvedValue(currentFixedFee);
 
       const previousFacilityUtilisation = 654.321;
-      const facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId(facilityId).withUtilisation(previousFacilityUtilisation).build();
-      when(getFixedFeeForFacility)
-        .calledWith(facilityId, previousFacilityUtilisation, facilityUtilisationData.reportPeriod)
-        .mockResolvedValue(previousFixedFee);
+      const facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId(facilityId)
+        .withUtilisation(previousFacilityUtilisation)
+        .withFixedFee(previousFixedFee)
+        .build();
 
       // Act
       const result = await calculateFixedFeeAdjustment(feeRecord, facilityUtilisationData, reportPeriod);

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import { FacilityUtilisationDataEntity, FeeRecordEntity, ReportPeriod } from '@ukef/dtfs2-common';
+import { FacilityUtilisationDataEntity, FeeRecordEntity, isEqualReportPeriod, ReportPeriod } from '@ukef/dtfs2-common';
 import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
 
 /**
@@ -18,11 +18,12 @@ export const calculateFixedFeeAdjustment = async (
   if (feeRecord.facilityId !== facilityUtilisationData.id) {
     throw new Error('Fee record facility id does not match the facility utilisation id');
   }
-  const previousPeriodFixedFee = await getFixedFeeForFacility(
-    facilityUtilisationData.id,
-    facilityUtilisationData.utilisation,
-    facilityUtilisationData.reportPeriod,
-  );
+
+  if (isEqualReportPeriod(reportPeriod, facilityUtilisationData.reportPeriod)) {
+    throw new Error('Fee record report period cannot be the same as the facility utilisation data report period');
+  }
+
+  const previousPeriodFixedFee = facilityUtilisationData.fixedFee;
   const currentPeriodFixedFee = await getFixedFeeForFacility(feeRecord.facilityId, feeRecord.facilityUtilisation, reportPeriod);
   return new Big(currentPeriodFixedFee).sub(previousPeriodFixedFee).round(2).toNumber();
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
@@ -2,6 +2,9 @@ import Big from 'big.js';
 import { FacilityUtilisationDataEntity, FeeRecordEntity, isEqualReportPeriod, ReportPeriod } from '@ukef/dtfs2-common';
 import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
 
+const hasFacilityUtilisationDataAlreadyBeenUpdated = (facilityUtilisationData: FacilityUtilisationDataEntity, reportPeriod: ReportPeriod): boolean =>
+  isEqualReportPeriod(facilityUtilisationData.reportPeriod, reportPeriod);
+
 /**
  * Calculates the fixed fee adjustment
  * @param feeRecord - The fee record entity
@@ -19,8 +22,8 @@ export const calculateFixedFeeAdjustment = async (
     throw new Error('Fee record facility id does not match the facility utilisation id');
   }
 
-  if (isEqualReportPeriod(reportPeriod, facilityUtilisationData.reportPeriod)) {
-    throw new Error('Fee record report period cannot be the same as the facility utilisation data report period');
+  if (hasFacilityUtilisationDataAlreadyBeenUpdated(facilityUtilisationData, reportPeriod)) {
+    throw new Error('Fixed fee adjustment must be calculated before the facility utilisation data has been updated');
   }
 
   const previousPeriodFixedFee = facilityUtilisationData.fixedFee;

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/index.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/index.ts
@@ -2,3 +2,4 @@ export * from './calculate-principal-balance-adjustment';
 export * from './calculate-fixed-fee';
 export * from './get-fixed-fee-for-facility';
 export * from './calculate-fixed-fee-adjustment';
+export * from './update-facility-utilisation-data';

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
@@ -59,7 +59,7 @@ describe('updateFacilityUtilisationData', () => {
     expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toBe(false);
   });
 
-  it('calculates the fixed fee using the supplied facility utilisation data id anf utilisation and the supplied report period and updates the facility utilisation data fixed fee', async () => {
+  it('calculates the fixed fee using the supplied facility utilisation data id and utilisation and the supplied report period and updates the facility utilisation data fixed fee', async () => {
     // Arrange
     const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
       .withUtilisation(123.45)

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
@@ -1,0 +1,91 @@
+import { EntityManager } from 'typeorm';
+import { when } from 'jest-when';
+import { DbRequestSource, FacilityUtilisationDataEntity, FacilityUtilisationDataEntityMockBuilder, ReportPeriod } from '@ukef/dtfs2-common';
+import { updateFacilityUtilisationData } from './update-facility-utilisation-data';
+import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
+import { aDbRequestSource } from '../../../../../../test-helpers/test-data';
+
+jest.mock('./get-fixed-fee-for-facility');
+
+describe('updateFacilityUtilisationData', () => {
+  const mockSave = jest.fn();
+
+  const mockEntityManager = {
+    save: mockSave,
+  } as unknown as EntityManager;
+
+  beforeEach(() => {
+    jest.mocked(getFixedFeeForFacility).mockResolvedValue(100);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('updates the facility utilisation data entity with the supplied report period, utilisation and request source and saves the entity', async () => {
+    // Arrange
+    const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
+      .withUtilisation(1234567.89)
+      .withReportPeriod({
+        start: { month: 1, year: 2021 },
+        end: { month: 2, year: 2022 },
+      })
+      .build();
+
+    const reportPeriod: ReportPeriod = {
+      start: { month: 6, year: 2026 },
+      end: { month: 7, year: 2027 },
+    };
+    const utilisation = 9876543.21;
+    const requestSource: DbRequestSource = {
+      platform: 'TFM',
+      userId: 'abc123',
+    };
+
+    // Act
+    await updateFacilityUtilisationData(facilityUtilisationDataEntity, {
+      reportPeriod,
+      utilisation,
+      requestSource,
+      entityManager: mockEntityManager,
+    });
+
+    // Assert
+    expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, facilityUtilisationDataEntity);
+    expect(facilityUtilisationDataEntity.utilisation).toBe(9876543.21);
+    expect(facilityUtilisationDataEntity.reportPeriod).toEqual(reportPeriod);
+    expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toBe('abc123');
+    expect(facilityUtilisationDataEntity.lastUpdatedByPortalUserId).toBeNull();
+    expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toBe(false);
+  });
+
+  it('calculates the fixed fee using the supplied facility utilisation data id anf utilisation and the supplied report period and updates the facility utilisation data fixed fee', async () => {
+    // Arrange
+    const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
+      .withUtilisation(123.45)
+      .withReportPeriod({
+        start: { month: 1, year: 2021 },
+        end: { month: 2, year: 2022 },
+      })
+      .build();
+
+    const reportPeriod: ReportPeriod = {
+      start: { month: 6, year: 2026 },
+      end: { month: 7, year: 2027 },
+    };
+    const utilisation = 9876543.21;
+
+    when(getFixedFeeForFacility).calledWith('12345678', utilisation, reportPeriod).mockResolvedValue(76543.21);
+
+    // Act
+    await updateFacilityUtilisationData(facilityUtilisationDataEntity, {
+      reportPeriod,
+      utilisation,
+      requestSource: aDbRequestSource(),
+      entityManager: mockEntityManager,
+    });
+
+    // Assert
+    expect(facilityUtilisationDataEntity.fixedFee).toBe(76543.21);
+  });
+});

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
@@ -1,0 +1,36 @@
+import { EntityManager } from 'typeorm';
+import { DbRequestSource, FacilityUtilisationDataEntity, ReportPeriod } from '@ukef/dtfs2-common';
+import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
+
+type UpdateFacilityUtilisationDataUpdate = {
+  entityManager: EntityManager;
+  reportPeriod: ReportPeriod;
+  utilisation: number;
+  requestSource: DbRequestSource;
+};
+
+/**
+ * Updates a facility utilisation data entity with the supplied report period
+ * and the fixed fee calculated relative to the new report period
+ * @param facilityUtilisationDataEntity - The facility utilisation data entity to update
+ * @param update - The values to update the entity with
+ * @param update.reportPeriod - The report period to update with
+ * @param update.utilisation - The utilisation to update with
+ * @param update.requestSource - The request source supplying the update
+ * @param update.entityManager - The entity manager
+ * @returns The updated entity
+ */
+export const updateFacilityUtilisationData = async (
+  facilityUtilisationDataEntity: FacilityUtilisationDataEntity,
+  { reportPeriod, utilisation, requestSource, entityManager }: UpdateFacilityUtilisationDataUpdate,
+): Promise<FacilityUtilisationDataEntity> => {
+  const nextReportPeriodFixedFee = await getFixedFeeForFacility(facilityUtilisationDataEntity.id, utilisation, reportPeriod);
+
+  facilityUtilisationDataEntity.updateWithFixedFeeUtilisationAndReportPeriod({
+    fixedFee: nextReportPeriodFixedFee,
+    utilisation,
+    reportPeriod,
+    requestSource,
+  });
+  return await entityManager.save(FacilityUtilisationDataEntity, facilityUtilisationDataEntity);
+};

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
@@ -10,8 +10,8 @@ type UpdateFacilityUtilisationDataUpdate = {
 };
 
 /**
- * Updates a facility utilisation data entity with the supplied report period
- * and the fixed fee calculated relative to the new report period
+ * Updates a facility utilisation data entity with the supplied update values and
+ * calculates the new fixed fee using the updated values
  * @param facilityUtilisationDataEntity - The facility utilisation data entity to update
  * @param update - The values to update the entity with
  * @param update.reportPeriod - The report period to update with

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
@@ -26,7 +26,7 @@ export const updateFacilityUtilisationData = async (
 ): Promise<FacilityUtilisationDataEntity> => {
   const nextReportPeriodFixedFee = await getFixedFeeForFacility(facilityUtilisationDataEntity.id, utilisation, reportPeriod);
 
-  facilityUtilisationDataEntity.updateWithFixedFeeUtilisationAndReportPeriod({
+  facilityUtilisationDataEntity.updateWithCurrentReportPeriodDetails({
     fixedFee: nextReportPeriodFixedFee,
     utilisation,
     reportPeriod,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -46,7 +46,7 @@ export const handleUtilisationReportGenerateKeyingDataEvent = async (
   });
 
   await Promise.all(
-    feeRecordsWithPayloads.map(({ feeRecord, payload }) => {
+    feeRecordsWithPayloads.map(async ({ feeRecord, payload }) => {
       const stateMachine = FeeRecordStateMachine.forFeeRecord(feeRecord);
       return stateMachine.handleEvent({
         type: 'GENERATE_KEYING_DATA',

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
@@ -101,7 +101,7 @@ describe('handleUtilisationReportReportUploadedEvent', () => {
     const createdFacilityUtilisationDataEntities = reportCsvDataWithoutExistingFacilityUtilisationData.map(({ 'ukef facility id': facilityId }) => {
       expect(mockExistsBy).toHaveBeenCalledWith(FacilityUtilisationDataEntity, { id: facilityId });
 
-      return FacilityUtilisationDataEntity.createWithoutUtilisation({
+      return FacilityUtilisationDataEntity.createWithoutUtilisationAndFixedFee({
         id: facilityId,
         reportPeriod: reportReportPeriod,
         requestSource,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.ts
@@ -30,7 +30,7 @@ const createFacilityUtilisationDataEntityIfNotExists = async (
   if (entityExists) {
     return null;
   }
-  return FacilityUtilisationDataEntity.createWithoutUtilisation({ id: facilityId, reportPeriod, requestSource });
+  return FacilityUtilisationDataEntity.createWithoutUtilisationAndFixedFee({ id: facilityId, reportPeriod, requestSource });
 };
 
 export type UtilisationReportReportUploadedEvent = BaseUtilisationReportEvent<'REPORT_UPLOADED', ReportUploadedEventPayload>;

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
@@ -78,8 +78,13 @@ describe('post-keying-data.controller', () => {
       // Arrange
       const { req, res } = getHttpMocks();
 
-      const undefinedReport = undefined as unknown as UtilisationReportEntity;
-      when(feeRecordRepoFindSpy).calledWith(reportId, ['MATCH']).mockResolvedValue(someFeeRecordsForReport(undefinedReport));
+      const feeRecords = someFeeRecordsForReport(UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build());
+      feeRecords.forEach((feeRecord) => {
+        // @ts-expect-error We are setting the report to be undefined purposefully
+        // eslint-disable-next-line no-param-reassign
+        delete feeRecord.report;
+      });
+      when(feeRecordRepoFindSpy).calledWith(reportId, ['MATCH']).mockResolvedValue(feeRecords);
 
       // Act
       await postKeyingData(req, res);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-upload-utilisation-report.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-upload-utilisation-report.controller/index.test.ts
@@ -127,7 +127,7 @@ describe('post-upload-utilisation-report controller', () => {
         status: errorStatus,
       });
 
-      jest.mocked(executeWithSqlTransaction).mockRejectedValue(new TransactionFailedError(testApiError));
+      jest.mocked(executeWithSqlTransaction).mockRejectedValue(TransactionFailedError.forApiError(testApiError));
 
       // Act
       await postUploadUtilisationReport(req, res);
@@ -160,7 +160,7 @@ describe('post-upload-utilisation-report controller', () => {
         // Arrange
         const { req, res } = getHttpMocks();
 
-        jest.mocked(executeWithSqlTransaction).mockRejectedValue(new TransactionFailedError());
+        jest.mocked(executeWithSqlTransaction).mockRejectedValue(TransactionFailedError.forUnknownError());
 
         // Act
         await postUploadUtilisationReport(req, res);

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-to-an-existing-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-to-an-existing-payment.spec.js
@@ -18,19 +18,20 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can add fee records to existing paymen
     const FEE_RECORD_ID_ONE = '11';
     const FEE_RECORD_ID_TWO = '22';
     const PAYMENT_CURRENCY = 'GBP';
-    cy.task(NODE_TASKS.REMOVE_ALL_UTILISATION_REPORTS_FROM_DB);
-    cy.task(NODE_TASKS.REMOVE_ALL_PAYMENTS_FROM_DB);
+    cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
 
     const report = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION)
       .withId(REPORT_ID)
       .withBankId(BANK_ID)
       .build();
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+
     const payment = PaymentEntityMockBuilder.forCurrency(PAYMENT_CURRENCY)
       .withAmount(60)
       .withDateReceived(new Date('2023-02-02'))
       .withReference('REF01234')
       .build();
-    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(undefined)
+    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report)
       .withId(FEE_RECORD_ID_ONE)
       .withFacilityId('11111111')
       .withExporter('Exporter 1')
@@ -40,7 +41,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can add fee records to existing paymen
       .withPaymentExchangeRate(2)
       .withStatus('TO_DO')
       .build();
-    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(undefined)
+    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report)
       .withId(FEE_RECORD_ID_TWO)
       .withFacilityId('22222222')
       .withExporter('Exporter 2')
@@ -51,9 +52,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can add fee records to existing paymen
       .withPayments([payment])
       .withStatus('DOES_NOT_MATCH')
       .build();
-    report.feeRecords = [feeRecordOne, feeRecordTwo];
-
-    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecordOne, feeRecordTwo]);
 
     pages.landingPage.visit();
     cy.login(USERS.PDC_RECONCILE);

--- a/libs/common/src/sql-db-connection/migrations/1723453818266-AddFacilityUtilisationDataFixedFeeColumn.ts
+++ b/libs/common/src/sql-db-connection/migrations/1723453818266-AddFacilityUtilisationDataFixedFeeColumn.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFacilityUtilisationDataFixedFeeColumn1723453818266 implements MigrationInterface {
+  name = 'AddFacilityUtilisationDataFixedFeeColumn1723453818266';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FacilityUtilisationData"
+            ADD "fixedFee" decimal(14, 2) NULL CONSTRAINT "DF_e4f3bdf7db7228fa36d4a6c9f4b" DEFAULT 0
+        `);
+
+    await queryRunner.query(`
+            UPDATE "FacilityUtilisationData"
+            SET "fixedFee" = 0 
+        `);
+
+    await queryRunner.query(`
+            ALTER TABLE "FacilityUtilisationData"
+            ALTER COLUMN "fixedFee" decimal(14, 2) NOT NULL
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "FacilityUtilisationData" DROP CONSTRAINT "DF_e4f3bdf7db7228fa36d4a6c9f4b"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "FacilityUtilisationData" DROP COLUMN "fixedFee"
+        `);
+  }
+}

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
@@ -1,0 +1,41 @@
+import { FacilityUtilisationDataEntityMockBuilder } from '../../test-helpers';
+
+describe('FacilityUtilisationDataEntity', () => {
+  describe('updateWithFixedFeeUtilisationAndReportPeriod', () => {
+    it("sets the fixed fee, utilisation and report period and updates the 'lastUpdatedBy...' fields", () => {
+      // Arrange
+      const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
+        .withUtilisation(123456.78)
+        .withFixedFee(123.45)
+        .withReportPeriod({
+          start: { month: 1, year: 2021 },
+          end: { month: 2, year: 2022 },
+        })
+        .build();
+
+      const userId = 'abc123';
+
+      // Act
+      facilityUtilisationDataEntity.updateWithFixedFeeUtilisationAndReportPeriod({
+        fixedFee: 543.21,
+        utilisation: 876543.21,
+        reportPeriod: {
+          start: { month: 3, year: 2023 },
+          end: { month: 4, year: 2024 },
+        },
+        requestSource: { platform: 'TFM', userId },
+      });
+
+      // Assert
+      expect(facilityUtilisationDataEntity.fixedFee).toBe(543.21);
+      expect(facilityUtilisationDataEntity.utilisation).toBe(876543.21);
+      expect(facilityUtilisationDataEntity.reportPeriod).toEqual({
+        start: { month: 3, year: 2023 },
+        end: { month: 4, year: 2024 },
+      });
+      expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toBe(false);
+      expect(facilityUtilisationDataEntity.lastUpdatedByPortalUserId).toBeNull();
+      expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toBe(userId);
+    });
+  });
+});

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
@@ -1,7 +1,7 @@
 import { FacilityUtilisationDataEntityMockBuilder } from '../../test-helpers';
 
 describe('FacilityUtilisationDataEntity', () => {
-  describe('updateWithFixedFeeUtilisationAndReportPeriod', () => {
+  describe('updateWithCurrentReportPeriodDetails', () => {
     it("sets the fixed fee, utilisation and report period and updates the 'lastUpdatedBy...' fields", () => {
       // Arrange
       const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
@@ -16,7 +16,7 @@ describe('FacilityUtilisationDataEntity', () => {
       const userId = 'abc123';
 
       // Act
-      facilityUtilisationDataEntity.updateWithFixedFeeUtilisationAndReportPeriod({
+      facilityUtilisationDataEntity.updateWithCurrentReportPeriodDetails({
         fixedFee: 543.21,
         utilisation: 876543.21,
         reportPeriod: {

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.ts
@@ -3,7 +3,7 @@ import { AuditableBaseEntity } from '../base-entities';
 import { FeeRecordEntity } from '../fee-record';
 import { MonetaryColumn } from '../custom-columns';
 import { ReportPeriodPartialEntity } from '../partial-entities';
-import { CreateFacilityUtilisationDataWithoutUtilisationParams, UpdateWithFixedFeeAndReportPeriodParams } from './facility-utilisation-data.types';
+import { CreateFacilityUtilisationDataWithoutUtilisationParams, UpdateWithCurrentReportPeriodDetailsParams } from './facility-utilisation-data.types';
 
 @Entity('FacilityUtilisationData')
 export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
@@ -49,7 +49,7 @@ export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
     return data;
   }
 
-  public updateWithFixedFeeUtilisationAndReportPeriod({ fixedFee, utilisation, reportPeriod, requestSource }: UpdateWithFixedFeeAndReportPeriodParams): void {
+  public updateWithCurrentReportPeriodDetails({ fixedFee, utilisation, reportPeriod, requestSource }: UpdateWithCurrentReportPeriodDetailsParams): void {
     this.fixedFee = fixedFee;
     this.utilisation = utilisation;
     this.reportPeriod = reportPeriod;

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.ts
@@ -3,7 +3,7 @@ import { AuditableBaseEntity } from '../base-entities';
 import { FeeRecordEntity } from '../fee-record';
 import { MonetaryColumn } from '../custom-columns';
 import { ReportPeriodPartialEntity } from '../partial-entities';
-import { CreateFacilityUtilisationDataWithoutUtilisationParams } from './facility-utilisation-data.types';
+import { CreateFacilityUtilisationDataWithoutUtilisationParams, UpdateWithFixedFeeAndReportPeriodParams } from './facility-utilisation-data.types';
 
 @Entity('FacilityUtilisationData')
 export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
@@ -31,7 +31,13 @@ export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
   @MonetaryColumn({ defaultValue: 0 })
   utilisation!: number;
 
-  public static createWithoutUtilisation({
+  /**
+   * The facility fixed fee
+   */
+  @MonetaryColumn({ defaultValue: 0 })
+  fixedFee!: number;
+
+  public static createWithoutUtilisationAndFixedFee({
     id,
     reportPeriod,
     requestSource,
@@ -41,5 +47,12 @@ export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
     data.reportPeriod = reportPeriod;
     data.updateLastUpdatedBy(requestSource);
     return data;
+  }
+
+  public updateWithFixedFeeUtilisationAndReportPeriod({ fixedFee, utilisation, reportPeriod, requestSource }: UpdateWithFixedFeeAndReportPeriodParams): void {
+    this.fixedFee = fixedFee;
+    this.utilisation = utilisation;
+    this.reportPeriod = reportPeriod;
+    this.updateLastUpdatedBy(requestSource);
   }
 }

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.types.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.types.ts
@@ -6,3 +6,10 @@ export type CreateFacilityUtilisationDataWithoutUtilisationParams = {
   reportPeriod: ReportPeriod;
   requestSource: DbRequestSource;
 };
+
+export type UpdateWithFixedFeeAndReportPeriodParams = {
+  fixedFee: number;
+  utilisation: number;
+  reportPeriod: ReportPeriod;
+  requestSource: DbRequestSource;
+};

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.types.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.types.ts
@@ -7,7 +7,7 @@ export type CreateFacilityUtilisationDataWithoutUtilisationParams = {
   requestSource: DbRequestSource;
 };
 
-export type UpdateWithFixedFeeAndReportPeriodParams = {
+export type UpdateWithCurrentReportPeriodDetailsParams = {
   fixedFee: number;
   utilisation: number;
   reportPeriod: ReportPeriod;

--- a/libs/common/src/test-helpers/mock-data/facility-utilisation-data.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/facility-utilisation-data.entity.mock-builder.ts
@@ -16,6 +16,7 @@ export class FacilityUtilisationDataEntityMockBuilder {
       start: { month: 1, year: 2024 },
       end: { month: 1, year: 2024 },
     };
+    facility.fixedFee = 0;
     facility.updateLastUpdatedBy({ platform: 'SYSTEM' });
     return new FacilityUtilisationDataEntityMockBuilder(facility);
   }
@@ -32,6 +33,11 @@ export class FacilityUtilisationDataEntityMockBuilder {
 
   public withReportPeriod(reportPeriod: ReportPeriod): FacilityUtilisationDataEntityMockBuilder {
     this.data.reportPeriod = reportPeriod;
+    return this;
+  }
+
+  public withFixedFee(fixedFee: number): FacilityUtilisationDataEntityMockBuilder {
+    this.data.fixedFee = fixedFee;
     return this;
   }
 

--- a/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
@@ -1,6 +1,16 @@
 import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, FacilityUtilisationDataEntity, PaymentEntity } from '../../sql-db-entities';
-import { Currency, FeeRecordStatus } from '../../types';
+import { Currency, FeeRecordStatus, ReportPeriod } from '../../types';
 import { FacilityUtilisationDataEntityMockBuilder } from './facility-utilisation-data.entity.mock-builder';
+
+const getPreviousMontlyReportPeriod = (reportPeriod: ReportPeriod): ReportPeriod => {
+  const previousReportPeriodIsInPreviousYear = reportPeriod.start.month === 1;
+  const previousReportPeriodMonth = previousReportPeriodIsInPreviousYear ? 12 : reportPeriod.start.month - 1;
+  const previousReportPeriodYear = previousReportPeriodIsInPreviousYear ? reportPeriod.start.year - 1 : reportPeriod.start.year;
+  return {
+    start: { month: previousReportPeriodMonth, year: previousReportPeriodYear },
+    end: { month: previousReportPeriodMonth, year: previousReportPeriodYear },
+  };
+};
 
 export class FeeRecordEntityMockBuilder {
   private readonly feeRecord: FeeRecordEntity;
@@ -18,7 +28,9 @@ export class FeeRecordEntityMockBuilder {
     };
 
     data.id = 1;
-    data.facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId('12345678').build();
+    data.facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
+      .withReportPeriod(getPreviousMontlyReportPeriod(report.reportPeriod))
+      .build();
     data.facilityId = '12345678';
     data.report = report;
     data.exporter = 'test exporter';

--- a/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
@@ -2,7 +2,16 @@ import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, FacilityUtil
 import { Currency, FeeRecordStatus, ReportPeriod } from '../../types';
 import { FacilityUtilisationDataEntityMockBuilder } from './facility-utilisation-data.entity.mock-builder';
 
-const getPreviousMontlyReportPeriod = (reportPeriod: ReportPeriod): ReportPeriod => {
+/**
+ * Gets the previous report period based on a monthly reporting
+ * schedule. This is used because the attached facility utilisation
+ * data entity should normally be referencing the previous report
+ * period (where the attached report report period is the current
+ * report period)
+ * @param reportPeriod - The current report period
+ * @returns The previous report period
+ */
+const getPreviousMonthlyReportPeriod = (reportPeriod: ReportPeriod): ReportPeriod => {
   const previousReportPeriodIsInPreviousYear = reportPeriod.start.month === 1;
   const previousReportPeriodMonth = previousReportPeriodIsInPreviousYear ? 12 : reportPeriod.start.month - 1;
   const previousReportPeriodYear = previousReportPeriodIsInPreviousYear ? reportPeriod.start.year - 1 : reportPeriod.start.year;
@@ -29,7 +38,7 @@ export class FeeRecordEntityMockBuilder {
 
     data.id = 1;
     data.facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
-      .withReportPeriod(getPreviousMontlyReportPeriod(report.reportPeriod))
+      .withReportPeriod(getPreviousMonthlyReportPeriod(report.reportPeriod))
       .build();
     data.facilityId = '12345678';
     data.report = report;

--- a/libs/common/src/utils/report-period.test.ts
+++ b/libs/common/src/utils/report-period.test.ts
@@ -7,6 +7,7 @@ import {
   getSubmissionMonthForReportPeriod,
   getFormattedReportPeriodWithShortMonth,
   getPreviousReportPeriodForBankScheduleByMonth,
+  isEqualReportPeriod,
 } from './report-period';
 import { OneIndexedMonth, BankReportPeriodSchedule, ReportPeriod } from '../types';
 
@@ -378,6 +379,44 @@ describe('report-period utils', () => {
 
       // Assert
       expect(response).toEqual('Mar 2023 to May 2023');
+    });
+  });
+
+  describe('isEqualReportPeriod', () => {
+    it('returns true when the two supplied report periods are equal', () => {
+      // Arrange
+      const reportPeriod1: ReportPeriod = {
+        start: { month: 1, year: 2024 },
+        end: { month: 1, year: 2024 },
+      };
+      const reportPeriod2: ReportPeriod = {
+        start: { month: 1, year: 2024 },
+        end: { month: 1, year: 2024 },
+      };
+
+      // Act
+      const result = isEqualReportPeriod(reportPeriod1, reportPeriod2);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the two supplied report periods are not equal', () => {
+      // Arrange
+      const reportPeriod1: ReportPeriod = {
+        start: { month: 1, year: 2024 },
+        end: { month: 1, year: 2024 },
+      };
+      const reportPeriod2: ReportPeriod = {
+        start: { month: 2, year: 2025 },
+        end: { month: 2, year: 2025 },
+      };
+
+      // Act
+      const result = isEqualReportPeriod(reportPeriod1, reportPeriod2);
+
+      // Assert
+      expect(result).toBe(false);
     });
   });
 });

--- a/libs/common/src/utils/report-period.ts
+++ b/libs/common/src/utils/report-period.ts
@@ -225,3 +225,12 @@ export const getFormattedReportPeriodWithLongMonth = (reportPeriod: ReportPeriod
  */
 export const getFormattedReportPeriodWithShortMonth = (reportPeriod: ReportPeriod, includePeriodicity: boolean, alwaysStateYear = false): string =>
   getFormattedReportPeriod(reportPeriod, 'MMM', includePeriodicity, alwaysStateYear);
+
+/**
+ * Checks whether or not two report periods are equal
+ * @param reportPeriod1 - A report period
+ * @param reportPeriod2 - Another report period
+ * @returns Whether or not the report periods are equal
+ */
+export const isEqualReportPeriod = (reportPeriod1: ReportPeriod, reportPeriod2: ReportPeriod): boolean =>
+  isEqualMonthAndYear(reportPeriod1.start, reportPeriod2.start) && isEqualMonthAndYear(reportPeriod1.end, reportPeriod2.end);


### PR DESCRIPTION
## Introduction :pencil2:
We want to update the facility utilisation data table when keying data is generated for a facility.

### Note
Due to the fact that keying data generation modifies data on the actual objects we pass in, it is important that the updates are performed in the correct order ie. the principal balance adjustment and fixed fee must be calculated before the facility utilisation data is updated. To ensure this is done, a check is performed in the `calculateFixedFeeAdjustment` function which ensures that the facility utilisation data report period is not the same as the current report report period which should be sufficient as a check for whether or not the facility utilisation data has been updated prematurely.

## Resolution :heavy_check_mark:
- Adds a new helper in the event handler to update the facility utilisation data
- Updates unit and api tests

## Miscellaneous :heavy_plus_sign:


