### PR TITLE
fix(DTFS2-7316): remove transactions from deletion audit logs

### DIFF
--- a/libs/common/src/change-stream/delete-many.ts
+++ b/libs/common/src/change-stream/delete-many.ts
@@ -47,6 +47,7 @@ const deleteManyWithAuditLogs = async <CollectionName extends MongoDbCollectionN
 
     const deletionCollection = await db.getCollection('deletion-audit-logs');
     const insertResult = await deletionCollection.insertMany(logsToInsert);
+
     if (!insertResult.acknowledged) {
       throw new WriteConcernError();
     }
@@ -60,11 +61,7 @@ const deleteManyWithAuditLogs = async <CollectionName extends MongoDbCollectionN
     }
     return deleteResult;
   } catch (error) {
-    console.error(
-      `Failed to delete many from collection ${collectionName} with filter ${JSON.stringify(
-        filter,
-      )}. Inconsistent deletion audit records may have been created`,
-    );
+    console.error('Failed to delete many from collection %s with filter %o. Inconsistent deletion audit records may have been created', collectionName, filter);
     throw error;
   }
 };
@@ -81,7 +78,7 @@ export const deleteMany = async <CollectionName extends MongoDbCollectionName>({
   auditDetails,
 }: DeleteManyParams<CollectionName>): Promise<DeleteResult> => {
   if (CHANGE_STREAM_ENABLED) {
-    return await deleteManyWithAuditLogs({
+    return deleteManyWithAuditLogs({
       filter,
       collectionName,
       db,
@@ -89,5 +86,5 @@ export const deleteMany = async <CollectionName extends MongoDbCollectionName>({
     });
   }
   const collection = await db.getCollection(collectionName);
-  return await collection.deleteMany(filter);
+  return collection.deleteMany(filter);
 };

--- a/libs/common/src/change-stream/delete-many.ts
+++ b/libs/common/src/change-stream/delete-many.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config.js';
-import { DeleteResult, Filter, ObjectId, TransactionOptions, WithoutId } from 'mongodb';
+import { DeleteResult, Filter, ObjectId, WithoutId } from 'mongodb';
 import { add } from 'date-fns';
 import { AuditDetails, DbModel, DeletionAuditLog, MongoDbCollectionName } from '../types';
 import { MongoDbClient } from '../mongo-db-client';
@@ -26,61 +26,42 @@ const deleteManyWithAuditLogs = async <CollectionName extends MongoDbCollectionN
   db,
   auditDetails,
 }: DeleteManyParams<CollectionName>): Promise<DeleteResult> => {
-  const client = await db.getClient();
-  const session = client.startSession();
+  const collection = await db.getCollection(collectionName);
+  const documentsToDeleteIds = await collection
+    .find(filter)
+    .project<{ _id: ObjectId }>({ _id: 1 })
+    .map(({ _id }) => _id)
+    .toArray();
 
-  try {
-    const transactionOptions: TransactionOptions = {
-      readConcern: { level: 'snapshot' },
-      writeConcern: { w: 'majority' },
-    };
-
-    let transactionDeleteResult: DeleteResult = { deletedCount: 0, acknowledged: false };
-    await session.withTransaction(async () => {
-      const collection = await db.getCollection(collectionName);
-      const documentsToDeleteIds = await collection
-        .find(filter, { session })
-        .project<{ _id: ObjectId }>({ _id: 1 })
-        .map(({ _id }) => _id)
-        .toArray();
-
-      if (!documentsToDeleteIds.length) {
-        throw new DocumentNotFoundError();
-      }
-
-      const logsToInsert: WithoutId<DeletionAuditLog>[] = documentsToDeleteIds.map((deletedDocumentId) => ({
-        collectionName,
-        deletedDocumentId,
-        auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
-        expireAt: add(new Date(), { seconds: DELETION_AUDIT_LOGS_TTL_SECONDS }),
-      }));
-
-      const deletionCollection = await db.getCollection('deletion-audit-logs');
-      const insertResult = await deletionCollection.insertMany(logsToInsert, { session });
-      if (!insertResult.acknowledged) {
-        throw new WriteConcernError();
-      }
-
-      const deleteManyFilter = {
-        _id: { $in: documentsToDeleteIds },
-      } as unknown as Filter<WithoutId<DbModel<CollectionName>>>;
-      const deleteResult = await collection.deleteMany(deleteManyFilter, { session });
-      if (!(deleteResult.acknowledged && deleteResult.deletedCount === documentsToDeleteIds.length)) {
-        throw new WriteConcernError();
-      }
-      transactionDeleteResult = { ...deleteResult };
-    }, transactionOptions);
-    return transactionDeleteResult;
-  } catch (error) {
-    console.error(`Failed to delete many from collection ${collectionName} with filter ${JSON.stringify(filter)}, rolling back changes.`);
-    throw error;
-  } finally {
-    await session.endSession();
+  if (!documentsToDeleteIds.length) {
+    throw new DocumentNotFoundError();
   }
+
+  const logsToInsert: WithoutId<DeletionAuditLog>[] = documentsToDeleteIds.map((deletedDocumentId) => ({
+    collectionName,
+    deletedDocumentId,
+    auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
+    expireAt: add(new Date(), { seconds: DELETION_AUDIT_LOGS_TTL_SECONDS }),
+  }));
+
+  const deletionCollection = await db.getCollection('deletion-audit-logs');
+  const insertResult = await deletionCollection.insertMany(logsToInsert);
+  if (!insertResult.acknowledged) {
+    throw new WriteConcernError();
+  }
+
+  const deleteManyFilter = {
+    _id: { $in: documentsToDeleteIds },
+  } as unknown as Filter<WithoutId<DbModel<CollectionName>>>;
+  const deleteResult = await collection.deleteMany(deleteManyFilter);
+  if (!(deleteResult.acknowledged && deleteResult.deletedCount === documentsToDeleteIds.length)) {
+    throw new WriteConcernError();
+  }
+  return deleteResult;
 };
 
 /**
- * When the `CHANGE_STREAM_ENABLED` feature flag is enabled adds deletions audit logs and calls Collection.deleteMany.
+ * Adds deletion audit logs and calls Collection.deleteMany.
  * @throws {DocumentNotFoundError} - if there are no documents matching the filter to delete
  * @throws {WriteConcernError} - if either the deletion-audit-log insertion or document deletion operations are not acknowledged
  */
@@ -90,14 +71,10 @@ export const deleteMany = async <CollectionName extends MongoDbCollectionName>({
   db,
   auditDetails,
 }: DeleteManyParams<CollectionName>): Promise<DeleteResult> => {
-  if (process.env.CHANGE_STREAM_ENABLED === 'true') {
-    return await deleteManyWithAuditLogs({
-      filter,
-      collectionName,
-      db,
-      auditDetails,
-    });
-  }
-  const collection = await db.getCollection(collectionName);
-  return await collection.deleteMany(filter);
+  return await deleteManyWithAuditLogs({
+    filter,
+    collectionName,
+    db,
+    auditDetails,
+  });
 };

--- a/libs/common/src/change-stream/delete-one.test.ts
+++ b/libs/common/src/change-stream/delete-one.test.ts
@@ -6,17 +6,6 @@ import { MONGO_DB_COLLECTIONS } from '../constants';
 import { generateMockNoUserLoggedInAuditDatabaseRecord } from './test-helpers';
 import { deleteOne } from './delete-one';
 
-const mockSession = {
-  withTransaction: jest.fn((callback: () => void) => {
-    callback();
-  }),
-  endSession: jest.fn(),
-};
-
-const mockClient = {
-  startSession: jest.fn(() => mockSession),
-};
-
 const mockGetCollection = jest.fn();
 
 const mockDeleteOne = jest.fn();
@@ -30,7 +19,6 @@ const mockDeletionsCollection = {
 };
 
 const mockDb = {
-  getClient: jest.fn(() => mockClient),
   getCollection: mockGetCollection,
 } as unknown as MongoDbClient;
 
@@ -44,77 +32,37 @@ describe('deleteOne', () => {
     process.env.DELETION_AUDIT_LOGS_TTL_SECONDS = originalDeletionAuditLogsDeleteAfterSeconds;
   });
 
-  describe('when change stream enabled', () => {
-    beforeAll(() => {
-      process.env.CHANGE_STREAM_ENABLED = 'true';
-      process.env.DELETION_AUDIT_LOGS_TTL_SECONDS = '60';
-    });
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-
-      when(mockGetCollection).calledWith('users').mockReturnValueOnce(mockUsersCollection);
-      when(mockGetCollection).calledWith(MONGO_DB_COLLECTIONS.DELETION_AUDIT_LOGS).mockReturnValueOnce(mockDeletionsCollection);
-    });
-
-    describe('when the insertion and deletion are successful', () => {
-      beforeEach(() => {
-        mockDeleteOneSuccess();
-        mockInsertOneSuccess();
-      });
-
-      it('adds a record to the deletion-audit-logs collection', async () => {
-        await deleteOne({
-          db: mockDb,
-          documentId,
-          collectionName: 'users',
-          auditDetails: generateNoUserLoggedInAuditDetails(),
-        });
-
-        expect(mockDeletionsCollection.insertOne).toHaveBeenCalledWith(
-          {
-            collectionName: 'users',
-            deletedDocumentId: documentId,
-            auditRecord: generateMockNoUserLoggedInAuditDatabaseRecord(),
-            expireAt: expect.any(Date) as Date,
-          },
-          { session: mockSession },
-        );
-      });
-
-      it('deletes the requested document', async () => {
-        await deleteOne({
-          db: mockDb,
-          documentId,
-          collectionName: 'users',
-          auditDetails: generateNoUserLoggedInAuditDetails(),
-        });
-
-        expect(mockUsersCollection.deleteOne).toHaveBeenCalledWith({ _id: { $eq: documentId } }, { session: mockSession });
-      });
-
-      it('ends the session', async () => {
-        await deleteOne({
-          db: mockDb,
-          documentId,
-          collectionName: 'users',
-          auditDetails: generateNoUserLoggedInAuditDetails(),
-        });
-
-        expect(mockSession.endSession).toHaveBeenCalledTimes(1);
-      });
-    });
+  beforeAll(() => {
+    process.env.DELETION_AUDIT_LOGS_TTL_SECONDS = '60';
   });
 
-  describe('when change stream disabled', () => {
-    beforeAll(() => {
-      process.env.CHANGE_STREAM_ENABLED = 'false';
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    when(mockGetCollection).calledWith('users').mockReturnValueOnce(mockUsersCollection);
+    when(mockGetCollection).calledWith(MONGO_DB_COLLECTIONS.DELETION_AUDIT_LOGS).mockReturnValueOnce(mockDeletionsCollection);
+  });
+
+  describe('when the insertion and deletion are successful', () => {
+    beforeEach(() => {
+      mockDeleteOneSuccess();
+      mockInsertOneSuccess();
     });
 
-    beforeEach(() => {
-      jest.clearAllMocks();
+    it('adds a record to the deletion-audit-logs collection', async () => {
+      await deleteOne({
+        db: mockDb,
+        documentId,
+        collectionName: 'users',
+        auditDetails: generateNoUserLoggedInAuditDetails(),
+      });
 
-      when(mockGetCollection).calledWith('users').mockReturnValueOnce(mockUsersCollection);
+      expect(mockDeletionsCollection.insertOne).toHaveBeenCalledWith({
+        collectionName: 'users',
+        deletedDocumentId: documentId,
+        auditRecord: generateMockNoUserLoggedInAuditDatabaseRecord(),
+        expireAt: expect.any(Date) as Date,
+      });
     });
 
     it('deletes the requested document', async () => {

--- a/libs/common/src/change-stream/delete-one.test.ts
+++ b/libs/common/src/change-stream/delete-one.test.ts
@@ -65,17 +65,18 @@ describe('deleteOne', () => {
           auditRecord: generateMockNoUserLoggedInAuditDatabaseRecord(),
           expireAt: expect.any(Date) as Date,
         });
+      });
 
-        it('deletes the requested document', async () => {
-          await deleteOne({
-            db: mockDb,
-            documentId,
-            collectionName: 'users',
-            auditDetails: generateNoUserLoggedInAuditDetails(),
-          });
-
-          expect(mockUsersCollection.deleteOne).toHaveBeenCalledWith({ _id: { $eq: documentId } });
+      it('deletes the requested document', async () => {
+        await deleteOne({
+          db: mockDb,
+          documentId,
+          collectionName: 'users',
+          auditDetails: generateNoUserLoggedInAuditDetails(),
         });
+
+        expect(mockUsersCollection.deleteOne).toHaveBeenCalledWith({ _id: { $eq: documentId } });
+        expect(mockUsersCollection.deleteOne).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/libs/common/src/change-stream/delete-one.test.ts
+++ b/libs/common/src/change-stream/delete-one.test.ts
@@ -65,17 +65,17 @@ describe('deleteOne', () => {
           auditRecord: generateMockNoUserLoggedInAuditDatabaseRecord(),
           expireAt: expect.any(Date) as Date,
         });
-      });
 
-      it('deletes the requested document', async () => {
-        await deleteOne({
-          db: mockDb,
-          documentId,
-          collectionName: 'users',
-          auditDetails: generateNoUserLoggedInAuditDetails(),
+        it('deletes the requested document', async () => {
+          await deleteOne({
+            db: mockDb,
+            documentId,
+            collectionName: 'users',
+            auditDetails: generateNoUserLoggedInAuditDetails(),
+          });
+
+          expect(mockUsersCollection.deleteOne).toHaveBeenCalledWith({ _id: { $eq: documentId } });
         });
-
-        expect(mockUsersCollection.deleteOne).toHaveBeenCalledWith({ _id: { $eq: documentId } });
       });
     });
   });

--- a/libs/common/src/change-stream/delete-one.ts
+++ b/libs/common/src/change-stream/delete-one.ts
@@ -27,6 +27,7 @@ const deleteDocumentWithAuditLogs = async ({ documentId, collectionName, db, aud
       auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
       expireAt: add(new Date(), { seconds: DELETION_AUDIT_LOGS_TTL_SECONDS }),
     });
+
     if (!insertResult.acknowledged) {
       throw new WriteConcernError();
     }
@@ -43,9 +44,7 @@ const deleteDocumentWithAuditLogs = async ({ documentId, collectionName, db, aud
 
     return deleteResult;
   } catch (error) {
-    console.error(
-      `Failed to delete document ${documentId.toString()} from collection ${collectionName}. An inconsistent deletion audit record may have been created`,
-    );
+    console.error(`Failed to delete document %s from collection %s. An inconsistent deletion audit record may have been created`, documentId, collectionName);
     throw error;
   }
 };
@@ -57,7 +56,7 @@ const deleteDocumentWithAuditLogs = async ({ documentId, collectionName, db, aud
  */
 export const deleteOne = async ({ documentId, collectionName, db, auditDetails }: DeleteOneParams): Promise<DeleteResult> => {
   if (process.env.CHANGE_STREAM_ENABLED === 'true') {
-    return await deleteDocumentWithAuditLogs({
+    return deleteDocumentWithAuditLogs({
       documentId,
       collectionName,
       db,
@@ -66,5 +65,5 @@ export const deleteOne = async ({ documentId, collectionName, db, auditDetails }
   }
 
   const collection = await db.getCollection(collectionName);
-  return await collection.deleteOne({ _id: { $eq: documentId } });
+  return collection.deleteOne({ _id: { $eq: documentId } });
 };

--- a/libs/common/src/change-stream/test-helpers/with-delete-many.api-tests.ts
+++ b/libs/common/src/change-stream/test-helpers/with-delete-many.api-tests.ts
@@ -2,6 +2,9 @@ import { Collection, ObjectId, WithoutId } from 'mongodb';
 import { when } from 'jest-when';
 import { MongoDbClient } from '../../mongo-db-client';
 import { AuditDatabaseRecord, DeletionAuditLog, MongoDbCollectionName } from '../../types';
+import { changeStreamConfig } from '../config';
+
+const { CHANGE_STREAM_ENABLED } = changeStreamConfig;
 
 type Params = {
   makeRequest: () => Promise<{ status: number; body: unknown }>;
@@ -37,23 +40,86 @@ export const withDeleteManyTests = ({ makeRequest, collectionName, auditRecord, 
       insertManyMock.mockRestore();
     });
 
-    describe('when the service is working normally', () => {
-      it('should add deletion audit logs', async () => {
-        await makeRequest();
+    if (CHANGE_STREAM_ENABLED) {
+      describe('when the service is working normally', () => {
+        it('should add deletion audit logs', async () => {
+          await makeRequest();
 
-        const deletionAuditLogs = await deletionAuditLogsCollection.find({ collectionName, deletedDocumentId: { $in: getDeletedDocumentIds() } }).toArray();
+          const deletionAuditLogs = await deletionAuditLogsCollection.find({ collectionName, deletedDocumentId: { $in: getDeletedDocumentIds() } }).toArray();
 
-        expect(deletionAuditLogs).toEqual(
-          getDeletedDocumentIds().map((id) => ({
-            _id: expect.any(ObjectId) as ObjectId,
-            collectionName,
-            deletedDocumentId: new ObjectId(id),
-            auditRecord,
-            expireAt: expect.any(Date) as Date,
-          })),
-        );
+          expect(deletionAuditLogs).toEqual(
+            getDeletedDocumentIds().map((id) => ({
+              _id: expect.any(ObjectId) as ObjectId,
+              collectionName,
+              deletedDocumentId: new ObjectId(id),
+              auditRecord,
+              expireAt: expect.any(Date) as Date,
+            })),
+          );
+        });
+
+        it('should delete the documents', async () => {
+          await makeRequest();
+
+          const collection = await mongoDbClient.getCollection(collectionName);
+          const deletedDocuments = await collection.find({ _id: { $in: getDeletedDocumentIds() } }).toArray();
+
+          expect(deletedDocuments.length).toBe(0);
+        });
+
+        it('should return 200', async () => {
+          const { status, body } = await makeRequest();
+
+          expect(status).toBe(200);
+          expect(body).toEqual(expectedSuccessResponseBody);
+        });
       });
 
+      describe('when inserting the deletion log is not acknowledged', () => {
+        beforeEach(() => {
+          when(insertManyMock)
+            .calledWith(
+              // @ts-ignore
+              expect.arrayContaining(
+                getDeletedDocumentIds().map((id) => ({
+                  collectionName,
+                  deletedDocumentId: new ObjectId(id),
+                  auditRecord,
+                  expireAt: expect.any(Date) as Date,
+                })),
+              ) as WithoutId<DeletionAuditLog>[],
+            )
+            // @ts-ignore
+            .mockResolvedValueOnce({
+              acknowledged: false,
+            });
+        });
+
+        itDoesNotUpdateTheDatabase();
+      });
+
+      describe('when inserting the deletion log throws an error', () => {
+        beforeEach(() => {
+          when(insertManyMock)
+            .calledWith(
+              // @ts-ignore
+              expect.arrayContaining(
+                getDeletedDocumentIds().map((id) => ({
+                  collectionName,
+                  deletedDocumentId: new ObjectId(id),
+                  auditRecord,
+                  expireAt: expect.any(Date) as Date,
+                })),
+              ) as WithoutId<DeletionAuditLog>[],
+            )
+            .mockImplementationOnce(() => {
+              throw new Error();
+            });
+        });
+
+        itDoesNotUpdateTheDatabase();
+      });
+    } else {
       it('should delete the documents', async () => {
         await makeRequest();
 
@@ -62,59 +128,7 @@ export const withDeleteManyTests = ({ makeRequest, collectionName, auditRecord, 
 
         expect(deletedDocuments.length).toBe(0);
       });
-
-      it('should return 200', async () => {
-        const { status, body } = await makeRequest();
-
-        expect(status).toBe(200);
-        expect(body).toEqual(expectedSuccessResponseBody);
-      });
-    });
-
-    describe('when inserting the deletion log is not acknowledged', () => {
-      beforeEach(() => {
-        when(insertManyMock)
-          .calledWith(
-            // @ts-ignore
-            expect.arrayContaining(
-              getDeletedDocumentIds().map((id) => ({
-                collectionName,
-                deletedDocumentId: new ObjectId(id),
-                auditRecord,
-                expireAt: expect.any(Date) as Date,
-              })),
-            ) as WithoutId<DeletionAuditLog>[],
-          )
-          // @ts-ignore
-          .mockResolvedValueOnce({
-            acknowledged: false,
-          });
-      });
-
-      itDoesNotUpdateTheDatabase();
-    });
-
-    describe('when inserting the deletion log throws an error', () => {
-      beforeEach(() => {
-        when(insertManyMock)
-          .calledWith(
-            // @ts-ignore
-            expect.arrayContaining(
-              getDeletedDocumentIds().map((id) => ({
-                collectionName,
-                deletedDocumentId: new ObjectId(id),
-                auditRecord,
-                expireAt: expect.any(Date) as Date,
-              })),
-            ) as WithoutId<DeletionAuditLog>[],
-          )
-          .mockImplementationOnce(() => {
-            throw new Error();
-          });
-      });
-
-      itDoesNotUpdateTheDatabase();
-    });
+    }
 
     function itDoesNotUpdateTheDatabase() {
       it('should not add deletion audit logs', async () => {

--- a/libs/common/src/change-stream/test-helpers/with-delete-one.api-tests.ts
+++ b/libs/common/src/change-stream/test-helpers/with-delete-one.api-tests.ts
@@ -3,6 +3,9 @@ import { Response } from 'supertest';
 import { when } from 'jest-when';
 import { MongoDbClient } from '../../mongo-db-client';
 import { ApiErrorResponseBody, AuditDatabaseRecord, DeletionAuditLog, MongoDbCollectionName } from '../../types';
+import { changeStreamConfig } from '../config';
+
+const { CHANGE_STREAM_ENABLED } = changeStreamConfig;
 
 interface ApiErrorResponse extends Response {
   body: ApiErrorResponseBody;
@@ -41,25 +44,90 @@ export const withDeleteOneTests = ({ makeRequest, collectionName, auditRecord, g
       mockInsertOne.mockRestore();
     });
 
-    describe('when the service is working normally', () => {
-      it('should add a deletion audit log', async () => {
-        await makeRequest();
+    if (CHANGE_STREAM_ENABLED) {
+      describe('when the service is working normally', () => {
+        it('should add a deletion audit log', async () => {
+          await makeRequest();
 
-        const deletionAuditLogs = await deletionAuditLogsCollection
-          .find({ collectionName: { $eq: collectionName }, deletedDocumentId: { $eq: getDeletedDocumentId() } })
-          .toArray();
+          const deletionAuditLogs = await deletionAuditLogsCollection
+            .find({ collectionName: { $eq: collectionName }, deletedDocumentId: { $eq: getDeletedDocumentId() } })
+            .toArray();
 
-        expect(deletionAuditLogs).toEqual([
-          {
-            _id: expect.any(ObjectId) as ObjectId,
-            collectionName,
-            deletedDocumentId: new ObjectId(getDeletedDocumentId()),
-            auditRecord,
-            expireAt: expect.any(Date) as Date,
-          },
-        ]);
+          expect(deletionAuditLogs).toEqual([
+            {
+              _id: expect.any(ObjectId) as ObjectId,
+              collectionName,
+              deletedDocumentId: new ObjectId(getDeletedDocumentId()),
+              auditRecord,
+              expireAt: expect.any(Date) as Date,
+            },
+          ]);
+        });
+
+        it('should delete the document', async () => {
+          await makeRequest();
+
+          const collection = await mongoDbClient.getCollection(collectionName);
+          const deletedDocument = await collection.findOne({ _id: { $eq: getDeletedDocumentId() } });
+
+          expect(deletedDocument).toBe(null);
+        });
+
+        it('should return 200', async () => {
+          const { status } = await makeRequest();
+
+          expect(status).toBe(200);
+        });
       });
 
+      describe('when inserting the deletion log is not acknowledged', () => {
+        beforeEach(() => {
+          when(mockInsertOne)
+            .calledWith({
+              // @ts-ignore
+              collectionName,
+              deletedDocumentId: getDeletedDocumentId(),
+              auditRecord,
+              expireAt: expect.any(Date) as Date,
+            })
+            .mockImplementationOnce(() => ({
+              acknowledged: false,
+            }));
+        });
+
+        itDoesNotUpdateTheDatabase();
+
+        it('should return 500', async () => {
+          const { status } = await makeRequest();
+
+          expect(status).toBe(500);
+        });
+      });
+
+      describe('when inserting the deletion log throws an error', () => {
+        beforeEach(() => {
+          when(mockInsertOne)
+            .calledWith({
+              // @ts-ignore
+              collectionName,
+              deletedDocumentId: getDeletedDocumentId(),
+              auditRecord,
+              expireAt: expect.any(Date) as Date,
+            })
+            .mockImplementationOnce(() => {
+              throw new Error();
+            });
+        });
+
+        itDoesNotUpdateTheDatabase();
+
+        it('should return 500', async () => {
+          const { status } = await makeRequest();
+
+          expect(status).toBe(500);
+        });
+      });
+    } else {
       it('should delete the document', async () => {
         await makeRequest();
 
@@ -74,55 +142,7 @@ export const withDeleteOneTests = ({ makeRequest, collectionName, auditRecord, g
 
         expect(status).toBe(200);
       });
-    });
-
-    describe('when inserting the deletion log is not acknowledged', () => {
-      beforeEach(() => {
-        when(mockInsertOne)
-          .calledWith({
-            // @ts-ignore
-            collectionName,
-            deletedDocumentId: getDeletedDocumentId(),
-            auditRecord,
-            expireAt: expect.any(Date) as Date,
-          })
-          .mockImplementationOnce(() => ({
-            acknowledged: false,
-          }));
-      });
-
-      itDoesNotUpdateTheDatabase();
-
-      it('should return 500', async () => {
-        const { status } = await makeRequest();
-
-        expect(status).toBe(500);
-      });
-    });
-
-    describe('when inserting the deletion log throws an error', () => {
-      beforeEach(() => {
-        when(mockInsertOne)
-          .calledWith({
-            // @ts-ignore
-            collectionName,
-            deletedDocumentId: getDeletedDocumentId(),
-            auditRecord,
-            expireAt: expect.any(Date) as Date,
-          })
-          .mockImplementationOnce(() => {
-            throw new Error();
-          });
-      });
-
-      itDoesNotUpdateTheDatabase();
-
-      it('should return 500', async () => {
-        const { status } = await makeRequest();
-
-        expect(status).toBe(500);
-      });
-    });
+    }
 
     function itDoesNotUpdateTheDatabase() {
       it('should not add a deletion audit log', async () => {

--- a/portal-api/api-tests/deal-versioning.api-test.js
+++ b/portal-api/api-tests/deal-versioning.api-test.js
@@ -49,6 +49,7 @@ const generateVersion0ApplicationToSubmit = () => ({
  */
 const generateVersion0ApplicationResponse = (makerId) => ({
   ...generateVersion0ApplicationToSubmit(),
+  mandatoryVersionId: expect.any(Number),
   version: 0,
   status: CONSTANTS.DEAL.DEAL_STATUS.DRAFT,
   editedBy: expect.any(Array),

--- a/portal-api/api-tests/deal-versioning.api-test.js
+++ b/portal-api/api-tests/deal-versioning.api-test.js
@@ -1,17 +1,14 @@
 const { MONGO_DB_COLLECTIONS, FACILITY_TYPE } = require('@ukef/dtfs2-common');
 const { generateParsedMockPortalUserAuditDatabaseRecord } = require('@ukef/dtfs2-common/change-stream/test-helpers');
 const databaseHelper = require('./database-helper');
-
 const app = require('../src/createApp');
 const testUserCache = require('./api-test-users');
 const { MAKER, ADMIN } = require('../src/v1/roles/roles');
-
 const { as } = require('./api')(app);
 const { expectMongoId } = require('./expectMongoIds');
-
 const CONSTANTS = require('../src/constants');
-
 const mockEligibilityCriteria = require('./fixtures/gef/eligibilityCriteria');
+const mockMandatoryCriteria = require('./fixtures/gef/mandatoryCriteriaVersioned');
 
 const expectedEligibilityCriteriaAuditRecord = {
   ...generateParsedMockPortalUserAuditDatabaseRecord('abcdef123456abcdef123456'),
@@ -23,6 +20,7 @@ const gefFacilitiesUrl = '/v1/gef/facilities';
 
 // NOTE: to maintain backwards compatibility we shouldn't change this from version 2.1
 const mockEligibilityCriteriaVersion = mockEligibilityCriteria.find((criteria) => criteria.version === 2.1);
+const mockMandatoryCriteriaVersion = mockMandatoryCriteria.find((criteria) => criteria.version === 2);
 
 const originalEnv = { ...process.env };
 
@@ -34,7 +32,7 @@ const generateVersion0ApplicationToSubmit = () => ({
   additionalRefName: 'Team 1',
   exporter: {},
   createdAt: '2021-01-01T00:00',
-  mandatoryVersionId: 33,
+  mandatoryVersionId: 2,
   status: CONSTANTS.DEAL.DEAL_STATUS.IN_PROGRESS,
   updatedAt: null,
   submissionCount: 0,
@@ -49,7 +47,6 @@ const generateVersion0ApplicationToSubmit = () => ({
  */
 const generateVersion0ApplicationResponse = (makerId) => ({
   ...generateVersion0ApplicationToSubmit(),
-  mandatoryVersionId: expect.any(Number),
   version: 0,
   status: CONSTANTS.DEAL.DEAL_STATUS.DRAFT,
   editedBy: expect.any(Array),
@@ -64,7 +61,7 @@ const generateVersion0ApplicationResponse = (makerId) => ({
   checkerId: null,
   portalActivities: [],
   eligibility: {
-    version: expect.any(Number),
+    version: 2.1,
     _id: expect.any(String),
     product: expect.any(String),
     createdAt: expect.any(Number),
@@ -140,8 +137,14 @@ describe('GEF deal versioning', () => {
   });
 
   beforeEach(async () => {
-    await databaseHelper.wipe([MONGO_DB_COLLECTIONS.DEALS, MONGO_DB_COLLECTIONS.FACILITIES, MONGO_DB_COLLECTIONS.ELIGIBILITY_CRITERIA]);
+    await databaseHelper.wipe([
+      MONGO_DB_COLLECTIONS.DEALS,
+      MONGO_DB_COLLECTIONS.FACILITIES,
+      MONGO_DB_COLLECTIONS.GEF_ELIGIBILITY_CRITERIA,
+      MONGO_DB_COLLECTIONS.GEF_MANDATORY_CRITERIA_VERSIONED,
+    ]);
     await as(anAdmin).post(mockEligibilityCriteriaVersion).to('/v1/gef/eligibility-criteria');
+    await as(anAdmin).post(mockMandatoryCriteriaVersion).to('/v1/gef/mandatory-criteria-versioned');
   });
 
   describe(`when GEF_DEAL_VERSION set to '0'`, () => {

--- a/portal-api/api-tests/v1/gef/facilities/facilities.delete.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities/facilities.delete.api-test.js
@@ -91,7 +91,7 @@ describe(baseUrl, () => {
       collectionName: MONGO_DB_COLLECTIONS.FACILITIES,
       auditRecord: expectAnyPortalUserAuditDatabaseRecord(),
       getDeletedDocumentIds: () => facilitiesToDeleteIds,
-      expectedSuccessResponseBody: { acknowledged: true },
+      expectedSuccessResponseBody: { acknowledged: true, deletedCount: 2 },
     });
 
     // This behaviour matches existing implimentation


### PR DESCRIPTION
## Introduction :pencil2:
There is a bug with delete one and delete many audit logs. This is due to us using a sharded database, which is required for change streams. With mongodb 4, we cannot have a sharded database and have transactions that update multiple tables.

## Resolution :heavy_check_mark:
Remove transactions from the deletion helpers


