### PR TITLE
fix(DTFS2-7316): add update and replace to deletion change stream

### DIFF
--- a/dtfs-central-api/src/services/changeStream/setupChangeStream.ts
+++ b/dtfs-central-api/src/services/changeStream/setupChangeStream.ts
@@ -34,7 +34,7 @@ const setupChangeStreamForDeletionCollection = async () => {
     // Deletion audit logs should never be updated or replaced. Cosmos DB does not currently support filtering at the `watch` step
     // (See here https://learn.microsoft.com/en-us/answers/questions/356668/how-to-get-inserted-change-stream-data-use-cosmosd)
     if (changeStreamDocument.operationType !== 'insert') {
-      throw new Error('A document in deletion-audit-logs has been %sd', changeStreamDocument.operationType);
+      throw new Error(`A document in deletion-audit-logs has been ${changeStreamDocument.operationType}d`);
     }
     postDeletionAuditDetails(changeStreamDocument).catch((error) => {
       console.error('Error sending change stream update to API', error);

--- a/dtfs-central-api/src/services/changeStream/setupChangeStream.ts
+++ b/dtfs-central-api/src/services/changeStream/setupChangeStream.ts
@@ -27,10 +27,15 @@ const setupChangeStreamForDeletionCollection = async () => {
   const databaseConnection = await mongoDbClient.getConnection();
   const changeStream = databaseConnection
     .collection(MONGO_DB_COLLECTIONS.DELETION_AUDIT_LOGS)
-    .watch([{ $match: { operationType: 'insert' } }, { $project: { _id: 1, fullDocument: 1, ns: 1, documentKey: 1 } }], {
+    .watch([{ $match: { operationType: { $in: ['insert', 'update', 'replace'] } } }, { $project: { _id: 1, fullDocument: 1, ns: 1, documentKey: 1 } }], {
       fullDocument: 'updateLookup',
     });
   changeStream.on('change', (changeStreamDocument: ChangeStreamInsertDocument<DeletionAuditLog>) => {
+    // Deletion audit logs should never be updated or replaced. Cosmos DB does not currently support filtering at the `watch` step
+    // (See here https://learn.microsoft.com/en-us/answers/questions/356668/how-to-get-inserted-change-stream-data-use-cosmosd)
+    if (changeStreamDocument.operationType !== 'insert') {
+      throw new Error('A document in deletion-audit-logs has been %sd', changeStreamDocument.operationType);
+    }
     postDeletionAuditDetails(changeStreamDocument).catch((error) => {
       console.error('Error sending change stream update to API', error);
     });


### PR DESCRIPTION
## Introduction :pencil2:
Cosmosdb's change stream differs from mongodb & does not allow distinction between "insert", "update", and "replace". ([See the replies here](https://learn.microsoft.com/en-us/answers/questions/356668/how-to-get-inserted-change-stream-data-use-cosmosd))

## Resolution :heavy_check_mark:
Add "update", and "replace" to deletion change stream

