### PR TITLE
feat(FN-3385): remove erroneous custom error handling

### DIFF
--- a/portal-api/src/generateApp.js
+++ b/portal-api/src/generateApp.js
@@ -63,9 +63,6 @@ const generateApp = () => {
 
   app.use('/', rootRouter);
 
-  app.use((error) => {
-    console.error(error);
-  });
   return app;
 };
 


### PR DESCRIPTION
## Introduction :pencil2:
When developing locally I made a typo in a route, but instead of receiving an error response due to route not found, no response was returned causing the page to hang indefinitely.

Looking into it closer the culprit was the following in portal-api `generateApp.js`:
```
app.use((error) => {
  console.error(error);
});
```

Which when the request wasn't met, was being called with the request as the error param, so the request was logged, but then since we don't send a response or call next, portal was not receiving a response to it's request and the call was hanging, which doesn't seem like desired behaviour.

At first I updated to:
```
app.use((error, req, res, next) => {
  console.error(error);
  next(error);
});
```
Which appears to be the more correct way to add custom error handling, but on inspection this caused any errors to be logged twice since the express error handling which gets called after next also logs the error, as well as returning a sensible response, so I decided to just remove it.

## Resolution :heavy_check_mark:
- Prevent hanging requests when making a request to an unhandled route

