### PR TITLE
feat(FN-2309): display payments in payment details tab

### DIFF
--- a/trade-finance-manager-ui/component-tests/assertions.ts
+++ b/trade-finance-manager-ui/component-tests/assertions.ts
@@ -102,6 +102,9 @@ export const assertions = <TParams extends object>(wrapper: CheerioAPI, html: st
     toHaveAttribute: (attr: string, value: string) => {
       expect(wrapper(selector).attr(attr)).toEqual(value);
     },
+    notToHaveAttribute: (attr: string) => {
+      expect(wrapper(selector).attr(attr)).toBeUndefined();
+    },
   }),
   expectInput: (selector: string) => ({
     toHaveValue: (value: string) => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
@@ -96,7 +96,7 @@ describe(component, () => {
       wrapper.expectElement('tr').toHaveCount(3);
     });
 
-    it('renders the none-fee record payment details data only in the first row', () => {
+    it('renders the non-fee record payment details data only in the first row', () => {
       const paymentDetailsRow: PaymentDetailsTableRow = {
         ...aPaymentDetailsTableRow(),
         feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
@@ -1,0 +1,223 @@
+import { PaymentDetailsPaymentViewModel, PaymentDetailsViewModel } from '../../../server/types/view-models';
+import { componentRenderer } from '../../componentRenderer';
+
+const component = '../templates/utilisation-reports/_macros/payment-details-table-row.njk';
+const render = componentRenderer(component, true);
+
+type PaymentDetailsTableRow = PaymentDetailsViewModel[number];
+
+describe(component, () => {
+  const aPaymentDetailsPayment = (): PaymentDetailsPaymentViewModel => ({
+    amount: {
+      formattedCurrencyAndAmount: 'GBP 100.00',
+      dataSortValue: 0,
+    },
+    reference: undefined,
+    dateReceived: {
+      formattedDateReceived: '9 Mar 2024',
+      dataSortValue: 0,
+    },
+  });
+
+  const aPaymentDetailsTableRow = (): PaymentDetailsTableRow => ({
+    payment: aPaymentDetailsPayment(),
+    feeRecords: [{ facilityId: '12345678', exporter: 'Test exporter' }],
+    reconciledBy: undefined,
+    dateReconciled: undefined,
+  });
+
+  const getWrapper = (paymentDetailsRow: PaymentDetailsTableRow) => render<PaymentDetailsTableRow>(paymentDetailsRow);
+
+  it('renders the payment reference and amount and fee record facility ID and exporter', () => {
+    const paymentDetailsRow: PaymentDetailsTableRow = {
+      ...aPaymentDetailsTableRow(),
+      payment: {
+        ...aPaymentDetailsPayment(),
+        amount: {
+          formattedCurrencyAndAmount: 'GBP 123.45',
+          dataSortValue: 0,
+        },
+        reference: 'Some payment reference',
+      },
+      feeRecords: [
+        {
+          facilityId: 'Some facility id',
+          exporter: 'Some exporter',
+        },
+      ],
+    };
+    const wrapper = getWrapper(paymentDetailsRow);
+
+    wrapper.expectElement(`tr td:contains("GBP 123.45")`).toExist();
+    wrapper.expectElement(`tr td:contains("Some payment reference")`).toExist();
+    wrapper.expectElement(`tr td:contains("Some facility id")`).toExist();
+    wrapper.expectElement(`tr td:contains("Some exporter")`).toExist();
+  });
+
+  it.each([
+    { column: 'reconciled by', property: 'reconciledBy' },
+    { column: 'date reconciled', property: 'dateReconciled' },
+  ] as const)("renders the '-' character when the $column column is undefined", ({ property }) => {
+    const paymentDetailsRow: PaymentDetailsTableRow = {
+      ...aPaymentDetailsTableRow(),
+      [property]: undefined,
+    };
+    const wrapper = getWrapper(paymentDetailsRow);
+
+    wrapper.expectElement(`tr td[data-cy="${property}"]:contains("-")`).toExist();
+  });
+
+  it.each([
+    { column: 'reconciled by', property: 'reconciledBy' },
+    { column: 'date reconciled', property: 'dateReconciled' },
+  ] as const)('renders the $column column', ({ property }) => {
+    const paymentDetailsRow: PaymentDetailsTableRow = {
+      ...aPaymentDetailsTableRow(),
+      [property]: 'Some custom property',
+    };
+    const wrapper = getWrapper(paymentDetailsRow);
+
+    wrapper.expectElement(`tr td[data-cy="${property}"]:contains("Some custom property")`).toExist();
+  });
+
+  describe('when there are multiple fee records for the payment', () => {
+    const aFeeRecord = (): { facilityId: string; exporter: string } => ({
+      facilityId: '12345678',
+      exporter: 'Test exporter',
+    });
+
+    it('renders as many rows as there are fee records', () => {
+      const paymentDetailsRow: PaymentDetailsTableRow = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
+      };
+      const wrapper = getWrapper(paymentDetailsRow);
+
+      wrapper.expectElement('tr').toHaveCount(3);
+    });
+
+    it('renders the none-fee record payment details data only in the first row', () => {
+      const paymentDetailsRow: PaymentDetailsTableRow = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
+        payment: {
+          ...aPaymentDetailsPayment(),
+          reference: 'Some reference',
+          amount: {
+            formattedCurrencyAndAmount: 'GBP 100.00',
+            dataSortValue: 0,
+          },
+          dateReceived: {
+            formattedDateReceived: 'Some date received',
+            dataSortValue: 0,
+          },
+        },
+        reconciledBy: 'Some reconciled by user',
+        dateReconciled: 'Some reconciled date',
+      };
+      const wrapper = getWrapper(paymentDetailsRow);
+
+      wrapper.expectElement('tr').toHaveCount(3);
+
+      wrapper.expectElement('tr:eq(0) td:contains("GBP 100.00")').toExist();
+      wrapper.expectElement('tr:eq(1) td:contains("GBP 100.00")').notToExist();
+      wrapper.expectElement('tr:eq(2) td:contains("GBP 100.00")').notToExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some reference")').toExist();
+      wrapper.expectElement('tr:eq(1) td:contains("Some reference")').notToExist();
+      wrapper.expectElement('tr:eq(2) td:contains("Some reference")').notToExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some date received")').toExist();
+      wrapper.expectElement('tr:eq(1) td:contains("Some date received")').notToExist();
+      wrapper.expectElement('tr:eq(2) td:contains("Some date received")').notToExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some reconciled by user")').toExist();
+      wrapper.expectElement('tr:eq(1) td:contains("Some reconciled by user")').notToExist();
+      wrapper.expectElement('tr:eq(2) td:contains("Some reconciled by user")').notToExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some reconciled date")').toExist();
+      wrapper.expectElement('tr:eq(1) td:contains("Some reconciled date")').notToExist();
+      wrapper.expectElement('tr:eq(2) td:contains("Some reconciled date")').notToExist();
+    });
+
+    it('sets the data sort value for each row to match the value in the first row for the non-fee record columns', () => {
+      const paymentDetailsRow: PaymentDetailsTableRow = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
+        payment: {
+          ...aPaymentDetailsPayment(),
+          reference: 'Some reference',
+          amount: {
+            formattedCurrencyAndAmount: 'GBP 100.00',
+            dataSortValue: 12,
+          },
+          dateReceived: {
+            formattedDateReceived: 'Some date received',
+            dataSortValue: 48,
+          },
+        },
+        reconciledBy: 'Some reconciled by user',
+        dateReconciled: 'Some reconciled date',
+      };
+      const wrapper = getWrapper(paymentDetailsRow);
+
+      wrapper.expectElement('tr').toHaveCount(3);
+
+      wrapper.expectElement('tr:eq(0) td:contains("GBP 100.00")').toHaveAttribute('data-sort-value', '12');
+      wrapper.expectElement('tr:eq(1) td[data-sort-value="12"]').toExist();
+      wrapper.expectElement('tr:eq(2) td[data-sort-value="12"]').toExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some reference")').toHaveAttribute('data-sort-value', 'Some reference');
+      wrapper.expectElement('tr:eq(1) td[data-sort-value="Some reference"]').toExist();
+      wrapper.expectElement('tr:eq(2) td[data-sort-value="Some reference"]').toExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some date received")').toHaveAttribute('data-sort-value', '48');
+      wrapper.expectElement('tr:eq(1) td[data-sort-value="48"]').toExist();
+      wrapper.expectElement('tr:eq(2) td[data-sort-value="48"]').toExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some reconciled by user")').toHaveAttribute('data-sort-value', 'Some reconciled by user');
+      wrapper.expectElement('tr:eq(1) td[data-sort-value="Some reconciled by user"]').toExist();
+      wrapper.expectElement('tr:eq(2) td[data-sort-value="Some reconciled by user"]').toExist();
+
+      wrapper.expectElement('tr:eq(0) td:contains("Some reconciled date")').toHaveAttribute('data-sort-value', 'Some reconciled date');
+      wrapper.expectElement('tr:eq(1) td[data-sort-value="Some reconciled date"]').toExist();
+      wrapper.expectElement('tr:eq(2) td[data-sort-value="Some reconciled date"]').toExist();
+    });
+
+    it('renders every cell except those in the last row using the no border class', () => {
+      const paymentDetailsRow: PaymentDetailsTableRow = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
+      };
+      const wrapper = getWrapper(paymentDetailsRow);
+
+      wrapper.expectElement('tr:eq(0) td.no-border').toHaveCount(7);
+      wrapper.expectElement('tr:eq(1) td.no-border').toHaveCount(7);
+      wrapper.expectElement('tr:eq(2) td.no-border').notToExist();
+    });
+
+    it('renders each of the fee records listed in the supplied array', () => {
+      const feeRecords: { facilityId: string; exporter: string }[] = [
+        { facilityId: '11111111', exporter: 'Test exporter 1' },
+        { facilityId: '22222222', exporter: 'Test exporter 2' },
+        { facilityId: '33333333', exporter: 'Test exporter 3' },
+      ];
+      const paymentDetailsRow: PaymentDetailsTableRow = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords,
+      };
+      const wrapper = getWrapper(paymentDetailsRow);
+
+      wrapper.expectElement('tr').toHaveCount(3);
+
+      wrapper.expectElement('tr:eq(0) td:contains("11111111")').toExist();
+      wrapper.expectElement('tr:eq(0) td:contains("Test exporter 1")').toExist();
+
+      wrapper.expectElement('tr:eq(1) td:contains("22222222")').toExist();
+      wrapper.expectElement('tr:eq(1) td:contains("Test exporter 2")').toExist();
+
+      wrapper.expectElement('tr:eq(2) td:contains("33333333")').toExist();
+      wrapper.expectElement('tr:eq(2) td:contains("Test exporter 3")').toExist();
+    });
+  });
+});

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table.component-test.ts
@@ -1,0 +1,59 @@
+import { PaymentDetailsViewModel } from '../../../server/types/view-models';
+import { componentRenderer } from '../../componentRenderer';
+
+const component = '../templates/utilisation-reports/_macros/payment-details-table.njk';
+const render = componentRenderer(component, true);
+
+type PaymentDetailsTableViewModel = {
+  paymentDetails: PaymentDetailsViewModel;
+};
+
+describe(component, () => {
+  const aPaymentDetailsTableViewModel = (): PaymentDetailsTableViewModel => ({
+    paymentDetails: [],
+  });
+
+  const getWrapper = (viewModel: PaymentDetailsTableViewModel = aPaymentDetailsTableViewModel()) => render(viewModel);
+
+  const tableHeaderSelector = (text: string) => `thead th:contains("${text}")`;
+
+  it('renders 7 table headings', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement('table thead tr').toHaveCount(1);
+    wrapper.expectElement('table thead th').toHaveCount(7);
+  });
+
+  it('renders the amount heading with the aria-sort attribute set to ascending', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement(tableHeaderSelector('Amount')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Amount')).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('renders the payment reference, date received, reconciled by and date reconciled headings with the aria-sort attribute set to none', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement(tableHeaderSelector('Payment reference')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Payment reference')).toHaveAttribute('aria-sort', 'none');
+
+    wrapper.expectElement(tableHeaderSelector('Date received')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Date received')).toHaveAttribute('aria-sort', 'none');
+
+    wrapper.expectElement(tableHeaderSelector('Reconciled by')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Reconciled by')).toHaveAttribute('aria-sort', 'none');
+
+    wrapper.expectElement(tableHeaderSelector('Date reconciled')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Date reconciled')).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('renders the facility ID and exporter headings as not sortable', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement(tableHeaderSelector('Facility ID')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Facility ID')).notToHaveAttribute('aria-sort');
+
+    wrapper.expectElement(tableHeaderSelector('Exporter')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Exporter')).notToHaveAttribute('aria-sort');
+  });
+});

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
@@ -221,4 +221,28 @@ describe(page, () => {
       .expectText(`${paymentDetailsTabSelector} p`)
       .toMatch(/Payment details will be displayed when payments have been entered on the premium payments tab./);
   });
+
+  it('should render the payment details tab with headings (without text), the show filter button and the table when there are payment details', () => {
+    const wrapper = getWrapper({
+      ...params,
+      paymentDetails: [
+        {
+          payment: {
+            amount: { formattedCurrencyAndAmount: 'GBP 100.00', dataSortValue: 0 },
+            dateReceived: { formattedDateReceived: '1 Jan 2024', dataSortValue: 0 },
+            reference: undefined,
+          },
+          feeRecords: [{ facilityId: '12345678', exporter: 'Test exporter' }],
+        },
+      ],
+    });
+    const paymentDetailsTabSelector = 'div#payment-details';
+
+    wrapper.expectText(`${paymentDetailsTabSelector} h2[data-cy="payment-details-heading"]`).toRead('Payment details');
+    wrapper.expectElement(`${paymentDetailsTabSelector} p`).notToExist();
+
+    wrapper.expectElement(`${paymentDetailsTabSelector} button[data-cy="payment-details-show-filter-button"]`).toExist();
+    wrapper.expectElement(`${paymentDetailsTabSelector} button[data-cy="payment-details-show-filter-button"]`).hasClass('govuk-button--secondary');
+    wrapper.expectElement(`${paymentDetailsTabSelector} table`).toExist();
+  });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -1,5 +1,9 @@
 import { Currency, CurrencyAndAmount, FeeRecordStatus } from '@ukef/dtfs2-common';
-import { mapFeeRecordPaymentGroupsToFeeRecordPaymentGroupViewModelItems, mapKeyingSheetToKeyingSheetViewModel } from './reconciliation-for-report-helper';
+import {
+  mapFeeRecordPaymentGroupsToFeeRecordPaymentGroupViewModelItems,
+  mapFeeRecordPaymentGroupsToPaymentDetailsViewModel,
+  mapKeyingSheetToKeyingSheetViewModel,
+} from './reconciliation-for-report-helper';
 import { FeeRecord, FeeRecordPaymentGroup, KeyingSheet, KeyingSheetRow, Payment } from '../../../api-response-types';
 import { aFeeRecordPaymentGroup, aFeeRecord, aPayment } from '../../../../test-helpers';
 
@@ -635,6 +639,185 @@ describe('reconciliation-for-report-helper', () => {
       // Assert
       expect(result).toHaveLength(1);
       expect(result[0].checkboxId).toBe('feeRecordId-123-status-TO_DO');
+    });
+  });
+
+  describe('mapFeeRecordPaymentGroupsToPaymentDetailsViewModel', () => {
+    it('creates a list item for each distinct payment in the supplied groups', () => {
+      // Arrange
+      const firstGroup: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [aFeeRecord(), aFeeRecord()],
+        paymentsReceived: [aPayment(), aPayment()],
+      };
+      const secondGroup: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
+        paymentsReceived: [aPayment()],
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([firstGroup, secondGroup]);
+
+      // Assert
+      expect(result).toHaveLength(3);
+    });
+
+    it('maps the payment reference to the payment details view model reference', () => {
+      // Arrange
+      const group: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [aFeeRecord()],
+        paymentsReceived: [
+          { ...aPayment(), reference: 'First reference' },
+          { ...aPayment(), reference: 'Second reference' },
+          { ...aPayment(), reference: undefined },
+        ],
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([group]);
+
+      // Assert
+      expect(result).toHaveLength(3);
+      expect(result[0].payment.reference).toBe('First reference');
+      expect(result[1].payment.reference).toBe('Second reference');
+      expect(result[2].payment.reference).toBeUndefined();
+    });
+
+    it('maps the fee records to an array of facility ids and exporters linked to the payment in the same group', () => {
+      // Arrange
+      const firstGroup: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [{ ...aFeeRecord(), facilityId: '11111111', exporter: 'Test exporter 1' }],
+        paymentsReceived: [aPayment()],
+      };
+      const secondGroup: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [{ ...aFeeRecord(), facilityId: '22222222', exporter: 'Test exporter 2' }],
+        paymentsReceived: [aPayment()],
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([firstGroup, secondGroup]);
+
+      // Assert
+      expect(result).toHaveLength(2);
+      expect(result[0].feeRecords).toHaveLength(1);
+      expect(result[0].feeRecords[0]).toEqual({ facilityId: '11111111', exporter: 'Test exporter 1' });
+      expect(result[1].feeRecords).toHaveLength(1);
+      expect(result[1].feeRecords[0]).toEqual({ facilityId: '22222222', exporter: 'Test exporter 2' });
+    });
+
+    it('maps the fee records in the group to an array of facility ids and exporters when a payment has multiple fee records', () => {
+      // Arrange
+      const group: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [
+          { ...aFeeRecord(), facilityId: '11111111', exporter: 'Test exporter 1' },
+          { ...aFeeRecord(), facilityId: '22222222', exporter: 'Test exporter 2' },
+          { ...aFeeRecord(), facilityId: '33333333', exporter: 'Test exporter 3' },
+        ],
+        paymentsReceived: [aPayment()],
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([group]);
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].feeRecords).toHaveLength(3);
+      expect(result[0].feeRecords[0]).toEqual({ facilityId: '11111111', exporter: 'Test exporter 1' });
+      expect(result[0].feeRecords[1]).toEqual({ facilityId: '22222222', exporter: 'Test exporter 2' });
+      expect(result[0].feeRecords[2]).toEqual({ facilityId: '33333333', exporter: 'Test exporter 3' });
+    });
+
+    it('maps the fee records to an array of facility ids and exporters for each payment in the group when a group has multiple fee records and payments', () => {
+      // Arrange
+      const group: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [
+          { ...aFeeRecord(), facilityId: '11111111', exporter: 'Test exporter 1' },
+          { ...aFeeRecord(), facilityId: '22222222', exporter: 'Test exporter 2' },
+          { ...aFeeRecord(), facilityId: '33333333', exporter: 'Test exporter 3' },
+        ],
+        paymentsReceived: [aPayment(), aPayment()],
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([group]);
+
+      // Assert
+      expect(result).toHaveLength(2);
+
+      expect(result[0].feeRecords).toHaveLength(3);
+      expect(result[0].feeRecords[0]).toEqual({ facilityId: '11111111', exporter: 'Test exporter 1' });
+      expect(result[0].feeRecords[1]).toEqual({ facilityId: '22222222', exporter: 'Test exporter 2' });
+      expect(result[0].feeRecords[2]).toEqual({ facilityId: '33333333', exporter: 'Test exporter 3' });
+
+      expect(result[1].feeRecords).toHaveLength(3);
+      expect(result[1].feeRecords[0]).toEqual({ facilityId: '11111111', exporter: 'Test exporter 1' });
+      expect(result[1].feeRecords[1]).toEqual({ facilityId: '22222222', exporter: 'Test exporter 2' });
+      expect(result[1].feeRecords[2]).toEqual({ facilityId: '33333333', exporter: 'Test exporter 3' });
+    });
+
+    it('maps the payment to a formatted currency and amount sorted first by currency alphabetically and second by amount ascending', () => {
+      // Arrange
+      const payments: Payment[] = [
+        { ...aPayment(), id: 1, currency: 'GBP', amount: 200 }, // 'GBP 200.00', dataSortValue = 2
+        { ...aPayment(), id: 2, currency: 'USD', amount: 50 }, // 'USD 50.00', dataSortValue = 4
+        { ...aPayment(), id: 3, currency: 'GBP', amount: 100 }, // 'GBP 100.00', dataSortValue = 1
+        { ...aPayment(), id: 4, currency: 'EUR', amount: 200 }, // 'EUR 200.00', dataSortValue = 0
+        { ...aPayment(), id: 5, currency: 'GBP', amount: 300 }, // 'GBP 300.00', dataSortValue = 3
+      ];
+      const group: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [aFeeRecord()],
+        paymentsReceived: payments,
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([group]);
+
+      // Assert
+      expect(result).toHaveLength(5);
+      expect(result.map(({ payment }) => payment.amount)).toEqual([
+        { formattedCurrencyAndAmount: 'GBP 200.00', dataSortValue: 2 },
+        { formattedCurrencyAndAmount: 'USD 50.00', dataSortValue: 4 },
+        { formattedCurrencyAndAmount: 'GBP 100.00', dataSortValue: 1 },
+        { formattedCurrencyAndAmount: 'EUR 200.00', dataSortValue: 0 },
+        { formattedCurrencyAndAmount: 'GBP 300.00', dataSortValue: 3 },
+      ]);
+    });
+
+    it('maps the payment to a formatted date received sorted by date ascending', () => {
+      // Arrange
+      // Example: May 1 2023 VS Apr 1 2024 - Apr comes first
+      const payments: Payment[] = [
+        { ...aPayment(), id: 1, dateReceived: new Date('2024-06-01').toISOString() }, // '1 Jun 2024', dataSortValue = 3
+        { ...aPayment(), id: 2, dateReceived: new Date('2024-07-01').toISOString() }, // '1 Jul 2024', dataSortValue = 4
+        { ...aPayment(), id: 3, dateReceived: new Date('2024-03-01').toISOString() }, // '1 Mar 2024', dataSortValue = 0
+        { ...aPayment(), id: 4, dateReceived: new Date('2024-05-01').toISOString() }, // '1 May 2024', dataSortValue = 2
+        { ...aPayment(), id: 5, dateReceived: new Date('2024-04-01').toISOString() }, // '1 Apr 2024', dataSortValue = 1
+      ];
+      const group: FeeRecordPaymentGroup = {
+        ...aFeeRecordPaymentGroup(),
+        feeRecords: [aFeeRecord()],
+        paymentsReceived: payments,
+      };
+
+      // Act
+      const result = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel([group]);
+
+      // Assert
+      expect(result).toHaveLength(5);
+      expect(result.map(({ payment }) => payment.dateReceived)).toEqual([
+        { formattedDateReceived: '1 Jun 2024', dataSortValue: 3 },
+        { formattedDateReceived: '1 Jul 2024', dataSortValue: 4 },
+        { formattedDateReceived: '1 Mar 2024', dataSortValue: 0 },
+        { formattedDateReceived: '1 May 2024', dataSortValue: 2 },
+        { formattedDateReceived: '1 Apr 2024', dataSortValue: 1 },
+      ]);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
@@ -180,7 +180,8 @@ const mapPaymentToPaymentDetailsViewModelPayment = (
  * @param payments - The payments to sort
  * @returns Sorted payments
  */
-const getPaymentsSortedByDateReceived = (payments: Payment[]): Payment[] => orderBy(payments, [({ dateReceived }) => parseISO(dateReceived).getTime()], ['asc']);
+const getPaymentsSortedByDateReceived = (payments: Payment[]): Payment[] =>
+  orderBy(payments, [({ dateReceived }) => parseISO(dateReceived).getTime()], ['asc']);
 
 /**
  * Maps the fee record payment groups to the payment details view model

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
@@ -54,6 +54,12 @@ const mapPaymentsToPaymentViewModelItems = (paymentsReceived: Payment[] | null):
 
 type SortableFeeRecordPaymentGroupProperty = 'totalReportedPayments' | 'totalPaymentsReceived';
 
+/**
+ * Gets the data sort value map for the fee record payment group by property
+ * @param feeRecordPaymentGroups - The fee record payment groups
+ * @param property - The property to sort by
+ * @returns The data sort value map
+ */
 const getDataSortValueMapForFeeRecordPaymentGroupProperty = (
   feeRecordPaymentGroups: FeeRecordPaymentGroup[],
   property: SortableFeeRecordPaymentGroupProperty,
@@ -62,17 +68,34 @@ const getDataSortValueMapForFeeRecordPaymentGroupProperty = (
   return getKeyToCurrencyAndAmountSortValueMap(propertyWithIndexAsKey);
 };
 
+/**
+ * Gets a checkbox id for a list of fee records and status
+ * @param feeRecords - The fee records
+ * @param status - The status
+ * @returns The checkbox id
+ */
 const getCheckboxIdForFeeRecordsAndStatus = (feeRecords: FeeRecord[], status: FeeRecordStatus): PremiumPaymentsTableCheckboxId => {
   const feeRecordIdList = feeRecords.map(({ id }) => id).join(',');
   const reportedPaymentsCurrency = feeRecords[0].reportedPayments.currency;
   return `feeRecordIds-${feeRecordIdList}-reportedPaymentsCurrency-${reportedPaymentsCurrency}-status-${status}`;
 };
 
+/**
+ * Gets a checkbox aria label
+ * @param feeRecords - The fee records
+ * @returns The checkbox aria label
+ */
 const getCheckboxAriaLabel = (feeRecords: FeeRecord[]): string => {
   const feeRecordFacilityIdList = feeRecords.map(({ facilityId }) => facilityId).join(' ');
   return `Select ${feeRecordFacilityIdList}`;
 };
 
+/**
+ * Maps the fee record payment groups to the fee record payment group view model items
+ * @param feeRecordPaymentGroups - The fee record payment groups
+ * @param isCheckboxChecked - Whether or not the fee record payment group checkbox is checked
+ * @returns The fee record payment group view model items
+ */
 export const mapFeeRecordPaymentGroupsToFeeRecordPaymentGroupViewModelItems = (
   feeRecordPaymentGroups: FeeRecordPaymentGroup[],
   isCheckboxChecked: (checkboxId: string) => boolean = () => false,
@@ -113,6 +136,11 @@ export const mapFeeRecordPaymentGroupsToFeeRecordPaymentGroupViewModelItems = (
   });
 };
 
+/**
+ * Gets the keying sheet adjustment view model
+ * @param adjustment - The keying sheet adjustment
+ * @returns The keying sheet adjustment view model
+ */
 const getKeyingSheetAdjustmentViewModel = (adjustment: KeyingSheetAdjustment | null): KeyingSheetAdjustmentViewModel => {
   if (!adjustment) {
     return { amount: undefined, change: 'NONE' };
@@ -123,12 +151,22 @@ const getKeyingSheetAdjustmentViewModel = (adjustment: KeyingSheetAdjustment | n
   };
 };
 
+/**
+ * Maps the keying sheet fee payments to the keying sheet fee payments view model
+ * @param feePayments - The fee payments
+ * @returns The fee payments view model
+ */
 const mapKeyingSheetFeePaymentsToKeyingSheetFeePaymentsViewModel = (feePayments: KeyingSheetRow['feePayments']) =>
   feePayments.map(({ currency, amount, dateReceived }) => ({
     formattedCurrencyAndAmount: getFormattedCurrencyAndAmount({ currency, amount }),
     formattedDateReceived: dateReceived ? format(new Date(dateReceived), 'd MMM yyyy') : undefined,
   }));
 
+/**
+ * Gets the keying sheet row checkbox id
+ * @param keyingSheetRow - The keying sheet row
+ * @returns The checkbox id
+ */
 const getKeyingSheetRowCheckboxId = (keyingSheetRow: KeyingSheetRow): KeyingSheetCheckboxId =>
   `feeRecordId-${keyingSheetRow.feeRecordId}-status-${keyingSheetRow.status}`;
 
@@ -153,13 +191,13 @@ export const mapKeyingSheetToKeyingSheetViewModel = (keyingSheet: KeyingSheet): 
   }));
 
 /**
- * Maps the payment to the payment details view model payment
- * @param paymentReceived - The received
+ * Maps the payment to the payment details payment view model
+ * @param paymentReceived - The received payment
  * @param amountDataSortValue - The amount data sort value
  * @param dateReceivedDataSortValue - The date received data sort value
  * @returns The payment details view model payment
  */
-const mapPaymentToPaymentDetailsViewModelPayment = (
+const mapPaymentToPaymentDetailsPaymentViewModel = (
   payment: Payment,
   amountDataSortValue: number,
   dateReceivedDataSortValue: number,
@@ -207,7 +245,7 @@ export const mapFeeRecordPaymentGroupsToPaymentDetailsViewModel = (feeRecordPaym
     return [
       ...paymentDetails,
       ...paymentsReceived.map((payment) => ({
-        payment: mapPaymentToPaymentDetailsViewModelPayment(
+        payment: mapPaymentToPaymentDetailsPaymentViewModel(
           payment,
           paymentIdToAmountDataSortValueMap[payment.id],
           paymentIdToDateReceivedDataSortValueMap[payment.id],

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
@@ -6,7 +6,7 @@ import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { aFeeRecordPaymentGroup, aUtilisationReportReconciliationDetailsResponse, aPayment } from '../../../../test-helpers';
 import { UtilisationReportReconciliationDetailsResponseBody } from '../../../api-response-types';
-import { FeeRecordPaymentGroupViewModelItem, UtilisationReportReconciliationForReportViewModel } from '../../../types/view-models';
+import { FeeRecordPaymentGroupViewModelItem, PaymentDetailsViewModel, UtilisationReportReconciliationForReportViewModel } from '../../../types/view-models';
 
 jest.mock('../../../api');
 jest.mock('../../../helpers/date');
@@ -83,7 +83,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
               },
             ],
             totalReportedPayments: { currency: 'GBP', amount: 100 },
-            paymentsReceived: [{ ...aPayment(), id: 1, currency: 'GBP', amount: 100 }],
+            paymentsReceived: [{ id: 1, currency: 'GBP', amount: 100, dateReceived: new Date('2024-01-01').toISOString() }],
             totalPaymentsReceived: { currency: 'GBP', amount: 100 },
             status: 'TO_DO',
           },
@@ -119,6 +119,17 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
         },
       ];
 
+      const paymentDetailsViewModel: PaymentDetailsViewModel = [
+        {
+          payment: {
+            amount: { formattedCurrencyAndAmount: 'GBP 100.00', dataSortValue: 0 },
+            dateReceived: { formattedDateReceived: '1 Jan 2024', dataSortValue: 0 },
+            reference: undefined,
+          },
+          feeRecords: [{ facilityId: '12345678', exporter: 'Test exporter' }],
+        },
+      ];
+
       jest.mocked(api.getUtilisationReportReconciliationDetailsById).mockResolvedValue(utilisationReportReconciliationDetails);
 
       // Act
@@ -139,7 +150,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
         facilityIdQueryError: undefined,
         facilityIdQuery,
         keyingSheet: [],
-        paymentDetails: [],
+        paymentDetails: paymentDetailsViewModel,
       });
     });
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
@@ -3,7 +3,11 @@ import { asString, getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-com
 import api from '../../../api';
 import { asUserSession } from '../../../helpers/express-session';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
-import { mapFeeRecordPaymentGroupsToFeeRecordPaymentGroupViewModelItems, mapKeyingSheetToKeyingSheetViewModel } from '../helpers';
+import {
+  mapFeeRecordPaymentGroupsToFeeRecordPaymentGroupViewModelItems,
+  mapFeeRecordPaymentGroupsToPaymentDetailsViewModel,
+  mapKeyingSheetToKeyingSheetViewModel,
+} from '../helpers';
 import { UtilisationReportReconciliationForReportViewModel } from '../../../types/view-models';
 import { validateFacilityIdQuery } from './validate-facility-id-query';
 import { getAndClearFieldsFromRedirectSessionData } from './get-and-clear-fields-from-redirect-session-data';
@@ -39,6 +43,8 @@ export const getUtilisationReportReconciliationByReportId = async (req: Request,
 
     const keyingSheetViewModel = mapKeyingSheetToKeyingSheetViewModel(keyingSheet);
 
+    const paymentDetailsViewModel = mapFeeRecordPaymentGroupsToPaymentDetailsViewModel(feeRecordPaymentGroups);
+
     return renderUtilisationReportReconciliationForReport(res, {
       user,
       activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
@@ -51,7 +57,7 @@ export const getUtilisationReportReconciliationByReportId = async (req: Request,
       facilityIdQueryError,
       facilityIdQuery: facilityIdQueryAsString,
       keyingSheet: keyingSheetViewModel,
-      paymentDetails: [],
+      paymentDetails: paymentDetailsViewModel,
     });
   } catch (error) {
     console.error(`Failed to render utilisation report with id ${reportId}`, error);

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -48,7 +48,27 @@ export type KeyingSheetViewModel = {
   isChecked: boolean;
 }[];
 
-export type PaymentDetailsViewModel = [];
+export type PaymentDetailsPaymentViewModel = {
+  amount: {
+    formattedCurrencyAndAmount: CurrencyAndAmountString;
+    dataSortValue: number;
+  };
+  reference: string | undefined;
+  dateReceived: {
+    formattedDateReceived: string;
+    dataSortValue: number;
+  };
+};
+
+export type PaymentDetailsViewModel = {
+  payment: PaymentDetailsPaymentViewModel;
+  feeRecords: {
+    facilityId: string;
+    exporter: string;
+  }[];
+  reconciledBy?: string;
+  dateReconciled?: string;
+}[];
 
 export type FeeRecordPaymentGroupViewModelItem = {
   feeRecords: FeeRecordViewModelItem[];

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table-row.njk
@@ -1,0 +1,19 @@
+{% macro render(paymentDetails) %}
+  {% set payment = paymentDetails.payment %}
+  {% set feeRecords = paymentDetails.feeRecords %}
+  {% set reconciledBy = paymentDetails.reconciledBy or "-" %}
+  {% set dateReconciled = paymentDetails.dateReconciled or "-" %}
+  {% for feeRecord in feeRecords %}
+    {% set isFirstLineOfRow = loop.index === 1 %}
+    {% set isLastLineOfRow = loop.index === feeRecords.length %}
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ payment.amount.dataSortValue }}">{{ payment.amount.formattedCurrencyAndAmount if isFirstLineOfRow }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ payment.reference }}">{{ payment.reference if isFirstLineOfRow }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}">{{ feeRecord.facilityId }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}">{{ feeRecord.exporter }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ payment.dateReceived.dataSortValue }}">{{ payment.dateReceived.formattedDateReceived if isFirstLineOfRow }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ reconciledBy }}" data-cy="reconciledBy">{{ reconciledBy if isFirstLineOfRow }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ dateReconciled }}" data-cy="dateReconciled">{{ dateReconciled if isFirstLineOfRow }}</td>
+    </tr>
+  {% endfor %}
+{% endmacro %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table.njk
@@ -1,0 +1,22 @@
+{% import "./payment-details-table-row.njk" as paymentDetailsTableRow %}
+{% macro render(params) %}
+  {% set paymentDetails = params.paymentDetails %}
+  <table class="govuk-table" data-module="moj-sortable-table" data-cy="payment-details-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header" aria-sort="ascending">Amount</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Payment reference</th>
+        <th scope="col" class="govuk-table__header">Facility ID</th>
+        <th scope="col" class="govuk-table__header">Exporter</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Date received</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Reconciled by</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Date reconciled</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for paymentDetailsRow in paymentDetails %}
+        {{ paymentDetailsTableRow.render(paymentDetailsRow) }}
+      {% endfor %}
+    </tbody>
+  </table>
+{% endmacro %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% import "./_macros/premium-payments-table.njk" as premiumPaymentsTable %}
 {% import "./_macros/keying-sheet-table.njk" as keyingSheetTable %}
+{% import "./_macros/payment-details-table.njk" as paymentDetailsTable %}
 
 {% extends "index.njk" %}
 
@@ -154,11 +155,20 @@
 {% set paymentDetailsHtml %}
   <h2 class="govuk-heading-l" data-cy="payment-details-heading">Payment details</h2>
 
-  <p class="govuk-body">
-    {% if paymentDetails.length === 0 %}
-      Payment details will be displayed when payments have been entered on the premium payments tab.
-    {% endif %}
-  </p>
+  {% if paymentDetails.length === 0 %}
+    <p class="govuk-body">Payment details will be displayed when payments have been entered on the premium payments tab.</p>
+  {% else %}
+    {{ govukButton({
+      text: "Show filter",
+      classes: "govuk-button govuk-button--secondary govuk-!-margin-left-2",
+      id: "payment-details-show-filter-button",
+      attributes: {'data-cy': 'payment-details-show-filter-button'}
+    }) }}
+
+    {{ paymentDetailsTable.render({
+      paymentDetails: paymentDetails
+    }) }}
+  {% endif %}
 {% endset %}
 
 {% set utilisationHtml %}


### PR DESCRIPTION
## Introduction :pencil2:
We want to display payments inside the payment details tab. This PR covers the first part of this - another PR will include displaying the user who reconciled the fee record payment group and the date it was reconciled.

Another important note is many-to-many behaviour of fee records and payments. The ticket documents that we should display many-to-many in the same way that we display one payment to many fee records ie. each payment in the many-to-many group should be displayed in the row with all the fee records in the group.

## Resolution :heavy_check_mark:
- Adds templates and component tests for the table and table row
- Updates existing tests
- Adds a new mapping function 

## Miscellaneous :heavy_plus_sign:

