### PR TITLE
feat(DTFS-7219): add any object type alias

### DIFF
--- a/libs/common/src/types/any-object.ts
+++ b/libs/common/src/types/any-object.ts
@@ -1,0 +1,24 @@
+/**
+ * This type is intended to represent any generic javascript
+ * object. This type is distinct from the `object` type.
+ *
+ * Many types in DTFS (specifically db models stored in the
+ * Mongo database) are not fully documented. Typically, the
+ * only thing we know for sure about these types is that they
+ * will be javascript objects. We normally use the `object`
+ * type in such cases, but the `object` type actually means
+ * "any type which is not `unknown` or `undefined`", which
+ * does not actually capture what we are intending to. The
+ * below type overcomes this issue, providing an alias that
+ * can be used in such cases where we know that the type
+ * will be "any 'javascript' object".
+ *
+ * @example
+ * const foo: object = { value: 100 };
+ * foo['value']; // Property 'value' does not exist on type '{}'
+ *
+ * const bar: AnyObject = { value: 100 };
+ * bar['value']; // works as expected, type = unknown
+ * bar.value; // even this is now fine, type = unknown
+ */
+export type AnyObject = Record<string, unknown>;

--- a/libs/common/src/types/index.ts
+++ b/libs/common/src/types/index.ts
@@ -20,3 +20,4 @@ export * from './amendment-status';
 export * from './api-error-response-body';
 export * from './api-error-code';
 export * from './facility-type';
+export * from './any-object';


### PR DESCRIPTION
## Introduction :pencil2:
Before now in the DTFS code base, we use the `object` type to refer both to "anything which is not `null` or `undefined`" (which is the actual meaning of `object`) and "a generic javascript object". This PR introduces an alias to capture the latter of these two definitions, allow us to create more accurate types. Below is an example of where this type comes in handy (copied from the type TSDoc).

```typescript
const foo: object = { value: 100 };
foo['value']; // Property 'value' does not exist on type '{}'

const bar: AnyObject = { value: 100 };
bar['value']; // works as expected, type = unknown
bar.value; // even this is now fine, type = unknown
```

## Resolution :heavy_check_mark:
- Adds the new type alias

## Miscellaneous :heavy_plus_sign:


