### PR TITLE
feat(FN-3389): add docstrings to event handlers and entities

### DIFF
--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -12,6 +12,12 @@ type GenerateKeyingDataEventPayload = {
 
 export type FeeRecordGenerateKeyingDataEvent = BaseFeeRecordEvent<'GENERATE_KEYING_DATA', GenerateKeyingDataEventPayload>;
 
+/**
+ * Handler for the generate keying data event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordGenerateKeyingDataEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, isFinalFeeRecordForFacility, reportPeriod, requestSource }: GenerateKeyingDataEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -16,6 +16,10 @@ export type FeeRecordGenerateKeyingDataEvent = BaseFeeRecordEvent<'GENERATE_KEYI
  * Handler for the generate keying data event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.isFinalFeeRecordForFacility - Whether or not the fee record is the final fee record for a facility
+ * @param param.reportPeriod - The report period
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordGenerateKeyingDataEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/get-fixed-fee-for-facility.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/get-fixed-fee-for-facility.ts
@@ -4,6 +4,11 @@ import { NotFoundError } from '../../../../../errors';
 import { convertTimestampToDate, getLatestCompletedAmendmentCoverEndDate } from '../../../../../helpers';
 import { calculateFixedFee } from './calculate-fixed-fee';
 
+/**
+ * Gets the latest values for the TFM facility with the supplied facility id
+ * @param facilityId - The facility id
+ * @returns The latest values
+ */
 const getLatestTfmFacilityValues = async (
   facilityId: string,
 ): Promise<{

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-ready-to-key/mark-as-ready-to-key.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-ready-to-key/mark-as-ready-to-key.event-handler.ts
@@ -13,6 +13,8 @@ export type FeeRecordMarkAsReadyToKeyEvent = BaseFeeRecordEvent<'MARK_AS_READY_T
  * Handler for the mark as ready to key event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordMarkAsReadyToKeyEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-ready-to-key/mark-as-ready-to-key.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-ready-to-key/mark-as-ready-to-key.event-handler.ts
@@ -9,6 +9,12 @@ type MarkAsReadyToKeyEventPayload = {
 
 export type FeeRecordMarkAsReadyToKeyEvent = BaseFeeRecordEvent<'MARK_AS_READY_TO_KEY', MarkAsReadyToKeyEventPayload>;
 
+/**
+ * Handler for the mark as ready to key event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordMarkAsReadyToKeyEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, requestSource }: MarkAsReadyToKeyEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.ts
@@ -9,6 +9,12 @@ type MarkAsReconciledEventPayload = {
 
 export type FeeRecordMarkAsReconciledEvent = BaseFeeRecordEvent<'MARK_AS_RECONCILED', MarkAsReconciledEventPayload>;
 
+/**
+ * Handler for the mark as reconciled event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordMarkAsReconciledEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, requestSource }: MarkAsReconciledEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.ts
@@ -13,6 +13,8 @@ export type FeeRecordMarkAsReconciledEvent = BaseFeeRecordEvent<'MARK_AS_RECONCI
  * Handler for the mark as reconciled event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordMarkAsReconciledEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.ts
@@ -10,6 +10,12 @@ type OtherFeeRecordAddedToPaymentGroupEventPayload = {
 
 export type FeeRecordOtherFeeAddedToPaymentGroupEvent = BaseFeeRecordEvent<'OTHER_FEE_ADDED_TO_PAYMENT_GROUP', OtherFeeRecordAddedToPaymentGroupEventPayload>;
 
+/**
+ * Handler for the other fee record added to payment group event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: OtherFeeRecordAddedToPaymentGroupEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.ts
@@ -14,6 +14,9 @@ export type FeeRecordOtherFeeAddedToPaymentGroupEvent = BaseFeeRecordEvent<'OTHE
  * Handler for the other fee record added to payment group event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.ts
@@ -13,6 +13,12 @@ export type FeeRecordOtherFeeRemovedFromPaymentGroupEvent = BaseFeeRecordEvent<
   OtherFeeRemovedFromPaymentGroupEventPayload
 >;
 
+/**
+ * Handler for the other fee record removed from payment group event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: OtherFeeRemovedFromPaymentGroupEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.ts
@@ -17,6 +17,9 @@ export type FeeRecordOtherFeeRemovedFromPaymentGroupEvent = BaseFeeRecordEvent<
  * Handler for the other fee record removed from payment group event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.ts
@@ -10,6 +10,12 @@ type PaymentAddedEventPayload = {
 
 export type FeeRecordPaymentAddedEvent = BaseFeeRecordEvent<'PAYMENT_ADDED', PaymentAddedEventPayload>;
 
+/**
+ * Handler for the payment added event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordPaymentAddedEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: PaymentAddedEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.ts
@@ -14,6 +14,9 @@ export type FeeRecordPaymentAddedEvent = BaseFeeRecordEvent<'PAYMENT_ADDED', Pay
  * Handler for the payment added event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordPaymentAddedEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
@@ -15,6 +15,10 @@ export type FeeRecordPaymentDeletedEvent = BaseFeeRecordEvent<'PAYMENT_DELETED',
  * Handler for the payment deleted event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param param.hasAttachedPayments - Whether or not the fee record has attached payments
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordPaymentDeletedEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
@@ -11,6 +11,12 @@ type PaymentDeletedEventPayload = {
 
 export type FeeRecordPaymentDeletedEvent = BaseFeeRecordEvent<'PAYMENT_DELETED', PaymentDeletedEventPayload>;
 
+/**
+ * Handler for the payment deleted event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordPaymentDeletedEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, hasAttachedPayments, requestSource }: PaymentDeletedEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.ts
@@ -14,6 +14,9 @@ export type FeeRecordPaymentEditedEvent = BaseFeeRecordEvent<'PAYMENT_EDITED', P
  * Handler for the payment edited event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordPaymentEditedEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.ts
@@ -10,6 +10,12 @@ type PaymentEditedEventPayload = {
 
 export type FeeRecordPaymentEditedEvent = BaseFeeRecordEvent<'PAYMENT_EDITED', PaymentEditedEventPayload>;
 
+/**
+ * Handler for the payment edited event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordPaymentEditedEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: PaymentEditedEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.ts
@@ -13,6 +13,8 @@ export type FeeRecordRemoveFromPaymentGroupEvent = BaseFeeRecordEvent<'REMOVE_FR
  * Handler for the remove from payment group event
  * @param feeRecord - The fee record
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.requestSource - The request source
  * @returns The modified fee record
  */
 export const handleFeeRecordRemoveFromPaymentGroupEvent = async (

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.ts
@@ -9,6 +9,12 @@ type RemoveFromPaymentGroupEventPayload = {
 
 export type FeeRecordRemoveFromPaymentGroupEvent = BaseFeeRecordEvent<'REMOVE_FROM_PAYMENT_GROUP', RemoveFromPaymentGroupEventPayload>;
 
+/**
+ * Handler for the remove from payment group event
+ * @param feeRecord - The fee record
+ * @param param - The payload
+ * @returns The modified fee record
+ */
 export const handleFeeRecordRemoveFromPaymentGroupEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, requestSource }: RemoveFromPaymentGroupEventPayload,

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.ts
@@ -50,6 +50,7 @@ export class FeeRecordStateMachine {
   /**
    * Handles an invalid transition event
    * @param param - The event
+   * @param param.type - The event type
    */
   private handleInvalidTransition = ({ type: eventType }: FeeRecordEvent): never => {
     const entityName = FeeRecordEntity.name;

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.ts
@@ -1,5 +1,5 @@
 import { FeeRecordEntity } from '@ukef/dtfs2-common';
-import { InvalidStateMachineTransitionError } from '../../../errors';
+import { InvalidStateMachineTransitionError, NotFoundError } from '../../../errors';
 import { FeeRecordRepo } from '../../../repositories/fee-record-repo';
 import { FeeRecordEvent } from './event/fee-record.event';
 import {
@@ -14,6 +14,9 @@ import {
   handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent,
 } from './event-handlers';
 
+/**
+ * The fee record state machine class
+ */
 export class FeeRecordStateMachine {
   private readonly feeRecord: FeeRecordEntity;
 
@@ -21,15 +24,33 @@ export class FeeRecordStateMachine {
     this.feeRecord = feeRecord;
   }
 
+  /**
+   * Creates a fee record state machine for the supplied fee record
+   * @param feeRecord - The fee record to create the state machine for
+   * @returns A state machine
+   */
   public static forFeeRecord(feeRecord: FeeRecordEntity): FeeRecordStateMachine {
     return new FeeRecordStateMachine(feeRecord);
   }
 
+  /**
+   * Creates a fee record state machine for the fee record with the supplied id
+   * @param id - The fee record id
+   * @returns A state machine
+   * @throws {NotFoundError} If a fee record with the supplied id cannot be found
+   */
   public static async forFeeRecordId(id: number): Promise<FeeRecordStateMachine> {
-    const feeRecord = await FeeRecordRepo.findOneByOrFail({ id });
+    const feeRecord = await FeeRecordRepo.findOneBy({ id });
+    if (!feeRecord) {
+      throw new NotFoundError(`Failed to find a fee record with id ${id}`);
+    }
     return new FeeRecordStateMachine(feeRecord);
   }
 
+  /**
+   * Handles an invalid transition event
+   * @param param - The event
+   */
   private handleInvalidTransition = ({ type: eventType }: FeeRecordEvent): never => {
     const entityName = FeeRecordEntity.name;
 
@@ -41,6 +62,11 @@ export class FeeRecordStateMachine {
     });
   };
 
+  /**
+   * Handles a state machine event
+   * @param event - The event
+   * @returns The modified fee record entity
+   */
   public async handleEvent(event: FeeRecordEvent): Promise<FeeRecordEntity> {
     switch (this.feeRecord.status) {
       case 'TO_DO':

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.ts
@@ -18,6 +18,10 @@ export type UtilisationReportAddAPaymentEvent = BaseUtilisationReportEvent<'ADD_
  * Handler for the add a payment event
  * @param report - The report
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecords - The fee records
+ * @param param.paymentDetails - The payment details
+ * @param param.requestSource - The request source
  * @returns The modified report
  */
 export const handleUtilisationReportAddAPaymentEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.ts
@@ -14,6 +14,12 @@ type AddAPaymentEventPayload = {
 
 export type UtilisationReportAddAPaymentEvent = BaseUtilisationReportEvent<'ADD_A_PAYMENT', AddAPaymentEventPayload>;
 
+/**
+ * Handler for the add a payment event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportAddAPaymentEvent = async (
   report: UtilisationReportEntity,
   { transactionEntityManager, feeRecords, paymentDetails, requestSource }: AddAPaymentEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-fees-to-an-existing-payment-group/add-fees-to-an-existing-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-fees-to-an-existing-payment-group/add-fees-to-an-existing-payment-group.event-handler.ts
@@ -17,13 +17,21 @@ export type UtilisationReportAddFeesToAnExistingPaymentGroupEvent = BaseUtilisat
   AddFeesToAnExistingPaymentGroupEventPayload
 >;
 
+/**
+ * Adds the selected fee records to the payment group
+ * @param transactionEntityManager - The entity manager
+ * @param feeRecordsToAdd - The fee records to add
+ * @param feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param payments - The payments
+ * @param requestSource - The request source
+ */
 const addSelectedFeeRecordsToPaymentGroup = async (
   transactionEntityManager: EntityManager,
   feeRecordsToAdd: FeeRecordEntity[],
   feeRecordsAndPaymentsMatch: boolean,
   payments: PaymentEntity[],
   requestSource: DbRequestSource,
-) => {
+): Promise<void> => {
   await Promise.all(
     payments.map(async (payment) => {
       payment.updateWithAdditionalFeeRecords({
@@ -49,12 +57,19 @@ const addSelectedFeeRecordsToPaymentGroup = async (
   );
 };
 
+/**
+ * Updates the existing fee records in the payment group
+ * @param transactionEntityManager - The entity manager
+ * @param feeRecordsToUpdate - The fee records to update
+ * @param feeRecordsAndPaymentsMatch - Whether or not the fee records match the payments
+ * @param requestSource - The request source
+ */
 const updateExistingFeeRecordsInPaymentGroup = async (
   transactionEntityManager: EntityManager,
   feeRecordsToUpdate: FeeRecordEntity[],
   feeRecordsAndPaymentsMatch: boolean,
   requestSource: DbRequestSource,
-) => {
+): Promise<void> => {
   const feeRecordStateMachines = feeRecordsToUpdate.map((feeRecord) => FeeRecordStateMachine.forFeeRecord(feeRecord));
   await Promise.all(
     feeRecordStateMachines.map((stateMachine) =>
@@ -70,6 +85,12 @@ const updateExistingFeeRecordsInPaymentGroup = async (
   );
 };
 
+/**
+ * Handler for the add fees to an existing payment group event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportAddFeesToAnExistingPaymentGroupEvent = async (
   report: UtilisationReportEntity,
   { transactionEntityManager, feeRecordsToAdd, existingFeeRecordsInPaymentGroup, payments, requestSource }: AddFeesToAnExistingPaymentGroupEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-fees-to-an-existing-payment-group/add-fees-to-an-existing-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-fees-to-an-existing-payment-group/add-fees-to-an-existing-payment-group.event-handler.ts
@@ -89,6 +89,11 @@ const updateExistingFeeRecordsInPaymentGroup = async (
  * Handler for the add fees to an existing payment group event
  * @param report - The report
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsToAdd - The fee records to add
+ * @param param.existingFeeRecordsInPaymentGroup - The existing fee records in the payment group
+ * @param param.payments - The payments
+ * @param param.requestSource - The request source
  * @returns The modified report
  */
 export const handleUtilisationReportAddFeesToAnExistingPaymentGroupEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/delete-payment/delete-payment.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/delete-payment/delete-payment.event-handler.ts
@@ -13,6 +13,12 @@ type DeletePaymentEventPayload = {
 
 export type UtilisationReportDeletePaymentEvent = BaseUtilisationReportEvent<'DELETE_PAYMENT', DeletePaymentEventPayload>;
 
+/**
+ * Handler for the delete payment event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportDeletePaymentEvent = async (
   report: UtilisationReportEntity,
   { paymentId, transactionEntityManager, requestSource }: DeletePaymentEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/delete-payment/delete-payment.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/delete-payment/delete-payment.event-handler.ts
@@ -17,6 +17,9 @@ export type UtilisationReportDeletePaymentEvent = BaseUtilisationReportEvent<'DE
  * Handler for the delete payment event
  * @param report - The report
  * @param param - The payload
+ * @param param.paymentId - The payment id
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.requestSource - The request source
  * @returns The modified report
  */
 export const handleUtilisationReportDeletePaymentEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/due-report-initialised/due-report-initialised.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/due-report-initialised/due-report-initialised.event-handler.ts
@@ -9,6 +9,12 @@ type DueReportInitialisedPayload = {
 
 export type UtilisationReportDueReportInitialisedEvent = BaseUtilisationReportEvent<'DUE_REPORT_INITIALISED', DueReportInitialisedPayload>;
 
+/**
+ * Handler for the due report initialised event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportDueReportInitialisedEvent = (payload: DueReportInitialisedPayload): Promise<UtilisationReportEntity> => {
   console.error('Utilisation due report error payload %o', payload);
   throw new NotImplementedError('TODO FN-1860');

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.ts
@@ -16,6 +16,12 @@ type EditPayloadEventPayload = {
 
 export type UtilisationReportEditPaymentEvent = BaseUtilisationReportEvent<'EDIT_PAYMENT', EditPayloadEventPayload>;
 
+/**
+ * Handler for the edit payment event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportEditPaymentEvent = async (
   report: UtilisationReportEntity,
   { transactionEntityManager, payment, feeRecords, paymentAmount, datePaymentReceived, paymentReference, requestSource }: EditPayloadEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.ts
@@ -20,6 +20,13 @@ export type UtilisationReportEditPaymentEvent = BaseUtilisationReportEvent<'EDIT
  * Handler for the edit payment event
  * @param report - The report
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.payment - The payment
+ * @param param.feeRecords - The fee records
+ * @param param.paymentAmount - The new payment amount
+ * @param param.datePaymentReceived - The new date payment received
+ * @param param.paymentReference - The new payment reference
+ * @param param.requestSource - The request source
  * @returns The modified report
  */
 export const handleUtilisationReportEditPaymentEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -48,6 +48,9 @@ export type UtilisationReportGenerateKeyingDataEvent = BaseUtilisationReportEven
  * Handler for the generate keying data event
  * @param report - The report
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.requestSource - The request source
+ * @param param.feeRecordsAtMatchStatusWithPayments - The fee records at MATCH status with payments
  * @returns The modified report
  */
 export const handleUtilisationReportGenerateKeyingDataEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/fee-records-match-attached-payments.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/fee-records-match-attached-payments.ts
@@ -2,14 +2,26 @@ import { EntityManager } from 'typeorm';
 import { FeeRecordEntity, PaymentEntity } from '@ukef/dtfs2-common';
 import { feeRecordsAndPaymentsMatch } from '../../../../../helpers/fee-record-matching';
 
-const getPaymentsAttachedToFeeRecord = async (feeRecord: FeeRecordEntity, transactionEntityManager: EntityManager): Promise<PaymentEntity[]> => {
-  const { payments } = await transactionEntityManager.findOneOrFail(FeeRecordEntity, {
+/**
+ * Gets the payments attached to the supplied fee record
+ * @param feeRecord - The fee record
+ * @param entityManager - The entity manager
+ * @returns The attached payments
+ */
+const getPaymentsAttachedToFeeRecord = async (feeRecord: FeeRecordEntity, entityManager: EntityManager): Promise<PaymentEntity[]> => {
+  const { payments } = await entityManager.findOneOrFail(FeeRecordEntity, {
     where: { id: feeRecord.id },
     relations: { payments: true },
   });
   return payments;
 };
 
-export const feeRecordsMatchAttachedPayments = async (feeRecords: FeeRecordEntity[], transactionEntityManager: EntityManager): Promise<boolean> => {
-  return feeRecordsAndPaymentsMatch(feeRecords, await getPaymentsAttachedToFeeRecord(feeRecords[0], transactionEntityManager), transactionEntityManager);
+/**
+ * Checks whether or not the supplied fee records match their attached payments
+ * @param feeRecords - The fee records
+ * @param entityManager - The entity manager
+ * @returns Whether or not the fee records match the attached payments
+ */
+export const feeRecordsMatchAttachedPayments = async (feeRecords: FeeRecordEntity[], entityManager: EntityManager): Promise<boolean> => {
+  return feeRecordsAndPaymentsMatch(feeRecords, await getPaymentsAttachedToFeeRecord(feeRecords[0], entityManager), entityManager);
 };

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.ts
@@ -13,6 +13,8 @@ export type UtilisationReportManuallySetCompletedEvent = BaseUtilisationReportEv
  * Handler for the manually set complete event
  * @param report - The report
  * @param param - The payload
+ * @param param.requestSource - The request source
+ * @param param.transactionEntityManager - The transaction entity manager
  * @returns The modified report
  */
 export const handleUtilisationReportManuallySetCompletedEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.ts
@@ -9,6 +9,12 @@ type ManuallySetCompletedEventPayload = {
 
 export type UtilisationReportManuallySetCompletedEvent = BaseUtilisationReportEvent<'MANUALLY_SET_COMPLETED', ManuallySetCompletedEventPayload>;
 
+/**
+ * Handler for the manually set complete event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportManuallySetCompletedEvent = async (
   report: UtilisationReportEntity,
   { requestSource, transactionEntityManager }: ManuallySetCompletedEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.ts
@@ -13,6 +13,8 @@ export type UtilisationReportManuallySetIncompleteEvent = BaseUtilisationReportE
  * Handler for the manually set incomplete event
  * @param report - The report
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.requestSource - The request source
  * @returns The modified report
  */
 export const handleUtilisationReportManuallySetIncompleteEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.ts
@@ -9,6 +9,12 @@ type ManuallySetIncompleteEventPayload = {
 
 export type UtilisationReportManuallySetIncompleteEvent = BaseUtilisationReportEvent<'MANUALLY_SET_INCOMPLETE', ManuallySetIncompleteEventPayload>;
 
+/**
+ * Handler for the manually set incomplete event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportManuallySetIncompleteEvent = async (
   report: UtilisationReportEntity,
   { requestSource, transactionEntityManager }: ManuallySetIncompleteEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.ts
@@ -14,6 +14,12 @@ export type UtilisationReportMarkFeeRecordsAsReadyToKeyEvent = BaseUtilisationRe
   MarkFeeRecordsAsReadyToKeyEventPayload
 >;
 
+/**
+ * Handler for the mark fee records as ready to key event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent = async (
   report: UtilisationReportEntity,
   { requestSource, transactionEntityManager, feeRecordsToMarkAsReadyToKey }: MarkFeeRecordsAsReadyToKeyEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.ts
@@ -18,6 +18,9 @@ export type UtilisationReportMarkFeeRecordsAsReadyToKeyEvent = BaseUtilisationRe
  * Handler for the mark fee records as ready to key event
  * @param report - The report
  * @param param - The payload
+ * @param param.requestSource - The request source
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsToMarkAsReadyToKey - The fee records to mark as ready to key
  * @returns The modified report
  */
 export const handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.ts
@@ -18,6 +18,9 @@ export type UtilisationReportMarkFeeRecordsAsReconciledEvent = BaseUtilisationRe
  * Handler for the mark fee records as reconciled event
  * @param report - The report
  * @param param - The payload
+ * @param param.requestSource - The request source
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsToReconcile - The fee records to reconcile
  * @returns The modified report
  */
 export const handleUtilisationReportMarkFeeRecordsAsReconciledEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.ts
@@ -14,6 +14,12 @@ export type UtilisationReportMarkFeeRecordsAsReconciledEvent = BaseUtilisationRe
   MarkFeeRecordsAsReconciledEventPayload
 >;
 
+/**
+ * Handler for the mark fee records as reconciled event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportMarkFeeRecordsAsReconciledEvent = async (
   report: UtilisationReportEntity,
   { requestSource, transactionEntityManager, feeRecordsToReconcile }: MarkFeeRecordsAsReconciledEventPayload,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.ts
@@ -16,7 +16,17 @@ export type UtilisationReportRemoveFeesFromPaymentGroupEvent = BaseUtilisationRe
   RemoveFeesFromPaymentGroupEventPayload
 >;
 
-const removeSelectedFeePaymentsFromGroup = async (transactionEntityManager: EntityManager, feeRecords: FeeRecordEntity[], requestSource: DbRequestSource) => {
+/**
+ * Removes the selected fee records from the group
+ * @param transactionEntityManager - The entity manager
+ * @param feeRecords - The fee records
+ * @param requestSource - The request source
+ */
+const removeSelectedFeeRecordsFromGroup = async (
+  transactionEntityManager: EntityManager,
+  feeRecords: FeeRecordEntity[],
+  requestSource: DbRequestSource,
+): Promise<void> => {
   const feeRecordStateMachines = feeRecords.map((feeRecord) => FeeRecordStateMachine.forFeeRecord(feeRecord));
   await Promise.all(
     feeRecordStateMachines.map((stateMachine) =>
@@ -31,7 +41,17 @@ const removeSelectedFeePaymentsFromGroup = async (transactionEntityManager: Enti
   );
 };
 
-const updateOtherFeePaymentsInGroup = async (transactionEntityManager: EntityManager, feeRecords: FeeRecordEntity[], requestSource: DbRequestSource) => {
+/**
+ * Updates the supplied remaining fee records
+ * @param transactionEntityManager - The entity manager
+ * @param feeRecords - The fee records
+ * @param requestSource - The request source
+ */
+const updateRemainingFeeRecords = async (
+  transactionEntityManager: EntityManager,
+  feeRecords: FeeRecordEntity[],
+  requestSource: DbRequestSource,
+): Promise<void> => {
   const feeRecordsAndPaymentsMatch = await feeRecordsMatchAttachedPayments(feeRecords, transactionEntityManager);
 
   const feeRecordStateMachines = feeRecords.map((feeRecord) => FeeRecordStateMachine.forFeeRecord(feeRecord));
@@ -49,12 +69,18 @@ const updateOtherFeePaymentsInGroup = async (transactionEntityManager: EntityMan
   );
 };
 
+/**
+ * Handler for the remove fees from payment group event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
+ */
 export const handleUtilisationReportRemoveFeesFromPaymentGroupEvent = async (
   report: UtilisationReportEntity,
   { transactionEntityManager, feeRecordsToRemove, otherFeeRecordsInGroup, requestSource }: RemoveFeesFromPaymentGroupEventPayload,
 ): Promise<UtilisationReportEntity> => {
-  await removeSelectedFeePaymentsFromGroup(transactionEntityManager, feeRecordsToRemove, requestSource);
-  await updateOtherFeePaymentsInGroup(transactionEntityManager, otherFeeRecordsInGroup, requestSource);
+  await removeSelectedFeeRecordsFromGroup(transactionEntityManager, feeRecordsToRemove, requestSource);
+  await updateRemainingFeeRecords(transactionEntityManager, otherFeeRecordsInGroup, requestSource);
 
   report.updateLastUpdatedBy(requestSource);
   return await transactionEntityManager.save(UtilisationReportEntity, report);

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.ts
@@ -73,6 +73,10 @@ const updateRemainingFeeRecords = async (
  * Handler for the remove fees from payment group event
  * @param report - The report
  * @param param - The payload
+ * @param param.transactionEntityManager - The transaction entity manager
+ * @param param.feeRecordsToRemove - The fee records to remove
+ * @param param.otherFeeRecordsInGroup - The other fee records in the group
+ * @param param.requestSource - The request source
  * @returns The modified report
  */
 export const handleUtilisationReportRemoveFeesFromPaymentGroupEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.ts
@@ -39,6 +39,11 @@ export type UtilisationReportReportUploadedEvent = BaseUtilisationReportEvent<'R
  * Handler for the report uploaded event
  * @param report - The report
  * @param param - The payload
+ * @param param.azureFileInfo - The azure file info
+ * @param param.reportCsvData - The report CSV data
+ * @param param.uploadedByUserId - The id of the user uploading the report
+ * @param param.requestSource - The request source
+ * @param param.transactionEntityManager - The transaction entity manager
  * @returns The modified report
  */
 export const handleUtilisationReportReportUploadedEvent = async (

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.ts
@@ -34,11 +34,12 @@ const createFacilityUtilisationDataEntityIfNotExists = async (
 };
 
 export type UtilisationReportReportUploadedEvent = BaseUtilisationReportEvent<'REPORT_UPLOADED', ReportUploadedEventPayload>;
+
 /**
- * Handler for the utilisation report "report uploaded" event
- * @param report - The report to update
- * @param param1 - The payload for the event
- * @returns The updated report
+ * Handler for the report uploaded event
+ * @param report - The report
+ * @param param - The payload
+ * @returns The modified report
  */
 export const handleUtilisationReportReportUploadedEvent = async (
   report: UtilisationReportEntity,

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.ts
@@ -64,6 +64,7 @@ export class UtilisationReportStateMachine {
   /**
    * Handles an invalid transition event
    * @param param - The event
+   * @param param.type - The event type
    */
   private handleInvalidTransition = ({ type: eventType }: UtilisationReportEvent): never => {
     const entityName = UtilisationReportEntity.name;

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.ts
@@ -17,6 +17,9 @@ import {
 } from './event-handlers';
 import { UtilisationReportEvent } from './event/utilisation-report.event';
 
+/**
+ * The utilisation report state machine class
+ */
 export class UtilisationReportStateMachine {
   private readonly report: UtilisationReportEntity | null;
 
@@ -24,10 +27,21 @@ export class UtilisationReportStateMachine {
     this.report = report;
   }
 
+  /**
+   * Creates a state machine for the supplied report
+   * @param report - The report to create a state machine for
+   * @returns The state machine
+   */
   public static forReport(report: UtilisationReportEntity): UtilisationReportStateMachine {
     return new UtilisationReportStateMachine(report);
   }
 
+  /**
+   * Creates a state machine for the report with the supplied id
+   * @param id - The report id
+   * @returns The state machine
+   * @throws {NotFoundError} If a report with the supplied id cannot be found
+   */
   public static async forReportId(id: number): Promise<UtilisationReportStateMachine> {
     const report = await UtilisationReportRepo.findOneBy({ id });
     if (!report) {
@@ -36,11 +50,21 @@ export class UtilisationReportStateMachine {
     return new UtilisationReportStateMachine(report);
   }
 
+  /**
+   * Creates a state machine for the report with the supplied bank id and report period
+   * @param bankId - The bank id
+   * @param reportPeriod - The report period
+   * @returns The state machine
+   */
   public static async forBankIdAndReportPeriod(bankId: string, reportPeriod: ReportPeriod): Promise<UtilisationReportStateMachine> {
     const report = await UtilisationReportRepo.findOneByBankIdAndReportPeriod(bankId, reportPeriod);
     return new UtilisationReportStateMachine(report);
   }
 
+  /**
+   * Handles an invalid transition event
+   * @param param - The event
+   */
   private handleInvalidTransition = ({ type: eventType }: UtilisationReportEvent): never => {
     const entityName = UtilisationReportEntity.name;
 
@@ -61,6 +85,8 @@ export class UtilisationReportStateMachine {
 
   /**
    * Implements the 'Utilisation Reports' state machine detailed in '/doc/state-machines.md'.
+   * @param event - The event
+   * @returns The modified report
    */
   public async handleEvent(event: UtilisationReportEvent): Promise<UtilisationReportEntity> {
     switch (this.report?.status) {

--- a/libs/common/src/sql-db-entities/azure-file-info/azure-file-info.entity.ts
+++ b/libs/common/src/sql-db-entities/azure-file-info/azure-file-info.entity.ts
@@ -53,6 +53,11 @@ export class AzureFileInfoEntity extends AuditableBaseEntity {
   @JoinColumn()
   utilisationReport!: UtilisationReportEntity;
 
+  /**
+   * Creates an instance of the azure file info entity
+   * @param param - The parameters to create the entity with
+   * @returns The created entity
+   */
   static create({ folder, filename, fullPath, url, mimetype, requestSource }: CreateAzureFileInfoParams): AzureFileInfoEntity {
     const azureFileInfo = new AzureFileInfoEntity();
     azureFileInfo.folder = folder;

--- a/libs/common/src/sql-db-entities/azure-file-info/azure-file-info.entity.ts
+++ b/libs/common/src/sql-db-entities/azure-file-info/azure-file-info.entity.ts
@@ -56,6 +56,12 @@ export class AzureFileInfoEntity extends AuditableBaseEntity {
   /**
    * Creates an instance of the azure file info entity
    * @param param - The parameters to create the entity with
+   * @param param.folder - The folder
+   * @param param.filename - The filename
+   * @param param.fullPath - The full path
+   * @param param.url - The URL
+   * @param param.mimetype - The mimetype
+   * @param param.requestSource - The request source
    * @returns The created entity
    */
   static create({ folder, filename, fullPath, url, mimetype, requestSource }: CreateAzureFileInfoParams): AzureFileInfoEntity {

--- a/libs/common/src/sql-db-entities/base-entities/auditable.base-entity.ts
+++ b/libs/common/src/sql-db-entities/base-entities/auditable.base-entity.ts
@@ -2,18 +2,36 @@ import { Column, UpdateDateColumn } from 'typeorm';
 import { DbRequestSource } from '../helpers';
 
 export abstract class AuditableBaseEntity {
+  /**
+   * The time where the entity was last updated
+   */
   @UpdateDateColumn()
   lastUpdatedAt!: Date;
 
+  /**
+   * The user id of the portal user who last updated the entity
+   * (null if the last update came from a non-portal user)
+   */
   @Column({ type: 'nvarchar', nullable: true })
   lastUpdatedByPortalUserId!: string | null;
 
+  /**
+   * The user id of the tfm user who last updated the entity
+   * (null if the last update came from a non-tfm user)
+   */
   @Column({ type: 'nvarchar', nullable: true })
   lastUpdatedByTfmUserId!: string | null;
 
+  /**
+   * Whether or not the entity was last updated by the system
+   */
   @Column({ default: false })
   lastUpdatedByIsSystemUser!: boolean;
 
+  /**
+   * Updates the audit fields
+   * @param requestSource - The request source
+   */
   public updateLastUpdatedBy(requestSource: DbRequestSource): void {
     const { platform } = requestSource;
     switch (platform) {

--- a/libs/common/src/sql-db-entities/custom-columns/exchange-rate-column.ts
+++ b/libs/common/src/sql-db-entities/custom-columns/exchange-rate-column.ts
@@ -1,5 +1,19 @@
 import { Column } from 'typeorm';
 
+/**
+ * Decorator which should be used for exchange rate columns in typeORM entities
+ * @returns A property decorator
+ * @example
+ * ```ts
+ * import { Entity } from 'typeorm';
+ *
+ * @Entity()
+ * class ExampleEntity {
+ *   @ExchangeRateColumn()
+ *   public exchangeRate!: number;
+ * }
+ * ```
+ */
 export const ExchangeRateColumn = (): PropertyDecorator =>
   Column({
     type: 'decimal',

--- a/libs/common/src/sql-db-entities/custom-columns/monetary-column.ts
+++ b/libs/common/src/sql-db-entities/custom-columns/monetary-column.ts
@@ -5,6 +5,21 @@ type MonetaryColumnOptions = {
   defaultValue?: number;
 };
 
+/**
+ * Decorator which should be used for monetary columns in typeORM entities
+ * @param options - The options for the column
+ * @returns A property decorator
+ * @example
+ * ```ts
+ * import { Entity } from 'typeorm';
+ *
+ * @Entity()
+ * class ExampleEntity {
+ *   @MonetaryColumn({ nullable: true })
+ *   public amount!: number | null;
+ * }
+ * ```
+ */
 export const MonetaryColumn = (options?: MonetaryColumnOptions): PropertyDecorator =>
   Column({
     type: 'decimal',

--- a/libs/common/src/sql-db-entities/custom-columns/monetary-column.ts
+++ b/libs/common/src/sql-db-entities/custom-columns/monetary-column.ts
@@ -1,7 +1,13 @@
 import { Column } from 'typeorm';
 
 type MonetaryColumnOptions = {
+  /**
+   * Whether or not the column is nullable
+   */
   nullable?: boolean;
+  /**
+   * The default value for the column
+   */
   defaultValue?: number;
 };
 

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.ts
@@ -55,7 +55,7 @@ export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
    * @param facilityUtilisationData.utilisation - The facility utilisation
    * @param facilityUtilisationData.fixedFee - The facility fixed fee
    * @param facilityUtilisationData.requestSource - The source of the request
-   * @returns {FacilityUtilisationDataEntity}
+   * @returns The created entity
    */
   public static create({ id, reportPeriod, utilisation, fixedFee, requestSource }: CreateFacilityUtilisationDataParams): FacilityUtilisationDataEntity {
     const data = new FacilityUtilisationDataEntity();
@@ -73,7 +73,7 @@ export class FacilityUtilisationDataEntity extends AuditableBaseEntity {
    * @param facilityUtilisationData.id - The ID of the entity
    * @param facilityUtilisationData.reportPeriod - The report period details
    * @param facilityUtilisationData.requestSource - The source of the request
-   * @returns {FacilityUtilisationDataEntity}
+   * @returns The created entity
    */
   public static createWithoutUtilisationAndFixedFee({
     id,

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -188,6 +188,8 @@ export class FeeRecordEntity extends AuditableBaseEntity {
   /**
    * Updates the fee record with a status
    * @param param - The update parameters
+   * @param param.status - The status
+   * @param param.requestSource - The request source
    */
   public updateWithStatus({ status, requestSource }: UpdateWithStatusParams): void {
     this.status = status;
@@ -197,6 +199,10 @@ export class FeeRecordEntity extends AuditableBaseEntity {
   /**
    * Updates a fee record with keying data
    * @param param - The update parameters
+   * @param param.fixedFeeAdjustment - The fixed fee adjustment
+   * @param param.principalBalanceAdjustment - The principal balance adjustment
+   * @param param.status - The status
+   * @param param.requestSource - The request source
    */
   public updateWithKeyingData({ fixedFeeAdjustment, principalBalanceAdjustment, status, requestSource }: UpdateWithKeyingDataParams): void {
     this.status = status;
@@ -208,6 +214,7 @@ export class FeeRecordEntity extends AuditableBaseEntity {
   /**
    * Removes all payments from the fee record
    * @param param - The update parameters
+   * @param param.requestSource - The request source
    */
   public removeAllPayments({ requestSource }: RemoveAllPaymentsParams): void {
     this.payments = [];

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -170,6 +170,10 @@ export class FeeRecordEntity extends AuditableBaseEntity {
     return feeRecord;
   }
 
+  /**
+   * Gets the fees paid to UKEF for the period converted to the payment currency
+   * @returns The fees paid
+   */
   public getFeesPaidToUkefForThePeriodInThePaymentCurrency(): number {
     if (this.paymentCurrency === this.feesPaidToUkefForThePeriodCurrency) {
       return this.feesPaidToUkefForThePeriod;
@@ -181,11 +185,19 @@ export class FeeRecordEntity extends AuditableBaseEntity {
     return feesPaidToUkefForThePeriodAsBig.div(paymentExchangeRateAsBig).round(precision).toNumber();
   }
 
+  /**
+   * Updates the fee record with a status
+   * @param param - The update parameters
+   */
   public updateWithStatus({ status, requestSource }: UpdateWithStatusParams): void {
     this.status = status;
     this.updateLastUpdatedBy(requestSource);
   }
 
+  /**
+   * Updates a fee record with keying data
+   * @param param - The update parameters
+   */
   public updateWithKeyingData({ fixedFeeAdjustment, principalBalanceAdjustment, status, requestSource }: UpdateWithKeyingDataParams): void {
     this.status = status;
     this.fixedFeeAdjustment = fixedFeeAdjustment;
@@ -193,6 +205,10 @@ export class FeeRecordEntity extends AuditableBaseEntity {
     this.updateLastUpdatedBy(requestSource);
   }
 
+  /**
+   * Removes all payments from the fee record
+   * @param param - The update parameters
+   */
   public removeAllPayments({ requestSource }: RemoveAllPaymentsParams): void {
     this.payments = [];
     this.status = 'TO_DO';

--- a/libs/common/src/sql-db-entities/join-tables/fee-record-payment/fee-record-payment.join-table.entity.ts
+++ b/libs/common/src/sql-db-entities/join-tables/fee-record-payment/fee-record-payment.join-table.entity.ts
@@ -50,6 +50,9 @@ export class FeeRecordPaymentJoinTableEntity {
   /**
    * Creates an instance of the entity
    * @param param - The parameters to create the entity with
+   * @param param.feeRecordId - The fee record id
+   * @param param.paymentId - The payment id
+   * @param param.paymentAmountUsedForFeeRecord - The payment amount used for the fee record
    * @returns The created entity
    */
   public static create({

--- a/libs/common/src/sql-db-entities/join-tables/fee-record-payment/fee-record-payment.join-table.entity.ts
+++ b/libs/common/src/sql-db-entities/join-tables/fee-record-payment/fee-record-payment.join-table.entity.ts
@@ -6,10 +6,16 @@ import { CreateFeeRecordPaymentJoinTableEntityParams } from './fee-record-paymen
 
 @Entity('fee_record_payments_payment')
 export class FeeRecordPaymentJoinTableEntity {
+  /**
+   * The id of the linked fee record
+   */
   @PrimaryColumn({ nullable: false })
   @Index('IDX_7a9b7aa849fc3bb09d80fa1f81')
   feeRecordId!: number;
 
+  /**
+   * The linked fee record
+   */
   @ManyToOne(() => FeeRecordEntity, (feeRecord) => feeRecord.id, {
     eager: false,
     onDelete: 'CASCADE',
@@ -18,10 +24,16 @@ export class FeeRecordPaymentJoinTableEntity {
   @JoinColumn({ name: 'feeRecordId', foreignKeyConstraintName: 'FK_7a9b7aa849fc3bb09d80fa1f812' })
   feeRecord!: FeeRecordEntity;
 
+  /**
+   * The id of the linked payment
+   */
   @PrimaryColumn({ nullable: false })
   @Index('IDX_23bbb10be5f2136a5a5086654e')
   paymentId!: number;
 
+  /**
+   * The linked payment
+   */
   @ManyToOne(() => PaymentEntity, (payment) => payment.id, {
     eager: false,
     onDelete: 'CASCADE',
@@ -29,9 +41,17 @@ export class FeeRecordPaymentJoinTableEntity {
   @JoinColumn({ name: 'paymentId', foreignKeyConstraintName: 'FK_23bbb10be5f2136a5a5086654e8' })
   payment!: PaymentEntity;
 
+  /**
+   * The payment amount used for the fee record
+   */
   @MonetaryColumn({ nullable: true })
   paymentAmountUsedForFeeRecord!: number | null;
 
+  /**
+   * Creates an instance of the entity
+   * @param param - The parameters to create the entity with
+   * @returns The created entity
+   */
   public static create({
     feeRecordId,
     paymentId,

--- a/libs/common/src/sql-db-entities/partial-entities/month-and-year.partial-entity.ts
+++ b/libs/common/src/sql-db-entities/partial-entities/month-and-year.partial-entity.ts
@@ -1,15 +1,16 @@
 import { Column } from 'typeorm';
+import { OneIndexedMonth } from '../../types';
 
 export class MonthAndYearPartialEntity {
   /**
-   * The month
+   * The month (one-indexed)
    */
-  @Column()
-  month!: number;
+  @Column({ type: 'int' })
+  month!: OneIndexedMonth;
 
   /**
    * The year
    */
-  @Column()
+  @Column({ type: 'int' })
   year!: number;
 }

--- a/libs/common/src/sql-db-entities/partial-entities/month-and-year.partial-entity.ts
+++ b/libs/common/src/sql-db-entities/partial-entities/month-and-year.partial-entity.ts
@@ -1,9 +1,15 @@
 import { Column } from 'typeorm';
 
 export class MonthAndYearPartialEntity {
+  /**
+   * The month
+   */
   @Column()
   month!: number;
 
+  /**
+   * The year
+   */
   @Column()
   year!: number;
 }

--- a/libs/common/src/sql-db-entities/partial-entities/report-period.partial-entity.ts
+++ b/libs/common/src/sql-db-entities/partial-entities/report-period.partial-entity.ts
@@ -2,9 +2,15 @@ import { Column } from 'typeorm';
 import { MonthAndYearPartialEntity } from './month-and-year.partial-entity';
 
 export class ReportPeriodPartialEntity {
+  /**
+   * The start of the report period
+   */
   @Column(() => MonthAndYearPartialEntity)
   start!: MonthAndYearPartialEntity;
 
+  /**
+   * The end of the report period
+   */
   @Column(() => MonthAndYearPartialEntity)
   end!: MonthAndYearPartialEntity;
 }

--- a/libs/common/src/sql-db-entities/payment/payment.entity.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.entity.ts
@@ -43,6 +43,11 @@ export class PaymentEntity extends AuditableBaseEntity {
   })
   feeRecords!: FeeRecordEntity[];
 
+  /**
+   * Creates an instance of the entity
+   * @param param - The parameters to create the entity with
+   * @returns The created entity
+   */
   static create({ currency, amount, dateReceived, reference, feeRecords, requestSource }: CreatePaymentParams): PaymentEntity {
     const payment = new PaymentEntity();
     payment.currency = currency;
@@ -54,6 +59,10 @@ export class PaymentEntity extends AuditableBaseEntity {
     return payment;
   }
 
+  /**
+   * Updates the payment entity
+   * @param param - The parameters to update the payment with
+   */
   public update({ amount, dateReceived, reference, requestSource }: UpdatePaymentParams): void {
     this.amount = amount;
     this.dateReceived = dateReceived;
@@ -61,6 +70,10 @@ export class PaymentEntity extends AuditableBaseEntity {
     this.updateLastUpdatedBy(requestSource);
   }
 
+  /**
+   * Updates the payment with additional fee records
+   * @param param - The parameters to update the payment with
+   */
   public updateWithAdditionalFeeRecords({ additionalFeeRecords, requestSource }: UpdateWithAdditionalFeeRecordsParams): void {
     const existingIds = new Set(this.feeRecords.map((record) => record.id));
     const duplicateIds = additionalFeeRecords.filter((record) => existingIds.has(record.id));

--- a/libs/common/src/sql-db-entities/payment/payment.entity.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.entity.ts
@@ -46,6 +46,12 @@ export class PaymentEntity extends AuditableBaseEntity {
   /**
    * Creates an instance of the entity
    * @param param - The parameters to create the entity with
+   * @param param.currency - The currency
+   * @param param.amount - The amount
+   * @param param.dateReceived - The date received
+   * @param param.reference - The reference
+   * @param param.feeRecords - The fee records
+   * @param param.requestSource - The request source
    * @returns The created entity
    */
   static create({ currency, amount, dateReceived, reference, feeRecords, requestSource }: CreatePaymentParams): PaymentEntity {
@@ -62,6 +68,10 @@ export class PaymentEntity extends AuditableBaseEntity {
   /**
    * Updates the payment entity
    * @param param - The parameters to update the payment with
+   * @param param.amount - The amount
+   * @param param.dateReceived - The date received
+   * @param param.reference - The reference
+   * @param param.requestSource - The request source
    */
   public update({ amount, dateReceived, reference, requestSource }: UpdatePaymentParams): void {
     this.amount = amount;
@@ -73,6 +83,8 @@ export class PaymentEntity extends AuditableBaseEntity {
   /**
    * Updates the payment with additional fee records
    * @param param - The parameters to update the payment with
+   * @param param.additionalFeeRecords - The additional fee records
+   * @param param.requestSource - The request source
    */
   public updateWithAdditionalFeeRecords({ additionalFeeRecords, requestSource }: UpdateWithAdditionalFeeRecordsParams): void {
     const existingIds = new Set(this.feeRecords.map((record) => record.id));

--- a/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.ts
+++ b/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.ts
@@ -66,6 +66,9 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
   /**
    * Creates a utilisation report entity with status REPORT_NOT_RECEIVED
    * @param param - The parameters to create the entity with
+   * @param param.bankId - The bank id
+   * @param param.reportPeriod - The report period
+   * @param param.requestSource - The request source
    * @returns The created entity
    */
   static createNotReceived({ bankId, reportPeriod, requestSource }: CreateNotReceivedUtilisationReportEntityParams): UtilisationReportEntity {
@@ -82,6 +85,9 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
   /**
    * Updates the report with the upload details
    * @param param - The parameters to update the report with
+   * @param param.azureFileInfo - The azure file info
+   * @param param.uploadedByUserId - The id of the user who uploaded the report
+   * @param param.requestSource - The request source
    */
   public updateWithUploadDetails({ azureFileInfo, uploadedByUserId, requestSource }: UpdateWithUploadDetailsParams): void {
     this.dateUploaded = new Date();
@@ -94,6 +100,7 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
   /**
    * Updates the report with fee records
    * @param param - The parameters to update the report with
+   * @param param.feeRecords - The fee records
    */
   public updateWithFeeRecords({ feeRecords }: UpdateWithFeeRecordsParams): void {
     this.feeRecords = feeRecords;
@@ -102,6 +109,8 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
   /**
    * Updates the report with a supplied status
    * @param param - The parameters to update the report with
+   * @param param.status - The status
+   * @param param.requestSource - The request source
    */
   public updateWithStatus({ status, requestSource }: UpdateWithStatusParams): void {
     this.status = status;

--- a/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.ts
+++ b/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.ts
@@ -63,6 +63,11 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
   })
   feeRecords!: FeeRecordEntity[];
 
+  /**
+   * Creates a utilisation report entity with status REPORT_NOT_RECEIVED
+   * @param param - The parameters to create the entity with
+   * @returns The created entity
+   */
   static createNotReceived({ bankId, reportPeriod, requestSource }: CreateNotReceivedUtilisationReportEntityParams): UtilisationReportEntity {
     const report = new UtilisationReportEntity();
     report.bankId = bankId;
@@ -74,6 +79,10 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
     return report;
   }
 
+  /**
+   * Updates the report with the upload details
+   * @param param - The parameters to update the report with
+   */
   public updateWithUploadDetails({ azureFileInfo, uploadedByUserId, requestSource }: UpdateWithUploadDetailsParams): void {
     this.dateUploaded = new Date();
     this.azureFileInfo = azureFileInfo;
@@ -82,10 +91,18 @@ export class UtilisationReportEntity extends AuditableBaseEntity {
     this.updateLastUpdatedBy(requestSource);
   }
 
+  /**
+   * Updates the report with fee records
+   * @param param - The parameters to update the report with
+   */
   public updateWithFeeRecords({ feeRecords }: UpdateWithFeeRecordsParams): void {
     this.feeRecords = feeRecords;
   }
 
+  /**
+   * Updates the report with a supplied status
+   * @param param - The parameters to update the report with
+   */
   public updateWithStatus({ status, requestSource }: UpdateWithStatusParams): void {
     this.status = status;
     this.updateLastUpdatedBy(requestSource);


### PR DESCRIPTION
## Note
This PR is primarily for documentation with minimal modifications to actual implementation. Any comments around implementation are therefore outside the scope of this PR.

## Introduction :pencil2:
We want to add docstrings to event handlers and typeORM entities.

## Resolution :heavy_check_mark:
- Adds docstrings to the event handlers
- Adds docstrings to the entities

## Miscellaneous :heavy_plus_sign:


