### PR TITLE
feat(FN-3417): add batch saving for facility utilisation data

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-upload-utilisation-report.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-upload-utilisation-report.api-test.ts
@@ -140,9 +140,11 @@ describe(`POST ${getUrl()}`, () => {
     const payload: PostUploadUtilisationReportRequestBody = { ...aValidPayload(), reportData };
 
     // Act
-    await testApi.post(payload).to(getUrl());
+    const response = await testApi.post(payload).to(getUrl());
 
     // Assert
+    expect(response.status).toBe(HttpStatusCode.Created);
+
     const numberOfInsertedFeeRecords = await SqlDbHelper.manager.count(FeeRecordEntity, {});
     expect(numberOfInsertedFeeRecords).toBe(numberOfReportDataEntriesToCreate);
   });
@@ -161,9 +163,11 @@ describe(`POST ${getUrl()}`, () => {
     const payload: PostUploadUtilisationReportRequestBody = { ...aValidPayload(), reportData };
 
     // Act
-    await testApi.post(payload).to(getUrl());
+    const response = await testApi.post(payload).to(getUrl());
 
     // Assert
+    expect(response.status).toBe(HttpStatusCode.Created);
+
     const numberOfInsertedFeeRecords = await SqlDbHelper.manager.count(FeeRecordEntity, {});
     expect(numberOfInsertedFeeRecords).toBe(numberOfReportDataEntriesToCreate);
   });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-upload-utilisation-report.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-upload-utilisation-report.api-test.ts
@@ -140,11 +140,9 @@ describe(`POST ${getUrl()}`, () => {
     const payload: PostUploadUtilisationReportRequestBody = { ...aValidPayload(), reportData };
 
     // Act
-    const response = await testApi.post(payload).to(getUrl());
+    await testApi.post(payload).to(getUrl());
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Created);
-
     const numberOfInsertedFeeRecords = await SqlDbHelper.manager.count(FeeRecordEntity, {});
     expect(numberOfInsertedFeeRecords).toBe(numberOfReportDataEntriesToCreate);
   });
@@ -163,11 +161,9 @@ describe(`POST ${getUrl()}`, () => {
     const payload: PostUploadUtilisationReportRequestBody = { ...aValidPayload(), reportData };
 
     // Act
-    const response = await testApi.post(payload).to(getUrl());
+    await testApi.post(payload).to(getUrl());
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Created);
-
     const numberOfInsertedFeeRecords = await SqlDbHelper.manager.count(FeeRecordEntity, {});
     expect(numberOfInsertedFeeRecords).toBe(numberOfReportDataEntriesToCreate);
   });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
@@ -107,6 +107,6 @@ describe('handleUtilisationReportReportUploadedEvent', () => {
         requestSource,
       });
     });
-    expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, createdFacilityUtilisationDataEntities);
+    expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, createdFacilityUtilisationDataEntities, { chunk: 100 });
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:
There was an issue with uploading reports with a large number of new facilities, where new refers to a facility which does not have an entry in the `FacilityUtilisationData` table.

## Resolution :heavy_check_mark:
- Adds a new api test to test for a large number of facilities
  - This api test was run before and after the new changes were included to replicate the existing issue and ensure it remains working in future
- Updates the event handler

## Miscellaneous :heavy_plus_sign:
- Adds a missing docstring

