### PR TITLE
feat(FN-2309): introduce a DRY aUtilisationReport method

### DIFF
--- a/dtfs-central-api/src/helpers/get-fee-record-payment-entity-groups-from-fee-record-entities.test.ts
+++ b/dtfs-central-api/src/helpers/get-fee-record-payment-entity-groups-from-fee-record-entities.test.ts
@@ -1,5 +1,6 @@
-import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { getFeeRecordPaymentEntityGroupsFromFeeRecordEntities } from './get-fee-record-payment-entity-groups-from-fee-record-entities';
+import { aUtilisationReport } from '../../test-helpers';
 
 describe('get-fee-record-payment-entity-groups-from-fee-record-entities.helper', () => {
   describe('getFeeRecordPaymentEntityGroupsFromFeeRecordEntities', () => {
@@ -76,9 +77,5 @@ describe('get-fee-record-payment-entity-groups-from-fee-record-entities.helper',
       expect(groups[1].feeRecords).toEqual(secondFeeRecords);
       expect(groups[1].payments).toEqual(secondPayments);
     });
-
-    function aUtilisationReport(): UtilisationReportEntity {
-      return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    }
   });
 });

--- a/dtfs-central-api/src/mapping/fee-record-mapper.test.ts
+++ b/dtfs-central-api/src/mapping/fee-record-mapper.test.ts
@@ -1,5 +1,6 @@
-import { CURRENCY, Currency, FeeRecordEntityMockBuilder, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { CURRENCY, Currency, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { mapFeeRecordEntityToFeeRecord, mapFeeRecordEntityToReportedFees, mapFeeRecordEntityToReportedPayments } from './fee-record-mapper';
+import { aUtilisationReport } from '../../test-helpers';
 
 describe('fee record mapper', () => {
   describe('mapFeeRecordEntityToReportedFees', () => {
@@ -215,8 +216,4 @@ describe('fee record mapper', () => {
       });
     });
   });
-
-  function aUtilisationReport(): UtilisationReportEntity {
-    return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-  }
 });

--- a/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
+++ b/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
@@ -1,13 +1,7 @@
 import { difference } from 'lodash';
-import {
-  Currency,
-  FEE_RECORD_STATUS,
-  FeeRecordEntityMockBuilder,
-  KeyingSheetRowStatus,
-  PaymentEntityMockBuilder,
-  UtilisationReportEntityMockBuilder,
-} from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, KeyingSheetRowStatus, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments, mapPaymentEntityToKeyingSheetFeePayment } from './keying-sheet-mapping';
+import { aUtilisationReport } from '../../test-helpers';
 
 describe('keying sheet mapping', () => {
   describe('mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments', () => {
@@ -130,8 +124,4 @@ describe('keying sheet mapping', () => {
       expect(feePayment.dateReceived).toEqual(new Date('2024-05-06'));
     });
   });
-
-  function aUtilisationReport() {
-    return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-  }
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
@@ -1,7 +1,13 @@
 import { when } from 'jest-when';
-import { FacilityUtilisationDataEntityMockBuilder, FeeRecordEntityMockBuilder, ReportPeriod, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  FacilityUtilisationDataEntityMockBuilder,
+  FeeRecordEntityMockBuilder,
+  ReportPeriod,
+  UTILISATION_REPORT_RECONCILIATION_STATUS,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { calculateFixedFeeAdjustment } from './calculate-fixed-fee-adjustment';
-import { aReportPeriod } from '../../../../../../test-helpers';
+import { aReportPeriod, aUtilisationReport } from '../../../../../../test-helpers';
 import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
 
 jest.mock('./get-fixed-fee-for-facility');
@@ -28,8 +34,9 @@ describe('calculateFixedFeeAdjustment', () => {
       start: { month: 1, year: 2024 },
       end: { month: 1, year: 2024 },
     };
-    const report = aUtilisationReport();
-    report.reportPeriod = reportPeriod;
+    const report = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
+      .withReportPeriod(reportPeriod)
+      .build();
     const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('11111111').build();
     const facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId('11111111').withReportPeriod(reportPeriod).build();
 
@@ -48,7 +55,9 @@ describe('calculateFixedFeeAdjustment', () => {
     async ({ previousFixedFee, currentFixedFee, expectedResult }) => {
       // Arrange
       const reportPeriod = aReportPeriod();
-      const utilisationReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withReportPeriod(reportPeriod).build();
+      const utilisationReport = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
+        .withReportPeriod(reportPeriod)
+        .build();
 
       const currentFacilityUtilisation = 123.456;
       const facilityId = '123456789';
@@ -71,8 +80,4 @@ describe('calculateFixedFeeAdjustment', () => {
       expect(result).toBe(expectedResult);
     },
   );
-
-  function aUtilisationReport() {
-    return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-  }
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.test.ts
@@ -1,5 +1,6 @@
-import { FacilityUtilisationDataEntityMockBuilder, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FacilityUtilisationDataEntityMockBuilder, FeeRecordEntityMockBuilder } from '@ukef/dtfs2-common';
 import { calculatePrincipalBalanceAdjustment } from './calculate-principal-balance-adjustment';
+import { aUtilisationReport } from '../../../../../../test-helpers';
 
 describe('calculatePrincipalBalanceAdjustment', () => {
   const aFeeRecordEntityWithFacilityUtilisation = (facilityUtilisation: number) =>
@@ -37,8 +38,4 @@ describe('calculatePrincipalBalanceAdjustment', () => {
       expect(result).toBe(expectedDifference);
     },
   );
-
-  function aUtilisationReport() {
-    return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-  }
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/get-keying-sheet-fee-payment-shares-for-fee-records.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/get-keying-sheet-fee-payment-shares-for-fee-records.test.ts
@@ -1,12 +1,6 @@
-import {
-  Currency,
-  FeeRecordEntity,
-  FeeRecordEntityMockBuilder,
-  PaymentEntity,
-  PaymentEntityMockBuilder,
-  UtilisationReportEntityMockBuilder,
-} from '@ukef/dtfs2-common';
+import { Currency, FeeRecordEntity, FeeRecordEntityMockBuilder, PaymentEntity, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { KeyingSheetFeePaymentShare, getKeyingSheetFeePaymentSharesForFeeRecords } from './get-keying-sheet-fee-payment-shares-for-fee-records';
+import { aUtilisationReport } from '../../../../../../test-helpers';
 
 describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
   describe('when there is one fee record linked to one payment', () => {
@@ -402,8 +396,4 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
       expect(result).toHaveLength(0);
     });
   });
-
-  function aUtilisationReport() {
-    return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-  }
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.test.ts
@@ -1,10 +1,10 @@
 import httpMocks from 'node-mocks-http';
 import { ObjectId } from 'mongodb';
-import { TestApiError, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { TestApiError } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { EntityManager } from 'typeorm';
 import { DeletePaymentRequest, deletePayment } from '.';
-import { aTfmSessionUser } from '../../../../../test-helpers';
+import { aTfmSessionUser, aUtilisationReport } from '../../../../../test-helpers';
 import { DeletePaymentPayload } from '../../../routes/middleware/payload-validation/validate-delete-payment-payload';
 import { executeWithSqlTransaction } from '../../../../helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
@@ -188,9 +188,5 @@ describe('delete-payment.controller', () => {
       // Assert
       expect(res._getData()).toBe(`Failed to delete payment with id ${paymentId}`);
     });
-
-    function aUtilisationReport(): UtilisationReportEntity {
-      return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    }
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.test.ts
@@ -1,13 +1,7 @@
 import { difference } from 'lodash';
-import {
-  CURRENCY,
-  FEE_RECORD_STATUS,
-  FeeRecordEntityMockBuilder,
-  PaymentEntityMockBuilder,
-  UtilisationReportEntity,
-  UtilisationReportEntityMockBuilder,
-} from '@ukef/dtfs2-common';
+import { CURRENCY, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { mapToFeeRecordsToKey } from './helpers';
+import { aUtilisationReport } from '../../../../../test-helpers';
 
 describe('get-fee-records-to-key.controller helpers', () => {
   describe('mapToFeeRecordsToKey', () => {
@@ -238,11 +232,9 @@ describe('get-fee-records-to-key.controller helpers', () => {
 
       const payments = [PaymentEntityMockBuilder.forCurrency(paymentCurrency).build()];
 
-      const utilisationReport = aUtilisationReport();
-
       const amount = 100;
       const feeRecords = [
-        FeeRecordEntityMockBuilder.forReport(utilisationReport)
+        FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
           .withStatus('MATCH')
           .withFeesPaidToUkefForThePeriod(amount)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -277,11 +269,9 @@ describe('get-fee-records-to-key.controller helpers', () => {
         PaymentEntityMockBuilder.forCurrency(paymentCurrency).withAmount(thirdPaymentAmount).build(),
       ];
 
-      const utilisationReport = aUtilisationReport();
-
       const amount = 100;
       const feeRecords = [
-        FeeRecordEntityMockBuilder.forReport(utilisationReport)
+        FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
           .withStatus('MATCH')
           .withFeesPaidToUkefForThePeriod(amount)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -309,9 +299,5 @@ describe('get-fee-records-to-key.controller helpers', () => {
         amount: thirdPaymentAmount,
       });
     });
-
-    function aUtilisationReport(): UtilisationReportEntity {
-      return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    }
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/filter-fee-record-payment-entity-groups-by-facility-id.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/filter-fee-record-payment-entity-groups-by-facility-id.test.ts
@@ -1,13 +1,7 @@
-import {
-  FeeRecordEntityMockBuilder,
-  PaymentEntity,
-  PaymentEntityMockBuilder,
-  UtilisationReportEntity,
-  UtilisationReportEntityMockBuilder,
-} from '@ukef/dtfs2-common';
+import { FeeRecordEntityMockBuilder, PaymentEntity, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { filterFeeRecordPaymentEntityGroupsByFacilityId } from './filter-fee-record-payment-entity-groups-by-facility-id';
 import { FeeRecordPaymentEntityGroup } from '../../../../../helpers';
-import { getSqlIdGenerator } from '../../../../../../test-helpers';
+import { aUtilisationReport, getSqlIdGenerator } from '../../../../../../test-helpers';
 
 describe('get-utilisation-report-reconciliation-details-by-id.controller helpers', () => {
   describe('filterFeeRecordPaymentEntityGroupsByFacilityId', () => {
@@ -92,9 +86,5 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
       expect(result).not.toContainEqual(secondFeeRecordPaymentGroup);
       expect(result).toContainEqual(anotherFeeRecordPaymentGroup);
     });
-
-    function aUtilisationReport(): UtilisationReportEntity {
-      return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    }
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
@@ -8,10 +8,10 @@ import {
   FeeRecordStatus,
   KEYING_SHEET_ROW_STATUS,
   PaymentEntityMockBuilder,
-  UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
 import { difference } from 'lodash';
 import { getKeyingSheetForReportId } from './get-keying-sheet-for-report-id';
+import { aUtilisationReport } from '../../../../../../test-helpers';
 
 jest.mock('@ukef/dtfs2-common/sql-db-connection', () => ({
   SqlDbDataSource: {
@@ -435,9 +435,5 @@ describe('getKeyingSheetForReportId', () => {
       data.paymentId = payment.id;
     }
     return data;
-  }
-
-  function aUtilisationReport() {
-    return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
   }
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-fee-record-payment-groups.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/map-fee-record-payment-entity-groups-to-fee-record-payment-groups.test.ts
@@ -1,14 +1,7 @@
-import {
-  Currency,
-  FEE_RECORD_STATUS,
-  FeeRecordEntityMockBuilder,
-  FeeRecordStatus,
-  PaymentEntityMockBuilder,
-  UtilisationReportEntity,
-  UtilisationReportEntityMockBuilder,
-} from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, FeeRecordStatus, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { mapFeeRecordPaymentEntityGroupsToFeeRecordPaymentGroups } from './map-fee-record-payment-entity-groups-to-fee-record-payment-groups';
 import { FeeRecordPaymentEntityGroup } from '../../../../../helpers';
+import { aUtilisationReport } from '../../../../../../test-helpers';
 
 describe('get-utilisation-report-reconciliation-details-by-id.controller helpers', () => {
   describe('mapFeeRecordPaymentEntityGroupsToFeeRecordPaymentGroups', () => {
@@ -213,9 +206,5 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         expect(result[0].totalPaymentsReceived).toEqual({ currency: 'GBP', amount: 500 });
       });
     });
-
-    function aUtilisationReport(): UtilisationReportEntity {
-      return UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    }
   });
 });

--- a/dtfs-central-api/test-helpers/test-data/index.ts
+++ b/dtfs-central-api/test-helpers/test-data/index.ts
@@ -10,3 +10,4 @@ export * from './facility';
 export * from './tfm-facility-amendment';
 export * from './tfm-facility';
 export * from './payment-matching-tolerances';
+export * from './utilisation-report';

--- a/dtfs-central-api/test-helpers/test-data/utilisation-report.ts
+++ b/dtfs-central-api/test-helpers/test-data/utilisation-report.ts
@@ -1,0 +1,12 @@
+import { UTILISATION_REPORT_RECONCILIATION_STATUS, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+
+/**
+ * Test helper which returns a utilisation report entity.
+ *
+ * This is to be used when the test just requires a utilisation report but does not care what the values of any fields are.
+ * To build a report for a test where it does matter what the fields are then you should use the entity mock builder directly.
+ *
+ * @returns a utilisation report entity
+ */
+export const aUtilisationReport = (): UtilisationReportEntity =>
+  UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS).build();


### PR DESCRIPTION
## Introduction :pencil2:
It was noted on another PR that there were 14 duplicate definitions for a test helper method.

## Resolution :heavy_check_mark:
Move the `aUtilisationReport` test helper to common place and remove all duplicates.

