### PR TITLE
feat(DTFS2-7346): await send email promises

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/send-deal-decision-email.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-decision-email.js
@@ -44,7 +44,7 @@ const sendDealDecisionEmail = async (mappedDeal) => {
 
   await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, mappedDeal);
   // send a copy of the email to bank's general email address
-  const bankResponse = bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, mappedDeal));
+  const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, mappedDeal)));
   // send a copy of the email to PIM
   await sendTfmEmail(templateId, pimEmail, emailVariables, mappedDeal);
 

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-decision-email.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-decision-email.js
@@ -44,11 +44,11 @@ const sendDealDecisionEmail = async (mappedDeal) => {
 
   await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, mappedDeal);
   // send a copy of the email to bank's general email address
-  const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, mappedDeal)));
+  const bankResponses = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, mappedDeal)));
   // send a copy of the email to PIM
   await sendTfmEmail(templateId, pimEmail, emailVariables, mappedDeal);
 
-  return bankResponse;
+  return bankResponses;
 };
 
 module.exports = sendDealDecisionEmail;

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-gef.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-gef.api-test.js
@@ -44,7 +44,7 @@ describe('send-deal-submit-emails - GEF', () => {
       email: 'mock@testing.com',
       template: {},
     },
-    bankResponse: [],
+    bankResponses: [],
     pimEmailResponse: {
       content: {
         body: {},

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-gef.api-test.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails-gef.api-test.js
@@ -35,7 +35,7 @@ describe('send-deal-submit-emails - GEF', () => {
       email: 'mock@testing.com',
       template: {},
     },
-    bankResponse: [],
+    bankResponses: [],
   };
   const emailAcknowledgementMIA = {
     emailResponse: {

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -62,38 +62,32 @@ const sendMiaAcknowledgement = async (deal) => {
   // get the email address for PIM user
   const { email: pimEmail } = await api.findOneTeam(CONSTANTS.TEAMS.PIM.id);
 
-  let templateId;
-  let emailVariables;
-  let emailResponse;
-  let bankResponse;
-  let pimEmailResponse;
-
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS) {
-    templateId = CONSTANTS.EMAIL_TEMPLATE_IDS.BSS_DEAL_MIA_RECEIVED;
+    const templateId = CONSTANTS.EMAIL_TEMPLATE_IDS.BSS_DEAL_MIA_RECEIVED;
 
-    emailVariables = generateMiaConfirmationEmailVars(deal);
+    const emailVariables = generateMiaConfirmationEmailVars(deal);
 
     // send an email to the maker
-    emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, deal);
+    const emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, deal);
     // send a copy of the email to the bank's general email address
-    bankResponse = bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal));
+    const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
     // send a copy of the email to PIM
-    pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
+    const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
 
     return { emailResponse, bankResponse, pimEmailResponse };
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
-    templateId = CONSTANTS.EMAIL_TEMPLATE_IDS.GEF_DEAL_MIA_RECEIVED;
+    const templateId = CONSTANTS.EMAIL_TEMPLATE_IDS.GEF_DEAL_MIA_RECEIVED;
 
-    emailVariables = generateMiaConfirmationEmailVars(deal);
+    const emailVariables = generateMiaConfirmationEmailVars(deal);
 
     // send an email to the maker
-    emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, deal);
+    const emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, deal);
     // send a copy of the email to the bank's general email address
-    bankResponse = bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal));
+    const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
     // send a copy of the email to PIM
-    pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
+    const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
 
     return { emailResponse, bankResponse, pimEmailResponse };
   }
@@ -148,7 +142,7 @@ const sendAinMinAcknowledgement = async (deal) => {
       // send a copy of the email to PIM
       const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
       // send a copy of the email to the bank's general email address
-      const bankResponse = bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal));
+      const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
       return { makerEmailResponse, pimEmailResponse, bankResponse };
     }
 
@@ -163,7 +157,7 @@ const sendAinMinAcknowledgement = async (deal) => {
       // send a copy of the email to PIM
       const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
       // send a copy of the email to the bank's general email address
-      const bankResponse = bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal));
+      const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
 
       return { makerEmailResponse, pimEmailResponse, bankResponse };
     }

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -70,11 +70,11 @@ const sendMiaAcknowledgement = async (deal) => {
     // send an email to the maker
     const emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, deal);
     // send a copy of the email to the bank's general email address
-    const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
+    const bankResponses = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
     // send a copy of the email to PIM
     const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
 
-    return { emailResponse, bankResponse, pimEmailResponse };
+    return { emailResponse, bankResponse: bankResponses, pimEmailResponse };
   }
 
   if (dealType === CONSTANTS.DEALS.DEAL_TYPE.GEF) {
@@ -85,11 +85,11 @@ const sendMiaAcknowledgement = async (deal) => {
     // send an email to the maker
     const emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables, deal);
     // send a copy of the email to the bank's general email address
-    const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
+    const bankResponses = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
     // send a copy of the email to PIM
     const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
 
-    return { emailResponse, bankResponse, pimEmailResponse };
+    return { emailResponse, bankResponses, pimEmailResponse };
   }
 
   return null;

--- a/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-deal-submit-emails.js
@@ -157,9 +157,9 @@ const sendAinMinAcknowledgement = async (deal) => {
       // send a copy of the email to PIM
       const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
       // send a copy of the email to the bank's general email address
-      const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
+      const bankResponses = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
 
-      return { makerEmailResponse, pimEmailResponse, bankResponse };
+      return { makerEmailResponse, pimEmailResponse, bankResponses };
     }
   } catch (error) {
     console.error('TFM-API - Error sending AIN/MIN acknowledgement email %o', error);

--- a/trade-finance-manager-api/src/v1/controllers/send-issued-facilities-received-email.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-issued-facilities-received-email.js
@@ -50,7 +50,7 @@ const sendIssuedFacilitiesReceivedEmail = async (deal, updatedFacilities) => {
       // send a copy of the email to PIM
       const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
       // send a copy of the email to bank's general email address
-      const bankResponse = bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal));
+      const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
 
       return { makerEmailResponse, pimEmailResponse, bankResponse };
     }

--- a/trade-finance-manager-api/src/v1/controllers/send-issued-facilities-received-email.js
+++ b/trade-finance-manager-api/src/v1/controllers/send-issued-facilities-received-email.js
@@ -50,9 +50,9 @@ const sendIssuedFacilitiesReceivedEmail = async (deal, updatedFacilities) => {
       // send a copy of the email to PIM
       const pimEmailResponse = await sendTfmEmail(templateId, pimEmail, emailVariables, deal);
       // send a copy of the email to bank's general email address
-      const bankResponse = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
+      const bankResponses = await Promise.all(bankEmails.map((email) => sendTfmEmail(templateId, email, emailVariables, deal)));
 
-      return { makerEmailResponse, pimEmailResponse, bankResponse };
+      return { makerEmailResponse, pimEmailResponse, bankResponses };
     }
   } catch (error) {
     console.error('TFM-API Error in sendIssuedFacilitiesReceivedEmail %o', error);


### PR DESCRIPTION
## Introduction :pencil2:
Sending emails to the bank was not being awaited.  This is unlikely to have caused the bug 7346, but it might have done & it should be fixed anyway.

## Resolution :heavy_check_mark:
Use `Promise.all` to await sending the emails


