### PR TITLE
chore(DTFS2-7380): dry cypress commands - keyboardInput - tfm

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/1. add-amendment-request.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/1. add-amendment-request.spec.js
@@ -74,9 +74,9 @@ context('Amendments - Request date', () => {
     facilityPage.facilityTabAmendments().click();
     amendmentsPage.addAmendmentButton().click();
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type('01');
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type('01');
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type('2020');
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), '01');
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), '01');
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '2020');
 
     cy.clickContinueButton();
 
@@ -93,9 +93,9 @@ context('Amendments - Request date', () => {
     facilityPage.facilityTabAmendments().click();
     amendmentsPage.addAmendmentButton().click();
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.threeMonthsDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.threeMonthsMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.threeMonthsYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.threeMonthsDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.threeMonthsMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.threeMonthsYear);
 
     cy.clickContinueButton();
 
@@ -112,36 +112,36 @@ context('Amendments - Request date', () => {
     facilityPage.facilityTabAmendments().click();
     amendmentsPage.addAmendmentButton().click();
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type('22');
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '22');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The year for the amendment request date must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type('2O22');
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '2O22');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The year for the amendment request date must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type('20 22');
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '20 22');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The year for the amendment request date must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type('2 22');
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '2 22');
 
     cy.clickContinueButton();
 
@@ -171,9 +171,9 @@ context('Amendments - Request date', () => {
     facilityPage.facilityTabAmendments().click();
     amendmentsPage.addAmendmentButton().click();
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
 
     cy.clickContinueButton();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/2. amendment-request-approval.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/2. amendment-request-approval.spec.js
@@ -42,9 +42,9 @@ context('Amendments - Request approval', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
   });
@@ -58,9 +58,9 @@ context('Amendments - Request approval', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
     cy.clickContinueButton();
@@ -78,9 +78,9 @@ context('Amendments - Request approval', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
     amendmentsPage.amendmentRequestApprovalYes().click();
@@ -97,9 +97,9 @@ context('Amendments - Request approval', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
     amendmentsPage.amendmentRequestApprovalNo().click();

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/3. amendment-effective-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/3. amendment-effective-date.spec.js
@@ -42,9 +42,9 @@ context('Amendments - Effective date', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -64,9 +64,9 @@ context('Amendments - Effective date', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -91,9 +91,9 @@ context('Amendments - Effective date', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -101,36 +101,36 @@ context('Amendments - Effective date', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type('22');
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), '22');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The year for the effective date must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year for the effective date must include 4 numbers');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type('2O22');
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), '2O22');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The year for the effective date must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year for the effective date must include 4 numbers');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type('20 22');
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), '20 22');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The year for the effective date must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year for the effective date must include 4 numbers');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type('2 22');
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), '2 22');
 
     cy.clickContinueButton();
 
@@ -149,9 +149,9 @@ context('Amendments - Effective date', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -159,9 +159,9 @@ context('Amendments - Effective date', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
 
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-options');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/4. amendment-options.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/4. amendment-options.spec.js
@@ -42,9 +42,9 @@ context('Amendments - Amendment options', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
   });
@@ -58,9 +58,9 @@ context('Amendments - Amendment options', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
     amendmentsPage.amendmentRequestApprovalYes().click();
@@ -81,9 +81,9 @@ context('Amendments - Amendment options', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
     amendmentsPage.amendmentRequestApprovalYes().click();

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/5. facility-value.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/5. facility-value.spec.js
@@ -42,9 +42,9 @@ context('Amendments - Facility value', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -76,7 +76,7 @@ context('Amendments - Facility value', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type(12345);
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), 12345);
     cy.clickContinueButton();
     errorSummary().contains('The new facility value cannot be the same as the current facility value');
   });
@@ -96,7 +96,7 @@ context('Amendments - Facility value', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234A23');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '1234A23');
     cy.clickContinueButton();
     errorSummary().contains('The new facility value must be a number');
   });
@@ -116,7 +116,7 @@ context('Amendments - Facility value', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/6. cover-end-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/6. cover-end-date.spec.js
@@ -44,9 +44,9 @@ context('Amendments - Cover End Date', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -74,33 +74,33 @@ context('Amendments - Cover End Date', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
     amendmentsPage.amendmentCurrentCoverEndDate().should('contain', dateConstants.oneMonthFormattedFull);
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.oneMonthDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.oneMonthMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.oneMonthYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.oneMonthDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.oneMonthMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.oneMonthYear);
     cy.clickContinueButton();
     errorSummary().contains('The new cover end date cannot be the same as the current cover end date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(20);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(10);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(22);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), 20);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), 10);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), 22);
     cy.clickContinueButton();
     errorSummary().contains('The year for the amendment cover end date must include 4 numbers');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(20);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(10);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type('2O22');
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), 20);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), 10);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), '2O22');
     cy.clickContinueButton();
     errorSummary().contains('The year for the amendment cover end date must include 4 numbers');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(20);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(10);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type('20 22');
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), 20);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), 10);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), '20 22');
     cy.clickContinueButton();
     errorSummary().contains('The year for the amendment cover end date must include 4 numbers');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(20);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(10);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type('2 22');
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), 20);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), 10);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), '2 22');
     cy.clickContinueButton();
     errorSummary().contains('The year for the amendment cover end date must include 4 numbers');
   });
@@ -115,9 +115,9 @@ context('Amendments - Cover End Date', () => {
     cy.url().should('contain', 'amendment-options');
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'check-answers');
@@ -138,9 +138,9 @@ context('Amendments - Cover End Date', () => {
     amendmentsPage.amendmentFacilityValueCheckbox().click();
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/7. amendment-details-automatic-approval.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/7. amendment-details-automatic-approval.spec.js
@@ -78,45 +78,45 @@ context('Amendments - automatic approval journey', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type('22');
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '22');
 
       cy.clickContinueButton();
 
       errorSummary().contains('The year for the amendment request date must include 4 numbers');
       amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type('2O22');
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '2O22');
 
       cy.clickContinueButton();
 
       errorSummary().contains('The year for the amendment request date must include 4 numbers');
       amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type('20 22');
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '20 22');
 
       cy.clickContinueButton();
 
       errorSummary().contains('The year for the amendment request date must include 4 numbers');
       amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type('2 22');
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), '2 22');
 
       cy.clickContinueButton();
 
       errorSummary().contains('The year for the amendment request date must include 4 numbers');
       amendmentsPage.errorMessage().contains('The year for the amendment request date must include 4 numbers');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -125,27 +125,27 @@ context('Amendments - automatic approval journey', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'amendment-effective-date');
 
-      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type('22');
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), '22');
 
       cy.clickContinueButton();
 
       errorSummary().contains('The year for the effective date must include 4 numbers');
       amendmentsPage.errorMessage().contains('The year for the effective date must include 4 numbers');
 
-      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type('2O22');
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), '2O22');
 
       cy.clickContinueButton();
 
       errorSummary().contains('The year for the effective date must include 4 numbers');
       amendmentsPage.errorMessage().contains('The year for the effective date must include 4 numbers');
 
-      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.fourDaysAgoDay);
-      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.fourDaysAgoMonth);
-      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.fourDaysAgoYear);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.fourDaysAgoDay);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.fourDaysAgoMonth);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.fourDaysAgoYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'amendment-options');
@@ -160,13 +160,13 @@ context('Amendments - automatic approval journey', () => {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'cover-end-date');
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.twoMonthsDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.twoMonthsMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.twoMonthsYear);
       cy.clickContinueButton();
       cy.url().should('contain', 'facility-value');
       amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-      amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+      cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');
@@ -304,9 +304,9 @@ context('Amendments - automatic approval journey', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -315,9 +315,9 @@ context('Amendments - automatic approval journey', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'amendment-effective-date');
 
-      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.fourDaysAgoDay);
-      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.fourDaysAgoMonth);
-      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.fourDaysAgoYear);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.fourDaysAgoDay);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.fourDaysAgoMonth);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.fourDaysAgoYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'amendment-options');
@@ -331,9 +331,9 @@ context('Amendments - automatic approval journey', () => {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'cover-end-date');
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.twoMonthsDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.twoMonthsMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.twoMonthsYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'check-answers');
@@ -466,9 +466,9 @@ context('Amendments - automatic approval journey', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -477,9 +477,9 @@ context('Amendments - automatic approval journey', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'amendment-effective-date');
 
-      amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.fourDaysAgoDay);
-      amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.fourDaysAgoMonth);
-      amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.fourDaysAgoYear);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.fourDaysAgoDay);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.fourDaysAgoMonth);
+      cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.fourDaysAgoYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'amendment-options');
@@ -494,7 +494,7 @@ context('Amendments - automatic approval journey', () => {
 
       cy.url().should('contain', 'facility-value');
       amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-      amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+      cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/8. amendment-details-manual-approval.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/8. amendment-details-manual-approval.spec.js
@@ -78,9 +78,9 @@ context('Amendments - Manual approval journey', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -100,14 +100,14 @@ context('Amendments - Manual approval journey', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'cover-end-date');
 
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-value');
       amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-      amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+      cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');
@@ -243,9 +243,9 @@ context('Amendments - Manual approval journey', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -264,9 +264,9 @@ context('Amendments - Manual approval journey', () => {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'cover-end-date');
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');
     });
@@ -397,9 +397,9 @@ context('Amendments - Manual approval journey', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -419,7 +419,7 @@ context('Amendments - Manual approval journey', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'facility-value');
       amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-      amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+      cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-amendment-request-check-previous.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-amendment-request-check-previous.spec.js
@@ -42,9 +42,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -54,9 +54,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
 
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'amendment-options');
@@ -71,14 +71,14 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.tomorrowMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.tomorrowYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.tomorrowMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.tomorrowYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
 
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
     cy.clickContinueButton();
 
     cy.url().should('contain', 'check-answers');
@@ -96,9 +96,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -118,28 +118,28 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.tomorrowMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.tomorrowYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.tomorrowMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.tomorrowYear);
     cy.clickContinueButton();
 
     errorSummary().contains('The new cover end date cannot be the same as the current cover end date');
     amendmentsPage.errorMessage().contains('The new cover end date cannot be the same as the current cover end date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeDaysDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeDaysMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeDaysYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.threeDaysDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.threeDaysMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.threeDaysYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The new facility value cannot be the same as the current facility value');
     amendmentsPage.errorMessage().contains('The new facility value cannot be the same as the current facility value');
 
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '1234');
 
     cy.clickContinueButton();
 
@@ -163,9 +163,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions');
 
-    amendmentsPage.amendmentsManagersDecisionConditions().clear().focused().type('This is a list of conditions');
-    amendmentsPage.amendmentsManagersDecisionReasons().clear().focused().type('This is the reason for declining the amendment');
-    amendmentsPage.amendmentsManagersDecisionComments().clear().focused().type('This is a comment visible only to UKEF staff');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionConditions(), 'This is a list of conditions');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionReasons(), 'This is the reason for declining the amendment');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionComments(), 'This is a comment visible only to UKEF staff');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');
@@ -183,15 +183,15 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/received-date');
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');
@@ -209,9 +209,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -231,20 +231,20 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeYearsDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeYearsMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeYearsYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.threeYearsDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.threeYearsMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.threeYearsYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '1234');
 
     cy.clickContinueButton();
 
     errorSummary().contains('The new facility value cannot be the same as the current facility value');
     amendmentsPage.errorMessage().contains('The new facility value cannot be the same as the current facility value');
 
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('12345');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '12345');
 
     cy.clickContinueButton();
 
@@ -268,8 +268,8 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions');
 
-    amendmentsPage.amendmentsManagersDecisionConditions().clear().focused().type('This is a list of conditions');
-    amendmentsPage.amendmentsManagersDecisionComments().clear().focused().type('This is a comment visible only to UKEF staff');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionConditions(), 'This is a list of conditions');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionComments(), 'This is a comment visible only to UKEF staff');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');
@@ -287,9 +287,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/received-date');
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');
@@ -307,9 +307,9 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -329,14 +329,14 @@ context('Amendments - should not allow amendments to have same coverEndDate/valu
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeDaysDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeDaysMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeDaysYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.threeDaysDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.threeDaysMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.threeDaysYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
 
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '1234');
 
     cy.clickContinueButton();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-proceed.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-proceed.spec.js
@@ -88,9 +88,9 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -110,14 +110,14 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(tomorrowMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(tomorrowYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), tomorrowMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), tomorrowYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -185,9 +185,9 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions');
 
-    amendmentsPage.amendmentsManagersDecisionConditions().clear().focused().type('This is a list of conditions');
-    amendmentsPage.amendmentsManagersDecisionReasons().clear().focused().type('This is the reason for declining the amendment');
-    amendmentsPage.amendmentsManagersDecisionComments().clear().focused().type('This is a comment visible only to UKEF staff');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionConditions(), 'This is a list of conditions');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionReasons(), 'This is the reason for declining the amendment');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionComments(), 'This is a comment visible only to UKEF staff');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');
@@ -280,44 +280,44 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     errorSummary().contains("Enter the date UKEF received the bank's decision");
     amendmentsPage.errorMessage().contains("Enter the date UKEF received the bank's decision");
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains("Enter the date UKEF received the bank's decision");
     amendmentsPage.errorMessage().contains("Enter the date UKEF received the bank's decision");
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '22');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2O22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2O22');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2 022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2 022');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2 22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2 22');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
@@ -334,9 +334,9 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
@@ -360,26 +360,26 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     errorSummary().contains('Enter the date the amendment will be effective from');
     amendmentsPage.errorMessage().contains('Enter the date the amendment will be effective from');
 
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
     errorSummary().contains('Enter the date the amendment will be effective from');
     amendmentsPage.errorMessage().contains('Enter the date the amendment will be effective from');
 
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '22');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('2O22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2O22');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
@@ -398,9 +398,9 @@ context('Amendments underwriting - add banks decision - proceed', () => {
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/effective-date');
 
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-underwriter-declined.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-underwriter-declined.spec.js
@@ -45,9 +45,9 @@ context('Amendments underwriting - add banks decision - declined by underwriter'
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -67,14 +67,14 @@ context('Amendments underwriting - add banks decision - declined by underwriter'
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -141,8 +141,8 @@ context('Amendments underwriting - add banks decision - declined by underwriter'
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions');
 
-    amendmentsPage.amendmentsManagersDecisionReasons().clear().focused().type('This is the reason for declining the amendment');
-    amendmentsPage.amendmentsManagersDecisionComments().clear().focused().type('This is a comment visible only to UKEF staff');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionReasons(), 'This is the reason for declining the amendment');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionComments(), 'This is a comment visible only to UKEF staff');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-withdraw.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision-withdraw.spec.js
@@ -45,9 +45,9 @@ context('Amendments underwriting - add banks decision - withdraw', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -67,14 +67,14 @@ context('Amendments underwriting - add banks decision - withdraw', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -142,9 +142,9 @@ context('Amendments underwriting - add banks decision - withdraw', () => {
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions');
 
-    amendmentsPage.amendmentsManagersDecisionConditions().clear().focused().type('This is a list of conditions');
-    amendmentsPage.amendmentsManagersDecisionReasons().clear().focused().type('This is the reason for declining the amendment');
-    amendmentsPage.amendmentsManagersDecisionComments().clear().focused().type('This is a comment visible only to UKEF staff');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionConditions(), 'This is a list of conditions');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionReasons(), 'This is the reason for declining the amendment');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionComments(), 'This is a comment visible only to UKEF staff');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');
@@ -185,36 +185,36 @@ context('Amendments underwriting - add banks decision - withdraw', () => {
     amendmentsPage.amendmentBankDecisionReceivedDateHeading().contains('What date did UKEF receive the bank’s decision?');
     amendmentsPage.amendmentBankDecisionReceivedDateHint().contains('For example, 31 3 1980');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '22');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2 022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2 022');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2 22');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2 22');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/received-date');
     errorSummary().contains('The year must include 4 numbers');
     amendmentsPage.errorMessage().contains('The year must include 4 numbers');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/banks-decision/check-answers');
@@ -345,9 +345,9 @@ context('Amendments underwriting - add banks decision - change from proceed to w
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -367,14 +367,14 @@ context('Amendments underwriting - add banks decision - change from proceed to w
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -442,9 +442,9 @@ context('Amendments underwriting - add banks decision - change from proceed to w
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions');
 
-    amendmentsPage.amendmentsManagersDecisionConditions().clear().focused().type('This is a list of conditions');
-    amendmentsPage.amendmentsManagersDecisionReasons().clear().focused().type('This is the reason for declining the amendment');
-    amendmentsPage.amendmentsManagersDecisionComments().clear().focused().type('This is a comment visible only to UKEF staff');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionConditions(), 'This is a list of conditions');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionReasons(), 'This is the reason for declining the amendment');
+    cy.keyboardInput(amendmentsPage.amendmentsManagersDecisionComments(), 'This is a comment visible only to UKEF staff');
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');
@@ -473,15 +473,15 @@ context('Amendments underwriting - add banks decision - change from proceed to w
 
     cy.url().should('contain', '/banks-decision/received-date');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-lead-underwriter.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-lead-underwriter.spec.js
@@ -46,9 +46,9 @@ context('Amendments underwriting - add lead underwriter', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -68,14 +68,14 @@ context('Amendments underwriting - add lead underwriter', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'cover-end-date');
 
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-value');
       amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-      amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+      cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-underwriter-decision.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-underwriter-decision.spec.js
@@ -47,9 +47,9 @@ context('Amendments underwriting - add underwriter decision', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -69,14 +69,14 @@ context('Amendments underwriting - add underwriter decision', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -210,25 +210,20 @@ context('Amendments underwriting - add underwriter decision', () => {
     amendmentsPage.amendmentDetails.row(1).ukefDecisionFacilityValue().should('contain', UNDERWRITER_MANAGER_DECISIONS.APPROVED_WITH_CONDITIONS);
     amendmentsPage.amendmentDetails.row(1).ukefDecisionFacilityValue().should('have.class', 'govuk-tag--green');
 
-    amendmentsPage
-      .amendmentsManagersDecisionConditions()
-      .clear()
-      .focused()
-      .type(
-        'This is a list of conditions <script>(\'hello world\')</script> <embed type="text/html" src="snippet.html" width="500" height="200"> <h1>html text </h1>',
-      );
-    amendmentsPage
-      .amendmentsManagersDecisionReasons()
-      .clear()
-      .focused()
-      .type(
-        'This is the reason for declining the amendment <img src=x onerror=console.log(\'img\')/> <object data="snippet.html" width="500" height="200"></object><h1>html text </h1>',
-      );
-    amendmentsPage
-      .amendmentsManagersDecisionComments()
-      .clear()
-      .focused()
-      .type('This is a comment visible only to UKEF staff <input type="text" name="state" value="INPUT_FROM_USER"> <h1>html text </h1>');
+    cy.keyboardInput(
+      amendmentsPage.amendmentsManagersDecisionConditions(),
+      'This is a list of conditions <script>(\'hello world\')</script> <embed type="text/html" src="snippet.html" width="500" height="200"> <h1>html text </h1>',
+    );
+
+    cy.keyboardInput(
+      amendmentsPage.amendmentsManagersDecisionReasons(),
+      'This is the reason for declining the amendment <img src=x onerror=console.log(\'img\')/> <object data="snippet.html" width="500" height="200"></object><h1>html text </h1>',
+    );
+
+    cy.keyboardInput(
+      amendmentsPage.amendmentsManagersDecisionComments(),
+      'This is a comment visible only to UKEF staff <input type="text" name="state" value="INPUT_FROM_USER"> <h1>html text </h1>',
+    );
 
     cy.clickContinueButton();
     cy.url().should('contain', '/managers-conditions/summary');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-changes-multiple-single-amendments.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-changes-multiple-single-amendments.spec.js
@@ -41,9 +41,9 @@ context('Amendments changes displayed - multiple single change amendments', () =
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -52,9 +52,9 @@ context('Amendments changes displayed - multiple single change amendments', () =
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-options');
 
@@ -66,9 +66,9 @@ context('Amendments changes displayed - multiple single change amendments', () =
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.twoMonthsDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.twoMonthsMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.twoMonthsYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.twoMonthsDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.twoMonthsMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.twoMonthsYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'check-answers');
@@ -86,9 +86,9 @@ context('Amendments changes displayed - multiple single change amendments', () =
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -97,9 +97,9 @@ context('Amendments changes displayed - multiple single change amendments', () =
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-options');
 
@@ -112,7 +112,7 @@ context('Amendments changes displayed - multiple single change amendments', () =
     cy.url().should('contain', 'facility-value');
 
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
     cy.clickContinueButton();

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-in-progress-deal-stage.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-in-progress-deal-stage.spec.js
@@ -101,9 +101,9 @@ context('Amendments deal stage - amendment in progress and in progress amendment
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -123,14 +123,14 @@ context('Amendments deal stage - amendment in progress and in progress amendment
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -148,9 +148,9 @@ context('Amendments deal stage - amendment in progress and in progress amendment
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -167,7 +167,7 @@ context('Amendments deal stage - amendment in progress and in progress amendment
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-should-change-all-facilities-values.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-should-change-all-facilities-values.spec.js
@@ -52,9 +52,9 @@ context('Amendments all facilities table - should show amendment value and cover
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -63,9 +63,9 @@ context('Amendments all facilities table - should show amendment value and cover
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-options');
 
@@ -77,9 +77,9 @@ context('Amendments all facilities table - should show amendment value and cover
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.tomorrowMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.tomorrowYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.tomorrowMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.tomorrowYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'check-answers');
@@ -97,9 +97,9 @@ context('Amendments all facilities table - should show amendment value and cover
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'request-approval');
 
@@ -108,9 +108,9 @@ context('Amendments all facilities table - should show amendment value and cover
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
     cy.url().should('contain', 'amendment-options');
 
@@ -123,7 +123,7 @@ context('Amendments all facilities table - should show amendment value and cover
     cy.url().should('contain', 'facility-value');
 
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
     cy.clickContinueButton();

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-tasks-automatic.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-tasks-automatic.spec.js
@@ -49,9 +49,9 @@ context('Amendments tasks - automatic amendment tasks', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -61,9 +61,9 @@ context('Amendments tasks - automatic amendment tasks', () => {
 
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'amendment-options');
@@ -78,14 +78,14 @@ context('Amendments tasks - automatic amendment tasks', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-tasks-manual.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-tasks-manual.spec.js
@@ -76,9 +76,9 @@ context('Amendments tasks - manual amendment tasks', () => {
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -98,14 +98,14 @@ context('Amendments tasks - manual amendment tasks', () => {
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-underwriting-page-multiple-amendments.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendment-underwriting-page-multiple-amendments.spec.js
@@ -42,9 +42,9 @@ context('Amendments underwriting page - multiple amendments should show without 
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -54,9 +54,9 @@ context('Amendments underwriting page - multiple amendments should show without 
 
     cy.url().should('contain', 'amendment-effective-date');
 
-    amendmentsPage.amendmentEffectiveDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentEffectiveMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentEffectiveYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'amendment-options');
@@ -71,14 +71,14 @@ context('Amendments underwriting page - multiple amendments should show without 
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -96,9 +96,9 @@ context('Amendments underwriting page - multiple amendments should show without 
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -118,13 +118,13 @@ context('Amendments underwriting page - multiple amendments should show without 
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeMonthsDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeMonthsMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeMonthsYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.threeMonthsDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.threeMonthsMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.threeMonthsYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '1234');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -142,9 +142,9 @@ context('Amendments underwriting page - multiple amendments should show without 
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -159,7 +159,7 @@ context('Amendments underwriting page - multiple amendments should show without 
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('12345');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '12345');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendments-version-order.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/amendments-version-order.spec.js
@@ -42,9 +42,9 @@ context('Amendments underwriting - amendments should be in correct order of vers
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -64,14 +64,14 @@ context('Amendments underwriting - amendments should be in correct order of vers
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
     amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -118,16 +118,16 @@ context('Amendments underwriting - amendments should be in correct order of vers
 
     cy.url().should('contain', '/banks-decision/received-date');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
 
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');
@@ -157,9 +157,9 @@ context('Amendments underwriting - amendments should be in correct order of vers
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -179,13 +179,13 @@ context('Amendments underwriting - amendments should be in correct order of vers
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeMonthsDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeMonthsMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeMonthsYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.threeMonthsDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.threeMonthsMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.threeMonthsYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('1234');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '1234');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -228,9 +228,9 @@ context('Amendments underwriting - amendments should be in correct order of vers
 
     cy.url().should('contain', '/banks-decision/received-date');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');
@@ -264,9 +264,9 @@ context('Amendments underwriting - amendments should be in correct order of vers
     amendmentsPage.addAmendmentButton().click();
     cy.url().should('contain', 'request-date');
 
-    amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -286,13 +286,13 @@ context('Amendments underwriting - amendments should be in correct order of vers
     cy.clickContinueButton();
     cy.url().should('contain', 'cover-end-date');
 
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.threeYearsDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.threeYearsMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.threeYearsYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.threeYearsDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.threeYearsMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.threeYearsYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'facility-value');
-    amendmentsPage.amendmentFacilityValueInput().clear().focused().type('12345');
+    cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '12345');
 
     cy.clickContinueButton();
     cy.url().should('contain', 'check-answers');
@@ -335,16 +335,16 @@ context('Amendments underwriting - amendments should be in correct order of vers
 
     cy.url().should('contain', '/banks-decision/received-date');
 
-    amendmentsPage.amendmentBankDecisionReceivedDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionReceivedDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionReceivedDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionReceivedDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/effective-date');
 
-    amendmentsPage.amendmentBankDecisionEffectiveDateDay().clear().focused().type('05');
-    amendmentsPage.amendmentBankDecisionEffectiveDateMonth().clear().focused().type('06');
-    amendmentsPage.amendmentBankDecisionEffectiveDateYear().clear().focused().type('2022');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateDay(), '05');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateMonth(), '06');
+    cy.keyboardInput(amendmentsPage.amendmentBankDecisionEffectiveDateYear(), '2022');
     cy.clickContinueButton();
 
     cy.url().should('contain', '/banks-decision/check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/bss-deal-expect-no-facility-end-date-features.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/bss-deal-expect-no-facility-end-date-features.spec.js
@@ -49,9 +49,9 @@ context('Amendments - BSS/EWCS deal does not display any Facility end date pages
     amendmentsPage.addAmendmentButton().click();
 
     cy.url().should('contain', 'request-date');
-    amendmentsPage.amendmentRequestDayInput().clear().type(dateConstants.todayDay);
-    amendmentsPage.amendmentRequestMonthInput().clear().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentRequestYearInput().clear().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'request-approval');
@@ -63,9 +63,9 @@ context('Amendments - BSS/EWCS deal does not display any Facility end date pages
     cy.clickContinueButton();
 
     cy.url().should('contain', 'cover-end-date');
-    amendmentsPage.amendmentCoverEndDateDayInput().clear().type(dateConstants.todayDay);
-    amendmentsPage.amendmentCoverEndDateMonthInput().clear().type(dateConstants.todayMonth);
-    amendmentsPage.amendmentCoverEndDateYearInput().clear().type(dateConstants.todayYear);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.todayDay);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+    cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
     cy.clickContinueButton();
 
     cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-disabled/gef-deal-expect-no-facility-end-date-features.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-disabled/gef-deal-expect-no-facility-end-date-features.spec.js
@@ -55,9 +55,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'false') {
       amendmentsPage.addAmendmentButton().click();
 
       cy.url().should('contain', 'request-date');
-      amendmentsPage.amendmentRequestDayInput().clear().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -69,9 +69,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'false') {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'cover-end-date');
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().type(dateConstants.todayDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-add-bank-review-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-add-bank-review-date.spec.js
@@ -78,9 +78,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         cy.clickContinueButton();
         cy.url().should('contain', 'bank-review-date');
 
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(dateConstants.sixYearsOneDayDay);
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(dateConstants.sixYearsOneDayMonth);
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(dateConstants.sixYearsOneDayYear);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), dateConstants.sixYearsOneDayDay);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), dateConstants.sixYearsOneDayMonth);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), dateConstants.sixYearsOneDayYear);
 
         cy.clickContinueButton();
       });
@@ -96,9 +96,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         cy.clickContinueButton();
 
         cy.url().should('contain', 'bank-review-date');
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(dateConstants.todayDay);
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(dateConstants.todayMonth);
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), dateConstants.todayDay);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), dateConstants.todayMonth);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), dateConstants.todayYear);
         cy.clickContinueButton();
       });
 
@@ -113,9 +113,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         cy.clickContinueButton();
 
         cy.url().should('contain', 'bank-review-date');
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(dateConstants.todayDay);
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(dateConstants.todayMonth);
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), dateConstants.todayDay);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), dateConstants.todayMonth);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), dateConstants.todayYear);
         cy.clickContinueButton();
       });
 
@@ -142,9 +142,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         amendmentsPage.amendmentAnswerBankReviewDateChangeLink().click();
 
         cy.url().should('contain', 'bank-review-date');
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(dateConstants.threeMonthsOneDayDay);
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(dateConstants.threeMonthsOneDayMonth);
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
 
         cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-add-facility-end-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-add-facility-end-date.spec.js
@@ -73,9 +73,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-end-date');
-      amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(dateConstants.sixYearsOneDayDay);
-      amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(dateConstants.sixYearsOneDayMonth);
-      amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(dateConstants.sixYearsOneDayYear);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), dateConstants.sixYearsOneDayDay);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), dateConstants.sixYearsOneDayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), dateConstants.sixYearsOneDayYear);
 
       cy.clickContinueButton();
       errorSummary().contains('Facility end date cannot be greater than 6 years in the future');
@@ -86,9 +86,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-end-date');
-      amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(dateConstants.todayDay);
-      amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-value');
@@ -99,9 +99,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-end-date');
-      amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(dateConstants.todayDay);
-      amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'check-answers');
@@ -121,9 +121,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
       amendmentsPage.amendmentAnswerFacilityEndDateChangeLink().click();
 
       cy.url().should('contain', 'facility-end-date');
-      amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(dateConstants.threeMonthsOneDayDay);
-      amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(dateConstants.threeMonthsOneDayMonth);
-      amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), dateConstants.threeMonthsOneDayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-add-multiple-amendments-impacting-facility-end-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-add-multiple-amendments-impacting-facility-end-date.spec.js
@@ -73,9 +73,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         amendmentsPage.amendmentCurrentBankReviewDate().should('have.text', format(Date1, currentDateFormat));
         amendmentsPage.amendmentBankReviewDateDetails().should('exist');
 
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(format(Date2, 'd'));
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(format(Date2, 'M'));
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(format(Date2, 'yyyy'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), format(Date2, 'd'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), format(Date2, 'M'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), format(Date2, 'yyyy'));
         cy.clickContinueButton();
       });
 
@@ -104,9 +104,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         amendmentsPage.amendmentCurrentBankReviewDate().should('have.text', format(Date2, currentDateFormat));
         amendmentsPage.amendmentBankReviewDateDetails().should('exist');
 
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(format(Date3, 'd'));
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(format(Date3, 'M'));
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(format(Date3, 'yyyy'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), format(Date3, 'd'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), format(Date3, 'M'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), format(Date3, 'yyyy'));
         cy.clickContinueButton();
       });
 
@@ -135,9 +135,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         amendmentsPage.amendmentCurrentFacilityEndDate().should('have.text', 'Not provided');
         amendmentsPage.amendmentFacilityEndDateDetails().should('exist');
 
-        amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(format(Date4, 'd'));
-        amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(format(Date4, 'M'));
-        amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(format(Date4, 'yyyy'));
+        cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), format(Date4, 'd'));
+        cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), format(Date4, 'M'));
+        cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), format(Date4, 'yyyy'));
         cy.clickContinueButton();
       });
 
@@ -166,9 +166,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         // There should no longer be a current bank review date value, as the last amendment had a facility end date.
         // We reset it to bank review date here.
         amendmentsPage.amendmentCurrentBankReviewDate().should('have.text', 'Not provided');
-        amendmentsPage.amendmentBankReviewDateDayInput().clear().type(format(Date5, 'd'));
-        amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(format(Date5, 'M'));
-        amendmentsPage.amendmentBankReviewDateYearInput().clear().type(format(Date5, 'yyyy'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), format(Date5, 'd'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), format(Date5, 'M'));
+        cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), format(Date5, 'yyyy'));
         cy.clickContinueButton();
 
         cy.url().should('contain', 'check-answers');
@@ -181,9 +181,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         amendmentsPage.amendmentCurrentFacilityEndDate().should('have.text', format(Date4, DATE_FORMATS.FULL));
         amendmentsPage.amendmentFacilityEndDateDetails().should('exist');
 
-        amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(format(Date5, 'd'));
-        amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(format(Date5, 'M'));
-        amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(format(Date5, 'yyyy'));
+        cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), format(Date5, 'd'));
+        cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), format(Date5, 'M'));
+        cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), format(Date5, 'yyyy'));
         cy.clickContinueButton();
       });
 
@@ -208,9 +208,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         amendmentsPage.addAmendmentButton().click();
 
         cy.url().should('contain', 'request-date');
-        amendmentsPage.amendmentRequestDayInput().clear().type(todayDay);
-        amendmentsPage.amendmentRequestMonthInput().clear().type(todayMonth);
-        amendmentsPage.amendmentRequestYearInput().clear().type(todayYear);
+        cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), todayDay);
+        cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), todayMonth);
+        cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), todayYear);
         cy.clickContinueButton();
 
         cy.url().should('contain', 'request-approval');
@@ -218,9 +218,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         cy.clickContinueButton();
 
         cy.url().should('contain', 'amendment-effective-date');
-        amendmentsPage.amendmentEffectiveDayInput().clear().type(todayDay);
-        amendmentsPage.amendmentEffectiveMonthInput().clear().type(todayMonth);
-        amendmentsPage.amendmentEffectiveYearInput().clear().type(todayYear);
+        cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), todayDay);
+        cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), todayMonth);
+        cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), todayYear);
         cy.clickContinueButton();
 
         cy.url().should('contain', 'amendment-options');
@@ -228,7 +228,7 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
         cy.clickContinueButton();
 
         cy.url().should('contain', 'facility-value');
-        amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+        cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
         cy.clickContinueButton();
       });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-amend-facility-end-date-and-then-change-to-bank-review-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/gef-deal-amend-facility-end-date-and-then-change-to-bank-review-date.spec.js
@@ -63,9 +63,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
       amendmentsPage.amendmentCurrentFacilityEndDate().should('have.text', '01 January 2023');
       amendmentsPage.amendmentFacilityEndDateDetails().should('exist');
 
-      amendmentsPage.amendmentFacilityEndDateDayInput().clear().type(dateConstants.todayDay);
-      amendmentsPage.amendmentFacilityEndDateMonthInput().clear().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentFacilityEndDateYearInput().clear().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentFacilityEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'check-answers');
@@ -81,9 +81,9 @@ if (Cypress.env('FF_TFM_FACILITY_END_DATE_ENABLED') === 'true') {
       amendmentsPage.amendmentCurrentBankReviewDate().should('have.text', 'Not provided');
       amendmentsPage.amendmentBankReviewDateDetails().should('exist');
 
-      amendmentsPage.amendmentBankReviewDateDayInput().clear().type(dateConstants.threeMonthsOneDayDay);
-      amendmentsPage.amendmentBankReviewDateMonthInput().clear().type(dateConstants.threeMonthsOneDayMonth);
-      amendmentsPage.amendmentBankReviewDateYearInput().clear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(amendmentsPage.amendmentBankReviewDateDayInput(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(amendmentsPage.amendmentBankReviewDateMonthInput(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentBankReviewDateYearInput(), dateConstants.threeMonthsOneDayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/underwriting-page-unassigned.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-amendments/underwriting-page-unassigned.spec.js
@@ -50,9 +50,9 @@ context('Amendments underwriting page', () => {
       amendmentsPage.addAmendmentButton().click();
       cy.url().should('contain', 'request-date');
 
-      amendmentsPage.amendmentRequestDayInput().clear().focused().type(dateConstants.todayDay);
-      amendmentsPage.amendmentRequestMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentRequestYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), dateConstants.todayDay);
+      cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'request-approval');
@@ -72,14 +72,14 @@ context('Amendments underwriting page', () => {
       cy.clickContinueButton();
       cy.url().should('contain', 'cover-end-date');
 
-      amendmentsPage.amendmentCoverEndDateDayInput().clear().focused().type(dateConstants.tomorrowDay);
-      amendmentsPage.amendmentCoverEndDateMonthInput().clear().focused().type(dateConstants.todayMonth);
-      amendmentsPage.amendmentCoverEndDateYearInput().clear().focused().type(dateConstants.todayYear);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), dateConstants.tomorrowDay);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), dateConstants.todayMonth);
+      cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), dateConstants.todayYear);
       cy.clickContinueButton();
 
       cy.url().should('contain', 'facility-value');
       amendmentsPage.amendmentCurrentFacilityValue().should('contain', '12,345.00');
-      amendmentsPage.amendmentFacilityValueInput().clear().focused().type('123');
+      cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
 
       cy.clickContinueButton();
       cy.url().should('contain', 'check-answers');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/loss-given-default.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/loss-given-default.spec.js
@@ -70,14 +70,14 @@ context('Case Underwriting - Pricing and risk - Loss Given Default', () => {
     });
 
     it('should return to pricing & risk page without updating value if cancel', () => {
-      pages.underwritingLossGivenDefaultPage.lossGivenDefaultInput().clear().type('45');
+      cy.keyboardInput(pages.underwritingLossGivenDefaultPage.lossGivenDefaultInput(), '45');
       pages.underwritingLossGivenDefaultPage.closeLink().click();
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
       cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableLossGivenDefault(), '50%');
     });
 
     it('should update LGD', () => {
-      pages.underwritingLossGivenDefaultPage.lossGivenDefaultInput().clear().type('45');
+      cy.keyboardInput(pages.underwritingLossGivenDefaultPage.lossGivenDefaultInput(), '45');
       cy.clickSubmitButton();
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
       cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableLossGivenDefault(), '45%');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/pricing-and-risk.spec.js
@@ -105,7 +105,7 @@ context('Case Underwriting - Pricing and risk', () => {
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('be.visible');
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('have.value', '');
-      pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().type('abc1');
+      cy.keyboardInput(pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther(), 'abc1');
       cy.clickSubmitButton();
 
       errorSummaryItems().should('have.length', 1);
@@ -153,7 +153,7 @@ context('Case Underwriting - Pricing and risk', () => {
       pages.underwritingPricingAndRiskEditPage.creditRatingRadioInputOther().click();
       pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().should('have.value', '');
 
-      pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther().type(MOCK_CREDIT_RATING_TEXT_INPUT_VALUE);
+      cy.keyboardInput(pages.underwritingPricingAndRiskEditPage.creditRatingTextInputOther(), MOCK_CREDIT_RATING_TEXT_INPUT_VALUE);
       cy.clickSubmitButton();
 
       cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableRatingValue(), MOCK_CREDIT_RATING_TEXT_INPUT_VALUE);

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/probability-of-default.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/probability-of-default.spec.js
@@ -71,41 +71,41 @@ context('Case Underwriting - Pricing and risk - Probability of default', () => {
     });
 
     it('should return to pricing & risk page without updating value if cancel', () => {
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('45');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), '45');
       pages.underwritingProbabilityOfDefaultPage.closeLink().click();
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));
       cy.assertText(pages.underwritingPricingAndRiskPage.exporterTableProbabilityOfDefault(), 'Less than 14.1%');
     });
 
     it('should display validation error if value is not a number, below 0.01, above 14.09 or more than 2 decimal places', () => {
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('15');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), '15');
       cy.clickSubmitButton();
       errorSummary().contains('You must enter a percentage between 0.01% to 14.09%');
       pages.underwritingProbabilityOfDefaultPage.errorMessage().contains('You must enter a percentage between 0.01% to 14.09%');
 
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('14.1');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), '14.1');
       cy.clickSubmitButton();
       errorSummary().contains('You must enter a percentage between 0.01% to 14.09%');
       pages.underwritingProbabilityOfDefaultPage.errorMessage().contains('You must enter a percentage between 0.01% to 14.09%');
 
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('12.123');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), '12.123');
       cy.clickSubmitButton();
       errorSummary().contains('You must enter a percentage between 0.01% to 14.09%');
       pages.underwritingProbabilityOfDefaultPage.errorMessage().contains('You must enter a percentage between 0.01% to 14.09%');
 
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('0');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), '0');
       cy.clickSubmitButton();
       errorSummary().contains('You must enter a percentage between 0.01% to 14.09%');
       pages.underwritingProbabilityOfDefaultPage.errorMessage().contains('You must enter a percentage between 0.01% to 14.09%');
 
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('abc');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), 'abc');
       cy.clickSubmitButton();
       errorSummary().contains('You must enter a percentage between 0.01% to 14.09%');
       pages.underwritingProbabilityOfDefaultPage.errorMessage().contains('You must enter a percentage between 0.01% to 14.09%');
     });
 
     it('should update Probability of default if between 0.01 and 14.09', () => {
-      pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput().clear().type('10.5');
+      cy.keyboardInput(pages.underwritingProbabilityOfDefaultPage.probabilityOfDefaultInput(), '10.5');
       cy.clickSubmitButton();
 
       cy.url().should('eq', relative(`/case/${dealId}/underwriting`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriter-managers-decision-decline.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriter-managers-decision-decline.spec.js
@@ -47,8 +47,8 @@ context('Case Underwriting - Pricing and risk', () => {
 
     pages.managersDecisionPage.decisionRadioInputDecline().click();
     pages.managersDecisionPage.commentsInputDecline().should('be.visible');
-    pages.managersDecisionPage.commentsInputDecline().type(MOCK_COMMENTS);
-    pages.managersDecisionPage.commentsInputInternal().type(MOCK_INTERNAL_COMMENTS);
+    cy.keyboardInput(pages.managersDecisionPage.commentsInputDecline(), MOCK_COMMENTS);
+    cy.keyboardInput(pages.managersDecisionPage.commentsInputInternal(), MOCK_INTERNAL_COMMENTS);
     cy.clickSubmitButton();
 
     cy.assertText(pages.managersDecisionPage.decisionStatusTag(), 'Declined');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriter-managers-decision.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case-underwriting/underwriter-managers-decision.spec.js
@@ -68,7 +68,7 @@ context("Case Underwriting - Underwriter Manager's decision - Form and Validatio
 
       pages.managersDecisionPage.decisionRadioInputApproveWithoutConditions().click();
 
-      pages.managersDecisionPage.commentsInputInternal().typeWithoutDelay('a'.repeat(8001));
+      cy.keyboardInput(pages.managersDecisionPage.commentsInputInternal(), 'a'.repeat(8001));
 
       cy.clickSubmitButton();
 
@@ -103,7 +103,7 @@ context("Case Underwriting - Underwriter Manager's decision - Form and Validatio
     });
 
     it('should throw validation error if approval comment is too long', () => {
-      pages.managersDecisionPage.commentsInputApproveWithConditions().typeWithoutDelay('a'.repeat(8001));
+      cy.keyboardInput(pages.managersDecisionPage.commentsInputApproveWithConditions(), 'a'.repeat(8001));
 
       cy.clickSubmitButton();
 
@@ -113,7 +113,7 @@ context("Case Underwriting - Underwriter Manager's decision - Form and Validatio
     });
 
     it('should throw validation error if approval comment is whitespace', () => {
-      pages.managersDecisionPage.commentsInputApproveWithConditions().type('      ');
+      cy.keyboardInput(pages.managersDecisionPage.commentsInputApproveWithConditions(), '      ');
 
       cy.clickSubmitButton();
 
@@ -149,7 +149,7 @@ context("Case Underwriting - Underwriter Manager's decision - Form and Validatio
     });
 
     it('should throw validation error if decline comment is too long', () => {
-      pages.managersDecisionPage.commentsInputDecline().typeWithoutDelay('a'.repeat(8001));
+      cy.keyboardInput(pages.managersDecisionPage.commentsInputDecline(), 'a'.repeat(8001));
 
       cy.clickSubmitButton();
 
@@ -159,7 +159,7 @@ context("Case Underwriting - Underwriter Manager's decision - Form and Validatio
     });
 
     it('should throw validation error if decline comment is whitespace', () => {
-      pages.managersDecisionPage.commentsInputDecline().type('      ');
+      cy.keyboardInput(pages.managersDecisionPage.commentsInputDecline(), '      ');
 
       cy.clickSubmitButton();
 
@@ -211,8 +211,8 @@ context("Case Underwriting - Underwriter Manager's decision - Submit Form", () =
 
     pages.managersDecisionPage.decisionRadioInputApproveWithConditions().click();
 
-    pages.managersDecisionPage.commentsInputApproveWithConditions().type(MOCK_COMMENTS);
-    pages.managersDecisionPage.commentsInputInternal().type(MOCK_INTERNAL_COMMENTS);
+    cy.keyboardInput(pages.managersDecisionPage.commentsInputApproveWithConditions(), MOCK_COMMENTS);
+    cy.keyboardInput(pages.managersDecisionPage.commentsInputInternal(), MOCK_INTERNAL_COMMENTS);
 
     cy.clickSubmitButton();
     cy.url().should('eq', relative(`/case/${dealId}/underwriting`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/activities/activities.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/activities/activities.spec.js
@@ -83,7 +83,7 @@ context('Users can create and submit comments', () => {
 
     it('should submit a comment under 1000 characters and render date of comment', () => {
       activitiesPage.addACommentButton().click();
-      activityCommentBoxPage.activityCommentBox().type('test');
+      cy.keyboardInput(activityCommentBoxPage.activityCommentBox(), 'test');
       activityCommentBoxPage.addCommentButton().click();
 
       activitiesPage.activitiesTimeline().contains('test');
@@ -96,7 +96,7 @@ context('Users can create and submit comments', () => {
 
     it('pressing cancel should not submit a comment', () => {
       activitiesPage.addACommentButton().click();
-      activityCommentBoxPage.activityCommentBox().type('should cancel');
+      cy.keyboardInput(activityCommentBoxPage.activityCommentBox(), 'should cancel');
       cy.clickCancelLink();
       activitiesPage.activitiesTimeline().contains('should cancel').should('not.exist');
     });
@@ -114,7 +114,7 @@ context('Users can create and submit comments', () => {
     it('should not be allowed to add comment over 1000 characters', () => {
       const longComment = 'aaaaaaaaaa'.repeat(101);
       activitiesPage.addACommentButton().click();
-      activityCommentBoxPage.activityCommentBox().typeWithoutDelay(longComment);
+      cy.keyboardInput(activityCommentBoxPage.activityCommentBox(), longComment);
       activityCommentBoxPage.addCommentButton().click();
       errorSummary().contains('Comments must be 1000 characters or fewer');
       activityCommentBoxPage.commentErrorMessage().contains('Comments must be 1000 characters or fewer');

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/agent.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/agent.spec.js
@@ -83,7 +83,7 @@ context('Agent Party URN - User can add, edit, confirm and submit URN to the TFM
         pages.agentPage.urnError().contains('Enter a unique reference number');
 
         pages.agentPage.agentUniqueRefInput().clear();
-        pages.agentPage.agentUniqueRefInput().type('test');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput(), 'test');
 
         pages.agentPage.saveButton().click();
 
@@ -91,35 +91,35 @@ context('Agent Party URN - User can add, edit, confirm and submit URN to the TFM
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.agentPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.agentPage.agentUniqueRefInput().clear().type('12');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput().clear(), '12');
         pages.agentPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.agentPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.agentPage.agentUniqueRefInput().clear().type('ABC123');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput().clear(), 'ABC123');
         pages.agentPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.agentPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.agentPage.agentUniqueRefInput().clear().type('"!£!"£!"£!"£');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput().clear(), '"!£!"£!"£!"£');
         pages.agentPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.agentPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.agentPage.agentUniqueRefInput().clear().type('1234!');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput().clear(), '1234!');
         pages.agentPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.agentPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.agentPage.agentUniqueRefInput().clear().type(' ');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput().clear(), ' ');
         pages.agentPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -130,7 +130,7 @@ context('Agent Party URN - User can add, edit, confirm and submit URN to the TFM
       it('should re-direct to non-existent party urn page', () => {
         pages.partiesPage.agentEditLink().click();
         pages.agentPage.agentUniqueRefInput().clear();
-        pages.agentPage.agentUniqueRefInput().type(mockUrn);
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput(), mockUrn);
 
         pages.agentPage.saveButton().click();
 
@@ -140,7 +140,7 @@ context('Agent Party URN - User can add, edit, confirm and submit URN to the TFM
       it('should re-direct to summary page', () => {
         pages.partiesPage.agentEditLink().click();
         pages.agentPage.agentUniqueRefInput().clear();
-        pages.agentPage.agentUniqueRefInput().type(partyUrn);
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput(), partyUrn);
 
         pages.agentPage.saveButton().click();
 
@@ -151,7 +151,7 @@ context('Agent Party URN - User can add, edit, confirm and submit URN to the TFM
       it('should submit the party URN to TFM', () => {
         pages.partiesPage.agentEditLink().click();
         pages.agentPage.agentUniqueRefInput().clear();
-        pages.agentPage.agentUniqueRefInput().type(partyUrn);
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput(), partyUrn);
 
         pages.agentPage.saveButton().click();
 
@@ -176,8 +176,8 @@ context('Agent Party URN - User can add, edit, confirm and submit URN to the TFM
         pages.partiesPage.agentEditLink().click();
         pages.agentPage.agentUniqueRefInput().clear();
         pages.agentPage.agentCommissionRateInput().clear();
-        pages.agentPage.agentUniqueRefInput().type(partyUrn);
-        pages.agentPage.agentCommissionRateInput().type('1.234');
+        cy.keyboardInput(pages.agentPage.agentUniqueRefInput(), partyUrn);
+        cy.keyboardInput(pages.agentPage.agentCommissionRateInput(), '1.234');
 
         pages.agentPage.saveButton().click();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-beneficiary.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-beneficiary.spec.js
@@ -86,8 +86,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
 
         pages.bondBeneficiaryPage.urnInput(1).clear();
         pages.bondBeneficiaryPage.urnInput(2).clear();
-        pages.bondBeneficiaryPage.urnInput(1).type('test');
-        pages.bondBeneficiaryPage.urnInput(2).type('test');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1), 'test');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2), 'test');
 
         pages.bondBeneficiaryPage.saveButton().click();
 
@@ -96,8 +96,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
         pages.bondBeneficiaryPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondBeneficiaryPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondBeneficiaryPage.urnInput(1).clear().type('12');
-        pages.bondBeneficiaryPage.urnInput(2).clear().type('12');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1).clear(), '12');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2).clear(), '12');
         pages.bondBeneficiaryPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -105,8 +105,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
         pages.bondBeneficiaryPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondBeneficiaryPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondBeneficiaryPage.urnInput(1).clear().type('ABC123');
-        pages.bondBeneficiaryPage.urnInput(2).clear().type('ABC123');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1).clear(), 'ABC123');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2).clear(), 'ABC123');
         pages.bondBeneficiaryPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -114,8 +114,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
         pages.bondBeneficiaryPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondBeneficiaryPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondBeneficiaryPage.urnInput(1).clear().type('"!£!"£!"£!"£');
-        pages.bondBeneficiaryPage.urnInput(2).clear().type('"!£!"£!"£!"£');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1).clear(), '"!£!"£!"£!"£');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2).clear(), '"!£!"£!"£!"£');
         pages.bondBeneficiaryPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -123,8 +123,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
         pages.bondBeneficiaryPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondBeneficiaryPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondBeneficiaryPage.urnInput(1).clear().type('1234!');
-        pages.bondBeneficiaryPage.urnInput(2).clear().type('1234!');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1).clear(), '1234!');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2).clear(), '1234!');
         pages.bondBeneficiaryPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -132,8 +132,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
         pages.bondBeneficiaryPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondBeneficiaryPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondBeneficiaryPage.urnInput(1).clear().type(' ');
-        pages.bondBeneficiaryPage.urnInput(2).clear().type(' ');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1).clear(), ' ');
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2).clear(), ' ');
         pages.bondBeneficiaryPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -147,8 +147,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
 
         pages.bondBeneficiaryPage.urnInput(1).clear();
         pages.bondBeneficiaryPage.urnInput(2).clear();
-        pages.bondBeneficiaryPage.urnInput(1).type(mockUrn[0]);
-        pages.bondBeneficiaryPage.urnInput(2).type(mockUrn[1]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1), mockUrn[0]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2), mockUrn[1]);
 
         pages.bondBeneficiaryPage.saveButton().click();
 
@@ -160,8 +160,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
 
         pages.bondBeneficiaryPage.urnInput(1).clear();
         pages.bondBeneficiaryPage.urnInput(2).clear();
-        pages.bondBeneficiaryPage.urnInput(1).type(mockUrn[0]);
-        pages.bondBeneficiaryPage.urnInput(2).type(partyUrn[0]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1), mockUrn[0]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2), partyUrn[0]);
 
         pages.bondBeneficiaryPage.saveButton().click();
 
@@ -173,8 +173,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
 
         pages.bondBeneficiaryPage.urnInput(1).clear();
         pages.bondBeneficiaryPage.urnInput(2).clear();
-        pages.bondBeneficiaryPage.urnInput(1).type(partyUrn[0]);
-        pages.bondBeneficiaryPage.urnInput(2).type(partyUrn[1]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1), partyUrn[0]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2), partyUrn[1]);
 
         pages.bondBeneficiaryPage.saveButton().click();
 
@@ -187,8 +187,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
 
         pages.bondBeneficiaryPage.urnInput(1).clear();
         pages.bondBeneficiaryPage.urnInput(2).clear();
-        pages.bondBeneficiaryPage.urnInput(1).type(partyUrn[0]);
-        pages.bondBeneficiaryPage.urnInput(2).type(partyUrn[1]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1), partyUrn[0]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2), partyUrn[1]);
 
         pages.bondBeneficiaryPage.saveButton().click();
 
@@ -207,8 +207,8 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
         pages.partiesPage.bondBeneficiaryEditLink().click();
         pages.bondBeneficiaryPage.urnInput(1).clear();
         pages.bondBeneficiaryPage.urnInput(2).clear();
-        pages.bondBeneficiaryPage.urnInput(1).type(partyUrn[0]);
-        pages.bondBeneficiaryPage.urnInput(2).type(partyUrn[1]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(1), partyUrn[0]);
+        cy.keyboardInput(pages.bondBeneficiaryPage.urnInput(2), partyUrn[1]);
 
         pages.bondBeneficiaryPage.saveButton().click();
         pages.bondBeneficiaryPage.saveButton().click();
@@ -219,7 +219,7 @@ context('Bond beneficiary URN - User can add, edit, confirm and submit URN to th
       function submitExporterUrn(urn) {
         pages.partiesPage.exporterEditLink().click();
         pages.exporterPage.urnInput().clear();
-        pages.exporterPage.urnInput().type(urn);
+        cy.keyboardInput(pages.exporterPage.urnInput(), urn);
         pages.exporterPage.saveButton().click();
         pages.exporterPage.saveButton().click();
       }

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-issuer.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/bond-issuer.spec.js
@@ -86,8 +86,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
 
         pages.bondIssuerPage.urnInput(1).clear();
         pages.bondIssuerPage.urnInput(2).clear();
-        pages.bondIssuerPage.urnInput(1).type('test');
-        pages.bondIssuerPage.urnInput(2).type('test');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1), 'test');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2), 'test');
 
         pages.bondIssuerPage.saveButton().click();
 
@@ -96,8 +96,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
         pages.bondIssuerPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondIssuerPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondIssuerPage.urnInput(1).clear().type('12');
-        pages.bondIssuerPage.urnInput(2).clear().type('12');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1).clear(), '12');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2).clear(), '12');
         pages.bondIssuerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -105,8 +105,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
         pages.bondIssuerPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondIssuerPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondIssuerPage.urnInput(1).clear().type('ABC123');
-        pages.bondIssuerPage.urnInput(2).clear().type('ABC123');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1).clear(), 'ABC123');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2).clear(), 'ABC123');
         pages.bondIssuerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -114,8 +114,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
         pages.bondIssuerPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondIssuerPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondIssuerPage.urnInput(1).clear().type('"!£!"£!"£!"£');
-        pages.bondIssuerPage.urnInput(2).clear().type('"!£!"£!"£!"£');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1).clear(), '"!£!"£!"£!"£');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2).clear(), '"!£!"£!"£!"£');
         pages.bondIssuerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -123,8 +123,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
         pages.bondIssuerPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondIssuerPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondIssuerPage.urnInput(1).clear().type('1234!');
-        pages.bondIssuerPage.urnInput(2).clear().type('1234!');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1).clear(), '1234!');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2).clear(), '1234!');
         pages.bondIssuerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -132,8 +132,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
         pages.bondIssuerPage.urnError(1).contains('Enter a minimum of 3 numbers');
         pages.bondIssuerPage.urnError(2).contains('Enter a minimum of 3 numbers');
 
-        pages.bondIssuerPage.urnInput(1).clear().type(' ');
-        pages.bondIssuerPage.urnInput(2).clear().type(' ');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1).clear(), ' ');
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2).clear(), ' ');
         pages.bondIssuerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -147,8 +147,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
 
         pages.bondIssuerPage.urnInput(1).clear();
         pages.bondIssuerPage.urnInput(2).clear();
-        pages.bondIssuerPage.urnInput(1).type(mockUrn[0]);
-        pages.bondIssuerPage.urnInput(2).type(mockUrn[1]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1), mockUrn[0]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2), mockUrn[1]);
 
         pages.bondIssuerPage.saveButton().click();
 
@@ -160,8 +160,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
 
         pages.bondIssuerPage.urnInput(1).clear();
         pages.bondIssuerPage.urnInput(2).clear();
-        pages.bondIssuerPage.urnInput(1).type(mockUrn[0]);
-        pages.bondIssuerPage.urnInput(2).type(partyUrn[0]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1), mockUrn[0]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2), partyUrn[0]);
 
         pages.bondIssuerPage.saveButton().click();
 
@@ -173,8 +173,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
 
         pages.bondIssuerPage.urnInput(1).clear();
         pages.bondIssuerPage.urnInput(2).clear();
-        pages.bondIssuerPage.urnInput(1).type(partyUrn[0]);
-        pages.bondIssuerPage.urnInput(2).type(partyUrn[1]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1), partyUrn[0]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2), partyUrn[1]);
 
         pages.bondIssuerPage.saveButton().click();
 
@@ -187,8 +187,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
 
         pages.bondIssuerPage.urnInput(1).clear();
         pages.bondIssuerPage.urnInput(2).clear();
-        pages.bondIssuerPage.urnInput(1).type(partyUrn[0]);
-        pages.bondIssuerPage.urnInput(2).type(partyUrn[1]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1), partyUrn[0]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2), partyUrn[1]);
 
         pages.bondIssuerPage.saveButton().click();
 
@@ -207,8 +207,8 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
         pages.partiesPage.bondIssuerEditLink().click();
         pages.bondIssuerPage.urnInput(1).clear();
         pages.bondIssuerPage.urnInput(2).clear();
-        pages.bondIssuerPage.urnInput(1).type(partyUrn[0]);
-        pages.bondIssuerPage.urnInput(2).type(partyUrn[1]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(1), partyUrn[0]);
+        cy.keyboardInput(pages.bondIssuerPage.urnInput(2), partyUrn[1]);
 
         pages.bondIssuerPage.saveButton().click();
         pages.bondIssuerPage.saveButton().click();
@@ -219,7 +219,7 @@ context('Bond issuer URN - User can add, edit, confirm and submit URN to the TFM
       function submitExporterUrn(urn) {
         pages.partiesPage.exporterEditLink().click();
         pages.exporterPage.urnInput().clear();
-        pages.exporterPage.urnInput().type(urn);
+        cy.keyboardInput(pages.exporterPage.urnInput(), urn);
         pages.exporterPage.saveButton().click();
         pages.exporterPage.saveButton().click();
       }

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/buyer.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/buyer.spec.js
@@ -83,7 +83,7 @@ context('Buyer Party URN - User can add, edit, confirm and submit URN to the TFM
         pages.buyerPage.urnError().contains('Enter a unique reference number');
 
         pages.buyerPage.urnInput().clear();
-        pages.buyerPage.urnInput().type('test');
+        cy.keyboardInput(pages.buyerPage.urnInput(), 'test');
 
         pages.buyerPage.saveButton().click();
 
@@ -91,35 +91,35 @@ context('Buyer Party URN - User can add, edit, confirm and submit URN to the TFM
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.buyerPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.buyerPage.urnInput().clear().type('12');
+        cy.keyboardInput(pages.buyerPage.urnInput().clear(), '12');
         pages.buyerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.buyerPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.buyerPage.urnInput().clear().type('ABC123');
+        cy.keyboardInput(pages.buyerPage.urnInput().clear(), 'ABC123');
         pages.buyerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.buyerPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.buyerPage.urnInput().clear().type('"!£!"£!"£!"£');
+        cy.keyboardInput(pages.buyerPage.urnInput().clear(), '"!£!"£!"£!"£');
         pages.buyerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.buyerPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.buyerPage.urnInput().clear().type('1234!');
+        cy.keyboardInput(pages.buyerPage.urnInput().clear(), '1234!');
         pages.buyerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.buyerPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.buyerPage.urnInput().clear().type(' ');
+        cy.keyboardInput(pages.buyerPage.urnInput().clear(), ' ');
         pages.buyerPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -130,7 +130,7 @@ context('Buyer Party URN - User can add, edit, confirm and submit URN to the TFM
       it('should re-direct to non-existent party urn page', () => {
         pages.partiesPage.buyerEditLink().click();
         pages.buyerPage.urnInput().clear();
-        pages.buyerPage.urnInput().type(mockUrn);
+        cy.keyboardInput(pages.buyerPage.urnInput(), mockUrn);
 
         pages.buyerPage.saveButton().click();
 
@@ -140,7 +140,7 @@ context('Buyer Party URN - User can add, edit, confirm and submit URN to the TFM
       it('should re-direct to summary page', () => {
         pages.partiesPage.buyerEditLink().click();
         pages.buyerPage.urnInput().clear();
-        pages.buyerPage.urnInput().type(partyUrn);
+        cy.keyboardInput(pages.buyerPage.urnInput(), partyUrn);
 
         pages.buyerPage.saveButton().click();
 
@@ -151,7 +151,7 @@ context('Buyer Party URN - User can add, edit, confirm and submit URN to the TFM
       it('should submit the party URN to TFM', () => {
         pages.partiesPage.buyerEditLink().click();
         pages.buyerPage.urnInput().clear();
-        pages.buyerPage.urnInput().type(partyUrn);
+        cy.keyboardInput(pages.buyerPage.urnInput(), partyUrn);
 
         pages.buyerPage.saveButton().click();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/exporter.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/exporter.spec.js
@@ -83,7 +83,7 @@ context('Exporter Party URN - User can add, edit, confirm and submit URN to the 
         pages.exporterPage.urnError().contains('Enter a unique reference number');
 
         pages.exporterPage.urnInput().clear();
-        pages.exporterPage.urnInput().type('test');
+        cy.keyboardInput(pages.exporterPage.urnInput(), 'test');
 
         pages.exporterPage.saveButton().click();
 
@@ -91,35 +91,35 @@ context('Exporter Party URN - User can add, edit, confirm and submit URN to the 
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.exporterPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.exporterPage.urnInput().clear().type('12');
+        cy.keyboardInput(pages.exporterPage.urnInput().clear(), '12');
         pages.exporterPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.exporterPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.exporterPage.urnInput().clear().type('ABC123');
+        cy.keyboardInput(pages.exporterPage.urnInput().clear(), 'ABC123');
         pages.exporterPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.exporterPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.exporterPage.urnInput().clear().type('"!£!"£!"£!"£');
+        cy.keyboardInput(pages.exporterPage.urnInput().clear(), '"!£!"£!"£!"£');
         pages.exporterPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.exporterPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.exporterPage.urnInput().clear().type('1234!');
+        cy.keyboardInput(pages.exporterPage.urnInput().clear(), '1234!');
         pages.exporterPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.exporterPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.exporterPage.urnInput().clear().type(' ');
+        cy.keyboardInput(pages.exporterPage.urnInput().clear(), ' ');
         pages.exporterPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -130,7 +130,7 @@ context('Exporter Party URN - User can add, edit, confirm and submit URN to the 
       it('should re-direct to non-existent party urn page', () => {
         pages.partiesPage.exporterEditLink().click();
         pages.exporterPage.urnInput().clear();
-        pages.exporterPage.urnInput().type(mockUrn);
+        cy.keyboardInput(pages.exporterPage.urnInput(), mockUrn);
 
         pages.exporterPage.saveButton().click();
 
@@ -140,7 +140,7 @@ context('Exporter Party URN - User can add, edit, confirm and submit URN to the 
       it('should re-direct to summary page', () => {
         pages.partiesPage.exporterEditLink().click();
         pages.exporterPage.urnInput().clear();
-        pages.exporterPage.urnInput().type(partyUrn);
+        cy.keyboardInput(pages.exporterPage.urnInput(), partyUrn);
 
         pages.exporterPage.saveButton().click();
 
@@ -151,7 +151,7 @@ context('Exporter Party URN - User can add, edit, confirm and submit URN to the 
       it('should submit the party URN to TFM', () => {
         pages.partiesPage.exporterEditLink().click();
         pages.exporterPage.urnInput().clear();
-        pages.exporterPage.urnInput().type(partyUrn);
+        cy.keyboardInput(pages.exporterPage.urnInput(), partyUrn);
 
         pages.exporterPage.saveButton().click();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/case/parties/indemnifier.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/case/parties/indemnifier.spec.js
@@ -83,7 +83,7 @@ context('Indemnifier Party URN - User can add, edit, confirm and submit URN to t
         pages.indemnifierPage.urnError().contains('Enter a unique reference number');
 
         pages.indemnifierPage.urnInput().clear();
-        pages.indemnifierPage.urnInput().type('test');
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), 'test');
 
         pages.indemnifierPage.saveButton().click();
 
@@ -91,35 +91,35 @@ context('Indemnifier Party URN - User can add, edit, confirm and submit URN to t
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.indemnifierPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.indemnifierPage.urnInput().clear().type('12');
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), '12');
         pages.indemnifierPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.indemnifierPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.indemnifierPage.urnInput().clear().type('ABC123');
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), 'ABC123');
         pages.indemnifierPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.indemnifierPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.indemnifierPage.urnInput().clear().type('"!£!"£!"£!"£');
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), '"!£!"£!"£!"£');
         pages.indemnifierPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.indemnifierPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.indemnifierPage.urnInput().clear().type('1234!');
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), '1234!');
         pages.indemnifierPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
         errorSummary().contains('Enter a minimum of 3 numbers');
         pages.indemnifierPage.urnError().contains('Enter a minimum of 3 numbers');
 
-        pages.indemnifierPage.urnInput().clear().type(' ');
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), ' ');
         pages.indemnifierPage.saveButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/parties/${party}`));
@@ -130,7 +130,7 @@ context('Indemnifier Party URN - User can add, edit, confirm and submit URN to t
       it('should re-direct to non-existent party urn page', () => {
         pages.partiesPage.indemnifierEditLink().click();
         pages.indemnifierPage.urnInput().clear();
-        pages.indemnifierPage.urnInput().type(mockUrn);
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), mockUrn);
 
         pages.indemnifierPage.saveButton().click();
 
@@ -140,7 +140,7 @@ context('Indemnifier Party URN - User can add, edit, confirm and submit URN to t
       it('should re-direct to summary page', () => {
         pages.partiesPage.indemnifierEditLink().click();
         pages.indemnifierPage.urnInput().clear();
-        pages.indemnifierPage.urnInput().type(partyUrn);
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), partyUrn);
 
         pages.indemnifierPage.saveButton().click();
 
@@ -151,7 +151,7 @@ context('Indemnifier Party URN - User can add, edit, confirm and submit URN to t
       it('should submit the party URN to TFM', () => {
         pages.partiesPage.indemnifierEditLink().click();
         pages.indemnifierPage.urnInput().clear();
-        pages.indemnifierPage.urnInput().type(partyUrn);
+        cy.keyboardInput(pages.indemnifierPage.urnInput(), partyUrn);
 
         pages.indemnifierPage.saveButton().click();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-pagination.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-pagination.spec.js
@@ -83,7 +83,7 @@ context('User can navigate through a paginated table of deals using the paginati
   it('should allow the user to navigate through the paginated deals table when filtering/search is active', () => {
     const searchString = 'Company 1';
     const expectedNumberOfMatches = Math.ceil(numberOfDeals / 2);
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.url().should('eq', relative('/deals/0?search=Company%201'));
@@ -113,7 +113,7 @@ context('User can navigate through a paginated table of deals using the paginati
   it('should redirect to the first page of the deals table when the user searches', () => {
     cy.visit('/deals/2');
     const searchString = 'Company 1';
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.url().should('eq', relative('/deals/0?search=Company%201'));

--- a/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-search.spec.js
@@ -148,7 +148,7 @@ context('User can view and filter multiple deals', () => {
 
     const expectedResultsLength = bssDealsWithUkefDealId.length;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
@@ -167,7 +167,7 @@ context('User can view and filter multiple deals', () => {
 
     const expectedResultsLength = 1;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
@@ -178,7 +178,7 @@ context('User can view and filter multiple deals', () => {
   it('search/filter by bank name', () => {
     const searchString = 'UKEF test bank';
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     const dealsWithMakerUkefTestBank = ALL_SUBMITTED_DEALS.filter((deal) => deal.dealSnapshot.bank.name.includes(searchString));
@@ -191,7 +191,7 @@ context('User can view and filter multiple deals', () => {
   it('search/filter by supplier name', () => {
     const searchString = DEAL_WITH_TEST_SUPPLIER_NAME.submissionDetails['supplier-name'];
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', 1);
@@ -202,7 +202,7 @@ context('User can view and filter multiple deals', () => {
   it('search/filter by submission type', () => {
     const searchString = DEAL_WITH_TEST_MIN_SUBMISSION_TYPE.submissionType;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', 1);
@@ -213,7 +213,7 @@ context('User can view and filter multiple deals', () => {
   it('search/filter by buyer name', () => {
     const searchString = DEAL_WITH_TEST_BUYER_NAME.submissionDetails['buyer-name'];
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', 1);
@@ -231,7 +231,7 @@ context('User can view and filter multiple deals', () => {
 
     const searchString = submittedMiaDeal.tfm.stage;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', 1);
@@ -255,7 +255,7 @@ context('User can view and filter multiple deals', () => {
 
     const expectedResultsLength = dealsWithBonds.length;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
@@ -268,7 +268,7 @@ context('User can view and filter multiple deals', () => {
 
     const expectedResultsLength = 1;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
@@ -285,7 +285,7 @@ context('User can view and filter multiple deals', () => {
     // all deals in this test are submitted at the same time.
     const expectedResultsLength = ALL_SUBMITTED_DEALS.length;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
@@ -302,7 +302,7 @@ context('User can view and filter multiple deals', () => {
     // all deals in this test are submitted at the same time.
     const expectedResultsLength = ALL_SUBMITTED_DEALS.length;
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
@@ -313,7 +313,7 @@ context('User can view and filter multiple deals', () => {
   it('updates heading text and does not render any deals when no results are found', () => {
     const searchString = 'bingo';
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     const expectedResultsLength = 0;
@@ -326,7 +326,7 @@ context('User can view and filter multiple deals', () => {
   it('after a search has been performed, clicking `All deals` nav item returns all deals ', () => {
     const searchString = DEAL_WITH_TEST_BUYER_NAME.submissionDetails['buyer-name'];
 
-    pages.dealsPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     pages.dealsPage.dealsTableRows().should('have.length', 1);

--- a/e2e-tests/tfm/cypress/e2e/journeys/facility/facilities-pagination.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/facility/facilities-pagination.spec.js
@@ -84,7 +84,7 @@ context('User can navigate through a paginated table of facilities using the pag
   it('should allow the user to navigate through the paginated facilities table when filtering/search is active', () => {
     const searchString = 'Company 1';
     const expectedNumberOfMatches = Math.ceil(numberOfFacilities / 2);
-    pages.facilitiesPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.facilitiesPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.url().should('eq', relative('/facilities/0?search=Company%201'));
@@ -112,7 +112,7 @@ context('User can navigate through a paginated table of facilities using the pag
   it('should redirect to the first page of the facilities table when the user searches', () => {
     cy.visit('/facilities/2');
     const searchString = 'Company 1';
-    pages.facilitiesPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.facilitiesPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.url().should('eq', relative('/facilities/0?search=Company%201'));

--- a/e2e-tests/tfm/cypress/e2e/journeys/facility/facilities.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/facility/facilities.spec.js
@@ -108,7 +108,7 @@ context('Facility page', () => {
     cy.visit(relative('/facilities'));
     cy.url().should('eq', relative('/facilities/0'));
     const searchString = '1000000';
-    pages.facilitiesPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.facilitiesPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.checkFacilitiesTableRowsTotal(4);
@@ -119,7 +119,7 @@ context('Facility page', () => {
     cy.url().should('eq', relative('/facilities/0'));
     const searchString = MOCK_DEAL_AIN.exporter.companyName;
 
-    pages.facilitiesPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.facilitiesPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.checkFacilitiesTableRowsTotal(2);
@@ -130,7 +130,7 @@ context('Facility page', () => {
     cy.url().should('eq', relative('/facilities/0'));
     const searchString = MOCK_DEAL_MIA.exporter.companyName;
 
-    pages.facilitiesPage.searchFormInput().type(searchString);
+    cy.keyboardInput(pages.facilitiesPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
     cy.checkFacilitiesTableRowsTotal(2);

--- a/e2e-tests/tfm/cypress/e2e/journeys/feedback/feedback.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/feedback/feedback.spec.js
@@ -37,7 +37,7 @@ context('User submit feedback on TFM', () => {
   it('feedback should give errors if incorrectly filled up', () => {
     pages.feedbackPage.visit();
 
-    pages.feedbackPage.emailAddress().type('a');
+    cy.keyboardInput(pages.feedbackPage.emailAddress(), 'a');
 
     cy.clickSubmitButton();
 
@@ -59,12 +59,12 @@ context('User submit feedback on TFM', () => {
   it('feedback should submit without errors and with correct thank you page', () => {
     pages.feedbackPage.visit();
 
-    pages.feedbackPage.role().type('test');
-    pages.feedbackPage.team().type('test');
-    pages.feedbackPage.whyUsingService().type('test');
+    cy.keyboardInput(pages.feedbackPage.role(), 'test');
+    cy.keyboardInput(pages.feedbackPage.team(), 'test');
+    cy.keyboardInput(pages.feedbackPage.whyUsingService(), 'test');
     pages.feedbackPage.easyToUseSelection().click();
     pages.feedbackPage.satisfiedSelection().click();
-    pages.feedbackPage.howCanWeImprove().type('test');
+    cy.keyboardInput(pages.feedbackPage.howCanWeImprove(), 'test');
     pages.feedbackPage.emailAddress().clear();
 
     cy.clickSubmitButton();

--- a/e2e-tests/tfm/cypress/e2e/journeys/login/login.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/login/login.spec.js
@@ -93,7 +93,7 @@ context('User can login', () => {
   });
 
   it('should not login and redirect to /deals with invalid email/username', () => {
-    pages.landingPage.email().type('wrongUser');
+    cy.keyboardInput(pages.landingPage.email(), 'wrongUser');
     cy.clickSubmitButton();
     cy.url().should('eq', relative('/'));
   });

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
@@ -104,10 +104,13 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
   });
 
   it('should display errors when form submitted with invalid values', () => {
-    cy.getInputByLabelText('Amount received').type('100');
-    cy.getInputByLabelText('Day').type('56');
-    cy.getInputByLabelText('Month').type('12');
-    cy.getInputByLabelText('Year').type('2023');
+    cy.keyboardInput(cy.getInputByLabelText('Amount received'), '100');
+
+    cy.keyboardInput(cy.getInputByLabelText('Day'), '56');
+
+    cy.keyboardInput(cy.getInputByLabelText('Month'), '12');
+
+    cy.keyboardInput(cy.getInputByLabelText('Year'), '2023');
 
     cy.contains('button', 'Continue').click();
 
@@ -127,11 +130,16 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
 
   it('submits form and redirects to premium payments page when user submits form with valid values and user selects no to adding another payment', () => {
     cy.getInputByLabelText('GBP').click();
+
     // 391 = (100 / 2) + (200 / 0.5) - 60 + a little extra under the tolerance
-    cy.getInputByLabelText('Amount received').type('391');
-    cy.getInputByLabelText('Day').type('12');
-    cy.getInputByLabelText('Month').type('12');
-    cy.getInputByLabelText('Year').type('2023');
+    cy.keyboardInput(cy.getInputByLabelText('Amount received'), '391');
+
+    cy.keyboardInput(cy.getInputByLabelText('Day'), '12');
+
+    cy.keyboardInput(cy.getInputByLabelText('Month'), '12');
+
+    cy.keyboardInput(cy.getInputByLabelText('Year'), '2023');
+
     cy.getInputByLabelText('No').click();
 
     cy.contains('button', 'Continue').click();
@@ -143,10 +151,10 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
 
   it('submits form and reloads the page with no values when user submits form with valid values and user selects yes to adding another payment', () => {
     cy.getInputByLabelText('GBP').click();
-    cy.getInputByLabelText('Amount received').type('100');
-    cy.getInputByLabelText('Day').type('12');
-    cy.getInputByLabelText('Month').type('12');
-    cy.getInputByLabelText('Year').type('2023');
+    cy.keyboardInput(cy.getInputByLabelText('Amount received'), '100');
+    cy.keyboardInput(cy.getInputByLabelText('Day'), '12');
+    cy.keyboardInput(cy.getInputByLabelText('Month'), '12');
+    cy.keyboardInput(cy.getInputByLabelText('Year'), '2023');
     cy.getInputByLabelText('Yes').click();
 
     cy.contains('button', 'Continue').click();

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/edit-payment.spec.js
@@ -163,11 +163,15 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
       getFeeRecordCheckbox(feeRecord.id).check();
 
-      cy.getInputByLabelText('Amount received').type('nonsense');
-      cy.getInputByLabelText('Day').type('nonsense');
-      cy.getInputByLabelText('Month').type('nonsense');
-      cy.getInputByLabelText('Year').type('nonsense');
-      cy.getInputByLabelText('Payment reference (optional)').type('This is valid');
+      cy.keyboardInput(cy.getInputByLabelText('Amount received'), 'nonsense');
+
+      cy.keyboardInput(cy.getInputByLabelText('Day'), 'nonsense');
+
+      cy.keyboardInput(cy.getInputByLabelText('Month'), 'nonsense');
+
+      cy.keyboardInput(cy.getInputByLabelText('Year'), 'nonsense');
+
+      cy.keyboardInput(cy.getInputByLabelText('Payment reference (optional)'), 'This is valid');
 
       pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 
@@ -208,11 +212,15 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
       clearFormValues();
 
-      cy.getInputByLabelText('Amount received').type(newPaymentAmount.toString());
-      cy.getInputByLabelText('Day').type(newPaymentDateDay);
-      cy.getInputByLabelText('Month').type(newPaymentDateMonth);
-      cy.getInputByLabelText('Year').type(newPaymentDateYear);
-      cy.getInputByLabelText('Payment reference (optional)').type(newPaymentReference);
+      cy.keyboardInput(cy.getInputByLabelText('Amount received'), newPaymentAmount.toString());
+
+      cy.keyboardInput(cy.getInputByLabelText('Day'), newPaymentDateDay);
+
+      cy.keyboardInput(cy.getInputByLabelText('Month'), newPaymentDateMonth);
+
+      cy.keyboardInput(cy.getInputByLabelText('Year'), newPaymentDateYear);
+
+      cy.keyboardInput(cy.getInputByLabelText('Payment reference (optional)'), newPaymentReference);
 
       pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 
@@ -247,8 +255,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
       cy.url().should('eq', relative(`${editPaymentUrl}?redirectTab=premium-payments`));
 
       cy.getInputByLabelText('Amount received').should('have.value', '200');
-      cy.getInputByLabelText('Amount received').clear();
-      cy.getInputByLabelText('Amount received').type('100');
+
+      cy.keyboardInput(cy.getInputByLabelText('Amount received'), '100');
 
       pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 
@@ -273,8 +281,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
       cy.url().should('eq', relative(`${editPaymentUrl}?redirectTab=premium-payments`));
 
       cy.getInputByLabelText('Amount received').should('have.value', '100');
-      cy.getInputByLabelText('Amount received').clear();
-      cy.getInputByLabelText('Amount received').type('200');
+
+      cy.keyboardInput(cy.getInputByLabelText('Amount received'), '200');
 
       pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 
@@ -290,8 +298,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
       cy.url().should('eq', relative(`${editPaymentUrl}?redirectTab=premium-payments`));
 
-      cy.getInputByLabelText('Amount received').clear();
-      cy.getInputByLabelText('Amount received').type('200');
+      cy.keyboardInput(cy.getInputByLabelText('Amount received'), '200');
 
       pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 
@@ -307,8 +314,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can edit payments`, () => {
 
       cy.url().should('eq', relative(`${editPaymentUrl}?redirectTab=payment-details`));
 
-      cy.getInputByLabelText('Amount received').clear();
-      cy.getInputByLabelText('Amount received').type('200');
+      cy.keyboardInput(cy.getInputByLabelText('Amount received'), '200');
 
       pages.utilisationReportEditPaymentPage.clickSaveChangesButton();
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
@@ -63,7 +63,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     cy.reload();
 
-    pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput().type('11111111');
+    cy.keyboardInput(pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput(), '11111111');
     pages.utilisationReportPage.premiumPaymentsTab.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=11111111`));
@@ -89,7 +89,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     cy.reload();
 
-    pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput().type('1111');
+    cy.keyboardInput(pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput(), '1111');
     pages.utilisationReportPage.premiumPaymentsTab.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=1111`));
@@ -108,7 +108,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
   });
 
   it('should display an error if the supplied facility id query is an invalid value and persist the inputted value', () => {
-    pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput().type('nonsense');
+    cy.keyboardInput(pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput(), 'nonsense');
     pages.utilisationReportPage.premiumPaymentsTab.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=nonsense`));
@@ -157,7 +157,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     pages.utilisationReportPage.premiumPaymentsTab.getPaymentLink(paymentId).should('exist');
 
-    pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput().type('1111');
+    cy.keyboardInput(pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput(), '1111');
     pages.utilisationReportPage.premiumPaymentsTab.submitFacilityIdFilter();
 
     toDoFeeRecords.forEach(({ id }) => {
@@ -181,7 +181,7 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
     cy.reload();
 
-    pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput().type('33333333');
+    cy.keyboardInput(pages.utilisationReportPage.premiumPaymentsTab.getFacilityIdFilterInput(), '33333333');
     pages.utilisationReportPage.premiumPaymentsTab.submitFacilityIdFilter();
 
     cy.url().should('eq', relative(`/utilisation-reports/${reportId}?facilityIdQuery=33333333`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/find-utilisation-reports-by-bank-and-year.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/find-utilisation-reports-by-bank-and-year.spec.js
@@ -67,7 +67,7 @@ context('PDC_RECONCILE users can search for reports by bank and year', () => {
     pages.searchUtilisationReportsFormPage.heading().should('exist');
 
     pages.searchUtilisationReportsFormPage.bankRadioButton(BANK_WITH_REPORTS_ID).click();
-    pages.searchUtilisationReportsFormPage.yearInput().type('2024');
+    cy.keyboardInput(pages.searchUtilisationReportsFormPage.yearInput(), '2024');
     cy.clickContinueButton();
 
     pages.searchUtilisationReportsResultsPage.heading().should('exist');
@@ -78,7 +78,7 @@ context('PDC_RECONCILE users can search for reports by bank and year', () => {
     pages.searchUtilisationReportsFormPage.heading().should('exist');
 
     pages.searchUtilisationReportsFormPage.bankRadioButton(BANK_WITHOUT_REPORTS_ID).click();
-    pages.searchUtilisationReportsFormPage.yearInput().type('2024');
+    cy.keyboardInput(pages.searchUtilisationReportsFormPage.yearInput(), '2024');
     cy.clickContinueButton();
 
     pages.searchUtilisationReportsResultsPage.heading().should('exist');

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/remove-fees-from-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/remove-fees-from-payment.spec.js
@@ -98,15 +98,20 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can remove fees from payments`, () => 
       getFeeRecordCheckbox(feeRecordId).check();
     });
 
-    cy.getInputByLabelText('Amount received').type('1234');
-    cy.getInputByLabelText('Day').type('nonsense');
-    cy.getInputByLabelText('Month').type('nonsense');
-    cy.getInputByLabelText('Year').type('nonsense');
-    cy.getInputByLabelText('Payment reference (optional)').type('Some payment reference');
+    cy.keyboardInput(cy.getInputByLabelText('Amount received'), '1234');
+
+    cy.keyboardInput(cy.getInputByLabelText('Day'), 'nonsense');
+
+    cy.keyboardInput(cy.getInputByLabelText('Month'), 'nonsense');
+
+    cy.keyboardInput(cy.getInputByLabelText('Year'), 'nonsense');
+
+    cy.keyboardInput(cy.getInputByLabelText('Payment reference (optional)'), 'Some payment reference');
 
     pages.utilisationReportEditPaymentPage.clickRemoveSelectedPaymentsButton();
 
     errorSummary().contains('You cannot remove all the fees. Delete the payment instead.');
+
     feeRecordIds.forEach((feeRecordId) => {
       getFeeRecordCheckbox(feeRecordId).should('be.checked');
     });
@@ -126,11 +131,15 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can remove fees from payments`, () => 
 
     getFeeRecordCheckbox(feeRecordIdToRemove).check();
 
-    cy.getInputByLabelText('Amount received').type('1234');
-    cy.getInputByLabelText('Day').type('nonsense');
-    cy.getInputByLabelText('Month').type('nonsense');
-    cy.getInputByLabelText('Year').type('nonsense');
-    cy.getInputByLabelText('Payment reference (optional)').type('Some payment reference');
+    cy.keyboardInput(cy.getInputByLabelText('Amount received'), '1234');
+
+    cy.keyboardInput(cy.getInputByLabelText('Day'), 'nonsense');
+
+    cy.keyboardInput(cy.getInputByLabelText('Month'), 'nonsense');
+
+    cy.keyboardInput(cy.getInputByLabelText('Year'), 'nonsense');
+
+    cy.keyboardInput(cy.getInputByLabelText('Payment reference (optional)'), 'Some payment reference');
 
     pages.utilisationReportEditPaymentPage.clickRemoveSelectedPaymentsButton();
 

--- a/e2e-tests/tfm/cypress/support/commands.js
+++ b/e2e-tests/tfm/cypress/support/commands.js
@@ -5,6 +5,8 @@ import './ui';
 // Preserve session cookie
 Cypress.Commands.add('saveSession', require('./utils/saveSession'));
 
+Cypress.Commands.add('keyboardInput', require('./utils/keyboardInput'));
+
 // Assert an element has some exact text
 Cypress.Commands.add('assertText', require('./utils/assertText'));
 

--- a/e2e-tests/tfm/cypress/support/ui/amendments/navigate-to-is-using-facility-end-date-page.js
+++ b/e2e-tests/tfm/cypress/support/ui/amendments/navigate-to-is-using-facility-end-date-page.js
@@ -24,9 +24,9 @@ const navigateToIsUsingFacilityEndDatePage = ({ startNewAmendment = false, chang
   }
 
   cy.url().should('contain', 'request-date');
-  amendmentsPage.amendmentRequestDayInput().clear().type(todayDay);
-  amendmentsPage.amendmentRequestMonthInput().clear().type(todayMonth);
-  amendmentsPage.amendmentRequestYearInput().clear().type(todayYear);
+  cy.keyboardInput(amendmentsPage.amendmentRequestDayInput(), todayDay);
+  cy.keyboardInput(amendmentsPage.amendmentRequestMonthInput(), todayMonth);
+  cy.keyboardInput(amendmentsPage.amendmentRequestYearInput(), todayYear);
   cy.clickContinueButton();
 
   cy.url().should('contain', 'request-approval');
@@ -34,9 +34,9 @@ const navigateToIsUsingFacilityEndDatePage = ({ startNewAmendment = false, chang
   cy.clickContinueButton();
 
   cy.url().should('contain', 'amendment-effective-date');
-  amendmentsPage.amendmentEffectiveDayInput().clear().type(todayDay);
-  amendmentsPage.amendmentEffectiveMonthInput().clear().type(todayMonth);
-  amendmentsPage.amendmentEffectiveYearInput().clear().type(todayYear);
+  cy.keyboardInput(amendmentsPage.amendmentEffectiveDayInput(), todayDay);
+  cy.keyboardInput(amendmentsPage.amendmentEffectiveMonthInput(), todayMonth);
+  cy.keyboardInput(amendmentsPage.amendmentEffectiveYearInput(), todayYear);
   cy.clickContinueButton();
 
   cy.url().should('contain', 'amendment-options');
@@ -48,9 +48,9 @@ const navigateToIsUsingFacilityEndDatePage = ({ startNewAmendment = false, chang
   cy.clickContinueButton();
 
   cy.url().should('contain', 'cover-end-date');
-  amendmentsPage.amendmentCoverEndDateDayInput().clear().type(format(newCoverEndDate, 'd'));
-  amendmentsPage.amendmentCoverEndDateMonthInput().clear().type(format(newCoverEndDate, 'M'));
-  amendmentsPage.amendmentCoverEndDateYearInput().clear().type(format(newCoverEndDate, 'yyyy'));
+  cy.keyboardInput(amendmentsPage.amendmentCoverEndDateDayInput(), format(newCoverEndDate, 'd'));
+  cy.keyboardInput(amendmentsPage.amendmentCoverEndDateMonthInput(), format(newCoverEndDate, 'M'));
+  cy.keyboardInput(amendmentsPage.amendmentCoverEndDateYearInput(), format(newCoverEndDate, 'yyyy'));
   cy.clickContinueButton();
 
   cy.url().should('contain', 'is-using-facility-end-date');

--- a/e2e-tests/tfm/cypress/support/ui/index.js
+++ b/e2e-tests/tfm/cypress/support/ui/index.js
@@ -4,4 +4,3 @@ import './deals';
 import './click-events';
 
 Cypress.Commands.add('login', require('./logIn'));
-Cypress.Commands.add('typeWithoutDelay', { prevSubject: true }, require('./type-without-delay'));

--- a/e2e-tests/tfm/cypress/support/ui/logIn.js
+++ b/e2e-tests/tfm/cypress/support/ui/logIn.js
@@ -4,7 +4,7 @@ export default (opts) => {
   const { username, password } = opts;
 
   pages.landingPage.visit();
-  pages.landingPage.email().type(username);
-  pages.landingPage.password().type(password);
+  cy.keyboardInput(pages.landingPage.email(), username);
+  cy.keyboardInput(pages.landingPage.password(), password);
   cy.clickSubmitButton();
 };

--- a/e2e-tests/tfm/cypress/support/ui/type-without-delay.js
+++ b/e2e-tests/tfm/cypress/support/ui/type-without-delay.js
@@ -1,3 +1,0 @@
-module.exports = (subject, toType) => {
-  cy.wrap(subject).type(toType, { delay: 0 });
-};

--- a/e2e-tests/tfm/cypress/support/utils/keyboardInput.js
+++ b/e2e-tests/tfm/cypress/support/utils/keyboardInput.js
@@ -1,0 +1,11 @@
+/**
+ * keyboardInput
+ * Clear and type text into an input.
+ * @param {Function} selector: Cypress selector
+ * @param {String} text: Text to enter
+ */
+const keyboardInput = (selector, text) => {
+  selector.clear().type(text, { delay: 0 });
+};
+
+export default keyboardInput;


### PR DESCRIPTION
## Introduction :pencil2:
This PR introduces a new `keyboardInput` cypress command to the TFM E2E suite. This enforces:

- Zero delay when inputting text. Therefore speeding up tests.
- A consistent way of inputting text.

This is part of a series of E2E improvements to reduce E2E GHA time.

## Resolution :heavy_check_mark:
- Create new `keyboardInput` cypress command.
- Update E2E tests.
