### PR TITLE
chore(DTFS-7379): dry cypress command - keyboardInput - gef

### DIFF
--- a/e2e-tests/gef/cypress/e2e/application/application-activities-MIA.spec.js
+++ b/e2e-tests/gef/cypress/e2e/application/application-activities-MIA.spec.js
@@ -57,8 +57,8 @@ context('Submit AIN deal and check portalActivities', () => {
       cy.uploadFile('upload-file-valid.doc', `/gef/application-details/${dealId}/supporting-information/document/manual-inclusion-questionnaire/upload`);
       manualInclusion.uploadSuccess('upload_file_valid.doc');
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test2');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
 
       cy.clickSubmitButton();

--- a/e2e-tests/gef/cypress/e2e/application/name-application-create-element.spec.js
+++ b/e2e-tests/gef/cypress/e2e/application/name-application-create-element.spec.js
@@ -18,7 +18,7 @@ context('Name Application Page - Add element to page', () => {
   });
 
   it("should not add added element's data to page", () => {
-    nameApplication.internalRef().type('NEW-REF-NAME');
+    cy.keyboardInput(nameApplication.internalRef(), 'NEW-REF-NAME');
 
     // adds extra populated text input element to page
     cy.insertElement('name-application-form');

--- a/e2e-tests/gef/cypress/e2e/application/name-application.spec.js
+++ b/e2e-tests/gef/cypress/e2e/application/name-application.spec.js
@@ -55,7 +55,7 @@ context('Name Application Page', () => {
     });
 
     it('Entering new Bank internal ref takes you application detail page', () => {
-      nameApplication.internalRef().type('NEW-REF-NAME');
+      cy.keyboardInput(nameApplication.internalRef(), 'NEW-REF-NAME');
       form().submit();
       nameApplication.applicationDetailsPage();
     });
@@ -81,7 +81,7 @@ context('Name Application Page', () => {
     });
 
     it('Entering new Bank internal ref takes you application detail page', () => {
-      nameApplication.internalRef().type('NEW-REF-NAME');
+      cy.keyboardInput(nameApplication.internalRef(), 'NEW-REF-NAME');
       form().submit();
       nameApplication.applicationDetailsPage();
     });

--- a/e2e-tests/gef/cypress/e2e/checker/application-details-submit-to-checker.spec.js
+++ b/e2e-tests/gef/cypress/e2e/checker/application-details-submit-to-checker.spec.js
@@ -48,25 +48,25 @@ context('Application Details Submission', () => {
     });
 
     it('allows submission with comments', () => {
-      applicationSubmission.commentsField().type('test');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'test');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
     });
 
     it('shows error when comments are too long', () => {
-      applicationSubmission.commentsField().type(longComment);
+      cy.keyboardInput(applicationSubmission.commentsField(), longComment);
       cy.clickSubmitButton();
       errorSummary();
     });
 
     it('takes user back to application details page if cancel link clicked', () => {
-      applicationSubmission.commentsField().type('test');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'test');
       cy.clickCancelLink();
       applicationPreview.applicationPreviewPage();
     });
 
     it('takes user back to application details page if back link clicked', () => {
-      applicationSubmission.commentsField().type('test');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'test');
       cy.clickBackLink();
       applicationPreview.applicationPreviewPage();
     });

--- a/e2e-tests/gef/cypress/e2e/checker/submit-to-checker-mia.spec.js
+++ b/e2e-tests/gef/cypress/e2e/checker/submit-to-checker-mia.spec.js
@@ -52,8 +52,8 @@ context('Submit to UKEF as MIA', () => {
       statusBanner.bannerDateCreated().contains(todayFormattedShort);
 
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test');
       cy.clickSubmitButton();
       securityDetails.visit(dealId);
       cy.clickCancelButton();

--- a/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
+++ b/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
@@ -97,7 +97,7 @@ context('Clone GEF (AIN) deal', () => {
       mandatoryCriteria.trueRadio().click();
       form().submit();
       cy.url().should('eq', relative(`/gef/application-details/${AINdealId}/clone/name-application`));
-      nameApplication.internalRef().type('Cloned AIN deal');
+      cy.keyboardInput(nameApplication.internalRef(), 'Cloned AIN deal');
       form().submit();
     });
 
@@ -125,7 +125,7 @@ context('Clone GEF (AIN) deal', () => {
       cy.url().then((url) => {
         cy.visit(`${url}/about-exporter`);
         aboutExporter.mediumRadioButton().click();
-        aboutExporter.probabilityOfDefaultInput().clear().focused().type('10');
+        cy.keyboardInput(aboutExporter.probabilityOfDefaultInput(), '10');
         aboutExporter.isFinancingIncreasingRadioNo().click();
         cy.clickSaveAndReturnButton();
       });
@@ -147,7 +147,7 @@ context('Clone GEF (AIN) deal', () => {
       mandatoryCriteria.trueRadio().click();
       form().submit();
       cy.url().should('eq', relative(`/gef/application-details/${AINdealId}/clone/name-application`));
-      nameApplication.internalRef().type('Cloned AIN deal');
+      cy.keyboardInput(nameApplication.internalRef(), 'Cloned AIN deal');
       form().submit();
 
       cy.get('[data-cy="success-message-link"]').click();
@@ -263,8 +263,8 @@ context('Clone GEF (MIA) deal', () => {
     it('should populate the `Security Details` section', () => {
       uploadFiles.supportingInfoSecurityDetailsButton().click();
       cy.url().should('eq', relative(`/gef/application-details/${MIAdealId}/supporting-information/security-details`));
-      uploadFiles.exporterSecurity().type('test');
-      uploadFiles.facilitySecurity().type('test2');
+      cy.keyboardInput(uploadFiles.exporterSecurity(), 'test');
+      cy.keyboardInput(uploadFiles.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
     });
 
@@ -278,7 +278,7 @@ context('Clone GEF (MIA) deal', () => {
       mandatoryCriteria.trueRadio().click();
       form().submit();
       cy.url().should('eq', relative(`/gef/application-details/${MIAdealId}/clone/name-application`));
-      nameApplication.internalRef().clear().type('Cloned MIA deal');
+      cy.keyboardInput(nameApplication.internalRef(), 'Cloned MIA deal');
       form().submit();
     });
 
@@ -288,7 +288,7 @@ context('Clone GEF (MIA) deal', () => {
       cy.url().then((url) => {
         cy.visit(`${url}/about-exporter`);
         aboutExporter.mediumRadioButton().click();
-        aboutExporter.probabilityOfDefaultInput().clear().focused().type('10');
+        cy.keyboardInput(aboutExporter.probabilityOfDefaultInput(), '10');
         aboutExporter.isFinancingIncreasingRadioNo().click();
         cy.clickSaveAndReturnButton();
       });
@@ -348,7 +348,7 @@ context('Clone GEF (MIN) deal', () => {
       mandatoryCriteria.trueRadio().click();
       form().submit();
       cy.url().should('eq', relative(`/gef/application-details/${MINdealId}/clone/name-application`));
-      nameApplication.internalRef().clear().type('Cloned MIN deal');
+      cy.keyboardInput(nameApplication.internalRef(), 'Cloned MIN deal');
       form().submit();
 
       cy.get('[data-cy="success-message-link"]').click();

--- a/e2e-tests/gef/cypress/e2e/exporter/about-exporter.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/about-exporter.spec.js
@@ -102,7 +102,7 @@ context('About Exporter Page', () => {
     it('takes user back to application details page when form has been filled in and renders `In progress` status', () => {
       cy.visit(relative(`/gef/application-details/${dealWithEmptyExporter._id}/about-exporter`));
       aboutExporter.microRadioButton().click();
-      aboutExporter.probabilityOfDefaultInput().type('10');
+      cy.keyboardInput(aboutExporter.probabilityOfDefaultInput(), '10');
       aboutExporter.isFinancingIncreasingRadioYes().click();
       aboutExporter.doneButton().click();
       cy.url().should('eq', relative(`/gef/application-details/${dealWithEmptyExporter._id}`));

--- a/e2e-tests/gef/cypress/e2e/exporter/enter-exporters-corr-address.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/enter-exporters-corr-address.spec.js
@@ -55,7 +55,7 @@ context('Enter Exporters Correspondence Address Page', () => {
     it('redirects user to select exporters address page when clicking on `Back` Link', () => {
       cy.visit(relative(`/gef/application-details/${dealIds[0].id}/exporters-address`));
       exportersAddress.yesRadioButton().click();
-      exportersAddress.correspondenceAddress().type(POSTCODE.INVALID);
+      cy.keyboardInput(exportersAddress.correspondenceAddress(), POSTCODE.INVALID);
       cy.clickContinueButton();
       exportersAddress.postcodeError();
       exportersAddress.manualAddressEntryLink().click();
@@ -109,11 +109,11 @@ context('Enter Exporters Correspondence Address Page', () => {
 
     describe('if form has been filled in correctly', () => {
       it('takes user to about export page ', () => {
-        enterExportersCorAddress.addressLine1().type('Line 1');
-        enterExportersCorAddress.addressLine2().type('Line 2');
-        enterExportersCorAddress.addressLine3().type('Line 3');
-        enterExportersCorAddress.locality().type('Locality');
-        enterExportersCorAddress.postcode().type('Postcode');
+        cy.keyboardInput(enterExportersCorAddress.addressLine1(), 'Line 1');
+        cy.keyboardInput(enterExportersCorAddress.addressLine2(), 'Line 2');
+        cy.keyboardInput(enterExportersCorAddress.addressLine3(), 'Line 3');
+        cy.keyboardInput(enterExportersCorAddress.locality(), 'Locality');
+        cy.keyboardInput(enterExportersCorAddress.postcode(), 'Postcode');
         cy.clickContinueButton();
         cy.url().should('eq', relative(`/gef/application-details/${dealIds[0].id}/about-exporter`));
       });

--- a/e2e-tests/gef/cypress/e2e/exporter/exporter-correspondence-address.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/exporter-correspondence-address.spec.js
@@ -23,7 +23,7 @@ context('Incomplete exporter section - application details page', () => {
       cy.clickContinueButton();
       dashboardPage.mandatoryCriteriaYes().click();
       cy.clickContinueButton();
-      dashboardPage.internalRefName().type('A');
+      cy.keyboardInput(dashboardPage.internalRefName(), 'A');
       cy.clickContinueButton();
       cy.url().then((thisUrl) => {
         url = thisUrl;
@@ -35,12 +35,12 @@ context('Incomplete exporter section - application details page', () => {
     it('completes the exporter section', () => {
       cy.visit(url);
       applicationDetails.exporterDetailsLink().click();
-      companiesHouse.regNumberField().type(MOCK_COMPANY_REGISTRATION_NUMBERS.VALID);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.VALID);
       cy.clickContinueButton();
       exportersAddress.noRadioButton().click();
       cy.clickContinueButton();
       aboutExporter.microRadioButton().click();
-      aboutExporter.probabilityOfDefaultInput().type('10');
+      cy.keyboardInput(aboutExporter.probabilityOfDefaultInput(), '10');
       aboutExporter.isFinancingIncreasingRadioYes().click();
       aboutExporter.doneButton().click();
     });
@@ -121,7 +121,7 @@ context('Incomplete exporter section - application details page', () => {
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/exporters-address`));
 
       exportersAddress.yesRadioButton().click();
-      exportersAddress.correspondenceAddress().type('SW1A 2AA');
+      cy.keyboardInput(exportersAddress.correspondenceAddress(), 'SW1A 2AA');
       cy.clickContinueButton();
 
       selectExportersCorAddress.selectAddress().select('0');

--- a/e2e-tests/gef/cypress/e2e/exporter/exporters-address-create-element.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/exporters-address-create-element.spec.js
@@ -27,7 +27,7 @@ context('Exporters Address Page - Add element to page', () => {
 
   it("should not add added element's data to exporter correspondence address", () => {
     exportersAddress.yesRadioButton().click();
-    exportersAddress.correspondenceAddress().type(POSTCODE.VALID);
+    cy.keyboardInput(exportersAddress.correspondenceAddress(), POSTCODE.VALID);
 
     // adds populated text element to form
     cy.insertElement('separate-correspondence-form');

--- a/e2e-tests/gef/cypress/e2e/exporter/exporters-address.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/exporters-address.spec.js
@@ -95,7 +95,7 @@ context('Exporters Address Page', () => {
 
     it('shows error message if user enter bad postcode and a valid manual address entry link', () => {
       exportersAddress.yesRadioButton().click();
-      exportersAddress.correspondenceAddress().type('1');
+      cy.keyboardInput(exportersAddress.correspondenceAddress(), '1');
       cy.clickContinueButton();
       exportersAddress.postcodeError();
       exportersAddress.manualAddressEntryLink().click();
@@ -104,7 +104,7 @@ context('Exporters Address Page', () => {
 
     it('redirects user to Select exporters correspondence address page if form filled in correctly', () => {
       exportersAddress.yesRadioButton().click();
-      exportersAddress.correspondenceAddress().type(POSTCODE.VALID);
+      cy.keyboardInput(exportersAddress.correspondenceAddress(), POSTCODE.VALID);
       cy.clickContinueButton();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/select-exporters-correspondence-address`));
     });

--- a/e2e-tests/gef/cypress/e2e/exporter/exporters-incomplete-details.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/exporters-incomplete-details.spec.js
@@ -20,7 +20,7 @@ context('Incomplete exporter section - application details page', () => {
       cy.clickContinueButton();
       dashboardPage.mandatoryCriteriaYes().click();
       cy.clickContinueButton();
-      dashboardPage.internalRefName().type('A');
+      cy.keyboardInput(dashboardPage.internalRefName(), 'A');
       cy.clickContinueButton();
       cy.url().then((thisUrl) => {
         url = thisUrl;
@@ -32,7 +32,7 @@ context('Incomplete exporter section - application details page', () => {
     it('add the exporter', () => {
       cy.visit(url);
       applicationDetails.exporterDetailsLink().click();
-      companiesHouse.regNumberField().type(MOCK_COMPANY_REGISTRATION_NUMBERS.VALID);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.VALID);
       cy.clickContinueButton();
       exportersAddress.noRadioButton().click();
       cy.clickContinueButton();

--- a/e2e-tests/gef/cypress/e2e/exporter/select-exporters-corr-address.spec.js
+++ b/e2e-tests/gef/cypress/e2e/exporter/select-exporters-corr-address.spec.js
@@ -24,7 +24,7 @@ context('Select Exporters Correspondence Address Page', () => {
     cy.saveSession();
     cy.visit(relative(`/gef/application-details/${dealId}/exporters-address`));
     exportersAddress.yesRadioButton().click();
-    exportersAddress.correspondenceAddress().type('E1 6JE');
+    cy.keyboardInput(exportersAddress.correspondenceAddress(), 'E1 6JE');
     cy.clickContinueButton();
   });
 

--- a/e2e-tests/gef/cypress/e2e/external/companies-house.spec.js
+++ b/e2e-tests/gef/cypress/e2e/external/companies-house.spec.js
@@ -67,7 +67,7 @@ context('Companies House Page', () => {
     });
 
     it('shows the correct error message if the registration number is too short', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_TOO_SHORT);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_TOO_SHORT);
       cy.clickContinueButton();
       errorSummary().should('be.visible');
       errorSummary().should('contain', 'Enter a valid Companies House registration number');
@@ -76,7 +76,7 @@ context('Companies House Page', () => {
     });
 
     it('shows the correct error message if the registration number is too long', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_TOO_LONG);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_TOO_LONG);
       cy.clickContinueButton();
       errorSummary().should('be.visible');
       errorSummary().should('contain', 'Enter a valid Companies House registration number');
@@ -85,7 +85,7 @@ context('Companies House Page', () => {
     });
 
     it('shows the correct error message if the registration number has a special character', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_WITH_SPECIAL_CHARACTER);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_WITH_SPECIAL_CHARACTER);
       cy.clickContinueButton();
       errorSummary().should('be.visible');
       errorSummary().should('contain', 'Enter a valid Companies House registration number');
@@ -94,7 +94,7 @@ context('Companies House Page', () => {
     });
 
     it('shows the correct error message if the registration number has a space', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_WITH_SPACE);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.INVALID_WITH_SPACE);
       cy.clickContinueButton();
       errorSummary().should('be.visible');
       errorSummary().should('contain', 'Enter a valid Companies House registration number');
@@ -103,7 +103,7 @@ context('Companies House Page', () => {
     });
 
     it('shows the correct error message if the registration number is valid but does not exist', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.VALID_NONEXISTENT);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.VALID_NONEXISTENT);
       cy.clickContinueButton();
       errorSummary().should('be.visible');
       errorSummary().should('contain', 'No company matching the Companies House registration number entered was found');
@@ -112,7 +112,7 @@ context('Companies House Page', () => {
     });
 
     it('shows the correct error message if the registration number is for an overseas company', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.VALID_OVERSEAS);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.VALID_OVERSEAS);
       cy.clickContinueButton();
       errorSummary().should('be.visible');
       errorSummary().should('contain', 'UKEF can only process applications from companies based in the UK');
@@ -121,7 +121,7 @@ context('Companies House Page', () => {
     });
 
     it('takes user to `exporters address` page if company registration number exists', () => {
-      companiesHouse.regNumberField().clear().type(MOCK_COMPANY_REGISTRATION_NUMBERS.VALID);
+      cy.keyboardInput(companiesHouse.regNumberField(), MOCK_COMPANY_REGISTRATION_NUMBERS.VALID);
       cy.clickContinueButton();
       cy.url().should('eq', relative(`/gef/application-details/${dealWithEmptyExporter._id}/exporters-address`));
     });

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/about-facility.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/about-facility.spec.js
@@ -117,24 +117,24 @@ context('About Facility Page', () => {
 
     it('should show an error message if coverStartDate or coverEndDate break validation rules', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionNo().click();
-      aboutFacility.coverStartDateDay().type(`${now.getDate()}-`);
-      aboutFacility.coverStartDateMonth().type(now.getMonth() + 1);
-      aboutFacility.coverStartDateYear().type(now.getFullYear());
-      aboutFacility.coverEndDateDay().type(`${now.getDate()}-`);
-      aboutFacility.coverEndDateMonth().type(now.getMonth() + 1);
-      aboutFacility.coverEndDateYear().type(now.getFullYear());
+      cy.keyboardInput(aboutFacility.coverStartDateDay(), `${now.getDate()}-`);
+      cy.keyboardInput(aboutFacility.coverStartDateMonth(), now.getMonth() + 1);
+      cy.keyboardInput(aboutFacility.coverStartDateYear(), now.getFullYear());
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), `${now.getDate()}-`);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), now.getMonth() + 1);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), now.getFullYear());
       cy.clickContinueButton();
       errorSummary().contains('The day for the cover start date must include 1 or 2 numbers');
       errorSummary().contains('The day for the cover end date must include 1 or 2 numbers');
       aboutFacility.coverStartDateError().contains('The day for the cover start date must include 1 or 2 numbers');
       aboutFacility.coverEndDateError().contains('The day for the cover end date must include 1 or 2 numbers');
 
-      aboutFacility.coverStartDateDay().clear().type(now.getDate());
-      aboutFacility.coverStartDateYear().type('-');
-      aboutFacility.coverEndDateDay().clear().type(now.getDate());
-      aboutFacility.coverEndDateYear().type('2');
+      cy.keyboardInput(aboutFacility.coverStartDateDay(), now.getDate());
+      cy.keyboardInput(aboutFacility.coverStartDateYear(), '-');
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), now.getDate());
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), '2');
       cy.clickContinueButton();
       errorSummary().contains('The year for the cover start date must include 4 numbers');
       errorSummary().contains('The year for the cover end date must include 4 numbers');
@@ -144,48 +144,36 @@ context('About Facility Page', () => {
 
     it('should show an error message if coverStartDate and coverEndDate are the same', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionNo().click();
-      aboutFacility.coverStartDateDay().clear().type(now.getDate());
-      aboutFacility
-        .coverStartDateMonth()
-        .clear()
-        .type(now.getMonth() + 1);
-      aboutFacility.coverStartDateYear().clear().type(now.getFullYear());
-      aboutFacility.coverEndDateDay().clear().type(now.getDate());
-      aboutFacility
-        .coverEndDateMonth()
-        .clear()
-        .type(now.getMonth() + 1);
-      aboutFacility.coverEndDateYear().clear().type(now.getFullYear());
+      cy.keyboardInput(aboutFacility.coverStartDateDay(), now.getDate());
+      cy.keyboardInput(aboutFacility.coverStartDateMonth(), now.getMonth() + 1);
+      cy.keyboardInput(aboutFacility.coverStartDateYear(), now.getFullYear());
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), now.getDate());
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), now.getMonth() + 1);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), now.getFullYear());
       cy.clickContinueButton();
       aboutFacility.coverEndDateError().contains('The cover end date must be after the cover start date');
     });
 
     it('should show an error message if coverStartDate and coverEndDate are the same - shouldCoverStartOnSubmission', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(now.getDate());
-      aboutFacility
-        .coverEndDateMonth()
-        .clear()
-        .type(now.getMonth() + 1);
-      aboutFacility.coverEndDateYear().clear().type(now.getFullYear());
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), now.getDate());
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), now.getMonth() + 1);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), now.getFullYear());
       cy.clickContinueButton();
       aboutFacility.coverEndDateError().contains('The cover end date must be after the cover start date');
     });
 
     it('should show an error message if coverEndDate is before the coverStartDate - shouldCoverStartOnSubmission', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(yesterday.getDate());
-      aboutFacility
-        .coverEndDateMonth()
-        .clear()
-        .type(yesterday.getMonth() + 1);
-      aboutFacility.coverEndDateYear().clear().type(yesterday.getFullYear());
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), yesterday.getDate());
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), yesterday.getMonth() + 1);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), yesterday.getFullYear());
       cy.clickContinueButton();
       aboutFacility.coverEndDateError().contains('Cover end date cannot be before cover start date');
     });
@@ -193,14 +181,14 @@ context('About Facility Page', () => {
     if (facilityEndDateEnabled) {
       it('redirects user to `facility end date` page when using facility end date', () => {
         cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-        aboutFacility.facilityName().clear().type('Name');
+        cy.keyboardInput(aboutFacility.facilityName(), 'Name');
         aboutFacility.shouldCoverStartOnSubmissionNo().click();
-        aboutFacility.coverStartDateDay().clear().type(dateConstants.todayDay);
-        aboutFacility.coverStartDateMonth().clear().type(dateConstants.todayMonth);
-        aboutFacility.coverStartDateYear().clear().type(dateConstants.todayYear);
-        aboutFacility.coverEndDateDay().clear().type(dateConstants.twoDaysDay);
-        aboutFacility.coverEndDateMonth().clear().type(dateConstants.twoDaysMonth);
-        aboutFacility.coverEndDateYear().clear().type(dateConstants.twoDaysYear);
+        cy.keyboardInput(aboutFacility.coverStartDateDay(), dateConstants.todayDay);
+        cy.keyboardInput(aboutFacility.coverStartDateMonth(), dateConstants.todayMonth);
+        cy.keyboardInput(aboutFacility.coverStartDateYear(), dateConstants.todayYear);
+        cy.keyboardInput(aboutFacility.coverEndDateDay(), dateConstants.twoDaysDay);
+        cy.keyboardInput(aboutFacility.coverEndDateMonth(), dateConstants.twoDaysMonth);
+        cy.keyboardInput(aboutFacility.coverEndDateYear(), dateConstants.twoDaysYear);
         aboutFacility.isUsingFacilityEndDateYes().click();
 
         cy.clickContinueButton();
@@ -210,17 +198,17 @@ context('About Facility Page', () => {
 
       it('wipes the facility end date value when updating the cover start date', () => {
         cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.tomorrowDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.tomorrowMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.tomorrowYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.tomorrowDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.tomorrowMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.tomorrowYear);
 
         cy.clickContinueButton();
 
         cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
 
-        aboutFacility.coverStartDateDay().clear().type(dateConstants.tomorrowDay);
-        aboutFacility.coverStartDateMonth().clear().type(dateConstants.tomorrowMonth);
-        aboutFacility.coverStartDateYear().clear().type(dateConstants.tomorrowYear);
+        cy.keyboardInput(aboutFacility.coverStartDateDay(), dateConstants.tomorrowDay);
+        cy.keyboardInput(aboutFacility.coverStartDateMonth(), dateConstants.tomorrowMonth);
+        cy.keyboardInput(aboutFacility.coverStartDateYear(), dateConstants.tomorrowYear);
 
         cy.clickContinueButton();
 
@@ -231,14 +219,14 @@ context('About Facility Page', () => {
 
       it('redirects user to `bank review date` page when not using facility end date', () => {
         cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-        aboutFacility.facilityName().clear().type('Name');
+        cy.keyboardInput(aboutFacility.facilityName(), 'Name');
         aboutFacility.shouldCoverStartOnSubmissionNo().click();
-        aboutFacility.coverStartDateDay().clear().type(dateConstants.todayDay);
-        aboutFacility.coverStartDateMonth().clear().type(dateConstants.todayMonth);
-        aboutFacility.coverStartDateYear().clear().type(dateConstants.todayYear);
-        aboutFacility.coverEndDateDay().clear().type(dateConstants.twoDaysDay);
-        aboutFacility.coverEndDateMonth().clear().type(dateConstants.twoDaysMonth);
-        aboutFacility.coverEndDateYear().clear().type(dateConstants.twoDaysYear);
+        cy.keyboardInput(aboutFacility.coverStartDateDay(), dateConstants.todayDay);
+        cy.keyboardInput(aboutFacility.coverStartDateMonth(), dateConstants.todayMonth);
+        cy.keyboardInput(aboutFacility.coverStartDateYear(), dateConstants.todayYear);
+        cy.keyboardInput(aboutFacility.coverEndDateDay(), dateConstants.twoDaysDay);
+        cy.keyboardInput(aboutFacility.coverEndDateMonth(), dateConstants.twoDaysMonth);
+        cy.keyboardInput(aboutFacility.coverEndDateYear(), dateConstants.twoDaysYear);
         aboutFacility.isUsingFacilityEndDateNo().click();
 
         cy.clickContinueButton();
@@ -254,9 +242,9 @@ context('About Facility Page', () => {
 
         cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
 
-        aboutFacility.coverStartDateDay().clear().type(dateConstants.tomorrowDay);
-        aboutFacility.coverStartDateMonth().clear().type(dateConstants.tomorrowMonth);
-        aboutFacility.coverStartDateYear().clear().type(dateConstants.tomorrowYear);
+        cy.keyboardInput(aboutFacility.coverStartDateDay(), dateConstants.tomorrowDay);
+        cy.keyboardInput(aboutFacility.coverStartDateMonth(), dateConstants.tomorrowMonth);
+        cy.keyboardInput(aboutFacility.coverStartDateYear(), dateConstants.tomorrowYear);
 
         cy.clickContinueButton();
 
@@ -267,14 +255,14 @@ context('About Facility Page', () => {
     } else {
       it('redirects the user to `provided facility` page', () => {
         cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-        aboutFacility.facilityName().clear().type('Name');
+        cy.keyboardInput(aboutFacility.facilityName(), 'Name');
         aboutFacility.shouldCoverStartOnSubmissionNo().click();
-        aboutFacility.coverStartDateDay().clear().type(dateConstants.todayDay);
-        aboutFacility.coverStartDateMonth().clear().type(dateConstants.todayMonth);
-        aboutFacility.coverStartDateYear().clear().type(dateConstants.todayYear);
-        aboutFacility.coverEndDateDay().clear().type(dateConstants.tomorrowDay);
-        aboutFacility.coverEndDateMonth().clear().type(dateConstants.tomorrowMonth);
-        aboutFacility.coverEndDateYear().clear().type(dateConstants.tomorrowYear);
+        cy.keyboardInput(aboutFacility.coverStartDateDay(), dateConstants.todayDay);
+        cy.keyboardInput(aboutFacility.coverStartDateMonth(), dateConstants.todayMonth);
+        cy.keyboardInput(aboutFacility.coverStartDateYear(), dateConstants.todayYear);
+        cy.keyboardInput(aboutFacility.coverEndDateDay(), dateConstants.tomorrowDay);
+        cy.keyboardInput(aboutFacility.coverEndDateMonth(), dateConstants.tomorrowMonth);
+        cy.keyboardInput(aboutFacility.coverEndDateYear(), dateConstants.tomorrowYear);
 
         cy.clickContinueButton();
 
@@ -284,14 +272,14 @@ context('About Facility Page', () => {
 
     it('stores the inputted values when returning to the page', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionNo().click();
-      aboutFacility.coverStartDateDay().clear().type(dateConstants.todayDay);
-      aboutFacility.coverStartDateMonth().clear().type(dateConstants.todayMonth);
-      aboutFacility.coverStartDateYear().clear().type(dateConstants.todayYear);
-      aboutFacility.coverEndDateDay().clear().type(dateConstants.tomorrowDay);
-      aboutFacility.coverEndDateMonth().clear().type(dateConstants.tomorrowMonth);
-      aboutFacility.coverEndDateYear().clear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(aboutFacility.coverStartDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacility.coverStartDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacility.coverStartDateYear(), dateConstants.todayYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), dateConstants.tomorrowYear);
       if (facilityEndDateEnabled) {
         aboutFacility.isUsingFacilityEndDateYes().click();
       }
@@ -358,7 +346,7 @@ context('About Facility Page', () => {
 
     it('does not validate facility name field as its optional', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.monthsOfCover().type('10');
+      cy.keyboardInput(aboutFacility.monthsOfCover(), '10');
       if (facilityEndDateEnabled) {
         aboutFacility.isUsingFacilityEndDateYes().click();
       }
@@ -370,12 +358,12 @@ context('About Facility Page', () => {
     it('validates `months of cover` field if not a number', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
       aboutFacility.monthsOfCover().clear();
-      aboutFacility.monthsOfCover().type('ab');
+      cy.keyboardInput(aboutFacility.monthsOfCover(), 'ab');
       cy.clickContinueButton();
       aboutFacility.monthsOfCoverError();
 
       aboutFacility.monthsOfCover().clear();
-      aboutFacility.monthsOfCover().type('-100');
+      cy.keyboardInput(aboutFacility.monthsOfCover(), '-100');
       cy.clickContinueButton();
       aboutFacility.monthsOfCoverError();
     });

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/bank-review-date.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/bank-review-date.spec.js
@@ -99,7 +99,7 @@ context('Bank Review Date Page', () => {
     it('validates the form if not blank when clicking on `save and return` button', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/bank-review-date`));
 
-      bankReviewDate.bankReviewDateDay().clear().type(todayDay);
+      cy.keyboardInput(bankReviewDate.bankReviewDateDay(), todayDay);
       bankReviewDate.bankReviewDateMonth().clear();
       cy.clickSaveAndReturnButton();
       errorSummary();
@@ -118,14 +118,14 @@ context('Bank Review Date Page', () => {
 
     it('when cover start date is given, it validates bank review date is after the cover start date', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionNo().click();
-      aboutFacility.coverStartDateDay().clear().type(tomorrowDay);
-      aboutFacility.coverStartDateMonth().clear().type(tomorrowMonth);
-      aboutFacility.coverStartDateYear().clear().type(tomorrowYear);
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverStartDateDay(), tomorrowDay);
+      cy.keyboardInput(aboutFacility.coverStartDateMonth(), tomorrowMonth);
+      cy.keyboardInput(aboutFacility.coverStartDateYear(), tomorrowYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateNo().click();
 
       cy.clickContinueButton();
@@ -148,11 +148,11 @@ context('Bank Review Date Page', () => {
 
     it('when cover start date is not given, it validates bank review date is after today', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateNo().click();
 
       cy.clickContinueButton();
@@ -205,11 +205,11 @@ context('Bank Review Date Page', () => {
 
     it('redirects to the About Facility page when using facility end date ', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateYes().click();
       cy.clickContinueButton();
 

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facilities-change-facility-end-date-to-bank-review-date-journey.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facilities-change-facility-end-date-to-bank-review-date-journey.spec.js
@@ -46,11 +46,11 @@ context('Changing between facility end date and bank review date', () => {
   if (facilityEndDateEnabled) {
     it('should wipe the values when changing between facility end date and bank review date', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateNo().click();
       cy.clickContinueButton();
 
@@ -69,9 +69,9 @@ context('Changing between facility end date and bank review date', () => {
       cy.clickContinueButton();
 
       cy.url().should('eq', relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
-      facilityEndDate.facilityEndDateDay().clear().type(tomorrowDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(tomorrowMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(tomorrowYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), tomorrowDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), tomorrowMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), tomorrowYear);
       cy.clickContinueButton();
 
       cy.url().should('eq', relative(`/gef/application-details/${application.id}/facilities/${facilityId}/provided-facility`));
@@ -107,9 +107,9 @@ context('Changing between facility end date and bank review date', () => {
       facilityEndDate.facilityEndDateMonth().should('have.value', '');
       facilityEndDate.facilityEndDateYear().should('have.value', '');
 
-      facilityEndDate.facilityEndDateDay().clear().type(tomorrowDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(tomorrowMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(tomorrowYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), tomorrowDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), tomorrowMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), tomorrowYear);
       cy.clickContinueButton();
     });
   }

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facilities-change-from-details-journey.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facilities-change-from-details-journey.spec.js
@@ -90,9 +90,9 @@ context('Changing facility details from application-details page should take you
 
         applicationDetails.facilitySummaryListTable(0).facilityEndDateAction().click();
 
-        facilityEndDate.facilityEndDateDay().type(todayDay);
-        facilityEndDate.facilityEndDateMonth().type(todayMonth);
-        facilityEndDate.facilityEndDateYear().type(Number(todayYear) + 1);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), todayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), Number(todayYear) + 1);
         cy.clickContinueButton();
         cy.url().should('eq', relative(`/gef/application-details/${application.id}/facilities/${facility._id}/provided-facility`));
       });

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date.spec.js
@@ -98,7 +98,7 @@ context('Facility End Date Page', () => {
     it('validates the form if not blank when clicking on `save and return` button', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate.facilityEndDateDay().clear().type(todayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
       facilityEndDate.facilityEndDateMonth().clear();
       cy.clickSaveAndReturnButton();
       errorSummary();
@@ -108,9 +108,9 @@ context('Facility End Date Page', () => {
     it('redirects user to application page when clicking on `save and return` button and form has been successfully filled in', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate.facilityEndDateDay().clear().type(todayDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(todayMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), todayMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), nextYear);
 
       cy.clickSaveAndReturnButton();
 
@@ -119,14 +119,14 @@ context('Facility End Date Page', () => {
 
     it('when cover start date is given, it validates facility end date is after the cover start date', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionNo().click();
-      aboutFacility.coverStartDateDay().clear().type(tomorrowDay);
-      aboutFacility.coverStartDateMonth().clear().type(tomorrowMonth);
-      aboutFacility.coverStartDateYear().clear().type(tomorrowYear);
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverStartDateDay(), tomorrowDay);
+      cy.keyboardInput(aboutFacility.coverStartDateMonth(), tomorrowMonth);
+      cy.keyboardInput(aboutFacility.coverStartDateYear(), tomorrowYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateYes().click();
 
       cy.clickContinueButton();
@@ -135,17 +135,17 @@ context('Facility End Date Page', () => {
 
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate.facilityEndDateDay().clear().type(todayDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(todayMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(todayYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), todayMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), todayYear);
 
       cy.clickContinueButton();
       errorSummary();
       facilityEndDate.facilityEndDateError();
 
-      facilityEndDate.facilityEndDateDay().clear().type(tomorrowDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(tomorrowMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(tomorrowYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), tomorrowDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), tomorrowMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), tomorrowYear);
 
       cy.clickContinueButton();
       errorSummary().should('not.exist');
@@ -153,27 +153,27 @@ context('Facility End Date Page', () => {
 
     it('when cover start date is not given, it validates facility end date is after today', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateYes().click();
 
       cy.clickContinueButton();
       cy.url().should('eq', relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate.facilityEndDateDay().clear().type(yesterdayDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(yesterdayMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(yesterdayYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), yesterdayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), yesterdayMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), yesterdayYear);
 
       cy.clickContinueButton();
       errorSummary();
       facilityEndDate.facilityEndDateError();
 
-      facilityEndDate.facilityEndDateDay().clear().type(todayDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(todayMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(todayYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), todayMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), todayYear);
 
       cy.clickContinueButton();
       errorSummary().should('not.exist');
@@ -182,18 +182,11 @@ context('Facility End Date Page', () => {
     it('validates facility end date is less than 6 years in the future', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate
-        .facilityEndDateDay()
-        .clear()
-        .type(now.getDate() + 1);
-      facilityEndDate
-        .facilityEndDateMonth()
-        .clear()
-        .type(now.getMonth() + 1);
-      facilityEndDate
-        .facilityEndDateYear()
-        .clear()
-        .type(now.getFullYear() + 7);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), now.getDate() + 1);
+
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), now.getMonth() + 1);
+
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), now.getFullYear() + 7);
 
       cy.clickContinueButton();
       errorSummary();
@@ -203,9 +196,9 @@ context('Facility End Date Page', () => {
     it('redirects the user to `provided facility` page when form has been successfully filled in', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate.facilityEndDateDay().clear().type(todayDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(todayMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), todayMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), nextYear);
 
       cy.clickContinueButton();
 
@@ -215,9 +208,9 @@ context('Facility End Date Page', () => {
     it('stores the inputted values', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/facility-end-date`));
 
-      facilityEndDate.facilityEndDateDay().clear().type(todayDay);
-      facilityEndDate.facilityEndDateMonth().clear().type(todayMonth);
-      facilityEndDate.facilityEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(facilityEndDate.facilityEndDateDay(), todayDay);
+      cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), todayMonth);
+      cy.keyboardInput(facilityEndDate.facilityEndDateYear(), nextYear);
 
       cy.clickContinueButton();
 
@@ -229,11 +222,11 @@ context('Facility End Date Page', () => {
 
     it('redirects to the Application Details page when not using facility end date ', () => {
       cy.visit(relative(`/gef/application-details/${application.id}/facilities/${facilityId}/about-facility`));
-      aboutFacility.facilityName().clear().type('Name');
+      cy.keyboardInput(aboutFacility.facilityName(), 'Name');
       aboutFacility.shouldCoverStartOnSubmissionYes().click();
-      aboutFacility.coverEndDateDay().clear().type(todayDay);
-      aboutFacility.coverEndDateMonth().clear().type(todayMonth);
-      aboutFacility.coverEndDateYear().clear().type(nextYear);
+      cy.keyboardInput(aboutFacility.coverEndDateDay(), todayDay);
+      cy.keyboardInput(aboutFacility.coverEndDateMonth(), todayMonth);
+      cy.keyboardInput(aboutFacility.coverEndDateYear(), nextYear);
       aboutFacility.isUsingFacilityEndDateNo().click();
       cy.clickContinueButton();
 

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-value.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-value.spec.js
@@ -69,41 +69,32 @@ context('Facility Value Page', () => {
   describe('Percentage of cover field', () => {
     it('only allows the user to enter a value between 1 and 80', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().type('0');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '0');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 1 and 80');
       facilityValuePage.percentageCoverError().contains('You can only enter a number between 1 and 80');
 
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('-1');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '-1');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 1 and 80');
       facilityValuePage.percentageCoverError().contains('You can only enter a number between 1 and 80');
 
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('a');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), 'a');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 1 and 80');
       facilityValuePage.percentageCoverError().contains('You can only enter a number between 1 and 80');
 
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('81');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '81');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 1 and 80');
       facilityValuePage.percentageCoverError().contains('You can only enter a number between 1 and 80');
 
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('80');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '80');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -111,10 +102,8 @@ context('Facility Value Page', () => {
       );
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('1');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '1');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -122,10 +111,8 @@ context('Facility Value Page', () => {
       );
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10');
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -137,34 +124,26 @@ context('Facility Value Page', () => {
   describe('Interest margin Percentage field', () => {
     it('only allows the user to enter a value between 0.0001 and 99, and allows decimal places', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('-1');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '-1');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('a');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), 'a');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('101');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '101');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('1');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '1');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -172,55 +151,43 @@ context('Facility Value Page', () => {
       );
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('100');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '100');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('0.0000');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '0.0000');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('0.12345');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '0.12345');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('99.0001');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '99.0001');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('-5');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '-5');
       cy.clickContinueButton();
       errorSummary().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
       facilityValuePage.interestPercentageError().contains('You can only enter a number between 0.0001 and 99 and can have up to 4 decimal places');
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('99.0000');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '99.0000');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -228,10 +195,8 @@ context('Facility Value Page', () => {
       );
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('79');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '79');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -239,10 +204,8 @@ context('Facility Value Page', () => {
       );
 
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('79');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('10.1');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '79');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '10.1');
       cy.clickContinueButton();
       cy.url().should(
         'eq',
@@ -254,9 +217,7 @@ context('Facility Value Page', () => {
   describe('Save and return', () => {
     it('displays an error for interest percentage when it has an invalid entry', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('-1');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '-1');
       cy.clickSaveAndReturnButton();
       errorSummary();
       facilityValuePage.interestPercentageError();
@@ -264,9 +225,7 @@ context('Facility Value Page', () => {
 
     it('displays an error for percentage cover when it has an invalid entry', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('-1');
-      facilityValuePage.interestPercentage().clear();
+      cy.keyboardInput(facilityValuePage.percentageCover(), '-1');
       cy.clickSaveAndReturnButton();
       errorSummary();
       facilityValuePage.percentageCoverError();
@@ -274,36 +233,28 @@ context('Facility Value Page', () => {
 
     it('returns to the application page when all the fields are blank', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.interestPercentage().clear();
       cy.clickSaveAndReturnButton();
       cy.url().should('eq', relative(`/gef/application-details/${applications[2].id}`));
     });
 
     it('returns to the application page when all the fields have valid entries', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('80');
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('1');
+      cy.keyboardInput(facilityValuePage.percentageCover(), '80');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '1');
       cy.clickSaveAndReturnButton();
       cy.url().should('eq', relative(`/gef/application-details/${applications[2].id}`));
     });
 
     it('returns to the application page when percentage cover is blank and interestPercentage is valid', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.interestPercentage().clear();
-      facilityValuePage.interestPercentage().type('80');
+      cy.keyboardInput(facilityValuePage.interestPercentage(), '80');
       cy.clickSaveAndReturnButton();
       cy.url().should('eq', relative(`/gef/application-details/${applications[2].id}`));
     });
 
     it('returns to the application page when percentage cover is valid and interestPercentage is blank', () => {
       cy.visit(relative(`/gef/application-details/${applications[2].id}/facilities/${applications[2].facilities[1].details._id}/facility-value`));
-      facilityValuePage.percentageCover().clear();
-      facilityValuePage.percentageCover().type('80');
-      facilityValuePage.interestPercentage().clear();
+      cy.keyboardInput(facilityValuePage.percentageCover(), '80');
       cy.clickSaveAndReturnButton();
       cy.url().should('eq', relative(`/gef/application-details/${applications[2].id}`));
     });

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/provided-facility.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/provided-facility.spec.js
@@ -144,7 +144,7 @@ context('Provided Facility Page', () => {
     it('filling in `Enter details` and clicking on `Continue` takes user to currency page', () => {
       cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
       providedFacility.otherCheckbox().click();
-      providedFacility.detailsOther().type('some text here');
+      cy.keyboardInput(providedFacility.detailsOther(), 'some text here');
       cy.clickContinueButton();
       cy.url().should(
         'eq',

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -19,7 +19,6 @@ import applicationSubmission from '../../pages/application-submission';
 import statusBanner from '../../pages/application-status-banner';
 import coverStartDate from '../../pages/cover-start-date';
 import applicationDetails from '../../pages/application-details';
-import facilityEndDate from '../../pages/facility-end-date';
 import applicationActivities from '../../pages/application-activities';
 
 const { format } = require('date-fns');
@@ -173,12 +172,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.todayDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.todayMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.todayYear);
 
       cy.clickContinueButton();
 
@@ -200,12 +196,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.threeDaysDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.threeDaysYear);
 
       cy.clickContinueButton();
 
@@ -220,12 +213,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.threeMonthsOneDayDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.threeMonthsOneDayYear);
 
       cy.clickContinueButton();
 
@@ -238,19 +228,19 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
 
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -259,9 +249,6 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -160,12 +160,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate without issuing faci
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.tomorrowDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.tomorrowMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.tomorrowYear);
 
       cy.clickContinueButton();
 
@@ -180,12 +177,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate without issuing faci
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.threeDaysDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.threeDaysYear);
 
       cy.clickContinueButton();
 
@@ -200,12 +194,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate without issuing faci
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.threeMonthsOneDayDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.threeMonthsOneDayYear);
 
       cy.clickContinueButton();
 
@@ -221,12 +212,9 @@ context('Review UKEF decision MIA -> confirm coverStartDate without issuing faci
 
       coverStartDate.coverStartDateNo().click();
 
-      coverStartDate.coverStartDateDay().clear();
-      coverStartDate.coverStartDateDay().type(dateConstants.todayDay);
-      coverStartDate.coverStartDateMonth().clear();
-      coverStartDate.coverStartDateMonth().type(dateConstants.todayMonth);
-      coverStartDate.coverStartDateYear().clear();
-      coverStartDate.coverStartDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(coverStartDate.coverStartDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(coverStartDate.coverStartDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(coverStartDate.coverStartDateYear(), dateConstants.todayYear);
 
       cy.clickContinueButton();
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
@@ -76,18 +76,18 @@ if (facilityEndDateEnabled) {
         cy.visit(getUnissuedFacilitiesUrl());
         unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-        aboutFacilityUnissued.issueDateDay().clear().type(threeDaysDay);
-        aboutFacilityUnissued.issueDateMonth().clear().type(threeDaysMonth);
-        aboutFacilityUnissued.issueDateYear().clear().type(threeDaysYear);
+        cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), threeDaysDay);
+        cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), threeDaysMonth);
+        cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), threeDaysYear);
 
         aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-        aboutFacilityUnissued.coverStartDateDay().clear().type(threeDaysDay);
-        aboutFacilityUnissued.coverStartDateMonth().clear().type(threeDaysMonth);
-        aboutFacilityUnissued.coverStartDateYear().clear().type(threeDaysYear);
+        cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), threeDaysDay);
+        cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), threeDaysMonth);
+        cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), threeDaysYear);
 
-        aboutFacilityUnissued.coverEndDateDay().clear().type(threeMonthsOneDayDay);
-        aboutFacilityUnissued.coverEndDateMonth().clear().type(threeMonthsOneDayMonth);
-        aboutFacilityUnissued.coverEndDateYear().clear().type(threeMonthsOneDayYear);
+        cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), threeMonthsOneDayDay);
+        cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), threeMonthsOneDayMonth);
+        cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), threeMonthsOneDayYear);
 
         aboutFacilityUnissued.isUsingFacilityEndDateNo().click();
 
@@ -105,7 +105,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display an error message when the date is entered incorrectly & click continue', () => {
-        bankReviewDate.bankReviewDateDay().clear().type('abcd');
+        cy.keyboardInput(bankReviewDate.bankReviewDateDay(), 'abcd');
         cy.clickContinueButton();
 
         errorSummary();
@@ -113,7 +113,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display an error message when the date is entered incorrectly & click save and return', () => {
-        bankReviewDate.bankReviewDateDay().clear().type('abcd');
+        cy.keyboardInput(bankReviewDate.bankReviewDateDay(), 'abcd');
         cy.clickSaveAndReturnButton();
 
         errorSummary();
@@ -156,7 +156,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display an error message when the date is entered incorrectly & click continue', () => {
-        bankReviewDate.bankReviewDateDay().clear().type('abcd');
+        cy.keyboardInput(bankReviewDate.bankReviewDateDay(), 'abcd');
         cy.clickContinueButton();
 
         errorSummary();
@@ -164,7 +164,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display an error message when the date is entered incorrectly & click saveAndReturn', () => {
-        bankReviewDate.bankReviewDateDay().clear().type('abcd');
+        cy.keyboardInput(bankReviewDate.bankReviewDateDay(), 'abcd');
         cy.clickSaveAndReturnButton();
 
         errorSummary();

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
@@ -156,92 +156,74 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       errorSummary().contains('Enter a cover end date');
 
       // entering date in the past for issue date
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.fourDaysAgoDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.fourDaysAgoMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.fourDaysAgoYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.fourDaysAgoDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.fourDaysAgoMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.fourDaysAgoYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.issueDateError().contains('The issue date must not be before the date of the inclusion notice submission date');
       errorSummary().contains('The issue date must not be before the date of the inclusion notice submission date');
 
       // entering issue date in the future
-      aboutFacilityUnissued.issueDateDay().clear();
-      aboutFacilityUnissued.issueDateMonth().clear();
-      aboutFacilityUnissued.issueDateYear().clear();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.tomorrowDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.tomorrowMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.tomorrowYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.issueDateError().contains('The issue date cannot be in the future');
       errorSummary().contains('The issue date cannot be in the future');
 
-      aboutFacilityUnissued.issueDateDay().clear();
-      aboutFacilityUnissued.issueDateMonth().clear();
-      aboutFacilityUnissued.issueDateYear().clear();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       // entering cover start date before issue date
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.coverStartDateError().contains('Cover start date cannot be before the issue date');
       errorSummary().contains('Cover start date cannot be before the issue date');
 
       // entering cover start date beyond 3 months from notice date
-      aboutFacilityUnissued.coverStartDateDay().clear();
-      aboutFacilityUnissued.coverStartDateMonth().clear();
-      aboutFacilityUnissued.coverStartDateYear().clear();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeMonthsOneDayYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.coverStartDateError().contains('The cover start date must be within 3 months of the inclusion notice submission date');
       errorSummary().contains('The cover start date must be within 3 months of the inclusion notice submission date');
 
       // coverEnd date before coverStartDate
-      aboutFacilityUnissued.coverStartDateDay().clear();
-      aboutFacilityUnissued.coverStartDateMonth().clear();
-      aboutFacilityUnissued.coverStartDateYear().clear();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.twentyEightDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.twentyEightMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.twentyEightYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.twentyEightDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.twentyEightMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.twentyEightYear);
       cy.clickContinueButton();
       errorSummary().contains('Cover end date cannot be before cover start date');
 
       // coverEnd date same as coverStartDate
-      aboutFacilityUnissued.coverStartDateDay().clear();
-      aboutFacilityUnissued.coverStartDateMonth().clear();
-      aboutFacilityUnissued.coverStartDateYear().clear();
-      aboutFacilityUnissued.coverEndDateDay().clear();
-      aboutFacilityUnissued.coverEndDateMonth().clear();
-      aboutFacilityUnissued.coverEndDateYear().clear();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.todayYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.todayYear);
       cy.clickContinueButton();
       errorSummary().contains('The cover end date must be after the cover start date');
 
-      aboutFacilityUnissued.issueDateDay().clear().type('**');
-      aboutFacilityUnissued.issueDateMonth().clear().type(`${dateConstants.threeDaysMonth}-`);
-      aboutFacilityUnissued.issueDateYear().clear().type(`${dateConstants.threeDaysYear}2`);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay().clear(), '**');
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth().clear(), `${dateConstants.threeDaysMonth}-`);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear().clear(), `${dateConstants.threeDaysYear}2`);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().clear().type(`${dateConstants.twoMonthsDay}/`);
-      aboutFacilityUnissued.coverStartDateMonth().clear().type(`${dateConstants.twoMonthsMonth}2`);
-      aboutFacilityUnissued.coverStartDateYear().clear().type(`${dateConstants.twoMonthsYear}/`);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay().clear(), `${dateConstants.twoMonthsDay}/`);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth().clear(), `${dateConstants.twoMonthsMonth}2`);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear().clear(), `${dateConstants.twoMonthsYear}/`);
 
-      aboutFacilityUnissued.coverEndDateDay().clear().type(`${dateConstants.threeMonthsOneDayDay}2`);
-      aboutFacilityUnissued.coverEndDateMonth().clear().type(`${dateConstants.threeMonthsOneDayMonth}-`);
-      aboutFacilityUnissued.coverEndDateYear().clear().type(`${dateConstants.threeMonthsOneDayYear}2`);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay().clear(), `${dateConstants.threeMonthsOneDayDay}2`);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth().clear(), `${dateConstants.threeMonthsOneDayMonth}-`);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear().clear(), `${dateConstants.threeMonthsOneDayYear}2`);
       cy.clickContinueButton();
 
       errorSummary().contains('The day for the issue date must include 1 or 2 numbers');
@@ -262,18 +244,18 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -284,9 +266,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       if (facilityEndDateEnabled) {
         cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/facility-end-date`));
 
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsYear);
         cy.clickContinueButton();
       }
 
@@ -297,17 +279,17 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -316,9 +298,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsYear);
         cy.clickContinueButton();
       }
 
@@ -327,18 +309,18 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateNo().click();
@@ -479,8 +461,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change`));
 
       // checks that cancel does not save changes
-      aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type('a new name');
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), 'a new name');
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
       cy.clickCancelLink();
 
@@ -488,8 +469,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).nameAction().click();
 
-      aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type(`${MOCK_FACILITY_ONE.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_ONE.name}name`);
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
 
       if (facilityEndDateEnabled) {
@@ -499,9 +479,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsYear);
         cy.clickContinueButton();
       }
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -101,18 +101,18 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -121,9 +121,9 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -134,17 +134,17 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateNo().click();
@@ -391,18 +391,18 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -411,9 +411,9 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
@@ -71,18 +71,18 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(1).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -91,9 +91,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -104,17 +104,17 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(1).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -123,9 +123,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -369,18 +369,18 @@ context('Return to maker for unissued to issued facilities', () => {
       applicationDetails.facilitySummaryListTable(3).hasBeenIssuedAction().click();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change`));
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -389,9 +389,9 @@ context('Return to maker for unissued to issued facilities', () => {
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
@@ -66,18 +66,18 @@ if (facilityEndDateEnabled) {
         cy.visit(relative(`/gef/application-details/${dealId}/unissued-facilities`));
         unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-        aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-        aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-        aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+        cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+        cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+        cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
         aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-        aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-        aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-        aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+        cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+        cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+        cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-        aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-        aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-        aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
 
@@ -93,7 +93,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display error messages when clicking continue', () => {
-        facilityEndDate.facilityEndDateDay().clear().type('abcd');
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), 'abcd');
         cy.clickContinueButton();
 
         errorSummary();
@@ -101,7 +101,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display error messages when clicking save and return', () => {
-        facilityEndDate.facilityEndDateDay().clear().type('abcd');
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), 'abcd');
         cy.clickSaveAndReturnButton();
 
         errorSummary();
@@ -109,9 +109,9 @@ if (facilityEndDateEnabled) {
       });
 
       it('should redirect user to the unissued facility page when clicking continue', () => {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.todayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.todayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.todayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.todayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.todayYear);
 
         cy.clickContinueButton();
 
@@ -119,9 +119,9 @@ if (facilityEndDateEnabled) {
       });
 
       it('should redirect user to the unissued facility page when clicking save and return', () => {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.todayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.todayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.todayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.todayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.todayYear);
 
         cy.clickSaveAndReturnButton();
 
@@ -144,7 +144,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display error messages when clicking continue', () => {
-        facilityEndDate.facilityEndDateDay().clear().type('abcd');
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), 'abcd');
         cy.clickContinueButton();
 
         errorSummary();
@@ -152,7 +152,7 @@ if (facilityEndDateEnabled) {
       });
 
       it('should display error messages when clicking save and return', () => {
-        facilityEndDate.facilityEndDateDay().clear().type('abcd');
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), 'abcd');
         cy.clickSaveAndReturnButton();
 
         errorSummary();
@@ -160,18 +160,18 @@ if (facilityEndDateEnabled) {
       });
 
       it('should redirect user to the application details page when clicking continue', () => {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.todayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.todayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.todayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.todayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.todayYear);
         cy.clickContinueButton();
 
         cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
       });
 
       it('should redirect user to the application details page when clicking save and return', () => {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.todayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.todayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.todayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.todayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.todayYear);
 
         cy.clickSaveAndReturnButton();
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
@@ -107,18 +107,18 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -127,9 +127,9 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -215,20 +215,20 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type(`${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -237,9 +237,9 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
     });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -123,20 +123,20 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
       // Issue date set to today's date
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       // Cover start date to user defined date - Three days in the past
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
       // Cover end date to user defined date
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -147,9 +147,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
@@ -131,77 +131,59 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       errorSummary().contains('Enter a cover end date');
 
       // entering date in the past for issue date
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.fourDaysAgoDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.fourDaysAgoMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.fourDaysAgoYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.fourDaysAgoDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.fourDaysAgoMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.fourDaysAgoYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.issueDateError().contains('The issue date must not be before the date of the inclusion notice submission date');
       errorSummary().contains('The issue date must not be before the date of the inclusion notice submission date');
 
       // entering issue date in the future
-      aboutFacilityUnissued.issueDateDay().clear();
-      aboutFacilityUnissued.issueDateMonth().clear();
-      aboutFacilityUnissued.issueDateYear().clear();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.tomorrowDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.tomorrowMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.tomorrowYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.issueDateError().contains('The issue date cannot be in the future');
       errorSummary().contains('The issue date cannot be in the future');
 
-      aboutFacilityUnissued.issueDateDay().clear();
-      aboutFacilityUnissued.issueDateMonth().clear();
-      aboutFacilityUnissued.issueDateYear().clear();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       // entering cover start date before issue date
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.coverStartDateError().contains('Cover start date cannot be before the issue date');
       errorSummary().contains('Cover start date cannot be before the issue date');
 
       // entering cover start date beyond 3 months from notice date
-      aboutFacilityUnissued.coverStartDateDay().clear();
-      aboutFacilityUnissued.coverStartDateMonth().clear();
-      aboutFacilityUnissued.coverStartDateYear().clear();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeMonthsOneDayYear);
       cy.clickContinueButton();
       aboutFacilityUnissued.coverStartDateError().contains('The cover start date must be within 3 months of the inclusion notice submission date');
       errorSummary().contains('The cover start date must be within 3 months of the inclusion notice submission date');
 
       // coverEnd date before coverStartDate
-      aboutFacilityUnissued.coverStartDateDay().clear();
-      aboutFacilityUnissued.coverStartDateMonth().clear();
-      aboutFacilityUnissued.coverStartDateYear().clear();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.twentyEightDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.twentyEightMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.twentyEightYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.twentyEightDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.twentyEightMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.twentyEightYear);
       cy.clickContinueButton();
       errorSummary().contains('Cover end date cannot be before cover start date');
 
       // coverEnd date same as coverStartDate
-      aboutFacilityUnissued.coverStartDateDay().clear();
-      aboutFacilityUnissued.coverStartDateMonth().clear();
-      aboutFacilityUnissued.coverStartDateYear().clear();
-      aboutFacilityUnissued.coverEndDateDay().clear();
-      aboutFacilityUnissued.coverEndDateMonth().clear();
-      aboutFacilityUnissued.coverEndDateYear().clear();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.todayYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.todayYear);
       cy.clickContinueButton();
       errorSummary().contains('The cover end date must be after the cover start date');
     });
@@ -210,18 +192,18 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -232,9 +214,9 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       if (facilityEndDateEnabled) {
         cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/facility-end-date`));
 
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsYear);
         cy.clickContinueButton();
       }
 
@@ -245,17 +227,17 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -264,9 +246,9 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay().clear(), dateConstants.threeMonthsDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth().clear(), dateConstants.threeMonthsMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear().clear(), dateConstants.threeMonthsYear);
         cy.clickContinueButton();
       }
 
@@ -275,20 +257,20 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
 
       // testing if MIN submission date so can do 3months
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateNo().click();
@@ -430,8 +412,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change`));
 
       // checks that cancel does not save changes
-      aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type('a new name');
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), 'a new name');
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
 
       if (facilityEndDateEnabled) {
@@ -449,8 +430,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).nameAction().click();
 
-      aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type(`${MOCK_FACILITY_ONE.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_ONE.name}name`);
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
 
       if (facilityEndDateEnabled) {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
@@ -72,18 +72,18 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(1).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.threeDaysYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -92,9 +92,9 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -105,17 +105,17 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       continueButton().should('not.exist');
 
       unissuedFacilityTable.updateIndividualFacilityButton(1).click();
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoMonthsYear);
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -124,9 +124,9 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -372,18 +372,18 @@ context('Return to maker for unissued to issued facilities', () => {
       applicationDetails.facilitySummaryListTable(3).hasBeenIssuedAction().click();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change`));
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.todayYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -391,9 +391,9 @@ context('Return to maker for unissued to issued facilities', () => {
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
@@ -103,18 +103,18 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.tomorrowDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.tomorrowMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.tomorrowYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
 
       cy.clickContinueButton();
 
@@ -132,18 +132,18 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(1).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.tomorrowDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.tomorrowMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.tomorrowYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -152,9 +152,9 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -178,9 +178,9 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       it('should display error on facility end date page if date is over 6 years in the future', () => {
         applicationPreview.facilitySummaryListTable(1).facilityEndDateAction().click();
 
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.sixYearsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.sixYearsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.sixYearsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.sixYearsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.sixYearsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.sixYearsOneDayYear);
         cy.clickContinueButton();
 
         errorSummary().contains('Facility end date cannot be greater than 6 years in the future');
@@ -190,9 +190,9 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       it('should display error on facility end date page if date before the cover start date', () => {
         applicationPreview.facilitySummaryListTable(1).facilityEndDateAction().click();
 
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.todayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.todayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.todayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.todayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.todayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.todayYear);
         cy.clickContinueButton();
 
         errorSummary().contains('Facility end date cannot be before the cover start date');
@@ -204,20 +204,20 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type(`${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.tomorrowDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.tomorrowMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.tomorrowYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.tomorrowYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
       cy.clickContinueButton();
 
       errorSummary().contains('The cover start date must be within 3 months of the inclusion notice submission date');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
@@ -108,18 +108,18 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoYearsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoYearsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoYearsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -130,24 +130,24 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       errorSummary().contains('The cover start date must be within 3 months of the inclusion notice submission date');
       aboutFacilityUnissued.coverStartDateError().contains('The cover start date must be within 3 months of the inclusion notice submission date');
 
-      aboutFacilityUnissued.issueDateDay().clear().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().clear().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().clear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().clear().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().clear().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().clear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
 
@@ -229,37 +229,37 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type(`${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoYearsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoYearsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoYearsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
       cy.clickContinueButton();
 
       errorSummary().contains('The cover start date must be within 3 months of the inclusion notice submission date');
       aboutFacilityUnissued.coverStartDateError().contains('The cover start date must be within 3 months of the inclusion notice submission date');
 
-      aboutFacilityUnissued.issueDateDay().clear().type(dateConstants.threeDaysDay);
-      aboutFacilityUnissued.issueDateMonth().clear().type(dateConstants.threeDaysMonth);
-      aboutFacilityUnissued.issueDateYear().clear().type(dateConstants.threeDaysYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.threeDaysDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.threeDaysMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.threeDaysYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().clear().type(dateConstants.twoMonthsDay);
-      aboutFacilityUnissued.coverStartDateMonth().clear().type(dateConstants.twoMonthsMonth);
-      aboutFacilityUnissued.coverStartDateYear().clear().type(dateConstants.twoMonthsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoMonthsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoMonthsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoMonthsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-      aboutFacilityUnissued.coverEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-      aboutFacilityUnissued.coverEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeMonthsOneDayYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -268,9 +268,9 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
     });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
@@ -118,18 +118,18 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       applicationPreview.unissuedFacilitiesReviewLink().click();
       unissuedFacilityTable.updateIndividualFacilityButton(0).click();
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionNo().click();
-      aboutFacilityUnissued.coverStartDateDay().type(dateConstants.twoYearsDay);
-      aboutFacilityUnissued.coverStartDateMonth().type(dateConstants.twoYearsMonth);
-      aboutFacilityUnissued.coverStartDateYear().type(dateConstants.twoYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateDay(), dateConstants.twoYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateMonth(), dateConstants.twoYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverStartDateYear(), dateConstants.twoYearsYear);
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -137,9 +137,9 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeYearsDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeYearsMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeYearsYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeYearsDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeYearsMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeYearsYear);
         cy.clickContinueButton();
       }
 
@@ -221,17 +221,17 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      aboutFacilityUnissued.facilityName().type(`${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
 
-      aboutFacilityUnissued.issueDateDay().type(dateConstants.todayDay);
-      aboutFacilityUnissued.issueDateMonth().type(dateConstants.todayMonth);
-      aboutFacilityUnissued.issueDateYear().type(dateConstants.todayYear);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(aboutFacilityUnissued.issueDateYear(), dateConstants.todayYear);
 
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
 
-      aboutFacilityUnissued.coverEndDateDay().type(dateConstants.threeYearsDay);
-      aboutFacilityUnissued.coverEndDateMonth().type(dateConstants.threeYearsMonth);
-      aboutFacilityUnissued.coverEndDateYear().type(dateConstants.threeYearsYear);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateDay(), dateConstants.threeYearsDay);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateMonth(), dateConstants.threeYearsMonth);
+      cy.keyboardInput(aboutFacilityUnissued.coverEndDateYear(), dateConstants.threeYearsYear);
 
       if (facilityEndDateEnabled) {
         aboutFacilityUnissued.isUsingFacilityEndDateYes().click();
@@ -240,9 +240,9 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       cy.clickContinueButton();
 
       if (facilityEndDateEnabled) {
-        facilityEndDate.facilityEndDateDay().clear().type(dateConstants.threeMonthsOneDayDay);
-        facilityEndDate.facilityEndDateMonth().clear().type(dateConstants.threeMonthsOneDayMonth);
-        facilityEndDate.facilityEndDateYear().clear().type(dateConstants.threeMonthsOneDayYear);
+        cy.keyboardInput(facilityEndDate.facilityEndDateDay(), dateConstants.threeMonthsOneDayDay);
+        cy.keyboardInput(facilityEndDate.facilityEndDateMonth(), dateConstants.threeMonthsOneDayMonth);
+        cy.keyboardInput(facilityEndDate.facilityEndDateYear(), dateConstants.threeMonthsOneDayYear);
         cy.clickContinueButton();
       }
     });

--- a/e2e-tests/gef/cypress/e2e/maker/return-to-maker-mia.spec.js
+++ b/e2e-tests/gef/cypress/e2e/maker/return-to-maker-mia.spec.js
@@ -53,8 +53,8 @@ context('Return to Maker as MIA', () => {
       cy.uploadFile('upload-file-valid.doc', `/gef/application-details/${dealId}/supporting-information/document/manual-inclusion-questionnaire/upload`);
       manualInclusion.uploadSuccess('upload_file_valid.doc');
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test2');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
 
       cy.clickSubmitButton();
@@ -77,7 +77,7 @@ context('Return to Maker as MIA', () => {
       applicationPreview.supportingInfoListRowAction(0, 0).should('not.exist');
       applicationPreview.supportingInfoListRowAction(0, 1).should('not.exist');
       applicationPreview.returnButton().click();
-      returnToMaker.comment().type('comment1');
+      cy.keyboardInput(returnToMaker.comment(), 'comment1');
       cy.clickSubmitButton();
       cy.location('pathname').should('contain', 'dashboard');
     });
@@ -164,8 +164,8 @@ context('Return to Maker as MIA', () => {
 
     it('can change security details comments', () => {
       securityDetails.securityDetailsChangeCta().click();
-      securityDetails.exporterSecurity().type(' test3');
-      securityDetails.facilitySecurity().type('test4');
+      cy.keyboardInput(securityDetails.exporterSecurity(), ' test3');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test4');
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/gef/cypress/e2e/maker/return-to-maker.spec.js
+++ b/e2e-tests/gef/cypress/e2e/maker/return-to-maker.spec.js
@@ -49,7 +49,7 @@ context('Return to Maker', () => {
     });
 
     it('submits with comments', () => {
-      returnToMaker.comment().type('Test comment');
+      cy.keyboardInput(returnToMaker.comment(), 'Test comment');
       cy.clickSubmitButton();
       cy.location('pathname').should('contain', 'dashboard');
     });
@@ -57,13 +57,13 @@ context('Return to Maker', () => {
     it('display an error when the comment is greater than 400 characters', () => {
       const longComment = 'a'.repeat(401);
 
-      returnToMaker.comment().type(longComment);
+      cy.keyboardInput(returnToMaker.comment(), longComment);
       cy.clickSubmitButton();
       errorSummary();
     });
 
     it('takes checker back to application preview page when cancelled', () => {
-      returnToMaker.comment().type('Some comments here ....');
+      cy.keyboardInput(returnToMaker.comment(), 'Some comments here ....');
       cy.clickCancelLink();
       cy.location('pathname').should('eq', `/gef/application-details/${dealIds[2]}`);
     });

--- a/e2e-tests/gef/cypress/e2e/scenarios/eligibility-criterion-16/eligibility-criterion-16.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/eligibility-criterion-16/eligibility-criterion-16.spec.js
@@ -88,8 +88,8 @@ context('Eligibility Criterion 16', () => {
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/supporting-information/security-details`));
 
       mainHeading().contains('Enter security details');
-      securityDetails.exporterSecurity().type('exporter test');
-      securityDetails.facilitySecurity().type('facility test');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'exporter test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'facility test');
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-add-document.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-add-document.spec.js
@@ -52,15 +52,15 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
 
       cy.login(BANK1_MAKER1);
       securityDetails.visit(dealIds[2]);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test2');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
 
       cy.login(BANK1_MAKER1);
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-delete-document.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-delete-document.spec.js
@@ -49,8 +49,8 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.uploadFile('upload-file-valid.doc', `/gef/application-details/${dealIds[2]}/supporting-information/document/manual-inclusion-questionnaire/upload`);
       manualInclusion.uploadSuccess('upload_file_valid.doc');
       securityDetails.visit(dealIds[2]);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test2');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
 
       // login as maker_checker only to delete a file.  file readded as maker
@@ -70,7 +70,7 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-deleted-facility.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-deleted-facility.spec.js
@@ -49,7 +49,7 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-edited-facility.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-edited-facility.spec.js
@@ -48,7 +48,7 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-eligibility-criteria.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-eligibility-criteria.spec.js
@@ -41,7 +41,7 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-security-questions.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-security-questions.spec.js
@@ -54,8 +54,8 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
 
       securityDetails.visit(dealIds[2]);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test2');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
 
       cy.login(BANK1_MAKER1);
@@ -63,7 +63,7 @@ context('Create application as MAKER, edit as MAKER_CHECKER, submit application 
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-submit-to-checker.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/maker-checker-user-role/maker_checker-should-not-submit-edited-deal-submit-to-checker.spec.js
@@ -41,7 +41,7 @@ context('Create application as MAKER, submit application to UKEF as MAKER_CHECKE
 
       // submit the deal
       cy.clickSubmitButton();
-      applicationSubmission.commentsField().type('DTFS2-4698 Comments from original maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'DTFS2-4698 Comments from original maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 
@@ -49,7 +49,7 @@ context('Create application as MAKER, submit application to UKEF as MAKER_CHECKE
       cy.login(BANK1_MAKER_CHECKER1);
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
       applicationPreview.returnButton().click();
-      returnToMaker.comment().type('nope');
+      cy.keyboardInput(returnToMaker.comment(), 'nope');
       cy.clickSubmitButton();
       cy.location('pathname').should('contain', 'dashboard');
       cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
@@ -69,7 +69,7 @@ context('Create application as MAKER, submit application to UKEF as MAKER_CHECKE
       cy.clickSubmitButton();
 
       // it allows the maker to optionally add additional comments
-      applicationSubmission.commentsField().type('Hello');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'Hello');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/scenarios/makers-input.spec.js
+++ b/e2e-tests/gef/cypress/e2e/scenarios/makers-input.spec.js
@@ -36,7 +36,7 @@ context('Review application when returned to maker', () => {
 
     // submit the deal with a comment
     cy.clickSubmitButton();
-    applicationSubmission.commentsField().type('Hello');
+    cy.keyboardInput(applicationSubmission.commentsField(), 'Hello');
     cy.clickSubmitButton();
     applicationSubmission.confirmationPanelTitle();
 
@@ -44,7 +44,7 @@ context('Review application when returned to maker', () => {
     cy.login(BANK1_CHECKER1);
     cy.visit(relative(`/gef/application-details/${dealIds[2]}`));
     applicationPreview.returnButton().click();
-    returnToMaker.comment().type('Nope');
+    cy.keyboardInput(returnToMaker.comment(), 'Nope');
     cy.clickSubmitButton();
     cy.location('pathname').should('contain', 'dashboard');
     cy.login(BANK1_MAKER1);
@@ -66,7 +66,7 @@ context('Review application when returned to maker', () => {
       cy.clickSubmitButton();
 
       // it allows the maker to optionally add additional comments
-      applicationSubmission.commentsField().type('Comments from the maker');
+      cy.keyboardInput(applicationSubmission.commentsField(), 'Comments from the maker');
       cy.clickSubmitButton();
       applicationSubmission.confirmationPanelTitle();
 

--- a/e2e-tests/gef/cypress/e2e/security/security-details.spec.js
+++ b/e2e-tests/gef/cypress/e2e/security/security-details.spec.js
@@ -47,8 +47,8 @@ context('Security Details Page', () => {
       const longString = new Array(402).join('t');
 
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type(longString);
-      securityDetails.facilitySecurity().type(longString);
+      cy.keyboardInput(securityDetails.exporterSecurity(), longString);
+      cy.keyboardInput(securityDetails.facilitySecurity(), longString);
       cy.clickSubmitButton();
       errorSummary();
       securityDetails.exporterSecurityError();
@@ -59,8 +59,8 @@ context('Security Details Page', () => {
       const invalidString = 'This text @ is not %()~# valid';
 
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type(invalidString);
-      securityDetails.facilitySecurity().type(invalidString);
+      cy.keyboardInput(securityDetails.exporterSecurity(), invalidString);
+      cy.keyboardInput(securityDetails.facilitySecurity(), invalidString);
       cy.clickSubmitButton();
       errorSummary();
       securityDetails.exporterSecurityError();
@@ -69,8 +69,8 @@ context('Security Details Page', () => {
 
     it('takes you to `Application details` page when clicking on `Continue` button', () => {
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type('Valid security details');
-      securityDetails.facilitySecurity().type('Valid security details');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'Valid security details');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'Valid security details');
       cy.clickSubmitButton();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
     });

--- a/e2e-tests/gef/cypress/e2e/ukef/submit-to-ukef-mia.spec.js
+++ b/e2e-tests/gef/cypress/e2e/ukef/submit-to-ukef-mia.spec.js
@@ -52,8 +52,8 @@ context('Submit MIA to UKEF', () => {
       manualInclusion.uploadSuccess('upload_file_valid.doc');
       cy.clickContinueButton();
       securityDetails.visit(dealId);
-      securityDetails.exporterSecurity().type('test');
-      securityDetails.facilitySecurity().type('test2');
+      cy.keyboardInput(securityDetails.exporterSecurity(), 'test');
+      cy.keyboardInput(securityDetails.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
       securityDetails.visit(dealId);
       cy.clickCancelButton();

--- a/e2e-tests/gef/cypress/e2e/upload/upload-files-to-azure.spec.js
+++ b/e2e-tests/gef/cypress/e2e/upload/upload-files-to-azure.spec.js
@@ -130,8 +130,8 @@ context('Upload files to Azure', () => {
     it('should populate the `Security Details` section', () => {
       uploadFiles.supportingInfoSecurityDetailsButton().click();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/supporting-information/security-details`));
-      uploadFiles.exporterSecurity().type('test');
-      uploadFiles.facilitySecurity().type('test2');
+      cy.keyboardInput(uploadFiles.exporterSecurity(), 'test');
+      cy.keyboardInput(uploadFiles.facilitySecurity(), 'test2');
       cy.clickSubmitButton();
     });
 

--- a/e2e-tests/gef/cypress/support/commands.js
+++ b/e2e-tests/gef/cypress/support/commands.js
@@ -5,6 +5,8 @@ import './commands/click-events';
 
 Cypress.Commands.add('saveSession', require('./utils/saveSession'));
 
+Cypress.Commands.add('keyboardInput', require('./utils/keyboardInput'));
+
 Cypress.Commands.add('assertText', require('./utils/assertText'));
 
 Cypress.Commands.add('login', require('./commands/portal/login'));

--- a/e2e-tests/gef/cypress/support/commands/fillInBankReviewDate.js
+++ b/e2e-tests/gef/cypress/support/commands/fillInBankReviewDate.js
@@ -7,7 +7,7 @@ import { longYearFormat, shortDayFormat, shortMonthFormat } from '../../../../e2
  * @param {Date} date
  */
 export const fillInBankReviewDate = (date) => {
-  bankReviewDate.bankReviewDateDay().clear().type(format(date, shortDayFormat));
-  bankReviewDate.bankReviewDateMonth().clear().type(format(date, shortMonthFormat));
-  bankReviewDate.bankReviewDateYear().clear().type(format(date, longYearFormat));
+  cy.keyboardInput(bankReviewDate.bankReviewDateDay(), format(date, shortDayFormat));
+  cy.keyboardInput(bankReviewDate.bankReviewDateMonth(), format(date, shortMonthFormat));
+  cy.keyboardInput(bankReviewDate.bankReviewDateYear(), format(date, longYearFormat));
 };

--- a/e2e-tests/gef/cypress/support/commands/insertElement.js
+++ b/e2e-tests/gef/cypress/support/commands/insertElement.js
@@ -20,7 +20,7 @@ const insertElement = (divId) => {
     // adds element to div so is part of the form
     div.appendChild(textInput);
     // types text into the field
-    cy.get('[data-cy="intruder"]').type('input text');
+    cy.keyboardInput(cy.get('[data-cy="intruder"]'), 'input text');
   });
 };
 

--- a/e2e-tests/gef/cypress/support/commands/portal/enterUsernameAndPassword.js
+++ b/e2e-tests/gef/cypress/support/commands/portal/enterUsernameAndPassword.js
@@ -2,7 +2,9 @@ const landingPage = require('../../../e2e/pages/landingPage');
 
 module.exports = ({ username, password }) => {
   landingPage.visit();
-  landingPage.email().type(username);
-  landingPage.password().type(password);
+
+  cy.keyboardInput(landingPage.email(), username);
+  cy.keyboardInput(landingPage.password(), password);
+
   landingPage.login().click();
 };

--- a/e2e-tests/gef/cypress/support/utils/keyboardInput.js
+++ b/e2e-tests/gef/cypress/support/utils/keyboardInput.js
@@ -1,0 +1,11 @@
+/**
+ * keyboardInput
+ * Clear and type text into an input.
+ * @param {Function} selector: Cypress selector
+ * @param {String} text: Text to enter
+ */
+const keyboardInput = (selector, text) => {
+  selector.clear().type(text, { delay: 0 });
+};
+
+export default keyboardInput;


### PR DESCRIPTION
## Introduction :pencil2:
This PR introduces a new `keyboardInput` cypress command to the GEF E2E suite. This enforces:

- Zero delay when inputting text. Therefore speeding up tests.
- A consistent way of inputting text.

This is part of a series of E2E improvements to reduce E2E GHA time.

## Resolution :heavy_check_mark:
- Create new `keyboardInput` cypress command.
- Update E2E tests.

## Miscellaneous :heavy_plus_sign:
- Minor readability improvements.

