### PR TITLE
chore(DTFS2-7392): refactor mock facilities into functions

### DIFF
--- a/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
+++ b/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
@@ -12,9 +12,13 @@ import mandatoryCriteria from '../pages/mandatory-criteria';
 import uploadFiles from '../pages/upload-files';
 import statusBanner from '../pages/application-status-banner';
 import CONSTANTS from '../../fixtures/constants';
-import { MOCK_FACILITY_ONE } from '../../fixtures/mocks/mock-facilities';
+import { anUnissuedCashFacility } from '../../fixtures/mocks/mock-facilities';
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../e2e-fixtures/portal-users.fixture';
 import { MOCK_APPLICATION_MIN } from '../../fixtures/mocks/mock-deals';
+
+const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
 
 context('Clone GEF (AIN) deal', () => {
   let AINdealId;

--- a/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
+++ b/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
@@ -18,8 +18,6 @@ import { MOCK_APPLICATION_MIN } from '../../fixtures/mocks/mock-deals';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const unissuedCashFacility = anUnissuedCashFacility({ facilityEndDateEnabled });
-
 context('Clone GEF (AIN) deal', () => {
   let AINdealId;
   let testDealId;
@@ -333,7 +331,7 @@ context('Clone GEF (MIN) deal', () => {
           cy.apiUpdateApplication(MINdealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(MINdealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facilityOneId, token, unissuedCashFacility);
+              cy.apiUpdateFacility(facilityOneId, token, anUnissuedCashFacility({ facilityEndDateEnabled }));
             });
           });
         });

--- a/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
+++ b/e2e-tests/gef/cypress/e2e/clone/clone-gef-deal.spec.js
@@ -18,7 +18,7 @@ import { MOCK_APPLICATION_MIN } from '../../fixtures/mocks/mock-deals';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const unissuedCashFacility = anUnissuedCashFacility({ facilityEndDateEnabled });
 
 context('Clone GEF (AIN) deal', () => {
   let AINdealId;
@@ -333,7 +333,7 @@ context('Clone GEF (MIN) deal', () => {
           cy.apiUpdateApplication(MINdealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(MINdealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facilityOneId, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facilityOneId, token, unissuedCashFacility);
             });
           });
         });

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -7,7 +7,12 @@ import dateConstants from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO_NULL_MIA, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacilityWithCoverDateConfirmed,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../fixtures/mocks/mock-facilities';
 
 import { toTitleCase } from '../../../fixtures/helpers';
 
@@ -21,6 +26,13 @@ import coverStartDate from '../../pages/cover-start-date';
 import applicationDetails from '../../pages/application-details';
 import applicationActivities from '../../pages/application-activities';
 
+const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO_NULL_MIA = anIssuedCashFacilityWithCoverDateConfirmed({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
 const { format } = require('date-fns');
 
 let dealId;
@@ -30,8 +42,6 @@ let facilityTwoId;
 const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
 
 const issuedFacilities = [MOCK_FACILITY_TWO_NULL_MIA];
-
-const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
 context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued facility', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -7,7 +7,7 @@ import dateConstants from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
-import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockFacilities } from '../../../fixtures/mocks/mock-facilities';
+import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockGefFacilities } from '../../../fixtures/mocks/mock-facilities';
 
 import { toTitleCase } from '../../../fixtures/helpers';
 
@@ -22,7 +22,7 @@ import applicationDetails from '../../pages/application-details';
 import applicationActivities from '../../pages/application-activities';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
-const { unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({ facilityEndDateEnabled });
+const { unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({ facilityEndDateEnabled });
 const issuedCashFacilityWithCoverDateConfirmed = anIssuedCashFacilityWithCoverDateConfirmed({ facilityEndDateEnabled });
 
 const { format } = require('date-fns');

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -7,12 +7,7 @@ import dateConstants from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacilityWithCoverDateConfirmed,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../fixtures/mocks/mock-facilities';
+import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockFacilities } from '../../../fixtures/mocks/mock-facilities';
 
 import { toTitleCase } from '../../../fixtures/helpers';
 
@@ -27,11 +22,8 @@ import applicationDetails from '../../pages/application-details';
 import applicationActivities from '../../pages/application-activities';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
-
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO_NULL_MIA = anIssuedCashFacilityWithCoverDateConfirmed({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({ facilityEndDateEnabled });
+const issuedCashFacilityWithCoverDateConfirmed = anIssuedCashFacilityWithCoverDateConfirmed({ facilityEndDateEnabled });
 
 const { format } = require('date-fns');
 
@@ -39,9 +31,9 @@ let dealId;
 let token;
 let facilityTwoId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
-const issuedFacilities = [MOCK_FACILITY_TWO_NULL_MIA];
+const issuedFacilities = [issuedCashFacilityWithCoverDateConfirmed];
 
 context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued facility', () => {
   before(() => {
@@ -57,18 +49,18 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
           cy.submitDealAfterUkefIds(dealId, 'GEF', BANK1_CHECKER1_WITH_MOCK_ID);
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
-              MOCK_FACILITY_ONE._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              unissuedCashFacility._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityTwoId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO_NULL_MIA);
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacilityWithCoverDateConfirmed);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_APPROVED_WITH_CONDITIONS);
             cy.addCommentObjToDeal(dealId, CONSTANTS.DEAL_COMMENT_TYPE_PORTAL.UKEF_DECISION, UKEF_DECISION);
@@ -555,11 +547,11 @@ context('Check activity feed', () => {
       applicationActivities.subNavigationBarActivities().click();
 
       // already issued facility should not appear in the activity list
-      applicationActivities.facilityActivityChangedBy(MOCK_FACILITY_TWO_NULL_MIA.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityCheckedBy(MOCK_FACILITY_TWO_NULL_MIA.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityUnissuedTag(MOCK_FACILITY_TWO_NULL_MIA.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityIssuedTag(MOCK_FACILITY_TWO_NULL_MIA.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityLink(MOCK_FACILITY_TWO_NULL_MIA.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityChangedBy(issuedCashFacilityWithCoverDateConfirmed.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityCheckedBy(issuedCashFacilityWithCoverDateConfirmed.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityUnissuedTag(issuedCashFacilityWithCoverDateConfirmed.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityIssuedTag(issuedCashFacilityWithCoverDateConfirmed.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityLink(issuedCashFacilityWithCoverDateConfirmed.ukefFacilityId).should('not.exist');
 
       // 2nd facility unissued so should not show up
       applicationActivities.facilityActivityChangedBy(unissuedFacilitiesArray[1].ukefFacilityId).should('not.exist');

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -7,7 +7,12 @@ import dateConstants from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO_NULL_MIA, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacilityWithCoverDateConfirmed,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../fixtures/mocks/mock-facilities';
 
 import { toTitleCase } from '../../../fixtures/helpers';
 
@@ -19,6 +24,13 @@ import statusBanner from '../../pages/application-status-banner';
 import coverStartDate from '../../pages/cover-start-date';
 import applicationDetails from '../../pages/application-details';
 import applicationActivities from '../../pages/application-activities';
+
+const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO_NULL_MIA = anIssuedCashFacilityWithCoverDateConfirmed({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
 
 let dealId;
 let token;

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -7,7 +7,7 @@ import dateConstants from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
-import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockFacilities } from '../../../fixtures/mocks/mock-facilities';
+import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockGefFacilities } from '../../../fixtures/mocks/mock-facilities';
 
 import { toTitleCase } from '../../../fixtures/helpers';
 
@@ -22,7 +22,7 @@ import applicationActivities from '../../pages/application-activities';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({ facilityEndDateEnabled });
+const { unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({ facilityEndDateEnabled });
 const issuedCashFacilityWithCoverDateConfirmed = anIssuedCashFacilityWithCoverDateConfirmed({ facilityEndDateEnabled });
 
 let dealId;

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
@@ -12,12 +12,7 @@ import {
 } from '../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
 import applicationPreview from '../../../pages/application-preview';
 import aboutFacilityUnissued from '../../../pages/unissued-facilities-about-facility';
@@ -25,10 +20,9 @@ import bankReviewDate from '../../../pages/bank-review-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
 if (facilityEndDateEnabled) {
   context('Unissued Facilities AIN - bank review date page', () => {
@@ -48,25 +42,25 @@ if (facilityEndDateEnabled) {
             cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
                 facilityOneId = facility.body.details._id;
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
               });
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+                cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
@@ -12,7 +12,7 @@ import {
 } from '../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
 import applicationPreview from '../../../pages/application-preview';
 import aboutFacilityUnissued from '../../../pages/unissued-facilities-about-facility';
@@ -20,7 +20,7 @@ import bankReviewDate from '../../../pages/bank-review-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
@@ -12,13 +12,23 @@ import {
 } from '../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
 import applicationPreview from '../../../pages/application-preview';
 import aboutFacilityUnissued from '../../../pages/unissued-facilities-about-facility';
 import bankReviewDate from '../../../pages/bank-review-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
 
 if (facilityEndDateEnabled) {
   context('Unissued Facilities AIN - bank review date page', () => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
@@ -8,7 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, errorSummary, mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -19,7 +19,7 @@ import facilityEndDate from '../../../pages/facility-end-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
@@ -8,7 +8,12 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, errorSummary, mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -17,13 +22,18 @@ import applicationSubmission from '../../../pages/application-submission';
 import statusBanner from '../../../pages/application-status-banner';
 import facilityEndDate from '../../../pages/facility-end-date';
 
+const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
 let dealId;
 let token;
 let facilityOneId;
 
 const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
-
-const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
 context('Unissued Facilities AIN - change all to issued from unissued table', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
@@ -8,12 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, errorSummary, mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -24,16 +19,15 @@ import facilityEndDate from '../../../pages/facility-end-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
 let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 context('Unissued Facilities AIN - change all to issued from unissued table', () => {
   before(() => {
@@ -48,16 +42,16 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -86,7 +80,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
        at least 1 changed from unissued table
     */
     it('facilities table does not contain any add or change links as have not changed any facilities to issued yet', () => {
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -132,7 +126,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
 
       mainHeading().contains("Tell us you've issued this facility");
       aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
-      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+      aboutFacilityUnissued.facilityName().should('have.value', unissuedCashFacility.name);
 
       aboutFacilityUnissued.issueDateDay().should('have.value', '');
       aboutFacilityUnissued.issueDateMonth().should('have.value', '');
@@ -369,7 +363,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       const coverEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
 
       // should be able to change facility four as changed to issued
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedValue().contains('Issued');
@@ -387,7 +381,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       }
 
       // should not be able to change facility two has previously issued (not changed from unissued to issued)
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_TWO.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(issuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedValue().contains('Issued');
@@ -458,7 +452,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       const coverStart = format(dateConstants.threeDaysAgo, 'd MMMM yyyy');
 
       // should be able to change number 1 as changed to issued
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(3).issueDateValue().contains(issuedDate);
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).coverStartDateValue().contains(coverStart);
@@ -475,11 +469,11 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
       cy.clickCancelLink();
 
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).nameAction().click();
 
-      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_ONE.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${unissuedCashFacility.name}name`);
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
 
       if (facilityEndDateEnabled) {
@@ -496,7 +490,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
       }
 
       // checks that name has been updated
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(`${MOCK_FACILITY_ONE.name}name`);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(`${unissuedCashFacility.name}name`);
       applicationPreview.facilitySummaryListTable(3).issueDateValue().contains(issuedDate);
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -7,7 +7,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { backLink, cancelLink, continueButton, headingCaption, mainHeading, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,7 +23,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -7,7 +7,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
-import { anUnissuedCashFacility, anIssuedCashFacility, anUnissuedContingentFacility } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { backLink, cancelLink, continueButton, headingCaption, mainHeading, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,11 +23,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility];
 
 context('Change issued facilities back to unissued AIN (changed to issued facilities post submission)', () => {
   before(() => {
@@ -42,13 +42,13 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -77,7 +77,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
          at least 1 changed from unissued table
       */
     it('facilities table does not contain any add or change links as have not changed any facilities to issued yet', () => {
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().should('have.class', 'govuk-!-display-none');
@@ -186,7 +186,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       const coverEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
 
       // should be able to change facility three as changed to issued
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedValue().contains('Issued');
@@ -204,7 +204,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       }
 
       // should not be able to change facility two has previously issued (not changed from unissued to issued)
-      applicationPreview.facilitySummaryListTable(1).nameValue().contains(MOCK_FACILITY_TWO.name);
+      applicationPreview.facilitySummaryListTable(1).nameValue().contains(issuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(1).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).hasBeenIssuedValue().contains('Issued');
@@ -221,7 +221,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
     // checks that can unissue a changed to issued facility
     it('clicking change on issued should take you to hasBeenIssued page with different url', () => {
       // should be able to change number 1 as changed to issued
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedAction().click();
 
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change-to-unissued`));
@@ -254,14 +254,14 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       const coverEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
       const facilityEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
       // should be able to change number 1 as changed to issued
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedAction().click();
 
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change-to-unissued`));
 
       cy.clickBackLink();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedValue().contains('Issued');
@@ -282,7 +282,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedAction().click();
       cy.clickCancelLink();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedValue().contains('Issued');
@@ -303,7 +303,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedAction().click();
       cy.clickContinueButton();
       cy.url().should('eq', relative(`/gef/application-details/${dealId}`));
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedValue().contains('Issued');
@@ -324,7 +324,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
 
     it('changing the facility to unissued should remove it from the list of issued facilities and remove dates', () => {
       // should be able to change number 1 as changed to issued
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedAction().click();
 
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities/${facilityOneId}/change-to-unissued`));
@@ -332,12 +332,12 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       facilities.hasBeenIssuedRadioNoRadioButton().click();
       cy.clickContinueButton();
 
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedValue().contains('Unissued');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedAction().contains('Change');
-      applicationPreview.facilitySummaryListTable(2).monthsOfCoverValue().contains(MOCK_FACILITY_ONE.monthsOfCover);
+      applicationPreview.facilitySummaryListTable(2).monthsOfCoverValue().contains(unissuedCashFacility.monthsOfCover);
       applicationPreview.facilitySummaryListTable(2).monthsOfCoverAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).facilityProvidedOnAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).valueAction().should('have.class', 'govuk-!-display-none');
@@ -362,17 +362,17 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
     });
 
     it('changing all facilities to unissued takes you back to initial view unissued facilities page', () => {
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
 
       facilities.hasBeenIssuedRadioNoRadioButton().click();
       cy.clickContinueButton();
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedValue().contains('Unissued');
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().should('have.class', 'govuk-!-display-none');
-      applicationPreview.facilitySummaryListTable(0).monthsOfCoverValue().contains(MOCK_FACILITY_THREE.monthsOfCover);
+      applicationPreview.facilitySummaryListTable(0).monthsOfCoverValue().contains(unissuedContingentFacility.monthsOfCover);
       applicationPreview.facilitySummaryListTable(0).monthsOfCoverAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).facilityProvidedOnAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).valueAction().should('have.class', 'govuk-!-display-none');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -7,7 +7,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE } from '../../../../fixtures/mocks/mock-facilities';
+import { anUnissuedCashFacility, anIssuedCashFacility, anUnissuedContingentFacility } from '../../../../fixtures/mocks/mock-facilities';
 import { backLink, cancelLink, continueButton, headingCaption, mainHeading, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -21,9 +21,13 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE];
 
 context('Change issued facilities back to unissued AIN (changed to issued facilities post submission)', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
@@ -8,12 +8,7 @@ import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -30,12 +25,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 context('Unissued Facilities AIN - change all to issued from unissued table', () => {
   before(() => {
@@ -50,19 +44,19 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              MOCK_FACILITY_ONE._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              unissuedCashFacility._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) => {
-              MOCK_FACILITY_THREE._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE);
+              unissuedContingentFacility._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
-              MOCK_FACILITY_FOUR._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR);
+              unissuedCashFacilityWith20MonthsOfCover._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover);
             });
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -406,7 +400,7 @@ context('Return to maker for unissued to issued facilities', () => {
       }
 
       // forth facility table has correct name and dates
-      applicationDetails.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationDetails.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationDetails.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationDetails.facilitySummaryListTable(3).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationDetails.facilitySummaryListTable(3).hasBeenIssuedAction().contains('Change');
@@ -627,11 +621,11 @@ context('Submit to UKEF with unissued to issued facilities', () => {
       applicationActivities.activityTimeline().should('not.contain', CONSTANTS.PORTAL_ACTIVITY_LABEL.AIN_SUBMISSION);
 
       // already issued facility should not appear in the activity list
-      applicationActivities.facilityActivityChangedBy(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityCheckedBy(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityUnissuedTag(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityIssuedTag(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityLink(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityChangedBy(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityCheckedBy(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityUnissuedTag(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityIssuedTag(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityLink(issuedCashFacility.ukefFacilityId).should('not.exist');
     });
   });
 });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
@@ -8,7 +8,12 @@ import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,9 +28,14 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
 
 context('Unissued Facilities AIN - change all to issued from unissued table', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
@@ -8,7 +8,7 @@ import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -25,7 +25,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
@@ -4,7 +4,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
 import applicationPreview from '../../../pages/application-preview';
 import aboutFacilityUnissued from '../../../pages/unissued-facilities-about-facility';
@@ -12,7 +12,7 @@ import facilityEndDate from '../../../pages/facility-end-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
@@ -4,13 +4,23 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
 import applicationPreview from '../../../pages/application-preview';
 import aboutFacilityUnissued from '../../../pages/unissued-facilities-about-facility';
 import facilityEndDate from '../../../pages/facility-end-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
 
 if (facilityEndDateEnabled) {
   context('Unissued Facilities AIN - facility end date page', () => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
@@ -4,12 +4,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
 import applicationPreview from '../../../pages/application-preview';
 import aboutFacilityUnissued from '../../../pages/unissued-facilities-about-facility';
@@ -17,10 +12,9 @@ import facilityEndDate from '../../../pages/facility-end-date';
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
 if (facilityEndDateEnabled) {
   context('Unissued Facilities AIN - facility end date page', () => {
@@ -40,25 +34,25 @@ if (facilityEndDateEnabled) {
             cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
                 facilityOneId = facility.body.details._id;
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
               });
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+                cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-                cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+                cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
               );
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
@@ -8,7 +8,7 @@ import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,7 +23,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
@@ -8,12 +8,7 @@ import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -28,12 +23,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 /*
   for changing facilities to issued from preview page.
@@ -51,16 +45,16 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -95,7 +89,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
 
       mainHeading().contains("Tell us you've issued this facility");
       aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
-      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+      aboutFacilityUnissued.facilityName().should('have.value', unissuedCashFacility.name);
 
       aboutFacilityUnissued.issueDateDay().should('have.value', '');
       aboutFacilityUnissued.issueDateMonth().should('have.value', '');
@@ -167,7 +161,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       const coverEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
 
       // can change facility one name and issue dates etc since changed to issued
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(3).hasBeenIssuedAction().contains('Change');
@@ -189,7 +183,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       }
 
       // not be able to change facility four name, but can change to issued
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -201,7 +195,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       applicationPreview.facilitySummaryListTable(0).coverEndDateAction().should('not.exist');
 
       // should not be able to change facility two has previously issued
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_TWO.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(issuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -225,7 +219,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${unissuedCashFacilityWith20MonthsOfCover.name}name`);
 
       cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
       cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
@@ -284,7 +278,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       }
 
       // facility three still unissued
-      applicationPreview.facilitySummaryListTable(1).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(1).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(1).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).hasBeenIssuedValue().contains('Unissued');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
@@ -8,7 +8,12 @@ import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -21,9 +26,14 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
 
 /*
   for changing facilities to issued from preview page.

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -8,7 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE } from '../../../../fixtures/mocks/mock-facilities';
+import { anUnissuedCashFacility } from '../../../../fixtures/mocks/mock-facilities';
 
 import { mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
@@ -21,9 +21,11 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE];
 
 context('Unissued Facilities AIN - change all to issued from unissued table', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -23,9 +23,9 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const unissuedCashFacility = anUnissuedCashFacility({ facilityEndDateEnabled });
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE];
+const unissuedFacilitiesArray = [unissuedCashFacility];
 
 context('Unissued Facilities AIN - change all to issued from unissued table', () => {
   before(() => {
@@ -40,7 +40,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -99,7 +99,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
 
       mainHeading().contains("Tell us you've issued this facility");
       aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
-      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+      aboutFacilityUnissued.facilityName().should('have.value', unissuedCashFacility.name);
 
       aboutFacilityUnissued.issueDateDay().should('have.value', '');
       aboutFacilityUnissued.issueDateMonth().should('have.value', '');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
@@ -8,7 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,7 +23,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
@@ -8,12 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -28,12 +23,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 context('Unissued Facilities MIN - change all to issued from unissued table', () => {
   before(() => {
@@ -48,16 +42,16 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -86,7 +80,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
        at least 1 changed from unissued table
     */
     it('facilities table does not contain any add or change links as have not changed any facilities to issued yet', () => {
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -318,7 +312,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       const coverEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
 
       // should be able to change facility four as changed to issued
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedValue().contains('Issued');
@@ -336,7 +330,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       }
 
       // should not be able to change facility two has previously issued (not changed from unissued to issued)
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_TWO.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(issuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(2).hasBeenIssuedValue().contains('Issued');
@@ -407,7 +401,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       const coverStart = format(dateConstants.threeDaysAgo, 'd MMMM yyyy');
 
       // should be able to change number 1 as changed to issued
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).coverStartDateValue().contains(coverStart);
 
@@ -430,7 +424,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
 
       cy.clickCancelLink();
 
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
 
       if (facilityEndDateEnabled) {
         applicationPreview.facilitySummaryListTable(3).isUsingFacilityEndDateValue().contains('Yes');
@@ -439,7 +433,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).nameAction().click();
 
-      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_ONE.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${unissuedCashFacility.name}name`);
       aboutFacilityUnissued.shouldCoverStartOnSubmissionYes().click();
 
       if (facilityEndDateEnabled) {
@@ -454,7 +448,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
       }
 
       // checks that name has been updated
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(`${MOCK_FACILITY_ONE.name}name`);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(`${unissuedCashFacility.name}name`);
       applicationPreview.facilitySummaryListTable(3).issueDateValue().contains(issuedDate);
 
       if (facilityEndDateEnabled) {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
@@ -8,8 +8,12 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
-
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -22,9 +26,14 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
 
 context('Unissued Facilities MIN - change all to issued from unissued table', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
@@ -7,7 +7,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -25,7 +25,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
@@ -7,12 +7,7 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -30,12 +25,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 context('Unissued Facilities MIN - change all to issued from unissued table', () => {
   before(() => {
@@ -50,19 +44,19 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              MOCK_FACILITY_ONE._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              unissuedCashFacility._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) => {
-              MOCK_FACILITY_THREE._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE);
+              unissuedContingentFacility._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
-              MOCK_FACILITY_FOUR._id = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR);
+              unissuedCashFacilityWith20MonthsOfCover._id = facility.body.details._id;
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover);
             });
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -407,7 +401,7 @@ context('Return to maker for unissued to issued facilities', () => {
       }
 
       // forth facility table has correct name and dates
-      applicationDetails.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationDetails.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationDetails.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationDetails.facilitySummaryListTable(3).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationDetails.facilitySummaryListTable(3).hasBeenIssuedAction().contains('Change');
@@ -630,11 +624,11 @@ context('Submit to UKEF with unissued to issued facilities', () => {
       applicationActivities.activityTimeline().should('not.contain', CONSTANTS.PORTAL_ACTIVITY_LABEL.AIN_SUBMISSION);
 
       // already issued facility should not appear in the activity list
-      applicationActivities.facilityActivityChangedBy(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityCheckedBy(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityUnissuedTag(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityIssuedTag(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
-      applicationActivities.facilityActivityLink(MOCK_FACILITY_TWO.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityChangedBy(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityCheckedBy(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityUnissuedTag(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityIssuedTag(issuedCashFacility.ukefFacilityId).should('not.exist');
+      applicationActivities.facilityActivityLink(issuedCashFacility.ukefFacilityId).should('not.exist');
     });
   });
 });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
@@ -7,8 +7,12 @@ import CONSTANTS from '../../../../fixtures/constants';
 import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
-
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -24,9 +28,14 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
 
 context('Unissued Facilities MIN - change all to issued from unissued table', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
@@ -6,7 +6,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -20,7 +20,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
@@ -6,8 +6,12 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
-
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -19,10 +23,15 @@ let dealId;
 let token;
 let facilityOneId;
 
+const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
 const FACILITY_THREE_SPECIAL = { ...MOCK_FACILITY_THREE };
 FACILITY_THREE_SPECIAL.specialIssuePermission = true;
-
-const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
 context('Unissued Facilities MIN - change to issued more than 3 months after MIN submission date', () => {
   before(() => {

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
@@ -6,12 +6,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -25,12 +20,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const FACILITY_THREE_SPECIAL = { ...MOCK_FACILITY_THREE };
+const FACILITY_THREE_SPECIAL = { ...unissuedContingentFacility };
 FACILITY_THREE_SPECIAL.specialIssuePermission = true;
 
 context('Unissued Facilities MIN - change to issued more than 3 months after MIN submission date', () => {
@@ -46,16 +40,16 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, FACILITY_THREE_SPECIAL),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -90,7 +84,7 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
 
       mainHeading().contains("Tell us you've issued this facility");
       aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
-      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+      aboutFacilityUnissued.facilityName().should('have.value', unissuedCashFacility.name);
 
       aboutFacilityUnissued.issueDateDay().should('have.value', '');
       aboutFacilityUnissued.issueDateMonth().should('have.value', '');
@@ -213,7 +207,7 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${unissuedCashFacilityWith20MonthsOfCover.name}name`);
 
       cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
       cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
@@ -8,7 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,7 +23,7 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
@@ -8,12 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -28,12 +23,11 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 /*
   for changing facilities to issued from preview page.
@@ -51,16 +45,16 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_ONE);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_TWO),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_THREE),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, MOCK_FACILITY_FOUR),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });
@@ -95,7 +89,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
 
       mainHeading().contains("Tell us you've issued this facility");
       aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
-      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+      aboutFacilityUnissued.facilityName().should('have.value', unissuedCashFacility.name);
 
       aboutFacilityUnissued.issueDateDay().should('have.value', '');
       aboutFacilityUnissued.issueDateMonth().should('have.value', '');
@@ -184,7 +178,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       const coverEnd = format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy');
 
       // can change facility one name and issue dates etc since changed to issued
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(3).hasBeenIssuedAction().contains('Change');
@@ -206,7 +200,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       }
 
       // not be able to change facility four name, but can change to issued
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -222,7 +216,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       }
 
       // should not be able to change facility two has previously issued
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_TWO.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(issuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -238,7 +232,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${unissuedCashFacilityWith20MonthsOfCover.name}name`);
 
       cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
       cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
@@ -314,7 +308,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       }
 
       // facility three still unissued
-      applicationPreview.facilitySummaryListTable(1).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(1).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(1).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).hasBeenIssuedValue().contains('Unissued');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
@@ -8,8 +8,12 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
-
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { mainHeading, continueButton, errorSummary } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -22,9 +26,14 @@ let dealId;
 let token;
 let facilityOneId;
 
-const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
-
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
+const unissuedFacilitiesArray = [MOCK_FACILITY_ONE, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR];
 
 /*
   for changing facilities to issued from preview page.

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
@@ -8,12 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import {
-  anUnissuedCashFacility,
-  anIssuedCashFacility,
-  anUnissuedContingentFacility,
-  anUnissuedCashFacilityWith20MonthsOfCover,
-} from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -28,15 +23,14 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
-const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+  facilityEndDateEnabled,
+});
 
-const FACILITY_ONE_SPECIAL = { ...MOCK_FACILITY_ONE };
-const FACILITY_TWO_SPECIAL = { ...MOCK_FACILITY_TWO };
-const FACILITY_THREE_SPECIAL = { ...MOCK_FACILITY_THREE };
-const FACILITY_FOUR_SPECIAL = { ...MOCK_FACILITY_FOUR };
+const FACILITY_ONE_SPECIAL = { ...unissuedCashFacility };
+const FACILITY_TWO_SPECIAL = { ...issuedCashFacility };
+const FACILITY_THREE_SPECIAL = { ...unissuedContingentFacility };
+const FACILITY_FOUR_SPECIAL = { ...unissuedCashFacilityWith20MonthsOfCover };
 
 FACILITY_ONE_SPECIAL.specialIssuePermission = true;
 FACILITY_TWO_SPECIAL.specialIssuePermission = true;
@@ -105,7 +99,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
 
       mainHeading().contains("Tell us you've issued this facility");
       aboutFacilityUnissued.facilityNameLabel().contains('Name for this cash facility');
-      aboutFacilityUnissued.facilityName().should('have.value', MOCK_FACILITY_ONE.name);
+      aboutFacilityUnissued.facilityName().should('have.value', unissuedCashFacility.name);
 
       aboutFacilityUnissued.issueDateDay().should('have.value', '');
       aboutFacilityUnissued.issueDateMonth().should('have.value', '');
@@ -176,7 +170,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       const coverEnd = format(dateConstants.threeYears, 'd MMMM yyyy');
 
       // can change facility one name and issue dates etc since changed to issued
-      applicationPreview.facilitySummaryListTable(3).nameValue().contains(MOCK_FACILITY_ONE.name);
+      applicationPreview.facilitySummaryListTable(3).nameValue().contains(unissuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(3).nameAction().contains('Change');
       applicationPreview.facilitySummaryListTable(3).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(3).hasBeenIssuedAction().contains('Change');
@@ -198,7 +192,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       }
 
       // not be able to change facility four name, but can change to issued
-      applicationPreview.facilitySummaryListTable(0).nameValue().contains(MOCK_FACILITY_FOUR.name);
+      applicationPreview.facilitySummaryListTable(0).nameValue().contains(unissuedCashFacilityWith20MonthsOfCover.name);
       applicationPreview.facilitySummaryListTable(0).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(0).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -210,7 +204,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       applicationPreview.facilitySummaryListTable(0).coverEndDateAction().should('not.exist');
 
       // should not be able to change facility two has previously issued
-      applicationPreview.facilitySummaryListTable(2).nameValue().contains(MOCK_FACILITY_TWO.name);
+      applicationPreview.facilitySummaryListTable(2).nameValue().contains(issuedCashFacility.name);
       applicationPreview.facilitySummaryListTable(2).nameAction().should('have.class', 'govuk-!-display-none');
 
       applicationPreview.facilitySummaryListTable(2).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
@@ -230,7 +224,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       // to change to issued from preview page by clicking change on issued row
       applicationPreview.facilitySummaryListTable(0).hasBeenIssuedAction().click();
       aboutFacilityUnissued.facilityName().clear();
-      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${MOCK_FACILITY_FOUR.name}name`);
+      cy.keyboardInput(aboutFacilityUnissued.facilityName(), `${unissuedCashFacilityWith20MonthsOfCover.name}name`);
 
       cy.keyboardInput(aboutFacilityUnissued.issueDateDay(), dateConstants.todayDay);
       cy.keyboardInput(aboutFacilityUnissued.issueDateMonth(), dateConstants.todayMonth);
@@ -286,7 +280,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       }
 
       // facility three still unissued
-      applicationPreview.facilitySummaryListTable(1).nameValue().contains(MOCK_FACILITY_THREE.name);
+      applicationPreview.facilitySummaryListTable(1).nameValue().contains(unissuedContingentFacility.name);
       applicationPreview.facilitySummaryListTable(1).nameAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).ukefFacilityIdAction().should('have.class', 'govuk-!-display-none');
       applicationPreview.facilitySummaryListTable(1).hasBeenIssuedValue().contains('Unissued');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
@@ -8,7 +8,7 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { multipleMockFacilities } from '../../../../fixtures/mocks/mock-facilities';
+import { multipleMockGefFacilities } from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -23,21 +23,16 @@ let facilityOneId;
 
 const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
-const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockFacilities({
+const { unissuedCashFacility, issuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover } = multipleMockGefFacilities({
   facilityEndDateEnabled,
 });
 
-const FACILITY_ONE_SPECIAL = { ...unissuedCashFacility };
-const FACILITY_TWO_SPECIAL = { ...issuedCashFacility };
-const FACILITY_THREE_SPECIAL = { ...unissuedContingentFacility };
-const FACILITY_FOUR_SPECIAL = { ...unissuedCashFacilityWith20MonthsOfCover };
+unissuedCashFacility.specialIssuePermission = true;
+issuedCashFacility.specialIssuePermission = true;
+unissuedContingentFacility.specialIssuePermission = true;
+unissuedCashFacilityWith20MonthsOfCover.specialIssuePermission = true;
 
-FACILITY_ONE_SPECIAL.specialIssuePermission = true;
-FACILITY_TWO_SPECIAL.specialIssuePermission = true;
-FACILITY_THREE_SPECIAL.specialIssuePermission = true;
-FACILITY_FOUR_SPECIAL.specialIssuePermission = true;
-
-const unissuedFacilitiesArray = [FACILITY_ONE_SPECIAL, FACILITY_THREE_SPECIAL, FACILITY_FOUR_SPECIAL];
+const unissuedFacilitiesArray = [unissuedCashFacility, unissuedContingentFacility, unissuedCashFacilityWith20MonthsOfCover];
 
 /*
   for changing facilities to issued from preview page.
@@ -55,16 +50,16 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
-              cy.apiUpdateFacility(facility.body.details._id, token, FACILITY_ONE_SPECIAL);
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, FACILITY_TWO_SPECIAL),
+              cy.apiUpdateFacility(facility.body.details._id, token, issuedCashFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, FACILITY_THREE_SPECIAL),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
-              cy.apiUpdateFacility(facility.body.details._id, token, FACILITY_FOUR_SPECIAL),
+              cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
           });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
@@ -8,8 +8,12 @@ import dateConstants from '../../../../../../e2e-fixtures/dateConstants';
 
 import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
-import { MOCK_FACILITY_ONE, MOCK_FACILITY_TWO, MOCK_FACILITY_THREE, MOCK_FACILITY_FOUR } from '../../../../fixtures/mocks/mock-facilities';
-
+import {
+  anUnissuedCashFacility,
+  anIssuedCashFacility,
+  anUnissuedContingentFacility,
+  anUnissuedCashFacilityWith20MonthsOfCover,
+} from '../../../../fixtures/mocks/mock-facilities';
 import { continueButton, mainHeading } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -22,6 +26,13 @@ let dealId;
 let token;
 let facilityOneId;
 
+const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
+
+const MOCK_FACILITY_ONE = anUnissuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_TWO = anIssuedCashFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_THREE = anUnissuedContingentFacility({ facilityEndDateEnabled });
+const MOCK_FACILITY_FOUR = anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled });
+
 const FACILITY_ONE_SPECIAL = { ...MOCK_FACILITY_ONE };
 const FACILITY_TWO_SPECIAL = { ...MOCK_FACILITY_TWO };
 const FACILITY_THREE_SPECIAL = { ...MOCK_FACILITY_THREE };
@@ -33,8 +44,6 @@ FACILITY_THREE_SPECIAL.specialIssuePermission = true;
 FACILITY_FOUR_SPECIAL.specialIssuePermission = true;
 
 const unissuedFacilitiesArray = [FACILITY_ONE_SPECIAL, FACILITY_THREE_SPECIAL, FACILITY_FOUR_SPECIAL];
-
-const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
 /*
   for changing facilities to issued from preview page.

--- a/e2e-tests/gef/cypress/fixtures/mocks/mock-facilities.js
+++ b/e2e-tests/gef/cypress/fixtures/mocks/mock-facilities.js
@@ -20,7 +20,7 @@ const getFacilityEndDateProperties = ({ facilityEndDateEnabled }) => {
  * @param {{ facilityEndDateEnabled?: boolean}} options
  * @returns {import('@ukef/dtfs2-common').Facility }
  */
-exports.anUnissuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
+const anUnissuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
   ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: false,
@@ -57,11 +57,13 @@ exports.anUnissuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
   canResubmitIssuedFacilities: null,
 });
 
+exports.anUnissuedCashFacility = anUnissuedCashFacility;
+
 /**
  * @param {{ facilityEndDateEnabled?: boolean}} options
  * @returns {import('@ukef/dtfs2-common').Facility }
  */
-exports.anIssuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
+const anIssuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
   ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: true,
@@ -102,7 +104,7 @@ exports.anIssuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
  * @param {{ facilityEndDateEnabled?: boolean}} options
  * @returns {import('@ukef/dtfs2-common').Facility }
  */
-exports.anIssuedCashFacilityWithCoverDateConfirmed = ({ facilityEndDateEnabled = false } = {}) => ({
+const anIssuedCashFacilityWithCoverDateConfirmed = ({ facilityEndDateEnabled = false } = {}) => ({
   ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: true,
@@ -139,11 +141,13 @@ exports.anIssuedCashFacilityWithCoverDateConfirmed = ({ facilityEndDateEnabled =
   canResubmitIssuedFacilities: null,
 });
 
+exports.anIssuedCashFacilityWithCoverDateConfirmed = anIssuedCashFacilityWithCoverDateConfirmed;
+
 /**
  * @param {{ facilityEndDateEnabled?: boolean}} options
  * @returns {import('@ukef/dtfs2-common').Facility }
  */
-exports.anUnissuedContingentFacility = ({ facilityEndDateEnabled = false } = {}) => ({
+const anUnissuedContingentFacility = ({ facilityEndDateEnabled = false } = {}) => ({
   ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CONTINGENT,
   hasBeenIssued: false,
@@ -184,7 +188,7 @@ exports.anUnissuedContingentFacility = ({ facilityEndDateEnabled = false } = {})
  * @param {{ facilityEndDateEnabled?: boolean}} options
  * @returns {import('@ukef/dtfs2-common').Facility }
  */
-exports.anUnissuedCashFacilityWith20MonthsOfCover = ({ facilityEndDateEnabled = false } = {}) => ({
+const anUnissuedCashFacilityWith20MonthsOfCover = ({ facilityEndDateEnabled = false } = {}) => ({
   ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: false,
@@ -219,4 +223,11 @@ exports.anUnissuedCashFacilityWith20MonthsOfCover = ({ facilityEndDateEnabled = 
   dayCountBasis: 365,
   coverDateConfirmed: false,
   canResubmitIssuedFacilities: null,
+});
+
+exports.multipleMockFacilities = ({ facilityEndDateEnabled }) => ({
+  unissuedCashFacility: anUnissuedCashFacility({ facilityEndDateEnabled }),
+  issuedCashFacility: anIssuedCashFacility({ facilityEndDateEnabled }),
+  unissuedContingentFacility: anUnissuedContingentFacility({ facilityEndDateEnabled }),
+  unissuedCashFacilityWith20MonthsOfCover: anUnissuedCashFacilityWith20MonthsOfCover({ facilityEndDateEnabled }),
 });

--- a/e2e-tests/gef/cypress/fixtures/mocks/mock-facilities.js
+++ b/e2e-tests/gef/cypress/fixtures/mocks/mock-facilities.js
@@ -225,7 +225,7 @@ const anUnissuedCashFacilityWith20MonthsOfCover = ({ facilityEndDateEnabled = fa
   canResubmitIssuedFacilities: null,
 });
 
-exports.multipleMockFacilities = ({ facilityEndDateEnabled }) => ({
+exports.multipleMockGefFacilities = ({ facilityEndDateEnabled }) => ({
   unissuedCashFacility: anUnissuedCashFacility({ facilityEndDateEnabled }),
   issuedCashFacility: anIssuedCashFacility({ facilityEndDateEnabled }),
   unissuedContingentFacility: anUnissuedContingentFacility({ facilityEndDateEnabled }),

--- a/e2e-tests/gef/cypress/fixtures/mocks/mock-facilities.js
+++ b/e2e-tests/gef/cypress/fixtures/mocks/mock-facilities.js
@@ -1,13 +1,12 @@
 const CONSTANTS = require('../constants');
 const dateConstants = require('../../../../e2e-fixtures/dateConstants');
 
-const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
-
 /**
  * Gets facility end date properties if enabled on default deal version
+ * @param {{ facilityEndDateEnabled?: boolean}} options
  * @returns {Pick<import('@ukef/dtfs2-common').Facility,'isUsingFacilityEndDate' | 'facilityEndDate'> | {} } mock facility end date properties if enabled, or empty object if not
  */
-const getFacilityEndDateProperties = () => {
+const getFacilityEndDateProperties = ({ facilityEndDateEnabled }) => {
   if (facilityEndDateEnabled) {
     return {
       isUsingFacilityEndDate: true,
@@ -17,8 +16,12 @@ const getFacilityEndDateProperties = () => {
   return {};
 };
 
-exports.MOCK_FACILITY_ONE = {
-  ...getFacilityEndDateProperties(),
+/**
+ * @param {{ facilityEndDateEnabled?: boolean}} options
+ * @returns {import('@ukef/dtfs2-common').Facility }
+ */
+exports.anUnissuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
+  ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: false,
   name: 'Facility one',
@@ -52,10 +55,14 @@ exports.MOCK_FACILITY_ONE = {
   dayCountBasis: 365,
   coverDateConfirmed: null,
   canResubmitIssuedFacilities: null,
-};
+});
 
-exports.MOCK_FACILITY_TWO = {
-  ...getFacilityEndDateProperties(),
+/**
+ * @param {{ facilityEndDateEnabled?: boolean}} options
+ * @returns {import('@ukef/dtfs2-common').Facility }
+ */
+exports.anIssuedCashFacility = ({ facilityEndDateEnabled = false } = {}) => ({
+  ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: true,
   name: 'Facility two',
@@ -89,10 +96,14 @@ exports.MOCK_FACILITY_TWO = {
   dayCountBasis: 365,
   coverDateConfirmed: true,
   canResubmitIssuedFacilities: null,
-};
+});
 
-exports.MOCK_FACILITY_TWO_NULL_MIA = {
-  ...getFacilityEndDateProperties(),
+/**
+ * @param {{ facilityEndDateEnabled?: boolean}} options
+ * @returns {import('@ukef/dtfs2-common').Facility }
+ */
+exports.anIssuedCashFacilityWithCoverDateConfirmed = ({ facilityEndDateEnabled = false } = {}) => ({
+  ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: true,
   name: 'Facility two',
@@ -126,10 +137,14 @@ exports.MOCK_FACILITY_TWO_NULL_MIA = {
   dayCountBasis: 365,
   coverDateConfirmed: null,
   canResubmitIssuedFacilities: null,
-};
+});
 
-exports.MOCK_FACILITY_THREE = {
-  ...getFacilityEndDateProperties(),
+/**
+ * @param {{ facilityEndDateEnabled?: boolean}} options
+ * @returns {import('@ukef/dtfs2-common').Facility }
+ */
+exports.anUnissuedContingentFacility = ({ facilityEndDateEnabled = false } = {}) => ({
+  ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CONTINGENT,
   hasBeenIssued: false,
   name: 'Facility three',
@@ -163,10 +178,14 @@ exports.MOCK_FACILITY_THREE = {
   dayCountBasis: 365,
   coverDateConfirmed: false,
   canResubmitIssuedFacilities: null,
-};
+});
 
-exports.MOCK_FACILITY_FOUR = {
-  ...getFacilityEndDateProperties(),
+/**
+ * @param {{ facilityEndDateEnabled?: boolean}} options
+ * @returns {import('@ukef/dtfs2-common').Facility }
+ */
+exports.anUnissuedCashFacilityWith20MonthsOfCover = ({ facilityEndDateEnabled = false } = {}) => ({
+  ...getFacilityEndDateProperties({ facilityEndDateEnabled }),
   type: CONSTANTS.FACILITY_TYPE.CASH,
   hasBeenIssued: false,
   name: 'Facility four',
@@ -200,4 +219,4 @@ exports.MOCK_FACILITY_FOUR = {
   dayCountBasis: 365,
   coverDateConfirmed: false,
   canResubmitIssuedFacilities: null,
-};
+});


### PR DESCRIPTION
## Introduction :pencil2:
The mock facilities currently access the environment variables to determine whether to add the facility end date values to the mock. In order to separate out the e2e tests with the feature flag on and off they need to be generated as a function & pass this env var in.

In the next PR the environment variable will not be accessed & the tests will be separated into two suites - ff on & ff off.

## Resolution :heavy_check_mark:
- Convert mock facilities into functions


