### PR TITLE
feat(DTFS2-7294): use deal type from libs/common

### DIFF
--- a/dtfs-central-api/src/constants/deals.js
+++ b/dtfs-central-api/src/constants/deals.js
@@ -1,3 +1,5 @@
+const { DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
+
 const DEAL_TYPE = {
   BSS_EWCS: 'BSS/EWCS',
   GEF: 'GEF',
@@ -16,11 +18,7 @@ const DEAL_STATUS = {
   UKEF_REFUSED: 'Rejected by UKEF',
 };
 
-const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 const SORT_BY = {
   ASCENDING: 'ascending',

--- a/e2e-tests/e2e-fixtures/constants.fixture.js
+++ b/e2e-tests/e2e-fixtures/constants.fixture.js
@@ -1,3 +1,5 @@
+import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
+
 export const TFM_URL = 'http://localhost:5003';
 
 export const DEAL_TYPE = {
@@ -5,11 +7,7 @@ export const DEAL_TYPE = {
   GEF: 'GEF',
 };
 
-export const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+export const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 export const FACILITY_TYPE = {
   CASH: 'Cash',

--- a/gef-ui/server/constants/index.js
+++ b/gef-ui/server/constants/index.js
@@ -1,11 +1,5 @@
-const { ROLES, FACILITY_TYPE } = require('@ukef/dtfs2-common');
+const { ROLES, FACILITY_TYPE, DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
 const ALL_BANKS_ID = require('./all-banks-id');
-
-const DEAL_SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
 
 const DEAL_STATUS = {
   // these statuses can be either on the top level

--- a/portal-api/src/constants/deal.js
+++ b/portal-api/src/constants/deal.js
@@ -1,3 +1,5 @@
+const { DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
+
 const DEAL_TYPE = {
   BSS_EWCS: 'BSS/EWCS',
   GEF: 'GEF',
@@ -22,11 +24,7 @@ const APPLICATION_GROUP = {
   EWCS: 'EWCS',
 };
 
-const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 const ACTION_NAME = {
   '001': 'NewDeal',

--- a/portal/server/constants/submission-type.js
+++ b/portal/server/constants/submission-type.js
@@ -1,7 +1,5 @@
-const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+const { DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
+
+const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 module.exports = SUBMISSION_TYPE;

--- a/trade-finance-manager-api/src/constants/deals.js
+++ b/trade-finance-manager-api/src/constants/deals.js
@@ -1,3 +1,5 @@
+const { DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
+
 const DEAL_TYPE = {
   GEF: 'GEF',
   BSS_EWCS: 'BSS/EWCS',
@@ -9,11 +11,7 @@ const DEAL_PRODUCT_CODE = {
   BOND_AND_LOAN: 'BSS & EWCS',
 };
 
-const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 const DEAL_STAGE_TFM = {
   CONFIRMED: 'Confirmed',

--- a/trade-finance-manager-ui/server/constants/deal.js
+++ b/trade-finance-manager-ui/server/constants/deal.js
@@ -1,8 +1,6 @@
-const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+const { DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
+
+const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 const DEAL_TYPE = {
   GEF: 'GEF',

--- a/utils/data-migration/constant/deal.js
+++ b/utils/data-migration/constant/deal.js
@@ -1,13 +1,11 @@
+const { DEAL_SUBMISSION_TYPE } = require('@ukef/dtfs2-common');
+
 const DEAL_TYPE = {
   GEF: 'GEF',
   BSS_EWCS: 'BSS/EWCS',
 };
 
-const SUBMISSION_TYPE = {
-  AIN: 'Automatic Inclusion Notice',
-  MIA: 'Manual Inclusion Application',
-  MIN: 'Manual Inclusion Notice',
-};
+const SUBMISSION_TYPE = DEAL_SUBMISSION_TYPE;
 
 const TFM_STATUS = {
   CONFIRMED: 'Confirmed',


### PR DESCRIPTION
## Introduction :pencil2:
In a recent PR the deal types were pulled out into libs/common. This ensures different services are using those values instead of being hardcoded each time. The implementation in this PR means I haven't had to refactor a lot of files. 

## Resolution :heavy_check_mark:
List all changes made to the codebase.

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

