### PR TITLE
feat(DTFS2-7296): add bank request date template

### DIFF
--- a/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
@@ -51,16 +51,6 @@ describe(page, () => {
     wrapper.expectElement('[data-cy="error-summary"]').notToExist();
   });
 
-  it('should not render in line error when there are errors', () => {
-    // Arrange
-    const bankRequestDateViewModel: BankRequestDateViewModel = aBankRequestDateViewModel();
-    // Act
-    const wrapper = render(bankRequestDateViewModel);
-
-    // Assert
-    wrapper.expectElement('[data-cy="bank-request-date-inline-error"]').notToExist();
-  });
-
   it('should render error summary when there are errors', () => {
     // Arrange
     const errorSummaryText = 'an error';

--- a/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
@@ -1,0 +1,91 @@
+import { BankRequestDateViewModel, ReasonForCancellingErrorsViewModel } from '../../../server/types/view-models';
+import { pageRenderer } from '../../pageRenderer';
+import { aBankRequestDateViewModel } from '../../../test-helpers/test-data/bank-request-date-view-model';
+
+const page = '../templates/case/cancellation/bank-request-date.njk';
+const render = pageRenderer(page);
+
+describe(page, () => {
+  it('should render the continue button', () => {
+    // Arrange
+    const bankRequestDateViewModel: BankRequestDateViewModel = aBankRequestDateViewModel();
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="continue-button"]').toExist();
+    wrapper.expectText('[data-cy="continue-button"]').toRead('Continue');
+  });
+
+  it('should render cancel link button linking to case deal page', () => {
+    // Arrange
+    const dealId = 'dealId';
+    const bankRequestDateViewModel: BankRequestDateViewModel = { ...aBankRequestDateViewModel(), dealId };
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="cancel-link"]').toExist();
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/deal`, 'Cancel');
+  });
+
+  it('should render back link button linking to the case deal page', () => {
+    // Arrange
+    const dealId = 'dealId';
+    const bankRequestDateViewModel: BankRequestDateViewModel = { ...aBankRequestDateViewModel(), dealId };
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="back-link"]').toExist();
+    wrapper.expectLink('[data-cy="back-link"]').toLinkTo(`/case/${dealId}/deal`, 'Back');
+  });
+
+  it('should not render error summary when no errors', () => {
+    // Arrange
+    const bankRequestDateViewModel: BankRequestDateViewModel = aBankRequestDateViewModel();
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="error-summary"]').notToExist();
+  });
+
+  it('should not render in line error when there are errors', () => {
+    // Arrange
+    const bankRequestDateViewModel: BankRequestDateViewModel = aBankRequestDateViewModel();
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="bank-request-date-inline-error"]').notToExist();
+  });
+
+  it('should render error summary when there are errors', () => {
+    // Arrange
+    const errorSummaryText = 'an error';
+    const errors: ReasonForCancellingErrorsViewModel = {
+      errorSummary: [{ text: errorSummaryText, href: 'bank-request-date' }],
+      reasonForCancellingErrorMessage: 'an error occurred',
+    };
+    const bankRequestDateViewModel: BankRequestDateViewModel = { ...aBankRequestDateViewModel(), errors };
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="error-summary"]').toExist();
+    wrapper.expectText('[data-cy="error-summary"]').toContain(errorSummaryText);
+  });
+
+  it('should render date input fields', () => {
+    // Arrange
+    const bankRequestDateViewModel: BankRequestDateViewModel = aBankRequestDateViewModel();
+    // Act
+    const wrapper = render(bankRequestDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="bank-request-date-day"]').toExist();
+    wrapper.expectElement('[data-cy="bank-request-date-month"]').toExist();
+    wrapper.expectElement('[data-cy="bank-request-date-year"]').toExist();
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.test.ts
@@ -1,0 +1,37 @@
+import { createMocks } from 'node-mocks-http';
+import { aTfmSessionUser } from '../../../../test-helpers';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+import { BankRequestDateViewModel } from '../../../types/view-models';
+import { getBankRequestDate, GetBankRequestDateRequest } from './bank-request-date.controller';
+
+const dealId = 'dealId';
+const mockUser = aTfmSessionUser();
+
+describe('getBankRequestDate', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders the bank request date page', () => {
+    // Arrange
+    const { req, res } = createMocks<GetBankRequestDateRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    getBankRequestDate(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('case/cancellation/bank-request-date.njk');
+    expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
+      activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+      user: mockUser,
+      ukefDealId: '0040613574', // TODO: DTFS2-7409 get values from database
+      dealId,
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.ts
@@ -1,0 +1,28 @@
+import { Response } from 'express';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+import { asUserSession } from '../../../helpers/express-session';
+import { BankRequestDateViewModel } from '../../../types/view-models';
+
+export type GetBankRequestDateRequest = CustomExpressRequest<{ params: { _id: string } }>;
+
+/**
+ * controller to get the bank request date page
+ *
+ * @param req - The express request
+ * @param res - The express response
+ */
+export const getBankRequestDate = (req: GetBankRequestDateRequest, res: Response) => {
+  const { _id } = req.params;
+  const { user } = asUserSession(req.session);
+
+  // TODO DTFS2-7409: Check deal type allows for cancellation and deal hasn't already been cancelled
+
+  const bankRequestDateViewModel: BankRequestDateViewModel = {
+    activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+    user,
+    ukefDealId: '0040613574', // TODO DTFS2-7409: get values from database
+    dealId: _id,
+  };
+  return res.render('case/cancellation/bank-request-date.njk', bankRequestDateViewModel);
+};

--- a/trade-finance-manager-ui/server/routes/case/cancellation.ts
+++ b/trade-finance-manager-ui/server/routes/case/cancellation.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { TEAM_IDS } from '@ukef/dtfs2-common';
 import { getReasonForCancelling, postReasonForCancelling } from '../../controllers/case/cancellation/reason-for-cancelling.controller';
+import { getBankRequestDate } from '../../controllers/case/cancellation/bank-request-date.controller';
 import { validateUserTeam } from '../../middleware';
 import { validateDealCancellationEnabled } from '../../middleware/feature-flags/deal-cancellation';
 
@@ -10,3 +11,5 @@ cancellationRouter.use(validateDealCancellationEnabled, validateUserTeam([TEAM_I
 
 cancellationRouter.get('/:_id/cancellation/reason', getReasonForCancelling);
 cancellationRouter.post('/:_id/cancellation/reason', postReasonForCancelling);
+
+cancellationRouter.get('/:_id/cancellation/bank-request-date', getBankRequestDate);

--- a/trade-finance-manager-ui/server/types/view-models/deal-cancellation/bank-request-date-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/deal-cancellation/bank-request-date-view-model.ts
@@ -1,0 +1,14 @@
+import { BaseViewModel } from '../base-view-model';
+import { ErrorSummaryViewModel } from '../error-summary-view-model';
+
+export type BankRequestDateErrorsViewModel = {
+  errorSummary: ErrorSummaryViewModel[];
+  bankRequestDateErrorMessage?: string;
+};
+
+export type BankRequestDateViewModel = BaseViewModel & {
+  ukefDealId: string;
+  dealId: string;
+  errors?: BankRequestDateErrorsViewModel;
+  bankRequestDate?: number;
+};

--- a/trade-finance-manager-ui/server/types/view-models/deal-cancellation/reason-for-cancelling-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/deal-cancellation/reason-for-cancelling-view-model.ts
@@ -1,5 +1,5 @@
-import { BaseViewModel } from './base-view-model';
-import { ErrorSummaryViewModel } from './error-summary-view-model';
+import { BaseViewModel } from '../base-view-model';
+import { ErrorSummaryViewModel } from '../error-summary-view-model';
 
 export type ReasonForCancellingErrorsViewModel = {
   errorSummary: ErrorSummaryViewModel[];

--- a/trade-finance-manager-ui/server/types/view-models/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/index.ts
@@ -11,4 +11,5 @@ export * from './edit-payment-view-model';
 export * from './confirm-delete-payment-view-model';
 export * from './utilisation-reports-view-model';
 export * from './selected-reported-fees-details-view-model';
-export * from './reason-for-cancelling-view-model';
+export * from './deal-cancellation/reason-for-cancelling-view-model';
+export * from './deal-cancellation/bank-request-date-view-model';

--- a/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
@@ -98,8 +98,7 @@
           {{ govukButton({
             text: "Continue",
             attributes: { "data-cy": "continue-button" }
-            })
-          }}
+          }) }}
           <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="cancel-link">Cancel</a>
         </div>
 

--- a/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
@@ -1,0 +1,109 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "index.njk" %}
+
+{% block pageTitle -%}
+  Cancellation - Bank request date
+{%- endblock %}
+
+{% set headingHtml %}
+<h1 class="govuk-label-wrapper">
+  <span class="govuk-caption-l govuk-!-margin-top-3 govuk-!-margin-bottom-1">Cancel deal {{ ukefDealId }}</span>
+  <label class="govuk-label govuk-label--l" for="bank-request-date">
+    Bank request date
+  </label>
+</h1>
+{% endset %}
+
+{% block sub_content %}
+  {{ govukBackLink({
+      text: "Back",
+      href: "/case/" + dealId + "/deal",
+      attributes: {
+        'data-cy': 'back-link'
+      }
+    }) }}
+
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors.errorSummary,
+      attributes: {
+        'data-cy': 'error-summary'
+      },
+      classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-4"
+    }) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <form method="POST" autocomplete="off">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        {{ govukDateInput({
+          id: "bankRequestDate",
+          namePrefix: "bank-request-date",
+          fieldset: {
+            legend: {
+              html: headingHtml
+            }
+          },
+          hint: {
+            text: "For example, 31 3 2023",
+            attributes: {
+              "data-cy": "bank-request-date-hint"
+            }
+          },
+          errorMessage: error and {
+            text: error.summary[0].text,
+            attributes: {
+              'data-cy': 'bank-request-date-inline-error'
+            }
+          },
+          items: [
+            {
+              label: "Day",
+              classes: (error and 'bank-request-date-day' in error.fields) and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+              name: "day",
+              value: dayInput,
+              attributes: {
+                'data-cy': "bank-request-date-day"
+              }
+            },
+            {
+              label: "Month",
+              classes: (error and 'bank-request-date-month' in error.fields) and "govuk-input--error govuk-input--width-2" or "govuk-input--width-2",
+              name: "month",
+              value: monthInput,
+              attributes: {
+                'data-cy': "bank-request-date-month"
+              }
+            },
+            {
+              label: "Year",
+              classes: (error and 'bank-request-date-year' in error.fields) and "govuk-input--error govuk-input--width-4" or "govuk-input--width-4",
+              name: "year",
+              value: yearInput,
+              attributes: {
+                'data-cy': "bank-request-date-year"
+              }
+            }
+          ]
+        }) }}
+
+        <div class="govuk-button-group govuk-!-margin-top-4">
+          {{ govukButton({
+            text: "Continue",
+            attributes: { "data-cy": "continue-button" }
+            })
+          }}
+          <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="cancel-link">Cancel</a>
+        </div>
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/trade-finance-manager-ui/test-helpers/test-data/bank-request-date-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/bank-request-date-view-model.ts
@@ -1,0 +1,10 @@
+import { PRIMARY_NAVIGATION_KEYS } from '../../server/constants';
+import { BankRequestDateViewModel } from '../../server/types/view-models';
+import { aTfmSessionUser } from './tfm-session-user';
+
+export const aBankRequestDateViewModel = (): BankRequestDateViewModel => ({
+  user: aTfmSessionUser(),
+  activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+  ukefDealId: 'testUkefId',
+  dealId: 'testId',
+});


### PR DESCRIPTION
## Introduction :pencil2:
The PIM user needs to be able to provide the bank request date for the deal cancellation. This ticket does not include validating the values or making updates to the database

## Resolution :heavy_check_mark:
Add bank request date template
Add a new GET endpoint to render this template

##  Screenshots 📸

![image](https://github.com/user-attachments/assets/d5e910d9-833c-428b-ad2f-9c4ec04378a2)

