### PR TITLE
fix(deployment): head branch for non release branches

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -78,6 +78,8 @@ jobs:
         run: |
           if [[ "${{ env.ENVIRONMENT }}" == *release* ]]; then
             echo "environment=staging" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Timezone 🌐


### PR DESCRIPTION
## Introduction :pencil2:
Ensure `non-release` branch have their head branches are set when deploying.
