### PR TITLE
feat(DTFS2-7300): add validation for effective from date

### DIFF
--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.test.ts
@@ -126,7 +126,7 @@ describe('postBankRequestDate', () => {
       });
     });
 
-    it('redirects to the bank request date page', () => {
+    it('redirects to the effective from date page', () => {
       // Arrange
       const today = new Date();
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.test.ts
@@ -127,7 +127,7 @@ describe('postEffectiveFromDate', () => {
       });
     });
 
-    it('redirects to the effective from date page', () => {
+    it('redirects to the check cancellation details page', () => {
       // Arrange
       const today = new Date();
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.test.ts
@@ -1,8 +1,18 @@
 import { createMocks } from 'node-mocks-http';
+import { DayMonthYearInput } from '@ukef/dtfs2-common';
 import { aTfmSessionUser } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
-import { getEffectiveFromDate, GetEffectiveFromDateRequest } from './effective-from-date.controller';
-import { EffectiveFromDateViewModel } from '../../../types/view-models';
+import { getEffectiveFromDate, GetEffectiveFromDateRequest, postEffectiveFromDate, PostEffectiveFromDateRequest } from './effective-from-date.controller';
+import { EffectiveFromDateValidationViewModel, EffectiveFromDateViewModel } from '../../../types/view-models';
+
+const validateEffectiveFromDateMock: jest.Mock<EffectiveFromDateValidationViewModel> = jest.fn(() => ({
+  errors: null,
+  effectiveFromDate: new Date(),
+}));
+
+jest.mock('./validation/validate-effective-from-date', () => ({
+  validateEffectiveFromDate: (date: DayMonthYearInput) => validateEffectiveFromDateMock(date),
+}));
 
 const dealId = 'dealId';
 const mockUser = aTfmSessionUser();
@@ -32,6 +42,113 @@ describe('getEffectiveFromDate', () => {
       user: mockUser,
       ukefDealId: '0040613574', // TODO: DTFS2-7417 get values from database
       dealId,
+    });
+  });
+});
+
+describe('postEffectiveFromDate', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when there are validation errors', () => {
+    const errors = {
+      summary: [{ text: 'error summary text', href: `#error-field` }],
+      effectiveFromDateError: { message: 'error text', fields: ['error-field'] },
+    };
+
+    const day = 1;
+    const month = 0;
+    const year = 'invalid year';
+
+    const inputtedDate = {
+      'effective-from-date-day': day,
+      'effective-from-date-month': month,
+      'effective-from-date-year': year,
+    };
+
+    beforeEach(() => {
+      validateEffectiveFromDateMock.mockReturnValueOnce({ errors });
+    });
+
+    it('calls validateEffectiveFromDate', () => {
+      // Arrange
+      const { req, res } = createMocks<PostEffectiveFromDateRequest>({
+        params: { _id: dealId },
+        session: {
+          user: mockUser,
+          userToken: 'a user token',
+        },
+        body: inputtedDate,
+      });
+
+      // Act
+      postEffectiveFromDate(req, res);
+
+      // Assert
+      expect(validateEffectiveFromDateMock).toHaveBeenCalledTimes(1);
+      expect(validateEffectiveFromDateMock).toHaveBeenCalledWith({ day, month, year });
+    });
+
+    it('renders the reason for cancelling page with errors', () => {
+      // Arrange
+      const { req, res } = createMocks<PostEffectiveFromDateRequest>({
+        params: { _id: dealId },
+        session: {
+          user: mockUser,
+          userToken: 'a user token',
+        },
+        body: inputtedDate,
+      });
+
+      // Act
+      postEffectiveFromDate(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toEqual('case/cancellation/effective-from-date.njk');
+      expect(res._getRenderData() as EffectiveFromDateViewModel).toEqual({
+        activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+        user: mockUser,
+        ukefDealId: '0040613574', // TODO: DTFS2-7350 get values from database
+        dealId,
+        errors,
+        day,
+        month,
+        year,
+      });
+    });
+  });
+
+  describe('when there are no validation errors', () => {
+    beforeEach(() => {
+      validateEffectiveFromDateMock.mockReturnValueOnce({
+        errors: null,
+        effectiveFromDate: new Date(),
+      });
+    });
+
+    it('redirects to the effective from date page', () => {
+      // Arrange
+      const today = new Date();
+
+      const { req, res } = createMocks<PostEffectiveFromDateRequest>({
+        params: { _id: dealId },
+        session: {
+          user: mockUser,
+          userToken: 'a user token',
+        },
+        body: {
+          'effective-from-date-day': today.getDate(),
+          'effective-from-date-month': today.getMonth() + 1,
+          'effective-from-date-year': today.getFullYear(),
+        },
+      });
+
+      // Act
+      postEffectiveFromDate(req, res);
+
+      // Assert
+      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/cancellation/check-details`);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.ts
@@ -3,8 +3,13 @@ import { CustomExpressRequest } from '@ukef/dtfs2-common';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { asUserSession } from '../../../helpers/express-session';
 import { EffectiveFromDateViewModel } from '../../../types/view-models';
+import { validateEffectiveFromDate } from './validation/validate-effective-from-date';
 
 export type GetEffectiveFromDateRequest = CustomExpressRequest<{ params: { _id: string } }>;
+export type PostEffectiveFromDateRequest = CustomExpressRequest<{
+  params: { _id: string };
+  reqBody: { 'effective-from-date-day': string; 'effective-from-date-month': string; 'effective-from-date-year': string };
+}>;
 
 /**
  * controller to get the effective from date page
@@ -25,4 +30,33 @@ export const getEffectiveFromDate = (req: GetEffectiveFromDateRequest, res: Resp
     dealId: _id,
   };
   return res.render('case/cancellation/effective-from-date.njk', effectiveFromDateViewModel);
+};
+
+/**
+ * controller to update the effective from date
+ *
+ * @param req - The express request
+ * @param res - The express response
+ */
+export const postEffectiveFromDate = (req: PostEffectiveFromDateRequest, res: Response) => {
+  const { _id } = req.params;
+  const { 'effective-from-date-day': day, 'effective-from-date-month': month, 'effective-from-date-year': year } = req.body;
+  const { user } = asUserSession(req.session);
+  const { errors: validationErrors } = validateEffectiveFromDate({ day, month, year });
+
+  if (validationErrors) {
+    const effectiveFromDateViewModel: EffectiveFromDateViewModel = {
+      activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+      user,
+      ukefDealId: '0040613574', // TODO DTFS2-7417: get values from database
+      dealId: _id,
+      day,
+      month,
+      year,
+      errors: validationErrors,
+    };
+
+    return res.render('case/cancellation/effective-from-date.njk', effectiveFromDateViewModel);
+  }
+  return res.redirect(`/case/${_id}/cancellation/check-details`);
 };

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-effective-from-date.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-effective-from-date.test.ts
@@ -1,11 +1,11 @@
 import { applyStandardValidationAndParseDateInput } from '@ukef/dtfs2-common';
 import { add, startOfDay } from 'date-fns';
-import { getErrorObjectFromMessageAndRefs, validateBankRequestDate } from './validate-bank-request-date';
-import { BankRequestDateValidationViewModel } from '../../../../types/view-models';
+import { getErrorObjectFromMessageAndRefs, validateEffectiveFromDate } from './validate-effective-from-date';
+import { EffectiveFromDateValidationViewModel } from '../../../../types/view-models';
 
 jest.mock('@ukef/dtfs2-common', () => ({ applyStandardValidationAndParseDateInput: jest.fn() }));
 
-describe('validate bank request date', () => {
+describe('validate effective from date', () => {
   describe('getErrorObjectFromMessageAndRefs', () => {
     it('correctly formats error messages', () => {
       const testErrorMessage = 'test error message';
@@ -16,7 +16,7 @@ describe('validate bank request date', () => {
       const expectedResult = {
         errors: {
           summary: [{ text: testErrorMessage, href: '#ref1' }],
-          bankRequestDateError: {
+          effectiveFromDateError: {
             message: testErrorMessage,
             fields: testRefs,
           },
@@ -27,7 +27,7 @@ describe('validate bank request date', () => {
     });
   });
 
-  describe('validateBankRequestDate', () => {
+  describe('validateEffectiveFromDate', () => {
     beforeEach(() => {
       jest.resetAllMocks();
     });
@@ -58,18 +58,18 @@ describe('validate bank request date', () => {
       const year = date.getUTCFullYear().toString();
 
       // Act
-      const result = validateBankRequestDate({ day, month, year });
+      const result = validateEffectiveFromDate({ day, month, year });
 
       // Assert
-      const expected: BankRequestDateValidationViewModel = {
+      const expected: EffectiveFromDateValidationViewModel = {
         errors: null,
-        bankRequestDate: date,
+        effectiveFromDate: date,
       };
       expect(result).toEqual(expected);
     });
 
     describe('custom date validation rules', () => {
-      it('returns an error if the bank request date is greater than 12 months in the future', () => {
+      it('returns an error if the effective from date is greater than 12 months in the future', () => {
         // Arrange
         const twelveMonthsAndDayInFuture = add(new Date(), { months: 12, days: 1 });
         jest.mocked(applyStandardValidationAndParseDateInput).mockReturnValueOnce({ error: null, parsedDate: twelveMonthsAndDayInFuture });
@@ -79,17 +79,21 @@ describe('validate bank request date', () => {
         const year = twelveMonthsAndDayInFuture.getFullYear().toString();
 
         // Act
-        const result = validateBankRequestDate({ day, month, year });
+        const result = validateEffectiveFromDate({ day, month, year });
 
         // Assert
-        const expectedMessage = 'The bank request date cannot exceed 12 months in the future from the submission date';
+        const expectedMessage = 'The effective date cannot exceed 12 months in the future from the submission date';
 
-        const expected = getErrorObjectFromMessageAndRefs(expectedMessage, ['bank-request-date-day', 'bank-request-date-month', 'bank-request-date-year']);
+        const expected = getErrorObjectFromMessageAndRefs(expectedMessage, [
+          'effective-from-date-day',
+          'effective-from-date-month',
+          'effective-from-date-year',
+        ]);
 
         expect(result).toEqual(expected);
       });
 
-      it('returns an error if the bank request date is greater than 12 months in the past', () => {
+      it('returns an error if the effective from date is greater than 12 months in the past', () => {
         // Arrange
         const twelveMonthsAndDayInPast = add(new Date(), { months: -12, days: -1 });
         jest.mocked(applyStandardValidationAndParseDateInput).mockReturnValueOnce({ error: null, parsedDate: twelveMonthsAndDayInPast });
@@ -99,12 +103,16 @@ describe('validate bank request date', () => {
         const year = twelveMonthsAndDayInPast.getFullYear().toString();
 
         // Act
-        const result = validateBankRequestDate({ day, month, year });
+        const result = validateEffectiveFromDate({ day, month, year });
 
         // Assert
-        const expectedMessage = 'The bank request date cannot exceed 12 months in the past from the submission date';
+        const expectedMessage = 'The effective date cannot exceed 12 months in the past from the submission date';
 
-        const expected = getErrorObjectFromMessageAndRefs(expectedMessage, ['bank-request-date-day', 'bank-request-date-month', 'bank-request-date-year']);
+        const expected = getErrorObjectFromMessageAndRefs(expectedMessage, [
+          'effective-from-date-day',
+          'effective-from-date-month',
+          'effective-from-date-year',
+        ]);
 
         expect(result).toEqual(expected);
       });
@@ -123,13 +131,13 @@ describe('validate bank request date', () => {
       });
 
       it('should call applyStandardValidationAndParseDateInput', () => {
-        validateBankRequestDate(dateObjectToTest);
+        validateEffectiveFromDate(dateObjectToTest);
 
         expect(applyStandardValidationAndParseDateInput).toHaveBeenCalledTimes(1);
       });
 
       it('should return the result of applyStandardValidationAndParseDateInput when it errors', () => {
-        const result = validateBankRequestDate(dateObjectToTest);
+        const result = validateEffectiveFromDate(dateObjectToTest);
 
         const expected = getErrorObjectFromMessageAndRefs(mockReturnedMessage, mockReturnedFieldRefs);
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-effective-from-date.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-effective-from-date.ts
@@ -1,0 +1,52 @@
+import { applyStandardValidationAndParseDateInput, DayMonthYearInput } from '@ukef/dtfs2-common';
+import { add, isAfter, isBefore, startOfDay } from 'date-fns';
+import { EffectiveFromDateValidationViewModel } from '../../../../types/view-models';
+
+const DATE_TOO_LATE_MESSAGE = 'The effective date cannot exceed 12 months in the future from the submission date';
+const DATE_TOO_EARLY_MESSAGE = 'The effective date cannot exceed 12 months in the past from the submission date';
+
+/**
+ * Returns the error object containing the error summary text with links and the inline error text with refs
+ * @private
+ * @param message the error message to display in the summary and inline
+ * @param refs a list of the specific date fields the error message relates to
+ */
+export const getErrorObjectFromMessageAndRefs = (message: string, refs: string[]) => {
+  return {
+    errors: {
+      summary: [{ text: message, href: `#${refs[0]}` }],
+      effectiveFromDateError: { message, fields: refs },
+    },
+  };
+};
+
+/**
+ * @param date The entered effective from date
+ * @returns a reason for cancelling errors view model
+ */
+export const validateEffectiveFromDate = (date: DayMonthYearInput): EffectiveFromDateValidationViewModel => {
+  const { error, parsedDate } = applyStandardValidationAndParseDateInput(date, 'date effective from', 'effective-from-date');
+
+  if (error) {
+    return getErrorObjectFromMessageAndRefs(error.message, error.fieldRefs);
+  }
+
+  const today = startOfDay(new Date());
+  const twelveMonthsFromToday = add(today, { months: 12 });
+  const twelveMonthsInPast = add(today, { months: -12 });
+
+  // checks if the entered effective from date is not beyond 12 months in the future
+  if (isAfter(parsedDate, twelveMonthsFromToday)) {
+    return getErrorObjectFromMessageAndRefs(DATE_TOO_LATE_MESSAGE, ['effective-from-date-day', 'effective-from-date-month', 'effective-from-date-year']);
+  }
+
+  // checks if the entered effective from date is not beyond 12 months in the past
+  if (isBefore(parsedDate, twelveMonthsInPast)) {
+    return getErrorObjectFromMessageAndRefs(DATE_TOO_EARLY_MESSAGE, ['effective-from-date-day', 'effective-from-date-month', 'effective-from-date-year']);
+  }
+
+  return {
+    effectiveFromDate: parsedDate,
+    errors: null,
+  };
+};

--- a/trade-finance-manager-ui/server/routes/case/cancellation.ts
+++ b/trade-finance-manager-ui/server/routes/case/cancellation.ts
@@ -4,7 +4,7 @@ import { getReasonForCancelling, postReasonForCancelling } from '../../controlle
 import { getBankRequestDate, postBankRequestDate } from '../../controllers/case/cancellation/bank-request-date.controller';
 import { validateUserTeam } from '../../middleware';
 import { validateDealCancellationEnabled } from '../../middleware/feature-flags/deal-cancellation';
-import { getEffectiveFromDate } from '../../controllers/case/cancellation/effective-from-date.controller';
+import { getEffectiveFromDate, postEffectiveFromDate } from '../../controllers/case/cancellation/effective-from-date.controller';
 
 export const cancellationRouter = Router();
 
@@ -17,3 +17,4 @@ cancellationRouter.get('/:_id/cancellation/bank-request-date', getBankRequestDat
 cancellationRouter.post('/:_id/cancellation/bank-request-date', postBankRequestDate);
 
 cancellationRouter.get('/:_id/cancellation/effective-from-date', getEffectiveFromDate);
+cancellationRouter.post('/:_id/cancellation/effective-from-date', postEffectiveFromDate);

--- a/trade-finance-manager-ui/server/types/view-models/deal-cancellation/effective-from-date-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/deal-cancellation/effective-from-date-view-model.ts
@@ -6,6 +6,11 @@ export type EffectiveFromDateErrorsViewModel = {
   effectiveFromDateError: { message: string; fields: string[] };
 };
 
+export type EffectiveFromDateValidationViewModel = {
+  errors: EffectiveFromDateErrorsViewModel | null;
+  effectiveFromDate?: Date;
+};
+
 export type EffectiveFromDateViewModel = BaseViewModel & {
   ukefDealId: string;
   dealId: string;


### PR DESCRIPTION
## Introduction :pencil2:
The input should be validated when the user submits an effective from date, both the usual date field validation checks, and also that it shouldn't be more than 12 months in the future or more than 12 months in the past.

## Resolution :heavy_check_mark:
Add post endpoint
Add validation helper, called by post endpoint

**Note this follows identically the implementation for the bank request date in PR https://github.com/UK-Export-Finance/dtfs2/pull/3561**

## Screenshots 📸
<img width="700" alt="image" src="https://github.com/user-attachments/assets/ab95154b-1389-4559-b627-5133fd0409a6">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/874d9a57-67a7-42d8-b25c-46f6eacc0499">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/4715ec48-db55-40d5-bbdb-f1120bf3d5a9">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/0707dbcc-e78b-45ab-9a2d-b43564491738">



