### PR TITLE
feat(DTFS2-7296): add to deal cancellation e2e tests

### DIFF
--- a/e2e-tests/e2e-fixtures/dateConstants.js
+++ b/e2e-tests/e2e-fixtures/dateConstants.js
@@ -134,6 +134,16 @@ const sixYearsOneDayDay = format(sixYearsOneDay, longDayFormat);
 const sixYearsOneDayMonth = format(sixYearsOneDay, longMonthFormat);
 const sixYearsOneDayYear = format(sixYearsOneDay, longYearFormat);
 
+const twelveMonthsOneDay = add(today, { months: 12, days: 1 });
+const twelveMonthsOneDayDay = format(twelveMonthsOneDay, longDayFormat);
+const twelveMonthsOneDayMonth = format(twelveMonthsOneDay, longMonthFormat);
+const twelveMonthsOneDayYear = format(twelveMonthsOneDay, longYearFormat);
+
+const twelveMonthsOneDayAgo = sub(today, { months: 12, days: 1 });
+const twelveMonthsOneDayAgoDay = format(twelveMonthsOneDayAgo, longDayFormat);
+const twelveMonthsOneDayAgoMonth = format(twelveMonthsOneDayAgo, longMonthFormat);
+const twelveMonthsOneDayAgoYear = format(twelveMonthsOneDayAgo, longYearFormat);
+
 const todayUnix = getUnixTime(today).toString();
 const todayUnixDay = format(threeDaysAgo, longDayFormat);
 const todayUnixMonth = format(threeDaysAgo, longMonthFormat);
@@ -267,4 +277,10 @@ module.exports = {
   oneYearAgoDay,
   oneYearAgoMonth,
   oneYearAgoYear,
+  twelveMonthsOneDayDay,
+  twelveMonthsOneDayMonth,
+  twelveMonthsOneDayYear,
+  twelveMonthsOneDayAgoDay,
+  twelveMonthsOneDayAgoMonth,
+  twelveMonthsOneDayAgoYear,
 };

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/bank-request-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/bank-request-date.spec.js
@@ -1,0 +1,107 @@
+import relative from '../../relativeURL';
+import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import caseDealPage from '../../pages/caseDealPage';
+import { backLink, cancelLink, continueButton, errorSummary } from '../../partials';
+import bankRequestDatePage from '../../pages/deal-cancellation/bank-request-date';
+import dateConstants from '../../../../../e2e-fixtures/dateConstants';
+
+context('Deal cancellation - bank request date', () => {
+  let dealId;
+  const dealFacilities = [];
+
+  before(() => {
+    cy.insertOneDeal(MOCK_DEAL_AIN, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      const { dealType, mockFacilities } = MOCK_DEAL_AIN;
+
+      cy.createFacilities(dealId, [mockFacilities[0]], BANK1_MAKER1).then((createdFacilities) => {
+        dealFacilities.push(...createdFacilities);
+      });
+
+      cy.submitDeal(dealId, dealType, PIM_USER_1);
+    });
+  });
+
+  after(() => {
+    cy.deleteDeals(dealId, ADMIN);
+    dealFacilities.forEach((facility) => {
+      cy.deleteFacility(facility._id, BANK1_MAKER1);
+    });
+  });
+
+  describe('when logged in as a PIM user', () => {
+    beforeEach(() => {
+      cy.login(PIM_USER_1);
+      cy.visit(relative(`/case/${dealId}/deal`));
+
+      caseDealPage.cancelDealButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+      cy.clickContinueButton();
+    });
+
+    it('should render page correctly', () => {
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+
+      cancelLink();
+      continueButton();
+      backLink();
+      bankRequestDatePage.bankRequestDateDay();
+      bankRequestDatePage.bankRequestDateMonth();
+      bankRequestDatePage.bankRequestDateYear();
+    });
+
+    it('should validate submitting a date more than 12 months in the future', () => {
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateDay(), dateConstants.twelveMonthsOneDayDay);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateMonth(), dateConstants.twelveMonthsOneDayMonth);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateYear(), dateConstants.twelveMonthsOneDayYear);
+
+      cy.clickContinueButton();
+      errorSummary().contains('The bank request date cannot exceed 12 months in the future from the submission date');
+    });
+
+    it('should validate submitting a date more than 12 months in the past', () => {
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateDay(), dateConstants.twelveMonthsOneDayAgoDay);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateMonth(), dateConstants.twelveMonthsOneDayAgoMonth);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateYear(), dateConstants.twelveMonthsOneDayAgoYear);
+
+      cy.clickContinueButton();
+      errorSummary().contains('The bank request date cannot exceed 12 months in the past from the submission date');
+    });
+
+    it('back link should take you to the reason for cancelling page', () => {
+      cy.clickBackLink();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+    });
+
+    it('continue button should take you to the effective from date page', () => {
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateYear(), dateConstants.todayYear);
+
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+    });
+
+    // TODO: DTFS2-7359 - add this test once cancel link is implemented
+    it.skip('cancel link should take you to confirm cancellation page', () => {
+      cy.clickCancelLink();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));
+    });
+  });
+
+  describe('when logged in as a non-PIM user', () => {
+    beforeEach(() => {
+      cy.login(T1_USER_1);
+    });
+
+    it('should redirect when visiting bank request date page ', () => {
+      cy.url().should('eq', relative('/deals/0'));
+    });
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
@@ -1,0 +1,114 @@
+import relative from '../../relativeURL';
+import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import caseDealPage from '../../pages/caseDealPage';
+import { backLink, cancelLink, continueButton, errorSummary } from '../../partials';
+import effectiveFromDatePage from '../../pages/deal-cancellation/effective-from-date';
+import dateConstants from '../../../../../e2e-fixtures/dateConstants';
+import bankRequestDatePage from '../../pages/deal-cancellation/bank-request-date';
+
+context('Deal cancellation - effective from date', () => {
+  let dealId;
+  const dealFacilities = [];
+
+  before(() => {
+    cy.insertOneDeal(MOCK_DEAL_AIN, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      const { dealType, mockFacilities } = MOCK_DEAL_AIN;
+
+      cy.createFacilities(dealId, [mockFacilities[0]], BANK1_MAKER1).then((createdFacilities) => {
+        dealFacilities.push(...createdFacilities);
+      });
+
+      cy.submitDeal(dealId, dealType, PIM_USER_1);
+    });
+  });
+
+  after(() => {
+    cy.deleteDeals(dealId, ADMIN);
+    dealFacilities.forEach((facility) => {
+      cy.deleteFacility(facility._id, BANK1_MAKER1);
+    });
+  });
+
+  describe('when logged in as a PIM user', () => {
+    beforeEach(() => {
+      cy.login(PIM_USER_1);
+      cy.visit(relative(`/case/${dealId}/deal`));
+
+      caseDealPage.cancelDealButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateYear(), dateConstants.todayYear);
+      cy.clickContinueButton();
+    });
+
+    it('should render page correctly', () => {
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+
+      cancelLink();
+      continueButton();
+      backLink();
+      effectiveFromDatePage.effectiveFromDateDay();
+      effectiveFromDatePage.effectiveFromDateMonth();
+      effectiveFromDatePage.effectiveFromDateYear();
+    });
+
+    it('should validate submitting a date more than 12 months in the future', () => {
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateDay(), dateConstants.twelveMonthsOneDayDay);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateMonth(), dateConstants.twelveMonthsOneDayMonth);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateYear(), dateConstants.twelveMonthsOneDayYear);
+
+      cy.clickContinueButton();
+      errorSummary().contains('The effective date cannot exceed 12 months in the future from the submission date');
+    });
+
+    it('should validate submitting a date more than 12 months in the past', () => {
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateDay(), dateConstants.twelveMonthsOneDayAgoDay);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateMonth(), dateConstants.twelveMonthsOneDayAgoMonth);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateYear(), dateConstants.twelveMonthsOneDayAgoYear);
+
+      cy.clickContinueButton();
+      errorSummary().contains('The effective date cannot exceed 12 months in the past from the submission date');
+    });
+
+    it('back link should take you to the bank request date page', () => {
+      cy.clickBackLink();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+    });
+
+    it('continue button should take you to the check answers page', () => {
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateYear(), dateConstants.todayYear);
+
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
+    });
+
+    // TODO: DTFS2-7359 - add this test once cancel link is implemented
+    it.skip('cancel link should take you to confirm cancellation page', () => {
+      cy.clickCancelLink();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));
+    });
+  });
+
+  describe('when logged in as a non-PIM user', () => {
+    beforeEach(() => {
+      cy.login(T1_USER_1);
+    });
+
+    it('should redirect when visiting effective from date page ', () => {
+      cy.url().should('eq', relative('/deals/0'));
+    });
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/reason-for-cancelling.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/reason-for-cancelling.spec.js
@@ -62,11 +62,10 @@ context('Deal cancellation - reason for cancelling', () => {
       cy.url().should('eq', relative(`/case/${dealId}/deal`));
     });
 
-    // TODO: DTFS2-7296 - add this test once bank request date page is implemented
-    it.skip('continue button should take you to bank request date page', () => {
+    it('continue button should take you to bank request date page', () => {
       cy.clickContinueButton();
 
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/request-date`));
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
     });
 
     // TODO: DTFS2-7359 - add this test once cancel link is implemented

--- a/e2e-tests/tfm/cypress/e2e/pages/deal-cancellation/bank-request-date.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/deal-cancellation/bank-request-date.js
@@ -1,0 +1,7 @@
+const bankRequestDatePage = {
+  bankRequestDateDay: () => cy.get('[data-cy="bank-request-date-day"]'),
+  bankRequestDateMonth: () => cy.get('[data-cy="bank-request-date-month"]'),
+  bankRequestDateYear: () => cy.get('[data-cy="bank-request-date-year"]'),
+};
+
+module.exports = bankRequestDatePage;

--- a/e2e-tests/tfm/cypress/e2e/pages/deal-cancellation/effective-from-date.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/deal-cancellation/effective-from-date.js
@@ -1,0 +1,7 @@
+const effectiveFromDatePage = {
+  effectiveFromDateDay: () => cy.get('[data-cy="effective-from-date-day"]'),
+  effectiveFromDateMonth: () => cy.get('[data-cy="effective-from-date-month"]'),
+  effectiveFromDateYear: () => cy.get('[data-cy="effective-from-date-year"]'),
+};
+
+module.exports = effectiveFromDatePage;


### PR DESCRIPTION
## Introduction :pencil2:
This adds the E2E tests for the bank request date and effective from date pages. 

![image](https://github.com/user-attachments/assets/87ea4ada-e94b-4536-a3f4-ffc9bee2fd0f)
![image](https://github.com/user-attachments/assets/15ac61a0-9966-4ae1-8060-7788ffd85d91)


## Resolution :heavy_check_mark:
List all changes made to the codebase.

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

