### PR TITLE
chore(DTFS2-7439): align some unit test naming conventions

### DIFF
--- a/dtfs-central-api/src/helpers/fee-record-matching.test.ts
+++ b/dtfs-central-api/src/helpers/fee-record-matching.test.ts
@@ -188,13 +188,13 @@ describe('fee-record-matching', () => {
 
       describe('and when the payment currency and fees paid currency do not match', () => {
         it.each`
-          condition            | expectedResult | paymentAmount
-          ${'equals'}          | ${true}        | ${95.91}
-          ${'is less than'}    | ${false}       | ${95.9}
-          ${'is greater than'} | ${false}       | ${95.92}
+          condition            | expected | paymentAmount
+          ${'equals'}          | ${true}  | ${95.91}
+          ${'is less than'}    | ${false} | ${95.9}
+          ${'is greater than'} | ${false} | ${95.92}
         `(
-          'returns $expectedResult if total received payments $condition the total reported payments with the reported payments converted into the payment currency',
-          async ({ expectedResult, paymentAmount }: { expectedResult: boolean; paymentAmount: number }) => {
+          'returns $expected if total received payments $condition the total reported payments with the reported payments converted into the payment currency',
+          async ({ expected, paymentAmount }: { expected: boolean; paymentAmount: number }) => {
             // Arrange
             const firstFeeRecordFeesPaidToUkefForThePeriodCurrency: Currency = 'EUR';
             const firstFeeRecordPaymentExchangeRate = 1.1;
@@ -232,7 +232,7 @@ describe('fee-record-matching', () => {
             const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
             // Assert
-            expect(result).toBe(expectedResult);
+            expect(result).toBe(expected);
           },
         );
 
@@ -543,13 +543,13 @@ describe('fee-record-matching', () => {
         });
 
         it.each`
-          condition      | expectedResult | paymentAmount
-          ${'less than'} | ${true}        | ${96.9}
-          ${'more than'} | ${false}       | ${96.92}
-          ${'equal to'}  | ${true}        | ${96.91}
+          condition      | expected | paymentAmount
+          ${'less than'} | ${true}  | ${96.9}
+          ${'more than'} | ${false} | ${96.92}
+          ${'equal to'}  | ${true}  | ${96.91}
         `(
-          'returns $expectedResult if received payments are greater than the reported payments converted to payment currency by an amount $condition the tolerance',
-          async ({ expectedResult, paymentAmount }: { expectedResult: boolean; paymentAmount: number }) => {
+          'returns $expected if received payments are greater than the reported payments converted to payment currency by an amount $condition the tolerance',
+          async ({ expected, paymentAmount }: { expected: boolean; paymentAmount: number }) => {
             // Arrange
             const tolerance = 1;
             const firstFeeRecordFeesPaidToUkefForThePeriodCurrency: Currency = 'EUR';
@@ -590,18 +590,18 @@ describe('fee-record-matching', () => {
             const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
             // Assert
-            expect(result).toBe(expectedResult);
+            expect(result).toBe(expected);
           },
         );
 
         it.each`
-          condition      | expectedResult | paymentAmount
-          ${'less than'} | ${true}        | ${94.92}
-          ${'more than'} | ${false}       | ${94.9}
-          ${'equal to'}  | ${true}        | ${94.91}
+          condition      | expected | paymentAmount
+          ${'less than'} | ${true}  | ${94.92}
+          ${'more than'} | ${false} | ${94.9}
+          ${'equal to'}  | ${true}  | ${94.91}
         `(
-          'returns $expectedResult if received payments are less than reported payments converted to payment currency by an amount $condition the tolerance',
-          async ({ expectedResult, paymentAmount }: { expectedResult: boolean; paymentAmount: number }) => {
+          'returns $expected if received payments are less than reported payments converted to payment currency by an amount $condition the tolerance',
+          async ({ expected, paymentAmount }: { expected: boolean; paymentAmount: number }) => {
             // Arrange
             const tolerance = 1;
             const firstFeeRecordFeesPaidToUkefForThePeriodCurrency: Currency = 'EUR';
@@ -642,7 +642,7 @@ describe('fee-record-matching', () => {
             const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
             // Assert
-            expect(result).toBe(expectedResult);
+            expect(result).toBe(expected);
           },
         );
       });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
@@ -47,12 +47,12 @@ describe('calculateFixedFeeAdjustment', () => {
   });
 
   it.each([
-    { condition: 'the previous fixed fee is greater', previousFixedFee: 123.456, currentFixedFee: 23.332, expectedResult: -100.12 },
-    { condition: 'the current fixed fee is greater', previousFixedFee: 23.332, currentFixedFee: 123.456, expectedResult: 100.12 },
-    { condition: 'both fixed fees are equal', previousFixedFee: 100, currentFixedFee: 100, expectedResult: 0 },
+    { condition: 'the previous fixed fee is greater', previousFixedFee: 123.456, currentFixedFee: 23.332, expected: -100.12 },
+    { condition: 'the current fixed fee is greater', previousFixedFee: 23.332, currentFixedFee: 123.456, expected: 100.12 },
+    { condition: 'both fixed fees are equal', previousFixedFee: 100, currentFixedFee: 100, expected: 0 },
   ])(
     'returns the difference between the current and previous fixed fee rounded to 2 decimal places when $condition',
-    async ({ previousFixedFee, currentFixedFee, expectedResult }) => {
+    async ({ previousFixedFee, currentFixedFee, expected }) => {
       // Arrange
       const reportPeriod = aReportPeriod();
       const utilisationReport = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
@@ -77,7 +77,7 @@ describe('calculateFixedFeeAdjustment', () => {
       const result = await calculateFixedFeeAdjustment(feeRecord, facilityUtilisationData, reportPeriod);
 
       // Assert
-      expect(result).toBe(expectedResult);
+      expect(result).toBe(expected);
     },
   );
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-search.spec.js
@@ -146,17 +146,17 @@ context('User can view and filter multiple deals', () => {
       (d) => d.dealSnapshot.details?.ukefDealId === searchString || d.dealSnapshot.ukefDealId === searchString,
     );
 
-    const expectedsLength = bssDealsWithUkefDealId.length;
+    const expectedLength = bssDealsWithUkefDealId.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    if (expectedsLength === 1) {
-      cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
+    if (expectedLength === 1) {
+      cy.assertText(pages.dealsPage.heading(), `${expectedLength} result for "${searchString}"`);
     } else {
-      cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
+      cy.assertText(pages.dealsPage.heading(), `${expectedLength} result for "${searchString}"`);
     }
   });
 
@@ -165,14 +165,14 @@ context('User can view and filter multiple deals', () => {
 
     const searchString = gefDeal.dealSnapshot.ukefDealId;
 
-    const expectedsLength = 1;
+    const expectedLength = 1;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedLength} result for "${searchString}"`);
   });
 
   it('search/filter by bank name', () => {
@@ -253,27 +253,27 @@ context('User can view and filter multiple deals', () => {
       return null;
     });
 
-    const expectedsLength = dealsWithBonds.length;
+    const expectedLength = dealsWithBonds.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedLength} results for "${searchString}"`);
   });
 
   it('search/filter by loan productCode', () => {
     const searchString = 'EWCS';
 
-    const expectedsLength = 1;
+    const expectedLength = 1;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedLength} result for "${searchString}"`);
   });
 
   it('search/filter by date received in DD/MM/YYYY format', () => {
@@ -283,14 +283,14 @@ context('User can view and filter multiple deals', () => {
 
     // Note: Date received is generated on submission.
     // all deals in this test are submitted at the same time.
-    const expectedsLength = ALL_SUBMITTED_DEALS.length;
+    const expectedLength = ALL_SUBMITTED_DEALS.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedLength} results for "${searchString}"`);
   });
 
   it('search/filter by date received in DD-MM-YYYY format', () => {
@@ -300,14 +300,14 @@ context('User can view and filter multiple deals', () => {
 
     // Note: Date received is generated on submission.
     // all deals in this test are submitted at the same time.
-    const expectedsLength = ALL_SUBMITTED_DEALS.length;
+    const expectedLength = ALL_SUBMITTED_DEALS.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedLength} results for "${searchString}"`);
   });
 
   it('updates heading text and does not render any deals when no results are found', () => {
@@ -316,11 +316,11 @@ context('User can view and filter multiple deals', () => {
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    const expectedsLength = 0;
+    const expectedLength = 0;
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedLength} results for "${searchString}"`);
   });
 
   it('after a search has been performed, clicking `All deals` nav item returns all deals ', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-search.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deals/deals-search.spec.js
@@ -146,17 +146,17 @@ context('User can view and filter multiple deals', () => {
       (d) => d.dealSnapshot.details?.ukefDealId === searchString || d.dealSnapshot.ukefDealId === searchString,
     );
 
-    const expectedResultsLength = bssDealsWithUkefDealId.length;
+    const expectedsLength = bssDealsWithUkefDealId.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    if (expectedResultsLength === 1) {
-      cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} result for "${searchString}"`);
+    if (expectedsLength === 1) {
+      cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
     } else {
-      cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} result for "${searchString}"`);
+      cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
     }
   });
 
@@ -165,14 +165,14 @@ context('User can view and filter multiple deals', () => {
 
     const searchString = gefDeal.dealSnapshot.ukefDealId;
 
-    const expectedResultsLength = 1;
+    const expectedsLength = 1;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} result for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
   });
 
   it('search/filter by bank name', () => {
@@ -253,27 +253,27 @@ context('User can view and filter multiple deals', () => {
       return null;
     });
 
-    const expectedResultsLength = dealsWithBonds.length;
+    const expectedsLength = dealsWithBonds.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
   });
 
   it('search/filter by loan productCode', () => {
     const searchString = 'EWCS';
 
-    const expectedResultsLength = 1;
+    const expectedsLength = 1;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} result for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} result for "${searchString}"`);
   });
 
   it('search/filter by date received in DD/MM/YYYY format', () => {
@@ -283,14 +283,14 @@ context('User can view and filter multiple deals', () => {
 
     // Note: Date received is generated on submission.
     // all deals in this test are submitted at the same time.
-    const expectedResultsLength = ALL_SUBMITTED_DEALS.length;
+    const expectedsLength = ALL_SUBMITTED_DEALS.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
   });
 
   it('search/filter by date received in DD-MM-YYYY format', () => {
@@ -300,14 +300,14 @@ context('User can view and filter multiple deals', () => {
 
     // Note: Date received is generated on submission.
     // all deals in this test are submitted at the same time.
-    const expectedResultsLength = ALL_SUBMITTED_DEALS.length;
+    const expectedsLength = ALL_SUBMITTED_DEALS.length;
 
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
   });
 
   it('updates heading text and does not render any deals when no results are found', () => {
@@ -316,11 +316,11 @@ context('User can view and filter multiple deals', () => {
     cy.keyboardInput(pages.dealsPage.searchFormInput(), searchString);
     cy.clickSubmitButton();
 
-    const expectedResultsLength = 0;
+    const expectedsLength = 0;
 
-    pages.dealsPage.dealsTableRows().should('have.length', expectedResultsLength);
+    pages.dealsPage.dealsTableRows().should('have.length', expectedsLength);
 
-    cy.assertText(pages.dealsPage.heading(), `${expectedResultsLength} results for "${searchString}"`);
+    cy.assertText(pages.dealsPage.heading(), `${expectedsLength} results for "${searchString}"`);
   });
 
   it('after a search has been performed, clicking `All deals` nav item returns all deals ', () => {

--- a/portal-api/src/v1/users/validation/rules/current-password-must-match.test.js
+++ b/portal-api/src/v1/users/validation/rules/current-password-must-match.test.js
@@ -22,8 +22,8 @@ describe('current password must match', () => {
       passwordConfirm: 'AAAA',
     };
 
-    const matchTest = currentPasswordMustMatch(user, change);
-    expect(matchTest).toEqual(errorResult);
+    const result = currentPasswordMustMatch(user, change);
+    expect(result).toEqual(errorResult);
   });
 
   it("should return error if current password doesn't match", () => {
@@ -33,8 +33,8 @@ describe('current password must match', () => {
       passwordConfirm: 'AAAA',
     };
 
-    const matchTest = currentPasswordMustMatch(user, change);
-    expect(matchTest).toEqual(errorResult);
+    const result = currentPasswordMustMatch(user, change);
+    expect(result).toEqual(errorResult);
   });
 
   it('should not return error if current password is valid', () => {
@@ -44,8 +44,8 @@ describe('current password must match', () => {
       passwordConfirm: 'AAAA',
     };
 
-    const matchTest = currentPasswordMustMatch(user, change);
-    expect(matchTest).toEqual([]);
+    const result = currentPasswordMustMatch(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if valid reset password token supplied', () => {
@@ -61,8 +61,8 @@ describe('current password must match', () => {
       ...user,
       resetPwdToken,
     };
-    const matchTest = currentPasswordMustMatch(userWithResetToken, change);
-    expect(matchTest).toEqual([]);
+    const result = currentPasswordMustMatch(userWithResetToken, change);
+    expect(result).toEqual([]);
   });
 
   it('should return error if invalid reset password token supplied', () => {
@@ -78,7 +78,7 @@ describe('current password must match', () => {
       ...user,
       resetPwdToken,
     };
-    const matchTest = currentPasswordMustMatch(userWithResetToken, change);
-    expect(matchTest).toEqual(errorResult);
+    const result = currentPasswordMustMatch(userWithResetToken, change);
+    expect(result).toEqual(errorResult);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-8-characters.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-8-characters.test.js
@@ -20,8 +20,8 @@ describe('at least 8 characters', () => {
       },
     ];
 
-    const matchTest = passwordAtLeast8Characters(user, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordAtLeast8Characters(user, change);
+    expect(result).toEqual(expected);
   });
 
   it('should not return error for passwords with 8 characters', () => {
@@ -29,12 +29,12 @@ describe('at least 8 characters', () => {
       password: '12345678',
     };
 
-    const matchTest = passwordAtLeast8Characters(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeast8Characters(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordAtLeast8Characters(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeast8Characters(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-8-characters.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-8-characters.test.js
@@ -11,7 +11,7 @@ describe('at least 8 characters', () => {
       password: '1234',
     };
 
-    const expectedResult = [
+    const expected = [
       {
         password: {
           order: '1',
@@ -21,7 +21,7 @@ describe('at least 8 characters', () => {
     ];
 
     const matchTest = passwordAtLeast8Characters(user, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it('should not return error for passwords with 8 characters', () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-lowercase.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-lowercase.test.js
@@ -20,8 +20,8 @@ describe('at least 1 lowercase', () => {
       },
     ];
 
-    const matchTest = passwordAtLeastOneLowercase(user, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordAtLeastOneLowercase(user, change);
+    expect(result).toEqual(expected);
   });
 
   it('should not return error for passwords with uppercase', () => {
@@ -29,12 +29,12 @@ describe('at least 1 lowercase', () => {
       password: 'Aaaa',
     };
 
-    const matchTest = passwordAtLeastOneLowercase(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneLowercase(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordAtLeastOneLowercase(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneLowercase(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-lowercase.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-lowercase.test.js
@@ -11,7 +11,7 @@ describe('at least 1 lowercase', () => {
       password: 'AAAA',
     };
 
-    const expectedResult = [
+    const expected = [
       {
         password: {
           order: '2',
@@ -21,7 +21,7 @@ describe('at least 1 lowercase', () => {
     ];
 
     const matchTest = passwordAtLeastOneLowercase(user, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it('should not return error for passwords with uppercase', () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-number.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-number.test.js
@@ -20,8 +20,8 @@ describe('at least 1 number', () => {
       },
     ];
 
-    const matchTest = passwordAtLeastOneNumber(user, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordAtLeastOneNumber(user, change);
+    expect(result).toEqual(expected);
   });
 
   it('should not return error for passwords with a number', () => {
@@ -29,12 +29,12 @@ describe('at least 1 number', () => {
       password: 'Aaaa1',
     };
 
-    const matchTest = passwordAtLeastOneNumber(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneNumber(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordAtLeastOneNumber(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneNumber(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-number.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-number.test.js
@@ -11,7 +11,7 @@ describe('at least 1 number', () => {
       password: 'aaaaa',
     };
 
-    const expectedResult = [
+    const expected = [
       {
         password: {
           order: '3',
@@ -21,7 +21,7 @@ describe('at least 1 number', () => {
     ];
 
     const matchTest = passwordAtLeastOneNumber(user, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it('should not return error for passwords with a number', () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-special-character.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-special-character.test.js
@@ -20,8 +20,8 @@ describe('at least 1 special character', () => {
       },
     ];
 
-    const matchTest = passwordAtLeastOneSpecialCharacter(user, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordAtLeastOneSpecialCharacter(user, change);
+    expect(result).toEqual(expected);
   });
 
   it('should not return error for passwords with uppercase', () => {
@@ -29,12 +29,12 @@ describe('at least 1 special character', () => {
       password: 'Aaaa$',
     };
 
-    const matchTest = passwordAtLeastOneSpecialCharacter(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneSpecialCharacter(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordAtLeastOneSpecialCharacter(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneSpecialCharacter(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-special-character.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-special-character.test.js
@@ -11,7 +11,7 @@ describe('at least 1 special character', () => {
       password: 'aaaaa',
     };
 
-    const expectedResult = [
+    const expected = [
       {
         password: {
           order: '4',
@@ -21,7 +21,7 @@ describe('at least 1 special character', () => {
     ];
 
     const matchTest = passwordAtLeastOneSpecialCharacter(user, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it('should not return error for passwords with uppercase', () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-uppercase.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-uppercase.test.js
@@ -11,7 +11,7 @@ describe('at least 1 uppercase', () => {
       password: 'aaaaa',
     };
 
-    const expectedResult = [
+    const expected = [
       {
         password: {
           order: '5',
@@ -21,7 +21,7 @@ describe('at least 1 uppercase', () => {
     ];
 
     const matchTest = passwordAtLeastOneUppercase(user, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it('should not return error for passwords with uppercase', () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-at-least-one-uppercase.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-at-least-one-uppercase.test.js
@@ -20,8 +20,8 @@ describe('at least 1 uppercase', () => {
       },
     ];
 
-    const matchTest = passwordAtLeastOneUppercase(user, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordAtLeastOneUppercase(user, change);
+    expect(result).toEqual(expected);
   });
 
   it('should not return error for passwords with uppercase', () => {
@@ -29,12 +29,12 @@ describe('at least 1 uppercase', () => {
       password: 'Aaaa',
     };
 
-    const matchTest = passwordAtLeastOneUppercase(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneUppercase(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordAtLeastOneUppercase(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordAtLeastOneUppercase(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-cannot-be-reused.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-cannot-be-reused.test.js
@@ -33,8 +33,8 @@ describe('passwords cannot be reused', () => {
       },
     ];
 
-    const matchTest = passwordsCannotBeReused(blockedUser, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordsCannotBeReused(blockedUser, change);
+    expect(result).toEqual(expected);
   });
 
   it("should not return error for passwords that haven't been previously used", () => {
@@ -42,12 +42,12 @@ describe('passwords cannot be reused', () => {
       password: 'AAAA',
     };
 
-    const matchTest = passwordsCannotBeReused(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordsCannotBeReused(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordsCannotBeReused(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordsCannotBeReused(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/portal-api/src/v1/users/validation/rules/passwords-cannot-be-reused.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-cannot-be-reused.test.js
@@ -24,7 +24,7 @@ describe('passwords cannot be reused', () => {
       ],
     };
 
-    const expectedResult = [
+    const expected = [
       {
         password: {
           order: '6',
@@ -34,7 +34,7 @@ describe('passwords cannot be reused', () => {
     ];
 
     const matchTest = passwordsCannotBeReused(blockedUser, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it("should not return error for passwords that haven't been previously used", () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-must-match.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-must-match.test.js
@@ -12,7 +12,7 @@ describe('passwords must match', () => {
       passwordConfirm: 'BBBB',
     };
 
-    const expectedResult = [
+    const expected = [
       {
         passwordConfirm: {
           order: '1',
@@ -22,7 +22,7 @@ describe('passwords must match', () => {
     ];
 
     const matchTest = passwordsMustMatch(user, change);
-    expect(matchTest).toEqual(expectedResult);
+    expect(matchTest).toEqual(expected);
   });
 
   it('should not return error for passwords match', () => {

--- a/portal-api/src/v1/users/validation/rules/passwords-must-match.test.js
+++ b/portal-api/src/v1/users/validation/rules/passwords-must-match.test.js
@@ -21,8 +21,8 @@ describe('passwords must match', () => {
       },
     ];
 
-    const matchTest = passwordsMustMatch(user, change);
-    expect(matchTest).toEqual(expected);
+    const result = passwordsMustMatch(user, change);
+    expect(result).toEqual(expected);
   });
 
   it('should not return error for passwords match', () => {
@@ -31,12 +31,12 @@ describe('passwords must match', () => {
       passwordConfirm: 'AAAA',
     };
 
-    const matchTest = passwordsMustMatch(user, change);
-    expect(matchTest).toEqual([]);
+    const result = passwordsMustMatch(user, change);
+    expect(result).toEqual([]);
   });
 
   it('should not return error if no change', () => {
-    const matchTest = passwordsMustMatch(user, '');
-    expect(matchTest).toEqual([]);
+    const result = passwordsMustMatch(user, '');
+    expect(result).toEqual([]);
   });
 });

--- a/trade-finance-manager-api/api-tests/v1/amendments/update-tfm-deal-amendment-completion.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/amendments/update-tfm-deal-amendment-completion.api-test.js
@@ -44,9 +44,11 @@ describe('update tfm-deals on amendment completion', () => {
       generateTfmAuditDetails(MOCK_USERS[0]._id),
     );
 
+    const formatted = format(result.tfm.lastUpdated, 'dd/MM/yyyy');
+
     const expected = format(new Date(), 'dd/MM/yyyy');
-    const expectedResult = format(result.tfm.lastUpdated, 'dd/MM/yyyy');
-    expect(expectedResult).toEqual(expected);
+
+    expect(formatted).toEqual(expected);
   });
 
   it('updateTFMDealLastUpdated() - should return null when dealId is null', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-bank-request-date.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-bank-request-date.test.ts
@@ -13,7 +13,7 @@ describe('validate bank request date', () => {
 
       const result = getErrorObjectFromMessageAndRefs(testErrorMessage, testRefs);
 
-      const expectedResult = {
+      const expected = {
         errors: {
           summary: [{ text: testErrorMessage, href: '#ref1' }],
           bankRequestDateError: {
@@ -23,7 +23,7 @@ describe('validate bank request date', () => {
         },
       };
 
-      expect(result).toEqual(expectedResult);
+      expect(result).toEqual(expected);
     });
   });
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-effective-from-date.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/validation/validate-effective-from-date.test.ts
@@ -13,7 +13,7 @@ describe('validate effective from date', () => {
 
       const result = getErrorObjectFromMessageAndRefs(testErrorMessage, testRefs);
 
-      const expectedResult = {
+      const expected = {
         errors: {
           summary: [{ text: testErrorMessage, href: '#ref1' }],
           effectiveFromDateError: {
@@ -23,7 +23,7 @@ describe('validate effective from date', () => {
         },
       };
 
-      expect(result).toEqual(expectedResult);
+      expect(result).toEqual(expected);
     });
   });
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-summary-helper.test.ts
@@ -177,7 +177,7 @@ describe('reconciliation-summary-helper', () => {
         const result = await getReportReconciliationSummariesViewModel(summariesApiResponse, 'user-token');
 
         // Assert
-        const expectedResult: Awaited<ReturnType<typeof getReportReconciliationSummariesViewModel>> = [
+        const expected: Awaited<ReturnType<typeof getReportReconciliationSummariesViewModel>> = [
           {
             items: [
               {
@@ -199,7 +199,7 @@ describe('reconciliation-summary-helper', () => {
           },
         ];
 
-        expect(result).toEqual(expectedResult);
+        expect(result).toEqual(expected);
       });
     });
 
@@ -234,7 +234,7 @@ describe('reconciliation-summary-helper', () => {
         const result = await getReportReconciliationSummariesViewModel(summariesApiResponse, 'user-token');
 
         // Assert
-        const expectedResult: Awaited<ReturnType<typeof getReportReconciliationSummariesViewModel>> = [
+        const expected: Awaited<ReturnType<typeof getReportReconciliationSummariesViewModel>> = [
           {
             items: [
               {
@@ -256,7 +256,7 @@ describe('reconciliation-summary-helper', () => {
           },
         ];
 
-        expect(result).toEqual(expectedResult);
+        expect(result).toEqual(expected);
       });
     });
   });

--- a/trade-finance-manager-ui/server/helpers/date.test.js
+++ b/trade-finance-manager-ui/server/helpers/date.test.js
@@ -25,25 +25,25 @@ describe('date', () => {
         const dateInMonth = new Date('2023-11-15');
 
         it.each([
-          { businessDay: 1, expectedResult: new Date('2023-11-01') },
-          { businessDay: 2, expectedResult: new Date('2023-11-02') },
-          { businessDay: 3, expectedResult: new Date('2023-11-03') },
+          { businessDay: 1, expected: new Date('2023-11-01') },
+          { businessDay: 2, expected: new Date('2023-11-02') },
+          { businessDay: 3, expected: new Date('2023-11-03') },
           //                                         '2023-11-04' - Saturday
           //                                         '2023-11-05' - Sunday
-          { businessDay: 4, expectedResult: new Date('2023-11-06') },
-          { businessDay: 5, expectedResult: new Date('2023-11-07') },
-          { businessDay: 6, expectedResult: new Date('2023-11-08') },
-          { businessDay: 7, expectedResult: new Date('2023-11-09') },
-          { businessDay: 8, expectedResult: new Date('2023-11-10') },
+          { businessDay: 4, expected: new Date('2023-11-06') },
+          { businessDay: 5, expected: new Date('2023-11-07') },
+          { businessDay: 6, expected: new Date('2023-11-08') },
+          { businessDay: 7, expected: new Date('2023-11-09') },
+          { businessDay: 8, expected: new Date('2023-11-10') },
           //                                         '2023-11-11' - Saturday
           //                                         '2023-11-12' - Sunday
-          { businessDay: 9, expectedResult: new Date('2023-11-13') },
-        ])(`returns $expectedResult when dateInMonth is ${dateInMonth.toISOString()} and businessDay is $businessDay`, ({ businessDay, expectedResult }) => {
+          { businessDay: 9, expected: new Date('2023-11-13') },
+        ])(`returns $expected when dateInMonth is ${dateInMonth.toISOString()} and businessDay is $businessDay`, ({ businessDay, expected }) => {
           // Act
           const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
           // Assert
-          expect(isSameDay(result, expectedResult)).toBe(true);
+          expect(isSameDay(result, expected)).toBe(true);
         });
       });
 
@@ -52,14 +52,14 @@ describe('date', () => {
 
         it.each([
           //                                               '2023-10-01' - Sunday
-          { businessDay: 1, expectedResult: new Date('2023-10-02') },
-          { businessDay: 2, expectedResult: new Date('2023-10-03') },
-        ])(`returns $expectedResult when dateInMonth is ${dateInMonth.toISOString()} and businessDay is $businessDay`, ({ businessDay, expectedResult }) => {
+          { businessDay: 1, expected: new Date('2023-10-02') },
+          { businessDay: 2, expected: new Date('2023-10-03') },
+        ])(`returns $expected when dateInMonth is ${dateInMonth.toISOString()} and businessDay is $businessDay`, ({ businessDay, expected }) => {
           // Act
           const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
           // Assert
-          expect(isSameDay(result, expectedResult)).toBe(true);
+          expect(isSameDay(result, expected)).toBe(true);
         });
       });
     });
@@ -73,13 +73,13 @@ describe('date', () => {
           new Date('2023-08-03'), // Thursday
         ];
         const businessDay = 2; // would expect '2023-08-02' without holidays
-        const expectedResult = new Date('2023-08-04');
+        const expected = new Date('2023-08-04');
 
         // Act
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         // Assert
-        expect(isSameDay(result, expectedResult)).toBe(true);
+        expect(isSameDay(result, expected)).toBe(true);
       });
 
       it('takes into account both holidays and weekend dates', () => {
@@ -90,13 +90,13 @@ describe('date', () => {
           new Date('2023-11-06'), // Monday
         ];
         const businessDay = 3; // would expect '2023-11-03' without holidays
-        const expectedResult = new Date('2023-11-07');
+        const expected = new Date('2023-11-07');
 
         // Act
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         // Assert
-        expect(isSameDay(result, expectedResult)).toBe(true);
+        expect(isSameDay(result, expected)).toBe(true);
       });
     });
   });


### PR DESCRIPTION
## Introduction :pencil2:
- Some tests were using an `expectedResult` convention, when `expected` should be used.
- Some tests were using an `matchTest` convention, when `result` should be used.

## Resolution :heavy_check_mark:
- Replace all instances of `expectedResult` with `expected`.
- Replace all instances of `matchTest` with `result`.
