### PR TITLE
chore(DTFS2-7427): remove FFs from e2e test config

### DIFF
--- a/e2e-tests/gef/cypress.config.js
+++ b/e2e-tests/gef/cypress.config.js
@@ -6,7 +6,7 @@ const { createTasks } = require('../support/tasks');
 // Read from root `./.env` directory
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
-const { PORTAL_API_KEY, GEF_DEAL_VERSION } = process.env;
+const { PORTAL_API_KEY } = process.env;
 
 module.exports = defineConfig({
   dealApiProtocol: 'http://',
@@ -35,9 +35,6 @@ module.exports = defineConfig({
     specPattern: 'cypress/e2e/**/*.spec.js',
     setupNodeEvents(on) {
       on('task', createTasks());
-    },
-    env: {
-      GEF_DEAL_VERSION,
     },
   },
   experimentalCspAllowList: ['child-src', 'default-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-disabled/provided-facility-back-link.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-disabled/provided-facility-back-link.spec.js
@@ -5,7 +5,7 @@ import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixtur
 const applications = [];
 let token;
 
-context('Provided Facility Page', () => {
+context('Provided Facility Page - feature flag disabled', () => {
   before(() => {
     cy.loadData();
     cy.apiLogin(BANK1_MAKER1)

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-disabled/provided-facility-back-link.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-disabled/provided-facility-back-link.spec.js
@@ -1,0 +1,47 @@
+import relative from '../../../relativeURL';
+import { errorSummary } from '../../../partials';
+import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
+
+const applications = [];
+let token;
+
+context('Provided Facility Page', () => {
+  before(() => {
+    cy.loadData();
+    cy.apiLogin(BANK1_MAKER1)
+      .then((tok) => {
+        token = tok;
+      })
+      .then(() => cy.apiFetchAllGefApplications(token))
+      .then(({ body }) => {
+        body.items.forEach((item) => {
+          cy.apiFetchAllFacilities(item._id, token).then((res) => {
+            applications.push({
+              id: item._id,
+              facilities: res.body.items.filter((it) => it.details.dealId === item._id),
+            });
+          });
+        });
+      });
+    cy.login(BANK1_MAKER1);
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+  it('redirects user to `about facility` page when clicking on `Back` Link ', () => {
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
+    cy.clickBackLink();
+    cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
+  });
+
+  it('The `Back` Link works after form has been validated', () => {
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
+    cy.clickContinueButton();
+    errorSummary();
+
+    cy.clickBackLink();
+
+    cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
+  });
+});

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-disabled/provided-facility-back-link.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-disabled/provided-facility-back-link.spec.js
@@ -29,13 +29,14 @@ context('Provided Facility Page - feature flag disabled', () => {
   beforeEach(() => {
     cy.saveSession();
   });
+
   it('redirects user to `about facility` page when clicking on `Back` Link ', () => {
     cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
     cy.clickBackLink();
     cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
   });
 
-  it('The `Back` Link works after form has been validated', () => {
+  it('the `Back` link works after form has been validated', () => {
     cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
     cy.clickContinueButton();
     errorSummary();

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-enabled/provided-facility-back-link.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-enabled/provided-facility-back-link.spec.js
@@ -6,7 +6,7 @@ import aboutFacility from '../../../pages/about-facility';
 const applications = [];
 let token;
 
-context('Provided Facility Page', () => {
+context('Provided Facility Page - feature flag enabled', () => {
   before(() => {
     cy.loadData();
     cy.apiLogin(BANK1_MAKER1)

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-enabled/provided-facility-back-link.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-enabled/provided-facility-back-link.spec.js
@@ -1,0 +1,69 @@
+import relative from '../../../relativeURL';
+import { errorSummary } from '../../../partials';
+import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
+import aboutFacility from '../../../pages/about-facility';
+
+const applications = [];
+let token;
+
+context('Provided Facility Page', () => {
+  before(() => {
+    cy.loadData();
+    cy.apiLogin(BANK1_MAKER1)
+      .then((tok) => {
+        token = tok;
+      })
+      .then(() => cy.apiFetchAllGefApplications(token))
+      .then(({ body }) => {
+        body.items.forEach((item) => {
+          cy.apiFetchAllFacilities(item._id, token).then((res) => {
+            applications.push({
+              id: item._id,
+              facilities: res.body.items.filter((it) => it.details.dealId === item._id),
+            });
+          });
+        });
+      });
+    cy.login(BANK1_MAKER1);
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+  });
+
+  it('redirects user to `about facility` page when clicking on `Back` Link if isUsingFacilityEndDate not selected', () => {
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
+    cy.clickBackLink();
+    cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
+  });
+
+  it('redirects user to `facility end date` page when clicking on `Back` Link if using facility end date', () => {
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
+    aboutFacility.isUsingFacilityEndDateYes().click();
+    cy.clickSaveAndReturnButton();
+
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
+    cy.clickBackLink();
+    cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/facility-end-date`));
+  });
+
+  it('redirects user to `bank review date` page when clicking on `Back` Link if not using facility end date', () => {
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
+    aboutFacility.isUsingFacilityEndDateNo().click();
+    cy.clickSaveAndReturnButton();
+
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
+    cy.clickBackLink();
+    cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/bank-review-date`));
+  });
+
+  it('The `Back` Link works after form has been validated', () => {
+    cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
+    cy.clickContinueButton();
+    errorSummary();
+
+    cy.clickBackLink();
+
+    cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/bank-review-date`));
+  });
+});

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-enabled/provided-facility-back-link.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/facility-end-date-enabled/provided-facility-back-link.spec.js
@@ -57,7 +57,7 @@ context('Provided Facility Page - feature flag enabled', () => {
     cy.url().should('eq', relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/bank-review-date`));
   });
 
-  it('The `Back` Link works after form has been validated', () => {
+  it('the `Back` link works after form has been validated', () => {
     cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
     cy.clickContinueButton();
     errorSummary();

--- a/e2e-tests/gef/cypress/e2e/facility/pre-submission/provided-facility.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/pre-submission/provided-facility.spec.js
@@ -2,12 +2,9 @@ import relative from '../../relativeURL';
 import { backLink, continueButton, headingCaption, errorSummary, mainHeading, form, saveAndReturnButton } from '../../partials';
 import providedFacility from '../../pages/provided-facility';
 import { BANK1_MAKER1 } from '../../../../../e2e-fixtures/portal-users.fixture';
-import aboutFacility from '../../pages/about-facility';
 
 const applications = [];
 let token;
-
-const facilityEndDateEnabled = Number(Cypress.env('GEF_DEAL_VERSION')) >= 1;
 
 context('Provided Facility Page', () => {
   before(() => {
@@ -47,78 +44,6 @@ context('Provided Facility Page', () => {
       continueButton();
       saveAndReturnButton();
     });
-
-    if (!facilityEndDateEnabled) {
-      it('redirects user to `about facility` page when clicking on `Back` Link ', () => {
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
-        cy.clickBackLink();
-        cy.url().should(
-          'eq',
-          relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`),
-        );
-      });
-
-      it('The `Back` Link works after form has been validated', () => {
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
-        cy.clickContinueButton();
-        errorSummary();
-
-        cy.clickBackLink();
-
-        cy.url().should(
-          'eq',
-          relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`),
-        );
-      });
-    } else {
-      it('redirects user to `about facility` page when clicking on `Back` Link if isUsingFacilityEndDate not selected', () => {
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
-        cy.clickBackLink();
-        cy.url().should(
-          'eq',
-          relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`),
-        );
-      });
-
-      it('redirects user to `facility end date` page when clicking on `Back` Link if using facility end date', () => {
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
-        aboutFacility.isUsingFacilityEndDateYes().click();
-        cy.clickSaveAndReturnButton();
-
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
-        cy.clickBackLink();
-        cy.url().should(
-          'eq',
-          relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/facility-end-date`),
-        );
-      });
-
-      it('redirects user to `bank review date` page when clicking on `Back` Link if not using facility end date', () => {
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/about-facility`));
-        aboutFacility.isUsingFacilityEndDateNo().click();
-        cy.clickSaveAndReturnButton();
-
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
-        cy.clickBackLink();
-        cy.url().should(
-          'eq',
-          relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/bank-review-date`),
-        );
-      });
-
-      it('The `Back` Link works after form has been validated', () => {
-        cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));
-        cy.clickContinueButton();
-        errorSummary();
-
-        cy.clickBackLink();
-
-        cy.url().should(
-          'eq',
-          relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/bank-review-date`),
-        );
-      });
-    }
 
     it('clicking continue without selecting any options shows error messages', () => {
       cy.visit(relative(`/gef/application-details/${applications[1].id}/facilities/${applications[1].facilities[1].details._id}/provided-facility`));

--- a/e2e-tests/tfm/cypress.config.js
+++ b/e2e-tests/tfm/cypress.config.js
@@ -6,7 +6,7 @@ const { createTasks } = require('../support/tasks');
 // Read from root `./.env` directory
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
-const { TFM_API_KEY, FF_TFM_FACILITY_END_DATE_ENABLED, FF_TFM_DEAL_CANCELLATION_ENABLED } = process.env;
+const { TFM_API_KEY } = process.env;
 
 module.exports = defineConfig({
   dealApiProtocol: 'http://',
@@ -40,10 +40,6 @@ module.exports = defineConfig({
     setupNodeEvents(on) {
       on('task', createTasks());
     },
-  },
-  env: {
-    FF_TFM_FACILITY_END_DATE_ENABLED,
-    FF_TFM_DEAL_CANCELLATION_ENABLED,
   },
   experimentalCspAllowList: ['child-src', 'default-src', 'frame-src', 'form-action', 'script-src', 'script-src-elem'],
 });


### PR DESCRIPTION
## Introduction :pencil2:
The FFs shouldnt be in the test config.

## Resolution :heavy_check_mark:
Remove the FF env vars from the e2e test config files.
Split up the provided facility tests, since they still used the env var
Remove the deal cancellation env var

