### PR TITLE
feat(DTFS2-7300): fix effective from date page test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,10 +349,10 @@ jobs:
     needs: setup
     env:
       # Various feature flags
-      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: true
-      FF_TFM_FACILITY_END_DATE_ENABLED: true
-      FF_TFM_DEAL_CANCELLATION_ENABLED: true
-      FF_TFM_SSO_ENABLED: true
+      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: 'true'
+      FF_TFM_FACILITY_END_DATE_ENABLED: 'true'
+      FF_TFM_DEAL_CANCELLATION_ENABLED: 'true'
+      FF_TFM_SSO_ENABLED: 'true'
       GEF_DEAL_VERSION: 1
     environment:
       name: ${{ needs.setup.outputs.environment }}
@@ -782,10 +782,10 @@ jobs:
     needs: setup
     env:
       # Various feature flags
+      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: 'true'
+      FF_TFM_FACILITY_END_DATE_ENABLED: 'true'
+      FF_TFM_DEAL_CANCELLATION_ENABLED: 'true'
       # TODO DTFS2-6892: add FF_TFM_SSO_ENABLED feature flag here when e2e tests implimented
-      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: true
-      FF_TFM_FACILITY_END_DATE_ENABLED: true
-      FF_TFM_DEAL_CANCELLATION_ENABLED: true
       GEF_DEAL_VERSION: 1
     environment:
       name: ${{ needs.setup.outputs.environment }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,10 +349,10 @@ jobs:
     needs: setup
     env:
       # Various feature flags
-      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: 'true'
-      FF_TFM_FACILITY_END_DATE_ENABLED: 'true'
-      FF_TFM_DEAL_CANCELLATION_ENABLED: 'true'
-      FF_TFM_SSO_ENABLED: 'true'
+      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: true
+      FF_TFM_FACILITY_END_DATE_ENABLED: true
+      FF_TFM_DEAL_CANCELLATION_ENABLED: true
+      FF_TFM_SSO_ENABLED: true
       GEF_DEAL_VERSION: 1
     environment:
       name: ${{ needs.setup.outputs.environment }}
@@ -782,10 +782,10 @@ jobs:
     needs: setup
     env:
       # Various feature flags
-      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: 'true'
-      FF_TFM_FACILITY_END_DATE_ENABLED: 'true'
-      FF_TFM_DEAL_CANCELLATION_ENABLED: 'true'
       # TODO DTFS2-6892: add FF_TFM_SSO_ENABLED feature flag here when e2e tests implimented
+      FF_TFM_PAYMENT_RECONCILIATION_ENABLED: true
+      FF_TFM_FACILITY_END_DATE_ENABLED: true
+      FF_TFM_DEAL_CANCELLATION_ENABLED: true
       GEF_DEAL_VERSION: 1
     environment:
       name: ${{ needs.setup.outputs.environment }}

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
@@ -108,7 +108,7 @@ context('Deal cancellation - effective from date', () => {
       cy.keyboardInput(effectiveFromDatePage.effectiveFromDateYear(), dateConstants.todayYear);
 
       cy.clickContinueButton();
-      cy.clickBackLink();
+      cy.visit(relative(`/case/${dealId}/cancellation/effective-from-date`));
 
       effectiveFromDatePage.effectiveFromDateDay().should('have.value', format(dateConstants.today, 'd'));
       effectiveFromDatePage.effectiveFromDateMonth().should('have.value', format(dateConstants.today, 'M'));


### PR DESCRIPTION
## Introduction :pencil2:
Fix a failing test - currently the page following the effective from date page is not implemented, and so clicking 'continue' on the effective from date page goes to the 'Not found' page which doesn't have a 'back' button.

## Resolution :heavy_check_mark:
This PR fixes this by instead returning to the effective from date page by using the URL instead of the back button

## Miscellaneous :heavy_plus_sign:
* Set the GitHub actions feature flags to boolean instead of string.

