### PR TITLE
fix(DTFS2-7317): set mongodb to version range 4.17.2 and 4.2.0 on dockerfile

### DIFF
--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.17.21",
     "lodash.orderby": "^4.6.0",
     "mongo-dot-notation": "3.1.0",
-    "mongodb": "4.17.2",
+    "mongodb": "^4.17.2",
     "node-cron": "^3.0.3",
     "reflect-metadata": "^0.2.2",
     "swagger-jsdoc": "^6.2.8",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -38,7 +38,7 @@
     "date-fns": "^2.30.0",
     "eslint": "^8.57.1",
     "eslint-plugin-cypress": "^2.15.2",
-    "mongodb": "^6.3.0"
+    "mongodb": "^4.17.2"
   },
   "engines": {
     "node": ">=22.8.0",

--- a/external-api/package.json
+++ b/external-api/package.json
@@ -46,7 +46,7 @@
     "express-rate-limit": "^6.11.2",
     "joi": "^17.13.3",
     "lodash": "^4.17.21",
-    "mongodb": "4.17.2",
+    "mongodb": "^4.17.2",
     "supertest": "^6.3.4",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3",

--- a/mongodb/Dockerfile
+++ b/mongodb/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM mongo:5.0.5
+FROM mongo:4.2.0
 
 # Enviornment variable
 ARG MONGO_INITDB_DATABASE

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
         "lodash": "^4.17.21",
         "lodash.orderby": "^4.6.0",
         "mongo-dot-notation": "3.1.0",
-        "mongodb": "4.17.2",
+        "mongodb": "^4.17.2",
         "node-cron": "^3.0.3",
         "reflect-metadata": "^0.2.2",
         "swagger-jsdoc": "^6.2.8",
@@ -172,16 +172,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "dtfs-central-api/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
     "dtfs-central-api/node_modules/bson": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
@@ -221,16 +211,6 @@
         "@mongodb-js/saslprep": "^1.1.0"
       }
     },
-    "dtfs-central-api/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
     "dtfs-central-api/node_modules/supertest": {
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
@@ -262,7 +242,7 @@
         "date-fns": "^2.30.0",
         "eslint": "^8.57.1",
         "eslint-plugin-cypress": "^2.15.2",
-        "mongodb": "^6.3.0"
+        "mongodb": "^4.17.2"
       },
       "engines": {
         "node": ">=22.8.0",
@@ -282,50 +262,35 @@
       }
     },
     "e2e-tests/node_modules/mongodb": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.9.0.tgz",
-      "integrity": "sha512-UMopBVx1LmEUbW/QE0Hw18u583PEDVQmUmVzzBRH0o/xtE9DBRA5ZYLOjpLIa03i8FXjzvQECJcqoMvCXftTUA==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+      "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.7.0",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "@mongodb-js/saslprep": "^1.1.0"
+      }
+    },
+    "e2e-tests/node_modules/mongodb/node_modules/bson": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "external-api": {
@@ -346,7 +311,7 @@
         "express-rate-limit": "^6.11.2",
         "joi": "^17.13.3",
         "lodash": "^4.17.21",
-        "mongodb": "4.17.2",
+        "mongodb": "^4.17.2",
         "supertest": "^6.3.4",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.3",
@@ -391,19 +356,10 @@
       "version": "18.19.53",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.53.tgz",
       "integrity": "sha512-GLxgUgHhDKO1Edw9Q0lvMbiO/IQXJwJlMaqxSGBXMpPy8uhkCs2iiPFaB2Q/gmobnFkckD3rqTBMVjXdwq+nKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
-      }
-    },
-    "external-api/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
       }
     },
     "external-api/node_modules/@typescript-eslint/scope-manager": {
@@ -765,16 +721,6 @@
         "@mongodb-js/saslprep": "^1.1.0"
       }
     },
-    "external-api/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
     "external-api/node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -971,6 +917,7 @@
       "version": "20.16.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.9.tgz",
       "integrity": "sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -985,16 +932,6 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
-      }
-    },
-    "libs/common/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
       }
     },
     "libs/common/node_modules/bson": {
@@ -1076,16 +1013,6 @@
         "@mongodb-js/saslprep": "^1.1.0"
       }
     },
-    "libs/common/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
     "libs/common/node_modules/superagent": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
@@ -1125,6 +1052,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
@@ -6343,8 +6271,8 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
       "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -7880,12 +7808,12 @@
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "dev": true,
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -20124,8 +20052,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -20412,52 +20340,13 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
-      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
-      "dev": true,
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^13.0.0"
-      }
-    },
-    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
-      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/mongodb/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       }
     },
     "node_modules/mongodb/node_modules/bson": {
@@ -20468,17 +20357,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.20.1"
-      }
-    },
-    "node_modules/mongodb/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
       }
     },
     "node_modules/morgan": {
@@ -23908,8 +23786,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -25913,6 +25791,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -27208,7 +27087,7 @@
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
-        "mongodb": "4.17.2",
+        "mongodb": "^4.17.2",
         "multer": "1.4.5-lts.1",
         "node-fetch": "^2.7.0",
         "passport": "0.6.0",
@@ -27254,16 +27133,6 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
-      }
-    },
-    "portal-api/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
       }
     },
     "portal-api/node_modules/bson": {
@@ -27339,16 +27208,6 @@
       "optionalDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
         "@mongodb-js/saslprep": "^1.1.0"
-      }
-    },
-    "portal-api/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
       }
     },
     "portal-api/node_modules/prettier": {
@@ -27463,7 +27322,7 @@
         "jsonwebtoken": "^9.0.2",
         "lodash": "^4.17.21",
         "mongo-dot-notation": "^3.1.0",
-        "mongodb": "4.17.2",
+        "mongodb": "^4.17.2",
         "passport": "0.6.0",
         "passport-jwt": "^4.0.1",
         "sanitize-html": "^2.13.0",
@@ -27655,16 +27514,6 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "trade-finance-manager-api/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
     "trade-finance-manager-api/node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
@@ -27786,16 +27635,6 @@
       "optionalDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
         "@mongodb-js/saslprep": "^1.1.0"
-      }
-    },
-    "trade-finance-manager-api/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
       }
     },
     "trade-finance-manager-api/node_modules/semver": {
@@ -28012,16 +27851,6 @@
         "npm": ">=10.8.2"
       }
     },
-    "utils/node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
     "utils/node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -28050,16 +27879,6 @@
       "optionalDependencies": {
         "@aws-sdk/credential-providers": "^3.186.0",
         "@mongodb-js/saslprep": "^1.1.0"
-      }
-    },
-    "utils/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
       }
     },
     "utils/node_modules/mongodb/node_modules/bson": {

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -50,7 +50,7 @@
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "mongodb": "4.17.2",
+    "mongodb": "^4.17.2",
     "multer": "1.4.5-lts.1",
     "node-fetch": "^2.7.0",
     "passport": "0.6.0",

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -52,7 +52,7 @@
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "mongo-dot-notation": "^3.1.0",
-    "mongodb": "4.17.2",
+    "mongodb": "^4.17.2",
     "passport": "0.6.0",
     "passport-jwt": "^4.0.1",
     "sanitize-html": "^2.13.0",


### PR DESCRIPTION
## Introduction :pencil2:
Ensure MongoDB version matches infrastructure version.

## Resolution :heavy_check_mark:
* MongoDB Docker base image set to `4.2.0`
* Due to existing implementation NPM package `4.2.0` cannot be therefore set all the microservices `mongodb` NPM package version to `4.17.2`. 