### PR TITLE
feat(DTFS2-7446): add delete cancellation endpoint in tfm-api

### DIFF
--- a/trade-finance-manager-api/api-tests/api.ts
+++ b/trade-finance-manager-api/api-tests/api.ts
@@ -106,4 +106,11 @@ export const createApi = (app: unknown): TestApi => ({
     }
     return requestInProgress.send(data);
   },
+  remove: async (url: string, data: AnyObject, { headers }: { headers: IncomingHttpHeaders | undefined } = { headers: undefined }) => {
+    const requestInProgress = request(app).delete(url);
+    if (headers) {
+      await requestInProgress.set(headers);
+    }
+    return requestInProgress.send(data);
+  },
 });

--- a/trade-finance-manager-api/api-tests/types/test-api.ts
+++ b/trade-finance-manager-api/api-tests/types/test-api.ts
@@ -11,21 +11,16 @@ export type TestRequestWithoutHeaders = (data: AnyObject) => {
 
 type TestGetWithHeaders = (
   url: string,
-  {
-    headers,
-    query,
-  }?: {
+  options?: {
     headers: IncomingHttpHeaders | undefined;
     query: AnyObject | undefined;
   },
 ) => Promise<Response>;
 
-type TestPutWithHeaders = (
+type TestRequestWithHeaders = (
   url: string,
   data: AnyObject,
-  {
-    headers,
-  }?: {
+  options?: {
     headers: IncomingHttpHeaders | undefined;
   },
 ) => Promise<Response>;
@@ -56,5 +51,6 @@ export type TestApi = {
   as: TestAs;
   post: TestRequestWithoutHeaders;
   get: TestGetWithHeaders;
-  put: TestPutWithHeaders;
+  put: TestRequestWithHeaders;
+  remove: TestRequestWithHeaders;
 };

--- a/trade-finance-manager-api/api-tests/v1/deal-cancellation/deal-cancellation.delete.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/deal-cancellation/deal-cancellation.delete.api-test.ts
@@ -1,0 +1,117 @@
+import { AnyObject, TEAM_IDS } from '@ukef/dtfs2-common';
+import { ObjectId } from 'mongodb';
+import { HttpStatusCode } from 'axios';
+import { createApi } from '../../api';
+import app from '../../../src/createApp';
+import { initialiseTestUsers } from '../../api-test-users';
+import { TestUser } from '../../types/test-user';
+import { withTeamAuthorisationTests } from '../../common-tests/with-team-authorisation.api-tests';
+import { getTfmDealCancellationUrl } from './get-cancellation-url';
+
+const deleteDealCancellationMock = jest.fn() as jest.Mock<Promise<void>>;
+
+jest.mock('../../../src/v1/api', () => ({
+  ...jest.requireActual<AnyObject>('../../../src/v1/api'),
+  deleteDealCancellation: () => deleteDealCancellationMock(),
+}));
+
+const originalProcessEnv = { ...process.env };
+const { as, remove } = createApi(app);
+
+const validId = new ObjectId().toString();
+
+describe('/v1/deals/:id/cancellation', () => {
+  let testUsers: Awaited<ReturnType<typeof initialiseTestUsers>>;
+  let aPimUser: TestUser;
+
+  beforeAll(async () => {
+    testUsers = await initialiseTestUsers(app);
+    aPimUser = testUsers().withTeam(TEAM_IDS.PIM).one();
+  });
+
+  describe('DELETE /v1/deals/:id/cancellation', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+      jest.mocked(deleteDealCancellationMock).mockResolvedValue(undefined);
+    });
+
+    afterAll(() => {
+      jest.restoreAllMocks();
+      process.env = originalProcessEnv;
+    });
+
+    describe('when FF_TFM_DEAL_CANCELLATION_ENABLED is disabled', () => {
+      beforeEach(() => {
+        process.env.FF_TFM_DEAL_CANCELLATION_ENABLED = 'false';
+      });
+
+      afterAll(() => {
+        jest.resetAllMocks();
+      });
+
+      it('returns a 404 response for an authenticated user with a valid id path', async () => {
+        // Arrange
+        const url = getTfmDealCancellationUrl({ id: validId });
+
+        // Act
+        const response = await as(aPimUser).remove({}).to(url);
+
+        // Assert
+        expect(response.status).toEqual(HttpStatusCode.NotFound);
+      });
+    });
+
+    describe('when FF_TFM_DEAL_CANCELLATION_ENABLED is enabled', () => {
+      beforeEach(() => {
+        process.env.FF_TFM_DEAL_CANCELLATION_ENABLED = 'true';
+      });
+
+      afterAll(() => {
+        jest.resetAllMocks();
+      });
+
+      withTeamAuthorisationTests({
+        allowedTeams: [TEAM_IDS.PIM],
+        getUserWithTeam: (team) => testUsers().withTeam(team).one(),
+        makeRequestAsUser: (user: TestUser) =>
+          as(user)
+            .remove({})
+            .to(getTfmDealCancellationUrl({ id: validId })),
+        successStatusCode: HttpStatusCode.NoContent,
+      });
+
+      it('returns a 401 response when user is not authenticated', async () => {
+        // Arrange
+        const url = getTfmDealCancellationUrl({ id: validId });
+
+        // Act
+        const response = await remove(url, {});
+
+        // Assert
+        expect(response.status).toEqual(401);
+      });
+
+      it('returns a 400 response when the id path param is invalid', async () => {
+        // Arrange
+        const url = getTfmDealCancellationUrl({ id: 'invalid' });
+
+        // Act
+        const response = await as(aPimUser).remove({}).to(url);
+
+        // Assert
+        expect(response.status).toEqual(400);
+      });
+
+      it('deletes the deal cancellation for an authenticated user', async () => {
+        // Arrange
+        const url = getTfmDealCancellationUrl({ id: validId });
+
+        // Act
+        const response = await as(aPimUser).remove({}).to(url);
+
+        // Assert
+        expect(response.status).toEqual(HttpStatusCode.NoContent);
+      });
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -250,6 +250,7 @@ module.exports = {
   removeFeesFromPayment: jest.fn(),
   updateDealCancellation: jest.fn(),
   getDealCancellation: jest.fn(),
+  deleteDealCancellation: jest.fn(),
   getSelectedFeeRecordsDetails: jest.fn(),
   addFeesToAnExistingPayment: jest.fn(),
 };

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -328,6 +328,35 @@ const getDealCancellation = async (dealId) => {
   }
 };
 
+/**
+ * Deletes the deal cancellation object on a TFM AIN or MIN deal
+ * @param {Object} params
+ * @param {string} params.dealId - deal cancellation to update
+ * @param {import('@ukef/dtfs2-common').AuditDetails} params.auditDetails - user making the request
+ * @returns {Promise<void>} update result object
+ */
+const deleteDealCancellation = async ({ dealId, auditDetails }) => {
+  try {
+    const isValidDealId = isValidMongoId(dealId);
+
+    if (!isValidDealId) {
+      throw new InvalidDealIdError(dealId);
+    }
+
+    await axios({
+      method: 'delete',
+      url: `${DTFS_CENTRAL_API_URL}/v1/tfm/deals/${dealId}/cancellation`,
+      headers: headers.central,
+      data: {
+        auditDetails,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
 const findOneFacility = async (facilityId) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
@@ -1633,6 +1662,7 @@ module.exports = {
   findUserById,
   updateDealCancellation,
   getDealCancellation,
+  deleteDealCancellation,
   findPortalUserById,
   updateUserTasks,
   findOneTeam,

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -329,7 +329,7 @@ const getDealCancellation = async (dealId) => {
 };
 
 /**
- * Deletes the deal cancellation object on a TFM AIN or MIN deal
+ * Deletes the deal cancellation object on a deal
  * @param {Object} params
  * @param {string} params.dealId - deal cancellation to update
  * @param {import('@ukef/dtfs2-common').AuditDetails} params.auditDetails - user making the request

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
@@ -2,6 +2,7 @@ import { ObjectId } from 'mongodb';
 import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
 import { TestApiError } from '@ukef/dtfs2-common';
+import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import api from '../../api';
 import { deleteDealCancellation, DeleteDealCancellationRequest } from './delete-deal-cancellation.controller';
 
@@ -22,7 +23,7 @@ describe('controllers - deal cancellation', () => {
         params: { dealId: mockDealId },
         user: { _id: mockUserId },
       });
-      const auditDetails = { id: mockUserId, userType: 'tfm' };
+      const auditDetails = generateTfmAuditDetails(mockUserId);
 
       // Act
       await deleteDealCancellation(req, res);

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
@@ -1,0 +1,87 @@
+import { ObjectId } from 'mongodb';
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { TestApiError } from '@ukef/dtfs2-common';
+import api from '../../api';
+import { deleteDealCancellation, DeleteDealCancellationRequest } from './delete-deal-cancellation.controller';
+
+jest.mock('../../api');
+
+const mockDealId = new ObjectId();
+const mockUserId = new ObjectId();
+
+describe('controllers - deal cancellation', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('DELETE - deleteDealCancellation', () => {
+    it('should call api.deleteDealCancellation with the correct parameters', async () => {
+      // Arrange
+      const { req, res } = httpMocks.createMocks<DeleteDealCancellationRequest>({
+        params: { dealId: mockDealId },
+        user: { _id: mockUserId },
+      });
+      const auditDetails = { id: mockUserId, userType: 'tfm' };
+
+      // Act
+      await deleteDealCancellation(req, res);
+
+      // Assert
+      expect(api.deleteDealCancellation).toHaveBeenCalledTimes(1);
+      expect(api.deleteDealCancellation).toHaveBeenCalledWith({ dealId: mockDealId, auditDetails });
+    });
+
+    it('should return 204 (No content) on success', async () => {
+      jest.mocked(api.deleteDealCancellation).mockResolvedValue();
+
+      // Arrange
+      const { req, res } = httpMocks.createMocks<DeleteDealCancellationRequest>({
+        params: { dealId: mockDealId },
+        user: { _id: mockUserId },
+      });
+
+      // Act
+      await deleteDealCancellation(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(HttpStatusCode.NoContent);
+    });
+
+    it('should return an error when there is an API error', async () => {
+      const testErrorStatus = 418;
+      const testApiErrorMessage = 'test api error message';
+      jest.mocked(api.deleteDealCancellation).mockRejectedValue(new TestApiError(testErrorStatus, testApiErrorMessage));
+
+      // Arrange
+      const { req, res } = httpMocks.createMocks<DeleteDealCancellationRequest>({
+        params: { dealId: mockDealId },
+        user: { _id: mockUserId },
+      });
+
+      // Act
+      await deleteDealCancellation(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(testErrorStatus);
+      expect(res._getData()).toEqual({ message: `Failed to delete deal cancellation: ${testApiErrorMessage}`, status: testErrorStatus });
+    });
+
+    it('should return an error when there is a general error', async () => {
+      jest.mocked(api.deleteDealCancellation).mockRejectedValue(new Error('Some error'));
+
+      // Arrange
+      const { req, res } = httpMocks.createMocks<DeleteDealCancellationRequest>({
+        params: { dealId: mockDealId },
+        user: { _id: mockUserId },
+      });
+
+      // Act
+      await deleteDealCancellation(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getData()).toEqual({ message: 'Failed to delete deal cancellation', status: 500 });
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
@@ -50,7 +50,7 @@ describe('controllers - deal cancellation', () => {
     });
 
     it('should return an error when there is an API error', async () => {
-      const testErrorStatus = 418;
+      const testErrorStatus = 400;
       const testApiErrorMessage = 'test api error message';
       jest.mocked(api.deleteDealCancellation).mockRejectedValue(new TestApiError(testErrorStatus, testApiErrorMessage));
 

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.ts
@@ -1,0 +1,45 @@
+import { HttpStatusCode } from 'axios';
+import { Response } from 'express';
+import { ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import api from '../../api';
+
+export type DeleteDealCancellationRequest = CustomExpressRequest<{
+  params: {
+    dealId: string;
+  };
+}>;
+
+/**
+ * Deletes the TFM deal cancellation object
+ * @param req - The request object
+ * @param res - The response object
+ */
+export const deleteDealCancellation = async (req: DeleteDealCancellationRequest, res: Response) => {
+  const { dealId } = req.params;
+
+  try {
+    await api.deleteDealCancellation({
+      dealId,
+      auditDetails: generateTfmAuditDetails(req.user._id),
+    });
+
+    return res.sendStatus(HttpStatusCode.NoContent);
+  } catch (error) {
+    const errorMessage = 'Failed to delete deal cancellation';
+    console.error(errorMessage, error);
+
+    if (error instanceof ApiError) {
+      return res.status(error.status).send({
+        status: error.status,
+        message: `${errorMessage}: ${error.message}`,
+        code: error.code,
+      });
+    }
+
+    return res.status(HttpStatusCode.InternalServerError).send({
+      status: HttpStatusCode.InternalServerError,
+      message: errorMessage,
+    });
+  }
+};

--- a/trade-finance-manager-api/src/v1/deals/routes.js
+++ b/trade-finance-manager-api/src/v1/deals/routes.js
@@ -5,6 +5,7 @@ const amendmentController = require('../controllers/amendment.controller');
 const dealController = require('../controllers/deal.controller');
 const { getDealCancellation } = require('../controllers/deal-cancellation/get-deal-cancellation.controller');
 const { updateDealCancellation } = require('../controllers/deal-cancellation/update-deal-cancellation.controller');
+const { deleteDealCancellation } = require('../controllers/deal-cancellation/delete-deal-cancellation.controller');
 const dealUnderwriterManagersDecisionController = require('../controllers/deal-underwriter-managers-decision.controller');
 const validation = require('../validation/route-validators/route-validators');
 const handleExpressValidatorResult = require('../validation/route-validators/express-validator-result-handler');
@@ -85,7 +86,8 @@ dealsAuthRouter
   .route('/deals/:dealId/cancellation')
   .all(validateDealCancellationEnabled, validateUserHasAtLeastOneAllowedTeam([TEAM_IDS.PIM]), validation.dealIdValidation, handleExpressValidatorResult)
   .put(validatePutDealCancellationPayload, updateDealCancellation)
-  .get(getDealCancellation);
+  .get(getDealCancellation)
+  .delete(deleteDealCancellation);
 
 dealsAuthRouter
   .route('/deals/:dealId/amendments/:status?/:type?')


### PR DESCRIPTION
## Introduction :pencil2:
The user can click cancel during the cancel deal journey. This should delete all cancellation data in the database

## Resolution :heavy_check_mark:
- Add deleteDealCancellation to api service, calling new endpoint in dtfs-central-api (#3634)
- Add delete cancellation endpoint and controller
- Add api and unit test coverage

