### PR TITLE
feat(DTFS2-7297): add deal cancellation check details page

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -93,10 +93,11 @@ context('Deal cancellation - check details', () => {
       cy.url().should('eq', relative(`/case/${dealId}/deal`));
     });
 
-    it('return to deal summary link should take you to the deal summary page', () => {
+    // TODO: DTFS2-7359 - add this test once cancel link is implemented
+    it.skip('return to deal summary link should take you to confirm cancellation page', () => {
       checkDetailsPage.returnLink().click();
 
-      cy.url().should('eq', relative(`/case/${dealId}/deal`));
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));
     });
 
     it('reason change link should take you to the reason for cancelling page and correctly update the reason', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -1,0 +1,168 @@
+import { format } from 'date-fns';
+import relative from '../../relativeURL';
+import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import caseDealPage from '../../pages/caseDealPage';
+import { backLink } from '../../partials';
+import effectiveFromDatePage from '../../pages/deal-cancellation/effective-from-date';
+import dateConstants from '../../../../../e2e-fixtures/dateConstants';
+import bankRequestDatePage from '../../pages/deal-cancellation/bank-request-date';
+import checkDetailsPage from '../../pages/deal-cancellation/check-details';
+import reasonForCancellingPage from '../../pages/deal-cancellation/reason-for-cancelling';
+
+context('Deal cancellation - check details', () => {
+  let dealId;
+  const dealFacilities = [];
+
+  before(() => {
+    cy.insertOneDeal(MOCK_DEAL_AIN, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      const { dealType, mockFacilities } = MOCK_DEAL_AIN;
+
+      cy.createFacilities(dealId, [mockFacilities[0]], BANK1_MAKER1).then((createdFacilities) => {
+        dealFacilities.push(...createdFacilities);
+      });
+
+      cy.submitDeal(dealId, dealType, PIM_USER_1);
+    });
+  });
+
+  after(() => {
+    cy.deleteDeals(dealId, ADMIN);
+    dealFacilities.forEach((facility) => {
+      cy.deleteFacility(facility._id, BANK1_MAKER1);
+    });
+  });
+
+  describe('when logged in as a PIM user', () => {
+    beforeEach(() => {
+      cy.login(PIM_USER_1);
+      cy.visit(relative(`/case/${dealId}/deal`));
+
+      caseDealPage.cancelDealButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateDay(), dateConstants.todayDay);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateMonth(), dateConstants.todayMonth);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateYear(), dateConstants.todayYear);
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateDay(), dateConstants.tomorrowDay);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateMonth(), dateConstants.tomorrowMonth);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateYear(), dateConstants.tomorrowYear);
+      cy.clickContinueButton();
+    });
+
+    it('should render page correctly', () => {
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
+
+      backLink();
+      checkDetailsPage.reasonResponse();
+      checkDetailsPage.reasonResponse().should('have.text', '-');
+
+      checkDetailsPage.reasonLink();
+
+      checkDetailsPage.bankRequestDateResponse();
+      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.today, 'd MMMM yyyy'));
+
+      checkDetailsPage.bankRequestDateLink();
+
+      checkDetailsPage.effectiveFromResponse();
+      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.tomorrow, 'd MMMM yyyy'));
+
+      checkDetailsPage.effectiveFromLink();
+
+      checkDetailsPage.dealDeletionButton();
+      checkDetailsPage.returnLink();
+    });
+
+    it('back link should take you to the effective from date page', () => {
+      cy.clickBackLink();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+    });
+
+    it('delete deal button should take you to the deal summary page', () => {
+      checkDetailsPage.dealDeletionButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/deal`));
+    });
+
+    it('return to deal summary link should take you to the deal summary page', () => {
+      checkDetailsPage.returnLink().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/deal`));
+    });
+
+    it('reason change link should take you to the reason for cancelling page and correctly update the reason', () => {
+      const testReason = 'test reason';
+
+      checkDetailsPage.reasonLink().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+
+      cy.keyboardInput(reasonForCancellingPage.reasonForCancellingTextBox(), testReason);
+
+      cy.clickContinueButton();
+      cy.clickContinueButton();
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
+      checkDetailsPage.reasonResponse().should('have.text', testReason);
+      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.today, 'd MMMM yyyy'));
+      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.tomorrow, 'd MMMM yyyy'));
+    });
+
+    it('bank request date change link should take you to the bank request date page and correctly update any changes', () => {
+      const testReason = 'test reason';
+      checkDetailsPage.bankRequestDateLink().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(bankRequestDatePage.bankRequestDateYear(), dateConstants.threeMonthsOneDayYear);
+
+      cy.clickContinueButton();
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
+      checkDetailsPage.reasonResponse().should('have.text', testReason);
+      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy'));
+      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.tomorrow, 'd MMMM yyyy'));
+    });
+
+    it('effective from date change link should take you to the effective from page and correctly update any changes', () => {
+      const testReason = 'test reason';
+      checkDetailsPage.effectiveFromLink().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateDay(), dateConstants.threeMonthsOneDayDay);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateMonth(), dateConstants.threeMonthsOneDayMonth);
+      cy.keyboardInput(effectiveFromDatePage.effectiveFromDateYear(), dateConstants.threeMonthsOneDayYear);
+
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
+      checkDetailsPage.reasonResponse().should('have.text', testReason);
+      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.today, 'd MMMM yyyy'));
+      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy'));
+    });
+  });
+
+  describe('when logged in as a non-PIM user', () => {
+    beforeEach(() => {
+      cy.login(T1_USER_1);
+    });
+
+    it('should redirect when visiting check details page', () => {
+      cy.url().should('eq', relative('/deals/0'));
+    });
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -93,8 +93,7 @@ context('Deal cancellation - check details', () => {
       cy.url().should('eq', relative(`/case/${dealId}/deal`));
     });
 
-    // TODO: DTFS2-7359 - add this test once cancel link is implemented
-    it.skip('return to deal summary link should take you to confirm cancellation page', () => {
+    it('return to deal summary link should take you to confirm cancellation page', () => {
       checkDetailsPage.returnLink().click();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -63,17 +63,17 @@ context('Deal cancellation - check details', () => {
 
       backLink();
       checkDetailsPage.reasonResponse();
-      checkDetailsPage.reasonResponse().should('have.text', '-');
+      cy.assertText(checkDetailsPage.reasonResponse(), '-');
 
       checkDetailsPage.reasonLink();
 
       checkDetailsPage.bankRequestDateResponse();
-      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.today, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.bankRequestDateResponse(), format(dateConstants.today, 'd MMMM yyyy'));
 
       checkDetailsPage.bankRequestDateLink();
 
       checkDetailsPage.effectiveFromResponse();
-      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.tomorrow, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.effectiveFromResponse(), format(dateConstants.tomorrow, 'd MMMM yyyy'));
 
       checkDetailsPage.effectiveFromLink();
 
@@ -114,9 +114,9 @@ context('Deal cancellation - check details', () => {
       cy.clickContinueButton();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
-      checkDetailsPage.reasonResponse().should('have.text', testReason);
-      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.today, 'd MMMM yyyy'));
-      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.tomorrow, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.reasonResponse(), testReason);
+      cy.assertText(checkDetailsPage.bankRequestDateResponse(), format(dateConstants.today, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.effectiveFromResponse(), format(dateConstants.tomorrow, 'd MMMM yyyy'));
     });
 
     it('bank request date change link should take you to the bank request date page and correctly update any changes', () => {
@@ -133,9 +133,9 @@ context('Deal cancellation - check details', () => {
       cy.clickContinueButton();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
-      checkDetailsPage.reasonResponse().should('have.text', testReason);
-      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy'));
-      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.tomorrow, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.reasonResponse(), testReason);
+      cy.assertText(checkDetailsPage.bankRequestDateResponse(), format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.effectiveFromResponse(), format(dateConstants.tomorrow, 'd MMMM yyyy'));
     });
 
     it('effective from date change link should take you to the effective from page and correctly update any changes', () => {
@@ -151,9 +151,9 @@ context('Deal cancellation - check details', () => {
       cy.clickContinueButton();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
-      checkDetailsPage.reasonResponse().should('have.text', testReason);
-      checkDetailsPage.bankRequestDateResponse().should('have.text', format(dateConstants.today, 'd MMMM yyyy'));
-      checkDetailsPage.effectiveFromResponse().should('have.text', format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.reasonResponse(), testReason);
+      cy.assertText(checkDetailsPage.bankRequestDateResponse(), format(dateConstants.today, 'd MMMM yyyy'));
+      cy.assertText(checkDetailsPage.effectiveFromResponse(), format(dateConstants.threeMonthsOneDay, 'd MMMM yyyy'));
     });
   });
 

--- a/e2e-tests/tfm/cypress/e2e/pages/deal-cancellation/check-details.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/deal-cancellation/check-details.js
@@ -1,0 +1,12 @@
+const checkDetailsPage = {
+  reasonResponse: () => cy.get('[data-cy="reason-response"]'),
+  bankRequestDateResponse: () => cy.get('[data-cy="bank-request-date-response"]'),
+  effectiveFromResponse: () => cy.get('[data-cy="effective-from-response"]'),
+  reasonLink: () => cy.get('[data-cy="reason-link"]'),
+  bankRequestDateLink: () => cy.get('[data-cy="bank-request-date-link"]'),
+  effectiveFromLink: () => cy.get('[data-cy="effective-from-link"]'),
+  dealDeletionButton: () => cy.get('[data-cy="delete-button"]'),
+  returnLink: () => cy.get('[data-cy="return-link"]'),
+};
+
+module.exports = checkDetailsPage;

--- a/trade-finance-manager-ui/component-tests/case/cancellation/check-details.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/check-details.component-test.ts
@@ -1,0 +1,136 @@
+import { CheckDetailsViewModel } from '../../../server/types/view-models';
+import { pageRenderer } from '../../pageRenderer';
+import { aCheckDetailsViewModel } from '../../../test-helpers/test-data/check-answers-view-model';
+
+const page = '../templates/case/cancellation/check-details.njk';
+const render = pageRenderer(page);
+
+describe(page, () => {
+  it('should render back link button linking to the effective from date page', () => {
+    // Arrange
+    const dealId = 'dealId';
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), dealId };
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="back-link"]').toExist();
+    wrapper.expectLink('[data-cy="back-link"]').toLinkTo(`/case/${dealId}/cancellation/effective-from-date`, 'Back');
+  });
+
+  it('should render the return to deal summary link, linking to case deal page', () => {
+    // Arrange
+    const dealId = 'dealId';
+    const effectiveFromDateViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), dealId };
+
+    // Act
+    const wrapper = render(effectiveFromDateViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="return-link"]').toExist();
+    wrapper.expectLink('[data-cy="return-link"]').toLinkTo(`/case/${dealId}/deal`, 'Return to deal summary');
+  });
+
+  it('should render the delete account button', () => {
+    // Arrange
+    const checkDetailsViewModel: CheckDetailsViewModel = aCheckDetailsViewModel();
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="delete-button"]').toExist();
+    wrapper.expectText('[data-cy="delete-button"]').toRead('Delete account');
+  });
+
+  it('should display a warning message about cancelling the deal', () => {
+    // Arrange
+    const checkDetailsViewModel: CheckDetailsViewModel = aCheckDetailsViewModel();
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="warning"]').toExist();
+    wrapper.expectText('[data-cy="warning"]').toContain('When you cancel the deal it cannot be undone');
+  });
+
+  it('should render all the headings of each row', () => {
+    // Arrange
+    const checkDetailsViewModel: CheckDetailsViewModel = aCheckDetailsViewModel();
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="reason-heading"]').toExist();
+    wrapper.expectElement('[data-cy="bank-request-date-heading"]').toExist();
+    wrapper.expectElement('[data-cy="effective-from-heading"]').toExist();
+  });
+
+  it('should display a dash when the reason for cancelling a deal is empty', () => {
+    // Arrange
+    const checkDetailsViewModel: CheckDetailsViewModel = aCheckDetailsViewModel();
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="reason-response"]').toExist();
+    wrapper.expectText('[data-cy="reason-response"]').toRead('-');
+  });
+
+  it('should display the reason for cancelling text when it exists', () => {
+    // Arrange
+    const reason = 'test reason';
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), reason };
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="reason-response"]').toExist();
+    wrapper.expectText('[data-cy="reason-response"]').toRead(reason);
+  });
+
+  it('should display the received bank request date date string', () => {
+    // Arrange
+    const receivedDateString = '1 January 2024';
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), bankRequestDate: receivedDateString };
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="bank-request-date-response"]').toExist();
+    wrapper.expectText('[data-cy="bank-request-date-response"]').toRead(receivedDateString);
+  });
+
+  it('should display the received effective from date string', () => {
+    // Arrange
+    const receivedDateString = '1 January 2024';
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), effectiveFromDate: receivedDateString };
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="effective-from-response"]').toExist();
+    wrapper.expectText('[data-cy="effective-from-response"]').toRead(receivedDateString);
+  });
+
+  it('should render the Change links', () => {
+    // Arrange
+    const dealId = 'dealId';
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), dealId };
+
+    // Act
+    const wrapper = render(checkDetailsViewModel);
+
+    // Assert
+    wrapper.expectElement('[data-cy="reason-link"]').toExist();
+    wrapper.expectElement('[data-cy="bank-request-date-link"]').toExist();
+    wrapper.expectElement('[data-cy="effective-from-link"]').toExist();
+  });
+});

--- a/trade-finance-manager-ui/component-tests/case/cancellation/check-details.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/check-details.component-test.ts
@@ -19,7 +19,7 @@ describe(page, () => {
     wrapper.expectLink('[data-cy="back-link"]').toLinkTo(`/case/${dealId}/cancellation/effective-from-date`, 'Back');
   });
 
-  it('should render the return to deal summary link, linking to case deal page', () => {
+  it('should render the return to deal summary link, linking to the cancel page', () => {
     // Arrange
     const dealId = 'dealId';
     const effectiveFromDateViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), dealId };
@@ -29,7 +29,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="return-link"]').toExist();
-    wrapper.expectLink('[data-cy="return-link"]').toLinkTo(`/case/${dealId}/deal`, 'Return to deal summary');
+    wrapper.expectLink('[data-cy="return-link"]').toLinkTo(`/case/${dealId}/cancellation/cancel`, 'Return to deal summary');
   });
 
   it('should render the delete account button', () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
@@ -1,0 +1,117 @@
+import { createMocks } from 'node-mocks-http';
+import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { aTfmSessionUser } from '../../../../test-helpers';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+import { BankRequestDateViewModel } from '../../../types/view-models';
+import api from '../../../api';
+import { getDealCancellationDetails, GetDealCancellationDetailsRequest } from './check-details.controller';
+
+jest.mock('../../../api', () => ({
+  getDeal: jest.fn(),
+  getDealCancellation: jest.fn(),
+}));
+
+const dealId = 'dealId';
+const ukefDealId = 'ukefDealId';
+const mockUser = aTfmSessionUser();
+
+describe('getDealCancellationDetails', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects to not found if the deal does not exist', async () => {
+    // Arrange
+    jest.mocked(api.getDeal).mockResolvedValue(undefined);
+
+    const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    await getDealCancellationDetails(req, res);
+
+    // Assert
+    expect(res._getRedirectUrl()).toBe(`/not-found`);
+  });
+
+  it('redirects to not found if the dealId is invalid', async () => {
+    // Arrange
+    jest.mocked(api.getDeal).mockResolvedValue({ status: 400, data: 'Invalid deal id' });
+
+    const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    await getDealCancellationDetails(req, res);
+
+    // Assert
+    expect(res._getRedirectUrl()).toBe(`/not-found`);
+  });
+
+  it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
+    // Arrange
+    jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: DEAL_SUBMISSION_TYPE.MIA } });
+
+    const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    await getDealCancellationDetails(req, res);
+
+    // Assert
+    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+  });
+
+  describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
+    it('renders the check details page with deal cancellation details', async () => {
+      const reason = 'test reaspn';
+      const bankRequestDate = new Date('2024-01-01');
+      const effectiveFromDate = new Date('2024-03-03');
+
+      // Arrange
+      jest
+        .mocked(api.getDealCancellation)
+        .mockResolvedValue({ reason, effectiveFrom: effectiveFromDate.valueOf(), bankRequestDate: bankRequestDate.valueOf() });
+      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
+
+      const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
+        params: { _id: dealId },
+        session: {
+          user: mockUser,
+          userToken: 'a user token',
+        },
+      });
+
+      // Act
+      await getDealCancellationDetails(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toEqual('case/cancellation/check-details.njk');
+      expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
+        activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+        user: mockUser,
+        ukefDealId,
+        dealId,
+        reason,
+        bankRequestDate: format(bankRequestDate, 'd MMMM yyyy'),
+        effectiveFromDate: format(effectiveFromDate, 'd MMMM yyyy'),
+      });
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
@@ -1,0 +1,101 @@
+import { createMocks } from 'node-mocks-http';
+import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
+import { aTfmSessionUser } from '../../../../test-helpers';
+import api from '../../../api';
+import { postDealCancellationDetails, PostDealCancellationDetailsRequest } from './check-details.controller';
+
+jest.mock('../../../api', () => ({
+  getDeal: jest.fn(),
+}));
+
+const dealId = 'dealId';
+const ukefDealId = 'ukefDealId';
+const mockUser = aTfmSessionUser();
+
+describe('postBankRequestDate', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects to not found if the deal does not exist', async () => {
+    // Arrange
+    jest.mocked(api.getDeal).mockResolvedValue(undefined);
+
+    const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    await postDealCancellationDetails(req, res);
+
+    // Assert
+    expect(res._getRedirectUrl()).toBe(`/not-found`);
+  });
+
+  it('redirects to not found if the dealId is invalid', async () => {
+    // Arrange
+    jest.mocked(api.getDeal).mockResolvedValue({ status: 400, data: 'Invalid deal id' });
+
+    const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    await postDealCancellationDetails(req, res);
+
+    // Assert
+    expect(res._getRedirectUrl()).toBe(`/not-found`);
+  });
+
+  it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
+    // Arrange
+    jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: DEAL_SUBMISSION_TYPE.MIA } });
+
+    const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+      params: { _id: dealId },
+      session: {
+        user: mockUser,
+        userToken: 'a user token',
+      },
+    });
+
+    // Act
+    await postDealCancellationDetails(req, res);
+
+    // Assert
+    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+  });
+
+  describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
+    beforeEach(() => {
+      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
+    });
+
+    // TODO: DTFS2-7298 - test deal cancellation endpoints are called with correct payload
+
+    it('redirects to the effective from date page', async () => {
+      // Arrange
+      const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+        params: { _id: dealId },
+        session: {
+          user: mockUser,
+          userToken: 'a user token',
+        },
+      });
+
+      // Act
+      await postDealCancellationDetails(req, res);
+
+      // Assert
+      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
@@ -73,6 +73,7 @@ export const postDealCancellationDetails = async (req: PostDealCancellationDetai
       return res.redirect(`/case/${_id}/deal`);
     }
 
+    // TODO: DTFS2-7298 - enact deal cancellation
     return res.redirect(`/case/${_id}/deal`);
   } catch (error) {
     console.error('Error cancelling deal', error);

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
@@ -1,0 +1,81 @@
+import { Response } from 'express';
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
+import { asUserSession } from '../../../helpers/express-session';
+import { canSubmissionTypeBeCancelled } from '../../helpers/deal-cancellation-enabled.helper';
+import api from '../../../api';
+import { CheckDetailsViewModel } from '../../../types/view-models';
+
+export type GetDealCancellationDetailsRequest = CustomExpressRequest<{ params: { _id: string } }>;
+export type PostDealCancellationDetailsRequest = CustomExpressRequest<{ params: { _id: string } }>;
+
+/**
+ * controller to get deal cancellation details
+ *
+ * @param req - The express request
+ * @param res - The express response
+ */
+export const getDealCancellationDetails = async (req: GetDealCancellationDetailsRequest, res: Response) => {
+  const { _id } = req.params;
+  const { user, userToken } = asUserSession(req.session);
+
+  try {
+    const deal = await api.getDeal(_id, userToken);
+
+    if (!deal || 'status' in deal) {
+      return res.redirect('/not-found');
+    }
+
+    if (!canSubmissionTypeBeCancelled(deal.dealSnapshot.submissionType)) {
+      return res.redirect(`/case/${_id}/deal`);
+    }
+
+    const { reason, bankRequestDate, effectiveFrom } = await api.getDealCancellation(_id, userToken);
+
+    const bankRequestDateFormatted = bankRequestDate ? format(new Date(bankRequestDate), 'd MMMM yyyy') : undefined;
+    const effectiveFromDateFormatted = effectiveFrom ? format(new Date(effectiveFrom), 'd MMMM yyyy') : undefined;
+
+    const effectiveFromDateViewModel: CheckDetailsViewModel = {
+      activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+      user,
+      ukefDealId: deal.dealSnapshot.details.ukefDealId,
+      dealId: _id,
+      reason,
+      bankRequestDate: bankRequestDateFormatted,
+      effectiveFromDate: effectiveFromDateFormatted,
+    };
+    return res.render('case/cancellation/check-details.njk', effectiveFromDateViewModel);
+  } catch (error) {
+    console.error('Error getting deal cancellation details', error);
+    return res.render('_partials/problem-with-service.njk');
+  }
+};
+
+/**
+ * controller to post the deal cancellation
+ *
+ * @param req - The express request
+ * @param res - The express response
+ */
+export const postDealCancellationDetails = async (req: PostDealCancellationDetailsRequest, res: Response) => {
+  const { _id } = req.params;
+  const { userToken } = asUserSession(req.session);
+
+  try {
+    const deal = await api.getDeal(_id, userToken);
+
+    if (!deal || 'status' in deal) {
+      return res.redirect('/not-found');
+    }
+
+    if (!canSubmissionTypeBeCancelled(deal.dealSnapshot.submissionType)) {
+      return res.redirect(`/case/${_id}/deal`);
+    }
+
+    return res.redirect(`/case/${_id}/deal`);
+  } catch (error) {
+    console.error('Error cancelling deal', error);
+    return res.render('_partials/problem-with-service.njk');
+  }
+};

--- a/trade-finance-manager-ui/server/routes/case/cancellation.ts
+++ b/trade-finance-manager-ui/server/routes/case/cancellation.ts
@@ -6,6 +6,7 @@ import { getBankRequestDate, postBankRequestDate } from '../../controllers/case/
 import { validateUserTeam } from '../../middleware';
 import { validateDealCancellationEnabled } from '../../middleware/feature-flags/deal-cancellation';
 import { getEffectiveFromDate, postEffectiveFromDate } from '../../controllers/case/cancellation/effective-from-date.controller';
+import { getDealCancellationDetails, postDealCancellationDetails } from '../../controllers/case/cancellation/check-details.controller';
 
 export const cancellationRouter = Router();
 
@@ -19,3 +20,6 @@ cancellationRouter.post('/:_id/cancellation/bank-request-date', postBankRequestD
 
 cancellationRouter.get('/:_id/cancellation/effective-from-date', getEffectiveFromDate);
 cancellationRouter.post('/:_id/cancellation/effective-from-date', postEffectiveFromDate);
+
+cancellationRouter.get('/:_id/cancellation/check-details', getDealCancellationDetails);
+cancellationRouter.post('/:_id/cancellation/check-details', postDealCancellationDetails);

--- a/trade-finance-manager-ui/server/types/view-models/deal-cancellation/check-details-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/deal-cancellation/check-details-view-model.ts
@@ -1,0 +1,9 @@
+import { BaseViewModel } from '../base-view-model';
+
+export type CheckDetailsViewModel = BaseViewModel & {
+  ukefDealId: string;
+  dealId: string;
+  reason?: string;
+  bankRequestDate?: string;
+  effectiveFromDate?: string;
+};

--- a/trade-finance-manager-ui/server/types/view-models/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/index.ts
@@ -14,3 +14,4 @@ export * from './selected-reported-fees-details-view-model';
 export * from './deal-cancellation/reason-for-cancelling-view-model';
 export * from './deal-cancellation/bank-request-date-view-model';
 export * from './deal-cancellation/effective-from-date-view-model';
+export * from './deal-cancellation/check-details-view-model';

--- a/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
@@ -1,0 +1,115 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% extends "index.njk" %}
+
+{% block pageTitle -%}
+  Check details before cancelling deal
+{%- endblock %}
+
+{% set optionsWithHTML = [] %}
+
+{% set rowTextClasses = "govuk-!-padding-top-6 govuk-!-padding-bottom-6" %}
+{% set rowLinkClasses = "govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-!-text-align-right" %}
+
+{% set reasonForCancellingUrl %}
+  <a
+    class="govuk-link"
+    href="/case/{{ dealId }}/cancellation/reason"
+    data-cy="reason-link">
+    Change <span class="govuk-visually-hidden">reason</span>
+  </a>
+{% endset %}
+{% set reasonForCancelling =
+  [
+    { text: 'Reason for cancelling deal', attributes: { "data-cy": "reason-heading" }, classes: rowTextClasses },
+    { text: reason | dashIfEmpty, attributes: { "data-cy": "reason-response" }, classes: rowTextClasses },
+    { html: reasonForCancellingUrl, classes: rowLinkClasses }
+  ]
+%}
+{% set optionsWithHTML = (optionsWithHTML.push(reasonForCancelling), optionsWithHTML) %}
+
+{% set bankRequestDateUrl %}
+  <a
+    class="govuk-link"
+    href="/case/{{ dealId }}/cancellation/bank-request-date"
+    data-cy="bank-request-date-link">
+    Change <span class="govuk-visually-hidden">bank request date</span>
+  </a>
+{% endset %}
+{% set bankRequestDate =
+  [
+    { text: 'Bank request date', attributes: { "data-cy": "bank-request-date-heading" }, classes: rowTextClasses},
+    { text: bankRequestDate | dashIfEmpty, attributes: { "data-cy": "bank-request-date-response" }, classes: rowTextClasses },
+    { html: bankRequestDateUrl, classes: rowLinkClasses }
+  ]
+%}
+{% set optionsWithHTML = (optionsWithHTML.push(bankRequestDate), optionsWithHTML) %}
+
+{% set effectiveFromDateUrl %}
+  <a
+    class="govuk-link"
+    href="/case/{{ dealId }}/cancellation/effective-from-date"
+    data-cy="effective-from-link">
+    Change <span class="govuk-visually-hidden">date effective from</span>
+  </a>
+{% endset %}
+  {% set effectiveFromDate =
+    [
+      { text: 'Date effective from', attributes: { "data-cy": "effective-from-heading" }, classes: rowTextClasses },
+      { text: effectiveFromDate | dashIfEmpty, attributes: { "data-cy": "effective-from-response" }, classes: rowTextClasses },
+      { html: effectiveFromDateUrl, classes: rowLinkClasses }
+    ]
+%}
+{% set optionsWithHTML = (optionsWithHTML.push(effectiveFromDate), optionsWithHTML) %}
+
+{% block sub_content %}
+  {{ govukBackLink({
+      text: "Back",
+      href: "/case/" + dealId + "/cancellation/effective-from-date",
+      attributes: {
+        'data-cy': 'back-link'
+      }
+    }) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+
+      <h1 class="govuk-label-wrapper">
+        <span class="govuk-caption-l govuk-!-margin-top-3 govuk-!-margin-bottom-1">Cancel deal {{ ukefDealId }}</span>
+        <label class="govuk-label govuk-label--l" for="check-details">
+          Check details before cancelling deal
+        </label>
+      </h1>
+
+      {{ govukTable({
+        rows: optionsWithHTML,
+       firstCellIsHeader: true,
+       classes: "govuk-!-margin-top-4"
+      }) }}
+
+      <div class="govuk-!-margin-bottom-9">
+      {{ govukWarningText({
+        text: "When you cancel the deal it cannot be undone",
+        iconFallbackText: "Warning",
+        attributes: { 'data-cy': 'warning' }
+      }) }}
+      </div>
+
+      <form method="POST" autocomplete="off">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <div class="govuk-!-margin-bottom-5">
+          {{ govukButton({
+            text: "Delete account",
+            classes: "govuk-button--warning",
+            attributes: { 'data-cy': 'delete-button' }
+          }) }}
+        </div>
+      </form>
+
+      <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="return-link">Return to deal summary</a>
+
+    </div>
+  </div>
+{% endblock %}

--- a/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
@@ -108,7 +108,7 @@
         </div>
       </form>
 
-      <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="return-link">Return to deal summary</a>
+      <a class="govuk-link" href="/case/{{ dealId }}/cancellation/cancel" data-cy="return-link">Return to deal summary</a>
 
     </div>
   </div>

--- a/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
@@ -85,8 +85,8 @@
 
       {{ govukTable({
         rows: optionsWithHTML,
-       firstCellIsHeader: true,
-       classes: "govuk-!-margin-top-4"
+        firstCellIsHeader: true,
+        classes: "govuk-!-margin-top-4"
       }) }}
 
       <div class="govuk-!-margin-bottom-9">

--- a/trade-finance-manager-ui/test-helpers/test-data/check-answers-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/check-answers-view-model.ts
@@ -1,0 +1,10 @@
+import { PRIMARY_NAVIGATION_KEYS } from '../../server/constants';
+import { aTfmSessionUser } from './tfm-session-user';
+import { CheckDetailsViewModel } from '../../server/types/view-models';
+
+export const aCheckDetailsViewModel = (): CheckDetailsViewModel => ({
+  user: aTfmSessionUser(),
+  activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
+  ukefDealId: 'testUkefId',
+  dealId: 'testId',
+});


### PR DESCRIPTION
## Introduction :pencil2:
Add the check details page to the deal cancellation flow

## Resolution :heavy_check_mark:
- Add nunjucks template
- Add controller (note the proper implementation of the POST endpoint will be handled in a separate ticket)
- Add component and unit tests
- Add e2e tests

## Screenshots
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/5aa615ef-c8ff-4660-ae81-b68cc5da754d">
<img width="1349" alt="image" src="https://github.com/user-attachments/assets/5541d714-314b-412d-958a-3152950ea66d">
