### PR TITLE
feat(DTFS2-7448): update cancel link hrefs

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/bank-request-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/bank-request-date.spec.js
@@ -88,8 +88,7 @@ context('Deal cancellation - bank request date', () => {
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
     });
 
-    // TODO: DTFS2-7359 - add this test once cancel link is implemented
-    it.skip('cancel link should take you to confirm cancellation page', () => {
+    it('cancel link should take you to confirm cancellation page', () => {
       cy.clickCancelLink();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
@@ -95,8 +95,7 @@ context('Deal cancellation - effective from date', () => {
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
     });
 
-    // TODO: DTFS2-7359 - add this test once cancel link is implemented
-    it.skip('cancel link should take you to confirm cancellation page', () => {
+    it('cancel link should take you to confirm cancellation page', () => {
       cy.clickCancelLink();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/reason-for-cancelling.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/reason-for-cancelling.spec.js
@@ -68,8 +68,7 @@ context('Deal cancellation - reason for cancelling', () => {
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
     });
 
-    // TODO: DTFS2-7359 - add this test once cancel link is implemented
-    it.skip('cancel link should take you to confirm cancellation page', () => {
+    it('cancel link should take you to confirm cancellation page', () => {
       cy.clickCancelLink();
 
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/cancel`));

--- a/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
@@ -28,7 +28,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="cancel-link"]').toExist();
-    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`cancel`, 'Cancel');
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/cancellation/cancel`, 'Cancel');
   });
 
   it('should render back link button linking to the deal cancellation reason page', () => {

--- a/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/bank-request-date.component-test.ts
@@ -28,7 +28,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="cancel-link"]').toExist();
-    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/deal`, 'Cancel');
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`cancel`, 'Cancel');
   });
 
   it('should render back link button linking to the deal cancellation reason page', () => {

--- a/trade-finance-manager-ui/component-tests/case/cancellation/effective-from-date.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/effective-from-date.component-test.ts
@@ -28,7 +28,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="cancel-link"]').toExist();
-    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`cancel`, 'Cancel');
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/cancellation/cancel`, 'Cancel');
   });
 
   it('should render back link button linking to the deal bank request date page', () => {

--- a/trade-finance-manager-ui/component-tests/case/cancellation/effective-from-date.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/effective-from-date.component-test.ts
@@ -28,7 +28,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="cancel-link"]').toExist();
-    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/deal`, 'Cancel');
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`cancel`, 'Cancel');
   });
 
   it('should render back link button linking to the deal bank request date page', () => {

--- a/trade-finance-manager-ui/component-tests/case/cancellation/reason-for-cancelling.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/reason-for-cancelling.component-test.ts
@@ -26,7 +26,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="cancel-link"]').toExist();
-    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/deal`, 'Cancel');
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`cancel`, 'Cancel');
   });
 
   it('should render back link button linking to the case deal page', () => {

--- a/trade-finance-manager-ui/component-tests/case/cancellation/reason-for-cancelling.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/reason-for-cancelling.component-test.ts
@@ -26,7 +26,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="cancel-link"]').toExist();
-    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`cancel`, 'Cancel');
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(`/case/${dealId}/cancellation/cancel`, 'Cancel');
   });
 
   it('should render back link button linking to the case deal page', () => {

--- a/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
@@ -100,7 +100,7 @@
             text: "Continue",
             attributes: { "data-cy": "continue-button" }
           }) }}
-          <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="cancel-link">Cancel</a>
+          <a class="govuk-link" href="cancel" data-cy="cancel-link">Cancel</a>
         </div>
 
       </form>

--- a/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/bank-request-date.njk
@@ -100,7 +100,7 @@
             text: "Continue",
             attributes: { "data-cy": "continue-button" }
           }) }}
-          <a class="govuk-link" href="cancel" data-cy="cancel-link">Cancel</a>
+          <a class="govuk-link" href="/case/{{ dealId }}/cancellation/cancel" data-cy="cancel-link">Cancel</a>
         </div>
 
       </form>

--- a/trade-finance-manager-ui/templates/case/cancellation/effective-from-date.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/effective-from-date.njk
@@ -100,7 +100,7 @@
             text: "Continue",
             attributes: { "data-cy": "continue-button" }
           }) }}
-          <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="cancel-link">Cancel</a>
+          <a class="govuk-link" href="cancel" data-cy="cancel-link">Cancel</a>
         </div>
 
       </form>

--- a/trade-finance-manager-ui/templates/case/cancellation/effective-from-date.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/effective-from-date.njk
@@ -100,7 +100,7 @@
             text: "Continue",
             attributes: { "data-cy": "continue-button" }
           }) }}
-          <a class="govuk-link" href="cancel" data-cy="cancel-link">Cancel</a>
+          <a class="govuk-link" href="/case/{{ dealId }}/cancellation/cancel" data-cy="cancel-link">Cancel</a>
         </div>
 
       </form>

--- a/trade-finance-manager-ui/templates/case/cancellation/reason-for-cancelling.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/reason-for-cancelling.njk
@@ -71,7 +71,7 @@
             attributes: { "data-cy": "continue-button" }
             })
           }}
-          <a class="govuk-link" href="/case/{{ dealId }}/deal" data-cy="cancel-link">Cancel</a>
+          <a class="govuk-link" href="cancel" data-cy="cancel-link">Cancel</a>
         </div>
       </form>
     </div>

--- a/trade-finance-manager-ui/templates/case/cancellation/reason-for-cancelling.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/reason-for-cancelling.njk
@@ -71,7 +71,7 @@
             attributes: { "data-cy": "continue-button" }
             })
           }}
-          <a class="govuk-link" href="cancel" data-cy="cancel-link">Cancel</a>
+          <a class="govuk-link" href="/case/{{ dealId }}/cancellation/cancel" data-cy="cancel-link">Cancel</a>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Introduction :pencil2:
The existing cancellation pages have cancel links redirecting to the deal summary page. These should take the user to the new cancel cancellation page

## Resolution :heavy_check_mark:
Update the cancel link hrefs
Update the e2e tests
Update the component tests

## Note ⚠️ 
This page doesnt exist yet (Implemented by #3640)

