### PR TITLE
feat(DTFS2-7454): redirect from cancellation pages if no cancellation in draft

### DIFF
--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.get.test.ts
@@ -1,7 +1,7 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { BankRequestDateViewModel } from '../../../types/view-models';
 import { getBankRequestDate, GetBankRequestDateRequest } from './bank-request-date.controller';
@@ -14,7 +14,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('getBankRequestDate', () => {
   beforeEach(() => {
@@ -27,10 +26,7 @@ describe('getBankRequestDate', () => {
 
     const { req, res } = createMocks<GetBankRequestDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -46,10 +42,7 @@ describe('getBankRequestDate', () => {
 
     const { req, res } = createMocks<GetBankRequestDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -68,10 +61,7 @@ describe('getBankRequestDate', () => {
       // Arrange
       const { req, res } = createMocks<GetBankRequestDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -85,10 +75,7 @@ describe('getBankRequestDate', () => {
       // Arrange
       const { req, res } = createMocks<GetBankRequestDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -110,10 +97,7 @@ describe('getBankRequestDate', () => {
 
       const { req, res } = createMocks<GetBankRequestDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -127,12 +111,11 @@ describe('getBankRequestDate', () => {
       // Arrange
       jest.mocked(api.getDealCancellation).mockResolvedValue({ reason: '' });
 
+      const session = aRequestSession();
+
       const { req, res } = createMocks<GetBankRequestDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -142,7 +125,7 @@ describe('getBankRequestDate', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/bank-request-date.njk');
       expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         dealId,
         day: '',
@@ -156,12 +139,11 @@ describe('getBankRequestDate', () => {
       const existingBankRequestDate = new Date('2024-03-21');
       jest.mocked(api.getDealCancellation).mockResolvedValue({ reason: '', bankRequestDate: existingBankRequestDate.valueOf() });
 
+      const session = aRequestSession();
+
       const { req, res } = createMocks<GetBankRequestDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -171,7 +153,7 @@ describe('getBankRequestDate', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/bank-request-date.njk');
       expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         dealId,
         day: format(existingBankRequestDate, 'd'),

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.get.test.ts
@@ -104,7 +104,7 @@ describe('getBankRequestDate', () => {
       await getBankRequestDate(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
 
     it('renders the bank request date page without prepopulated data when it does not exist', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.post.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DayMonthYearInput, DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { BankRequestDateValidationViewModel, BankRequestDateViewModel } from '../../../types/view-models';
 import { postBankRequestDate, PostBankRequestDateRequest } from './bank-request-date.controller';
@@ -22,7 +22,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('postBankRequestDate', () => {
   beforeEach(() => {
@@ -35,10 +34,7 @@ describe('postBankRequestDate', () => {
 
     const { req, res } = createMocks<PostBankRequestDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -54,10 +50,7 @@ describe('postBankRequestDate', () => {
 
     const { req, res } = createMocks<PostBankRequestDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -73,10 +66,7 @@ describe('postBankRequestDate', () => {
 
     const { req, res } = createMocks<PostBankRequestDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -112,10 +102,7 @@ describe('postBankRequestDate', () => {
         // Arrange
         const { req, res } = createMocks<PostBankRequestDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: inputtedDate,
         });
 
@@ -128,12 +115,11 @@ describe('postBankRequestDate', () => {
 
       it('renders the bank request date page with errors', async () => {
         // Arrange
+        const session = aRequestSession();
+
         const { req, res } = createMocks<PostBankRequestDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session,
           body: inputtedDate,
         });
 
@@ -144,7 +130,7 @@ describe('postBankRequestDate', () => {
         expect(res._getRenderView()).toEqual('case/cancellation/bank-request-date.njk');
         expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
           activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-          user: mockUser,
+          user: session.user,
           ukefDealId,
           dealId,
           errors,
@@ -158,10 +144,7 @@ describe('postBankRequestDate', () => {
         // Arrange
         const { req, res } = createMocks<PostBankRequestDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: inputtedDate,
         });
 
@@ -192,10 +175,7 @@ describe('postBankRequestDate', () => {
 
         const { req, res } = createMocks<PostBankRequestDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken,
-          },
+          session: aRequestSession(),
           body: {
             'bank-request-date-day': testDate.getDate(),
             'bank-request-date-month': testDate.getMonth() + 1,
@@ -215,10 +195,7 @@ describe('postBankRequestDate', () => {
         // Arrange
         const { req, res } = createMocks<PostBankRequestDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: {
             'bank-request-date-day': testDate.getDate(),
             'bank-request-date-month': testDate.getMonth() + 1,

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.post.test.ts
@@ -171,11 +171,11 @@ describe('postBankRequestDate', () => {
 
       it('updates the deal cancellation bank request date', async () => {
         // Arrange
-        const userToken = 'userToken';
+        const session = aRequestSession();
 
         const { req, res } = createMocks<PostBankRequestDateRequest>({
           params: { _id: dealId },
-          session: aRequestSession(),
+          session,
           body: {
             'bank-request-date-day': testDate.getDate(),
             'bank-request-date-month': testDate.getMonth() + 1,
@@ -188,7 +188,7 @@ describe('postBankRequestDate', () => {
 
         // Assert
         expect(api.updateDealCancellation).toHaveBeenCalledTimes(1);
-        expect(api.updateDealCancellation).toHaveBeenCalledWith(dealId, { bankRequestDate: testDate.valueOf() }, userToken);
+        expect(api.updateDealCancellation).toHaveBeenCalledWith(dealId, { bankRequestDate: testDate.valueOf() }, session.userToken);
       });
 
       it('redirects to the effective from date page', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { CustomExpressRequest } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
+import { isEmpty } from 'lodash';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { asUserSession } from '../../../helpers/express-session';
 import { BankRequestDateViewModel } from '../../../types/view-models';
@@ -36,6 +37,10 @@ export const getBankRequestDate = async (req: GetBankRequestDateRequest, res: Re
     }
 
     const cancellation = await api.getDealCancellation(_id, userToken);
+
+    if (isEmpty(cancellation)) {
+      return res.redirect(`/case/${_id}/deal`);
+    }
 
     const previouslyEnteredBankRequestDate = cancellation?.bankRequestDate && new Date(cancellation.bankRequestDate);
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.get.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { CancelCancellationViewModel } from '../../../types/view-models';
 import { getCancelCancellation, GetCancelCancellationRequest } from './cancel-cancellation.controller';
@@ -13,7 +13,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('getCancelCancellation', () => {
   beforeEach(() => {
@@ -26,10 +25,7 @@ describe('getCancelCancellation', () => {
 
     const { req, res } = createMocks<GetCancelCancellationRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -45,10 +41,7 @@ describe('getCancelCancellation', () => {
 
     const { req, res } = createMocks<GetCancelCancellationRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -67,10 +60,7 @@ describe('getCancelCancellation', () => {
       // Arrange
       const { req, res } = createMocks<GetCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -84,10 +74,7 @@ describe('getCancelCancellation', () => {
       // Arrange
       const { req, res } = createMocks<GetCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -109,10 +96,7 @@ describe('getCancelCancellation', () => {
 
       const { req, res } = createMocks<GetCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -127,13 +111,11 @@ describe('getCancelCancellation', () => {
       jest.mocked(api.getDealCancellation).mockResolvedValue({ reason: 'reason' });
 
       const previousPage = 'previousPage';
+      const session = aRequestSession();
 
       const { req, res } = createMocks<GetCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session,
         headers: {
           referer: previousPage,
         },
@@ -146,7 +128,7 @@ describe('getCancelCancellation', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/cancel.njk');
       expect(res._getRenderData() as CancelCancellationViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         previousPage,
       });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.get.test.ts
@@ -103,7 +103,7 @@ describe('getCancelCancellation', () => {
       await getCancelCancellation(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
 
     it('renders the cancel cancellation page', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.post.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { postCancelCancellation, PostCancelCancellationRequest } from './cancel-cancellation.controller';
 import api from '../../../api';
 
@@ -11,7 +11,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('postCancelCancellation', () => {
   beforeEach(() => {
@@ -24,10 +23,7 @@ describe('postCancelCancellation', () => {
 
     const { req, res } = createMocks<PostCancelCancellationRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
       query: {
         return: 'true',
       },
@@ -49,10 +45,7 @@ describe('postCancelCancellation', () => {
 
     const { req, res } = createMocks<PostCancelCancellationRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -68,10 +61,7 @@ describe('postCancelCancellation', () => {
 
     const { req, res } = createMocks<PostCancelCancellationRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -90,10 +80,7 @@ describe('postCancelCancellation', () => {
       // Arrange
       const { req, res } = createMocks<PostCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -107,10 +94,7 @@ describe('postCancelCancellation', () => {
       // Arrange
       const { req, res } = createMocks<PostCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -130,10 +114,7 @@ describe('postCancelCancellation', () => {
 
       const { req, res } = createMocks<PostCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken,
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -150,10 +131,7 @@ describe('postCancelCancellation', () => {
 
       const { req, res } = createMocks<PostCancelCancellationRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'userToken',
-        },
+        session: aRequestSession(),
       });
 
       // Act

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.post.test.ts
@@ -36,7 +36,7 @@ describe('postCancelCancellation', () => {
     await postCancelCancellation(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(previousPage);
+    expect(res._getRedirectUrl()).toEqual(previousPage);
   });
 
   it('redirects to not found if the deal does not exist', async () => {
@@ -52,7 +52,7 @@ describe('postCancelCancellation', () => {
     await postCancelCancellation(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -68,7 +68,7 @@ describe('postCancelCancellation', () => {
     await postCancelCancellation(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   describe(`when the deal type is ${DEAL_SUBMISSION_TYPE.MIA}`, () => {
@@ -87,7 +87,7 @@ describe('postCancelCancellation', () => {
       await postCancelCancellation(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
 
     it('does not delete the deal cancellation', async () => {
@@ -138,7 +138,7 @@ describe('postCancelCancellation', () => {
       await postCancelCancellation(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.post.test.ts
@@ -110,11 +110,11 @@ describe('postCancelCancellation', () => {
       // Arrange
       jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
 
-      const userToken = 'userToken';
+      const session = aRequestSession();
 
       const { req, res } = createMocks<PostCancelCancellationRequest>({
         params: { _id: dealId },
-        session: aRequestSession(),
+        session,
       });
 
       // Act
@@ -122,7 +122,7 @@ describe('postCancelCancellation', () => {
 
       // Assert
       expect(api.deleteDealCancellation).toHaveBeenCalledTimes(1);
-      expect(api.deleteDealCancellation).toHaveBeenCalledWith(dealId, userToken);
+      expect(api.deleteDealCancellation).toHaveBeenCalledWith(dealId, session.userToken);
     });
 
     it('redirects to the deal summary page', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express';
 import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import { isEmpty } from 'lodash';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { asUserSession } from '../../../helpers/express-session';
 import { CancelCancellationViewModel } from '../../../types/view-models';
@@ -28,6 +29,12 @@ export const getCancelCancellation = async (req: GetCancelCancellationRequest, r
     }
 
     if (!canSubmissionTypeBeCancelled(deal.dealSnapshot.submissionType)) {
+      return res.redirect(`/case/${_id}/deal`);
+    }
+
+    const cancellation = await api.getDealCancellation(_id, userToken);
+
+    if (isEmpty(cancellation)) {
       return res.redirect(`/case/${_id}/deal`);
     }
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
@@ -104,7 +104,7 @@ describe('getDealCancellationDetails', () => {
       await getDealCancellationDetails(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
 
     it('renders the check details page with deal cancellation details', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
@@ -1,7 +1,7 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { BankRequestDateViewModel } from '../../../types/view-models';
 import api from '../../../api';
@@ -14,7 +14,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('getDealCancellationDetails', () => {
   beforeEach(() => {
@@ -27,10 +26,7 @@ describe('getDealCancellationDetails', () => {
 
     const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -46,10 +42,7 @@ describe('getDealCancellationDetails', () => {
 
     const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -68,10 +61,7 @@ describe('getDealCancellationDetails', () => {
       // Arrange
       const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -85,10 +75,7 @@ describe('getDealCancellationDetails', () => {
       // Arrange
       const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -110,10 +97,7 @@ describe('getDealCancellationDetails', () => {
 
       const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -128,6 +112,8 @@ describe('getDealCancellationDetails', () => {
       const bankRequestDate = new Date('2024-01-01');
       const effectiveFromDate = new Date('2024-03-03');
 
+      const session = aRequestSession();
+
       // Arrange
       jest
         .mocked(api.getDealCancellation)
@@ -135,10 +121,7 @@ describe('getDealCancellationDetails', () => {
 
       const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session,
       });
 
       // Act
@@ -148,7 +131,7 @@ describe('getDealCancellationDetails', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/check-details.njk');
       expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         dealId,
         reason,

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import api from '../../../api';
 import { postDealCancellationDetails, PostDealCancellationDetailsRequest } from './check-details.controller';
 
@@ -10,7 +10,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('postBankRequestDate', () => {
   beforeEach(() => {
@@ -23,10 +22,7 @@ describe('postBankRequestDate', () => {
 
     const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -42,10 +38,7 @@ describe('postBankRequestDate', () => {
 
     const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -61,10 +54,7 @@ describe('postBankRequestDate', () => {
 
     const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -85,10 +75,7 @@ describe('postBankRequestDate', () => {
       // Arrange
       const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express';
 import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import { isEmpty } from 'lodash';
 import { format } from 'date-fns';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { asUserSession } from '../../../helpers/express-session';
@@ -31,7 +32,13 @@ export const getDealCancellationDetails = async (req: GetDealCancellationDetails
       return res.redirect(`/case/${_id}/deal`);
     }
 
-    const { reason, bankRequestDate, effectiveFrom } = await api.getDealCancellation(_id, userToken);
+    const cancellation = await api.getDealCancellation(_id, userToken);
+
+    if (isEmpty(cancellation)) {
+      return res.redirect(`/case/${_id}/deal`);
+    }
+
+    const { reason, bankRequestDate, effectiveFrom } = cancellation;
 
     const bankRequestDateFormatted = bankRequestDate ? format(new Date(bankRequestDate), 'd MMMM yyyy') : undefined;
     const effectiveFromDateFormatted = effectiveFrom ? format(new Date(effectiveFrom), 'd MMMM yyyy') : undefined;

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
@@ -1,7 +1,7 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { getEffectiveFromDate, GetEffectiveFromDateRequest } from './effective-from-date.controller';
 import { EffectiveFromDateViewModel } from '../../../types/view-models';
@@ -14,7 +14,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('getEffectiveFromDate', () => {
   beforeEach(() => {
@@ -27,10 +26,7 @@ describe('getEffectiveFromDate', () => {
 
     const { req, res } = createMocks<GetEffectiveFromDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -46,10 +42,7 @@ describe('getEffectiveFromDate', () => {
 
     const { req, res } = createMocks<GetEffectiveFromDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -68,10 +61,7 @@ describe('getEffectiveFromDate', () => {
       // Arrange
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -85,10 +75,7 @@ describe('getEffectiveFromDate', () => {
       // Arrange
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -110,10 +97,7 @@ describe('getEffectiveFromDate', () => {
 
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session: aRequestSession(),
       });
 
       // Act
@@ -127,12 +111,11 @@ describe('getEffectiveFromDate', () => {
       // Arrange
       jest.mocked(api.getDealCancellation).mockResolvedValue({ bankRequestDate: new Date().valueOf() });
 
+      const session = aRequestSession();
+
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session,
       });
 
       // Act
@@ -142,7 +125,7 @@ describe('getEffectiveFromDate', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/effective-from-date.njk');
       expect(res._getRenderData() as EffectiveFromDateViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         dealId,
         day: '',
@@ -156,12 +139,11 @@ describe('getEffectiveFromDate', () => {
       const existingEffectiveFromDate = new Date('2024-03-21');
       jest.mocked(api.getDealCancellation).mockResolvedValue({ bankRequestDate: new Date().valueOf(), effectiveFrom: existingEffectiveFromDate.valueOf() });
 
+      const session = aRequestSession();
+
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session,
       });
 
       // Act
@@ -171,7 +153,7 @@ describe('getEffectiveFromDate', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/effective-from-date.njk');
       expect(res._getRenderData() as EffectiveFromDateViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         dealId,
         day: format(existingEffectiveFromDate, 'd'),

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
@@ -100,10 +100,13 @@ describe('getEffectiveFromDate', () => {
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
+    beforeEach(() => {
+      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
+    });
+
     it('redirects to deal summary page if the deal cancellation is empty', async () => {
       // Arrange
       jest.mocked(api.getDealCancellation).mockResolvedValue({});
-      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
 
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
@@ -123,7 +126,6 @@ describe('getEffectiveFromDate', () => {
     it('renders the effective from date page without prepopulated data when it does not exist', async () => {
       // Arrange
       jest.mocked(api.getDealCancellation).mockResolvedValue({ bankRequestDate: new Date().valueOf() });
-      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
 
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },
@@ -153,7 +155,6 @@ describe('getEffectiveFromDate', () => {
       // Arrange
       const existingEffectiveFromDate = new Date('2024-03-21');
       jest.mocked(api.getDealCancellation).mockResolvedValue({ bankRequestDate: new Date().valueOf(), effectiveFrom: existingEffectiveFromDate.valueOf() });
-      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
 
       const { req, res } = createMocks<GetEffectiveFromDateRequest>({
         params: { _id: dealId },

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
@@ -104,7 +104,7 @@ describe('getEffectiveFromDate', () => {
       await getEffectiveFromDate(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
 
     it('renders the effective from date page without prepopulated data when it does not exist', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.post.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DayMonthYearInput, DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { postEffectiveFromDate, PostEffectiveFromDateRequest } from './effective-from-date.controller';
 import { EffectiveFromDateValidationViewModel, EffectiveFromDateViewModel } from '../../../types/view-models';
@@ -22,7 +22,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('postEffectiveFromDate', () => {
   beforeEach(() => {
@@ -35,10 +34,7 @@ describe('postEffectiveFromDate', () => {
 
     const { req, res } = createMocks<PostEffectiveFromDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -54,10 +50,7 @@ describe('postEffectiveFromDate', () => {
 
     const { req, res } = createMocks<PostEffectiveFromDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -73,10 +66,7 @@ describe('postEffectiveFromDate', () => {
 
     const { req, res } = createMocks<PostEffectiveFromDateRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -112,10 +102,7 @@ describe('postEffectiveFromDate', () => {
         // Arrange
         const { req, res } = createMocks<PostEffectiveFromDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: inputtedDate,
         });
 
@@ -129,12 +116,11 @@ describe('postEffectiveFromDate', () => {
 
       it('renders the effective from page with errors', async () => {
         // Arrange
+        const session = aRequestSession();
+
         const { req, res } = createMocks<PostEffectiveFromDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session,
           body: inputtedDate,
         });
 
@@ -145,7 +131,7 @@ describe('postEffectiveFromDate', () => {
         expect(res._getRenderView()).toEqual('case/cancellation/effective-from-date.njk');
         expect(res._getRenderData() as EffectiveFromDateViewModel).toEqual({
           activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-          user: mockUser,
+          user: session.user,
           ukefDealId,
           dealId,
           errors,
@@ -159,10 +145,7 @@ describe('postEffectiveFromDate', () => {
         // Arrange
         const { req, res } = createMocks<PostEffectiveFromDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: inputtedDate,
         });
 
@@ -189,14 +172,11 @@ describe('postEffectiveFromDate', () => {
 
       it('updates the deal cancellation effective from date', async () => {
         // Arrange
-        const userToken = 'userToken';
+        const session = aRequestSession();
 
         const { req, res } = createMocks<PostEffectiveFromDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken,
-          },
+          session,
           body: {
             'effective-from-date-day': testDate.getDate(),
             'effective-from-date-month': testDate.getMonth() + 1,
@@ -209,19 +189,14 @@ describe('postEffectiveFromDate', () => {
 
         // Assert
         expect(api.updateDealCancellation).toHaveBeenCalledTimes(1);
-        expect(api.updateDealCancellation).toHaveBeenCalledWith(dealId, { effectiveFrom: testDate.valueOf() }, userToken);
+        expect(api.updateDealCancellation).toHaveBeenCalledWith(dealId, { effectiveFrom: testDate.valueOf() }, session.userToken);
       });
 
       it('redirects to the check cancellation details page', async () => {
         // Arrange
-        const userToken = 'userToken';
-
         const { req, res } = createMocks<PostEffectiveFromDateRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken,
-          },
+          session: aRequestSession(),
           body: {
             'effective-from-date-day': testDate.getDate(),
             'effective-from-date-month': testDate.getMonth() + 1,

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { CustomExpressRequest } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
+import { isEmpty } from 'lodash';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { asUserSession } from '../../../helpers/express-session';
 import { EffectiveFromDateViewModel } from '../../../types/view-models';
@@ -36,6 +37,10 @@ export const getEffectiveFromDate = async (req: GetEffectiveFromDateRequest, res
     }
 
     const cancellation = await api.getDealCancellation(_id, userToken);
+
+    if (isEmpty(cancellation)) {
+      return res.redirect(`/case/${_id}/deal`);
+    }
 
     const previouslyEnteredEffectiveFromDate = cancellation?.effectiveFrom && new Date(cancellation.effectiveFrom);
 

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/helpers/get-previous-page-url.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/helpers/get-previous-page-url.test.ts
@@ -14,7 +14,7 @@ describe('getPreviousPageUrl', () => {
       const response = getPreviousPageUrl(url, dealId);
 
       // Assert
-      expect(response).toBe(`/case/${dealId}/cancellation/${page}`);
+      expect(response).toEqual(`/case/${dealId}/cancellation/${page}`);
     });
 
     it('returns the correct relative url, when given an absolute URL', () => {
@@ -25,7 +25,7 @@ describe('getPreviousPageUrl', () => {
       const response = getPreviousPageUrl(url, dealId);
 
       // Assert
-      expect(response).toBe(`/case/${dealId}/cancellation/${page}`);
+      expect(response).toEqual(`/case/${dealId}/cancellation/${page}`);
     });
 
     it('returns the correct relative url, when given a localhost URL', () => {
@@ -36,7 +36,7 @@ describe('getPreviousPageUrl', () => {
       const response = getPreviousPageUrl(url, dealId);
 
       // Assert
-      expect(response).toBe(`/case/${dealId}/cancellation/${page}`);
+      expect(response).toEqual(`/case/${dealId}/cancellation/${page}`);
     });
   });
 
@@ -48,6 +48,6 @@ describe('getPreviousPageUrl', () => {
     const response = getPreviousPageUrl(url, dealId);
 
     // Assert
-    expect(response).toBe(`/case/${dealId}/deal`);
+    expect(response).toEqual(`/case/${dealId}/deal`);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.get.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { getReasonForCancelling, GetReasonForCancellingRequest } from './reason-for-cancelling.controller';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { ReasonForCancellingViewModel } from '../../../types/view-models';
@@ -13,7 +13,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('getReasonForCancelling', () => {
   beforeEach(() => {
@@ -26,10 +25,7 @@ describe('getReasonForCancelling', () => {
 
     const { req, res } = createMocks<GetReasonForCancellingRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -45,10 +41,7 @@ describe('getReasonForCancelling', () => {
 
     const { req, res } = createMocks<GetReasonForCancellingRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -64,10 +57,7 @@ describe('getReasonForCancelling', () => {
 
     const { req, res } = createMocks<GetReasonForCancellingRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
     });
 
     // Act
@@ -84,12 +74,11 @@ describe('getReasonForCancelling', () => {
       jest.mocked(api.getDealCancellation).mockResolvedValue({ reason });
       jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
 
+      const session = aRequestSession();
+
       const { req, res } = createMocks<GetReasonForCancellingRequest>({
         params: { _id: dealId },
-        session: {
-          user: mockUser,
-          userToken: 'a user token',
-        },
+        session,
       });
 
       // Act
@@ -99,7 +88,7 @@ describe('getReasonForCancelling', () => {
       expect(res._getRenderView()).toEqual('case/cancellation/reason-for-cancelling.njk');
       expect(res._getRenderData() as ReasonForCancellingViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-        user: mockUser,
+        user: session.user,
         ukefDealId,
         dealId,
         reasonForCancelling: reason,

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.post.test.ts
@@ -1,6 +1,6 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { aTfmSessionUser } from '../../../../test-helpers';
+import { aRequestSession } from '../../../../test-helpers';
 import { postReasonForCancelling, PostReasonForCancellingRequest } from './reason-for-cancelling.controller';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { ReasonForCancellingErrorsViewModel, ReasonForCancellingViewModel } from '../../../types/view-models';
@@ -22,7 +22,6 @@ jest.mock('../../../api', () => ({
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
-const mockUser = aTfmSessionUser();
 
 describe('postReasonForCancelling', () => {
   beforeEach(() => {
@@ -37,10 +36,7 @@ describe('postReasonForCancelling', () => {
 
     const { req, res } = createMocks<PostReasonForCancellingRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
       body: {
         reason: 'reasonForCancelling',
       },
@@ -59,10 +55,7 @@ describe('postReasonForCancelling', () => {
 
     const { req, res } = createMocks<PostReasonForCancellingRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
       body: {
         reason: 'reasonForCancelling',
       },
@@ -81,10 +74,7 @@ describe('postReasonForCancelling', () => {
 
     const { req, res } = createMocks<PostReasonForCancellingRequest>({
       params: { _id: dealId },
-      session: {
-        user: mockUser,
-        userToken: 'a user token',
-      },
+      session: aRequestSession(),
       body: {
         reason: 'reasonForCancelling',
       },
@@ -114,10 +104,7 @@ describe('postReasonForCancelling', () => {
         const reasonForCancelling = 'reasonForCancelling';
         const { req, res } = createMocks<PostReasonForCancellingRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: {
             reason: reasonForCancelling,
           },
@@ -133,12 +120,11 @@ describe('postReasonForCancelling', () => {
       it('renders the reason for cancelling page with errors', async () => {
         // Arrange
         const reasonForCancelling = 'reasonForCancelling';
+        const session = aRequestSession();
+
         const { req, res } = createMocks<PostReasonForCancellingRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session,
           body: {
             reason: reasonForCancelling,
           },
@@ -151,7 +137,7 @@ describe('postReasonForCancelling', () => {
         expect(res._getRenderView()).toEqual('case/cancellation/reason-for-cancelling.njk');
         expect(res._getRenderData() as ReasonForCancellingViewModel).toEqual({
           activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
-          user: mockUser,
+          user: session.user,
           ukefDealId,
           dealId,
           errors: validationErrors,
@@ -164,10 +150,7 @@ describe('postReasonForCancelling', () => {
         const reasonForCancelling = 'reasonForCancelling';
         const { req, res } = createMocks<PostReasonForCancellingRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: {
             reason: reasonForCancelling,
           },
@@ -195,14 +178,12 @@ describe('postReasonForCancelling', () => {
       it('updates the deal cancellation reason', async () => {
         // Arrange
         const reason = 'reason';
-        const userToken = 'userToken';
+
+        const session = aRequestSession();
 
         const { req, res } = createMocks<PostReasonForCancellingRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken,
-          },
+          session,
           body: {
             reason,
           },
@@ -213,17 +194,14 @@ describe('postReasonForCancelling', () => {
 
         // Assert
         expect(api.updateDealCancellation).toHaveBeenCalledTimes(1);
-        expect(api.updateDealCancellation).toHaveBeenCalledWith(dealId, { reason }, userToken);
+        expect(api.updateDealCancellation).toHaveBeenCalledWith(dealId, { reason }, session.userToken);
       });
 
       it('redirects to the bank request date page', async () => {
         // Arrange
         const { req, res } = createMocks<PostReasonForCancellingRequest>({
           params: { _id: dealId },
-          session: {
-            user: mockUser,
-            userToken: 'a user token',
-          },
+          session: aRequestSession(),
           body: {
             reason: 'reasonForCancelling',
           },

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.test.ts
@@ -4,7 +4,7 @@ import { SessionData } from 'express-session';
 import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user';
 import { PostEditPaymentRequest, getEditPayment, postEditPayment } from '.';
 import api from '../../../api';
-import { aPaymentDetailsWithFeeRecordsResponseBody, aTfmSessionUser, aPayment, aFeeRecord } from '../../../../test-helpers';
+import { aPaymentDetailsWithFeeRecordsResponseBody, aTfmSessionUser, aPayment, aFeeRecord, aRequestSession } from '../../../../test-helpers';
 import { EMPTY_PAYMENT_ERRORS_VIEW_MODEL, EditPaymentFormRequestBody } from '../helpers';
 import { RECONCILIATION_FOR_REPORT_TABS } from '../../../constants/reconciliation-for-report-tabs';
 import { EditPaymentViewModel } from '../../../types/view-models/edit-payment-view-model';
@@ -14,11 +14,6 @@ import { EditPaymentFormValues, ParsedEditPaymentFormValues } from '../../../typ
 jest.mock('../../../api');
 
 describe('controllers/utilisation-reports/edit-payment', () => {
-  const aRequestSession = () => ({
-    user: aTfmSessionUser(),
-    userToken: 'abc123',
-  });
-
   beforeEach(() => {
     jest.mocked(api.getPaymentDetailsWithFeeRecords).mockResolvedValue(aPaymentDetailsWithFeeRecordsResponseBody());
   });

--- a/trade-finance-manager-ui/test-helpers/test-data/a-request-session.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/a-request-session.ts
@@ -1,0 +1,6 @@
+import { aTfmSessionUser } from './tfm-session-user';
+
+export const aRequestSession = () => ({
+  user: aTfmSessionUser(),
+  userToken: 'a user token',
+});

--- a/trade-finance-manager-ui/test-helpers/test-data/index.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/index.ts
@@ -1,3 +1,4 @@
 export * from './bank-report-period-schedule';
 export * from './bank';
 export * from './tfm-session-user';
+export * from './a-request-session';


### PR DESCRIPTION
## Introduction :pencil2:
When a user visits certain cancellation pages, if they dont have a draft cancellation already they should be redirected to the deal cancellation page. This should only happen if they use URL navigation, or browser history, rather than clicking buttons available on screen.

## Resolution :heavy_check_mark:
- Check the deal cancellation exists when visiting:
    - bank request date
    - effective from date page
    - cancel cancellation page
    - check details page
- The reason for cancelling page is the start of the journey so does not need a draft cancellation to exist
- Update unit tests

## Misc ➕ 
- Use `toEqual` not `toBe` in cancellation unit tests
- Create new `aRequestSession` mock data helper and use in cancellation unit tests
