### PR TITLE
chore(DTFS2-7462): replace toBe assertions with toEqual

### DIFF
--- a/azure-functions/acbs-function/helpers/date.format-date.test.js
+++ b/azure-functions/acbs-function/helpers/date.format-date.test.js
@@ -97,6 +97,6 @@ describe('formatDate', () => {
   it.each(testData)('$description ($mockValue to $expected)', ({ mockValue, expected }) => {
     const result = formatDate(mockValue);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.format-year.test.js
+++ b/azure-functions/acbs-function/helpers/date.format-year.test.js
@@ -72,6 +72,6 @@ describe('formatYear', () => {
   it.each(testData)('$description', ({ mockValue, expected }) => {
     const result = formatYear(mockValue);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.get-date-string-from-year-month-day.test.js
+++ b/azure-functions/acbs-function/helpers/date.get-date-string-from-year-month-day.test.js
@@ -84,6 +84,6 @@ describe('getDateStringFromYearMonthDay', () => {
   it.each(testData)('$description ($year, $month, $day returns $expected)', ({ year, month, day, expected }) => {
     const result = getDateStringFromYearMonthDay(year, month, day);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.get-inclusive-month-difference.test.js
+++ b/azure-functions/acbs-function/helpers/date.get-inclusive-month-difference.test.js
@@ -149,6 +149,6 @@ describe('getInclusiveMonthDifference', () => {
   it.each(testData)('$description ($date1 & $date2 to $expected)', ({ date1, date2, expected }) => {
     const result = getInclusiveMonthDifference(date1, date2);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.get-now-as-iso-string.test.js
+++ b/azure-functions/acbs-function/helpers/date.get-now-as-iso-string.test.js
@@ -14,7 +14,7 @@ describe('getNowAsIsoString', () => {
 
     const result = getNowAsIsoString();
 
-    expect(result).toBe('2024-03-02T00:00:00+00:00');
+    expect(result).toEqual('2024-03-02T00:00:00+00:00');
   });
 
   it('when timezone is BST returns the current date formatted to ISO-8601 without milliseconds & with UTC offset', () => {
@@ -22,6 +22,6 @@ describe('getNowAsIsoString', () => {
 
     const result = getNowAsIsoString();
 
-    expect(result).toBe('2024-08-10T00:00:00+01:00');
+    expect(result).toEqual('2024-08-10T00:00:00+01:00');
   });
 });

--- a/azure-functions/acbs-function/helpers/date.is-date.test.js
+++ b/azure-functions/acbs-function/helpers/date.is-date.test.js
@@ -76,6 +76,6 @@ describe('isDate', () => {
   it.each(testData)('$description', ({ mockString, expected }) => {
     const result = isDate(mockString);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.is-epoch.test.js
+++ b/azure-functions/acbs-function/helpers/date.is-epoch.test.js
@@ -87,6 +87,6 @@ describe('isEpoch', () => {
   it.each(testData)('$description ($mockValue)', ({ mockValue, expected }) => {
     const result = isEpoch(mockValue);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.is-string.test.js
+++ b/azure-functions/acbs-function/helpers/date.is-string.test.js
@@ -52,6 +52,6 @@ describe('isString', () => {
   it.each(testData)('$description ($mockValue)', ({ mockValue, expected }) => {
     const result = isString(mockValue);
 
-    expect(result).toBe(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/azure-functions/acbs-function/helpers/date.now.test.js
+++ b/azure-functions/acbs-function/helpers/date.now.test.js
@@ -12,6 +12,6 @@ describe('now', () => {
   it('returns the current date in the format `yyyy-MM-dd', () => {
     const result = now();
 
-    expect(result).toBe('2024-03-02');
+    expect(result).toEqual('2024-03-02');
   });
 });

--- a/dtfs-central-api/api-tests/helpers/with-validate-audit-details.api-tests.ts
+++ b/dtfs-central-api/api-tests/helpers/with-validate-audit-details.api-tests.ts
@@ -33,8 +33,8 @@ export const withValidateAuditDetailsTests = ({ makeRequest, validUserTypes = AU
     it(`should return 400 (Bad request) and set the body 'code' field to '${API_ERROR_CODE.INVALID_AUDIT_DETAILS}' if no auditDetails provided`, async () => {
       const { status, body } = await makeRequest();
 
-      expect(status).toBe(400);
-      expect(body.code).toBe(API_ERROR_CODE.INVALID_AUDIT_DETAILS);
+      expect(status).toEqual(400);
+      expect(body.code).toEqual(API_ERROR_CODE.INVALID_AUDIT_DETAILS);
     });
   });
 };
@@ -43,7 +43,7 @@ function withValidAuditDetailsTests(validAuditDetails: AuditDetails[], makeReque
   it.each(validAuditDetails)('it should return status 200 if the userType is $userType', async (auditDetails) => {
     const { status } = await makeRequest(auditDetails);
 
-    expect(status).toBe(200);
+    expect(status).toEqual(200);
   });
 }
 
@@ -53,8 +53,8 @@ function withInvalidAuditDetailsTests(invalidAuditDetails: AuditDetails[], makeR
     async (auditDetails) => {
       const { status, body } = await makeRequest(auditDetails);
 
-      expect(status).toBe(400);
-      expect(body.code).toBe(API_ERROR_CODE.INVALID_AUDIT_DETAILS);
+      expect(status).toEqual(400);
+      expect(body.code).toEqual(API_ERROR_CODE.INVALID_AUDIT_DETAILS);
     },
   );
 }

--- a/dtfs-central-api/api-tests/v1/bank/banks-get.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/bank/banks-get.api-test.ts
@@ -46,7 +46,7 @@ describe(`GET ${BASE_URL}`, () => {
       const response = await testApi.get(requestUrl);
 
       // Assert
-      expect(response.status).toBe(axios.HttpStatusCode.Ok);
+      expect(response.status).toEqual(axios.HttpStatusCode.Ok);
       expect(response.body).toEqual(banks);
     });
   });
@@ -101,7 +101,7 @@ describe(`GET ${BASE_URL}`, () => {
       const response = await testApi.get(requestUrl);
 
       // Assert
-      expect(response.status).toBe(axios.HttpStatusCode.Ok);
+      expect(response.status).toEqual(axios.HttpStatusCode.Ok);
       expect(response.body).toEqual(banksWithReportingYears);
     });
   });

--- a/dtfs-central-api/api-tests/v1/cron-jobs/cron-jobs.api-test.js
+++ b/dtfs-central-api/api-tests/v1/cron-jobs/cron-jobs.api-test.js
@@ -57,7 +57,7 @@ describe('DELETE v1/portal/cron-jobs', () => {
       })
       .to(`/v1/portal/cron-jobs`);
 
-    expect(firstStatus).toBe(200);
-    expect(secondStatus).toBe(200);
+    expect(firstStatus).toEqual(200);
+    expect(secondStatus).toEqual(200);
   });
 });

--- a/dtfs-central-api/api-tests/v1/durable-functions/durable-functions.api-test.js
+++ b/dtfs-central-api/api-tests/v1/durable-functions/durable-functions.api-test.js
@@ -56,7 +56,7 @@ describe('DELETE /v1/portal/durable-functions', () => {
       })
       .to(`/v1/portal/durable-functions`);
 
-    expect(firstStatus).toBe(200);
-    expect(secondStatus).toBe(200);
+    expect(firstStatus).toEqual(200);
+    expect(secondStatus).toEqual(200);
   });
 });

--- a/dtfs-central-api/api-tests/v1/middleware/api-rate-limiting.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/middleware/api-rate-limiting.api-test.ts
@@ -29,7 +29,7 @@ describe('api rate limiting', () => {
   };
 
   function assertPromiseIsFulfilled(result: PromiseSettledResult<Response>): asserts result is PromiseFulfilledResult<Response> {
-    expect(result.status).toBe('fulfilled');
+    expect(result.status).toEqual('fulfilled');
   }
 
   it('returns a 429 response if more than RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -38,7 +38,7 @@ describe('api rate limiting', () => {
     const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0];
 
     assertPromiseIsFulfilled(responseAfterRateLimitExceeded);
-    expect(responseAfterRateLimitExceeded.value.status).toBe(429);
+    expect(responseAfterRateLimitExceeded.value.status).toEqual(429);
   });
 
   it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -47,6 +47,6 @@ describe('api rate limiting', () => {
     const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0];
 
     assertPromiseIsFulfilled(responseThatMeetsRateLimit);
-    expect(responseThatMeetsRateLimit.value.status).toBe(200);
+    expect(responseThatMeetsRateLimit.value.status).toEqual(200);
   });
 });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/delete-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/delete-payment.api-test.ts
@@ -78,7 +78,7 @@ describe(`DELETE ${BASE_URL}`, () => {
     const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it("returns a 400 when the 'user' object is an empty object", async () => {
@@ -91,7 +91,7 @@ describe(`DELETE ${BASE_URL}`, () => {
     const response = await testApi.remove(requestBody).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('returns a 404 when the report with the supplied id cannot be found', async () => {
@@ -102,7 +102,7 @@ describe(`DELETE ${BASE_URL}`, () => {
     const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(invalidReportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 404 when the payment with the id cannot be found', async () => {
@@ -113,6 +113,6 @@ describe(`DELETE ${BASE_URL}`, () => {
     const response = await testApi.remove(aDeletePaymentRequestBody()).to(getUrl(reportId, invalidPaymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
@@ -107,7 +107,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportId + 1));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 404 when the bank with the same id as the report cannot be found', async () => {
@@ -120,7 +120,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(2));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 200 with a valid report id', async () => {
@@ -128,7 +128,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it('returns a body containing the report id', async () => {
@@ -136,7 +136,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportId));
 
     // Assert
-    expect(response.body.reportId).toBe(reportId);
+    expect(response.body.reportId).toEqual(reportId);
   });
 
   it('returns a body containing the session bank', async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-payment-details-by-id.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-payment-details-by-id.api-test.ts
@@ -97,7 +97,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportId, paymentId + 1));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 404 when the payment is not attached to a report with the supplied id', async () => {
@@ -105,7 +105,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportId + 1, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 404 when the bank with the same id as the report cannot be found', async () => {
@@ -120,7 +120,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(2, 2));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 200 with a valid report and payment id', async () => {
@@ -128,7 +128,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it('returns a request body containing the feeRecords and totalReportedPayments when the includeFeeRecords query is set to true', async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-report-reconciliation-details-by-id.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-report-reconciliation-details-by-id.api-test.ts
@@ -67,7 +67,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(99999));
 
     // Assert
-    expect(response.status).toBe(404);
+    expect(response.status).toEqual(404);
   });
 
   it('returns a 404 when a bank can not be found with the same id as the bankId in the report', async () => {
@@ -85,7 +85,7 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(getUrl(reportIdWithNoMatchingBank));
 
     // Assert
-    expect(response.status).toBe(404);
+    expect(response.status).toEqual(404);
   });
 
   it('gets a utilisation report', async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
@@ -48,7 +48,7 @@ describe(`GET ${BASE_URL}`, () => {
     // Assert
     expect(response.status).toEqual(200);
     expect(response.body).toHaveLength(1);
-    expect(response.body[0].submissionMonth).toBe(submissionMonth);
+    expect(response.body[0].submissionMonth).toEqual(submissionMonth);
     expect(response.body[0].items).toHaveLength(0);
   });
 
@@ -84,12 +84,12 @@ describe(`GET ${BASE_URL}`, () => {
     const response: CustomResponse = await testApi.get(`/v1/utilisation-reports/reconciliation-summary/${submissionMonth}`);
 
     // Assert
-    expect(response.status).toBe(200);
+    expect(response.status).toEqual(200);
     expect(response.body).toHaveLength(1);
-    expect(response.body[0].submissionMonth).toBe(submissionMonth);
+    expect(response.body[0].submissionMonth).toEqual(submissionMonth);
     expect(response.body[0].items).toHaveLength(1);
-    expect(response.body[0].items[0].totalFeesReported).toBe(feeRecords.length);
-    expect(response.body[0].items[0].reportedFeesLeftToReconcile).toBe(feeRecords.length);
+    expect(response.body[0].items[0].totalFeesReported).toEqual(feeRecords.length);
+    expect(response.body[0].items[0].reportedFeesLeftToReconcile).toEqual(feeRecords.length);
   });
 });
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/patch-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/patch-payment.api-test.ts
@@ -77,7 +77,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const response = await testApi.patch(aPatchPaymentRequestBody()).to(getUrl(reportId, paymentId + 1));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 404 when the payment with the supplied id exists but it is not attached to a report with the supplied id', async () => {
@@ -90,7 +90,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const response = await testApi.patch(aPatchPaymentRequestBody()).to(getUrl(reportId, differentPaymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it.each(difference(Object.values(UTILISATION_REPORT_RECONCILIATION_STATUS), [UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS]))(
@@ -108,7 +108,7 @@ describe(`PATCH ${BASE_URL}`, () => {
       const response = await testApi.patch(aPatchPaymentRequestBody()).to(getUrl(reportId, paymentId));
 
       // Assert
-      expect(response.status).toBe(HttpStatusCode.BadRequest);
+      expect(response.status).toEqual(HttpStatusCode.BadRequest);
     },
   );
 
@@ -117,7 +117,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const response = await testApi.patch(aPatchPaymentRequestBody()).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it('updates the payment, fee records and report with the fields supplied in the payload', async () => {
@@ -141,31 +141,31 @@ describe(`PATCH ${BASE_URL}`, () => {
     const response = await testApi.patch(requestBody).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
 
     const paymentEntity = (await SqlDbHelper.manager.findOneBy(PaymentEntity, { id: paymentId }))!;
 
-    expect(paymentEntity.amount).toBe(paymentAmount);
+    expect(paymentEntity.amount).toEqual(paymentAmount);
     expect(paymentEntity.dateReceived).toEqual(datePaymentReceived);
-    expect(paymentEntity.reference).toBe(paymentReference);
+    expect(paymentEntity.reference).toEqual(paymentReference);
 
-    expect(paymentEntity.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(paymentEntity.lastUpdatedByTfmUserId).toEqual(tfmUserId);
     expect(paymentEntity.lastUpdatedByPortalUserId).toBeNull();
-    expect(paymentEntity.lastUpdatedByIsSystemUser).toBe(false);
+    expect(paymentEntity.lastUpdatedByIsSystemUser).toEqual(false);
 
     const reportEntity = (await SqlDbHelper.manager.findOneBy(UtilisationReportEntity, { id: reportId }))!;
 
-    expect(reportEntity.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(reportEntity.lastUpdatedByTfmUserId).toEqual(tfmUserId);
     expect(reportEntity.lastUpdatedByPortalUserId).toBeNull();
-    expect(reportEntity.lastUpdatedByIsSystemUser).toBe(false);
+    expect(reportEntity.lastUpdatedByIsSystemUser).toEqual(false);
 
     const feeRecordEntities = await SqlDbHelper.manager.findBy(FeeRecordEntity, { id: In([1, 2]) });
 
     expect(feeRecordEntities).toHaveLength(2);
     feeRecordEntities.forEach((feeRecord) => {
-      expect(feeRecord.lastUpdatedByTfmUserId).toBe(tfmUserId);
+      expect(feeRecord.lastUpdatedByTfmUserId).toEqual(tfmUserId);
       expect(feeRecord.lastUpdatedByPortalUserId).toBeNull();
-      expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
+      expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
     });
   });
 
@@ -207,7 +207,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const newFeeRecords = await SqlDbHelper.manager.findBy(FeeRecordEntity, { id: In([1, 2]) });
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
 
     expect(oldFeeRecords).toHaveLength(feeRecords.length);
     oldFeeRecords.forEach((feeRecord) => {
@@ -258,7 +258,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const newFeeRecords = await SqlDbHelper.manager.findBy(FeeRecordEntity, { id: In([1, 2]) });
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
 
     expect(oldFeeRecords).toHaveLength(feeRecords.length);
     oldFeeRecords.forEach((feeRecord) => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-add-fees-to-an-existing-payment-group.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-add-fees-to-an-existing-payment-group.api-test.ts
@@ -70,7 +70,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(aPostAddFeesToAnExistingPaymentGroupRequestBody()).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it("returns a 400 when the 'feeRecordIds' list is empty", async () => {
@@ -84,7 +84,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'paymentIds' list is empty", async () => {
@@ -98,7 +98,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'user' object is an empty object", async () => {
@@ -111,7 +111,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('returns a 404 when no payments with the supplied ids can be found', async () => {
@@ -125,6 +125,6 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-payment.api-test.ts
@@ -107,7 +107,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it("returns a 400 when the 'feeRecordIds' array is empty", async () => {
@@ -121,7 +121,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'user' object is an empty object", async () => {
@@ -135,7 +135,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it.each(Object.values(CURRENCY))("returns a 200 when 'paymentCurrency' is '%s'", async (currency) => {
@@ -157,7 +157,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it("returns a 400 when the 'paymentCurrency' is not a valid currency", async () => {
@@ -171,7 +171,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'feeRecordIds' array is empty", async () => {
@@ -185,7 +185,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'paymentAmount' is less than zero", async () => {
@@ -199,7 +199,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'paymentAmount' is less than zero", async () => {
@@ -213,7 +213,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'datePaymentReceived' cannot be coerced to a 'Date' object", async () => {
@@ -227,7 +227,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 200 when the 'paymentReference' is undefined", async () => {
@@ -241,7 +241,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it('returns a 400 when the new payment currency does not match the existing fee record currency', async () => {
@@ -263,7 +263,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBodyWithEURPaymentCurrency).to(getUrl(reportId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('adds a new payment to the fee record when the fee record already has payments', async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-remove-fees-from-payment-group.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-remove-fees-from-payment-group.api-test.ts
@@ -73,7 +73,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(aRemoveFeesFromPaymentGroupRequestBody()).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.Ok);
+    expect(response.status).toEqual(HttpStatusCode.Ok);
   });
 
   it('returns a 400 when all selectable fee records are selected', async () => {
@@ -85,7 +85,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(paymentRequestBody).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it("returns a 400 when the 'user' object is an empty object", async () => {
@@ -98,7 +98,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(requestBody).to(getUrl(reportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('returns a 404 when the report with the supplied id cannot be found', async () => {
@@ -109,7 +109,7 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(aRemoveFeesFromPaymentGroupRequestBody()).to(getUrl(invalidReportId, paymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('returns a 404 when the payment with the id cannot be found', async () => {
@@ -120,6 +120,6 @@ describe(`POST ${BASE_URL}`, () => {
     const response = await testApi.post(aRemoveFeesFromPaymentGroupRequestBody()).to(getUrl(reportId, invalidPaymentId));
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.NotFound);
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
   });
 });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-validate-utilisation-report-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-validate-utilisation-report-data.api-test.ts
@@ -24,7 +24,7 @@ describe(`POST ${URL}`, () => {
     const response = await testApi.post(requestBody).to(URL);
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it(`returns a ${HttpStatusCode.BadRequest} when the 'reportData' items are not csv rows`, async () => {
@@ -37,7 +37,7 @@ describe(`POST ${URL}`, () => {
     const response = await testApi.post(requestBody).to(URL);
 
     // Assert
-    expect(response.status).toBe(HttpStatusCode.BadRequest);
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   describe('when the request body is valid', () => {
@@ -51,7 +51,7 @@ describe(`POST ${URL}`, () => {
       const response = await testApi.post(requestBody).to(URL);
 
       // Assert
-      expect(response.status).toBe(HttpStatusCode.Ok);
+      expect(response.status).toEqual(HttpStatusCode.Ok);
     });
 
     describe('and when the UKEF facility ID is an 8 to 10 digit string', () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/put-utilisation-report-status.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/put-utilisation-report-status.api-test.ts
@@ -35,7 +35,7 @@ describe(`PUT ${BASE_URL}`, () => {
     const { status } = await testApi.put(requestBody).to(BASE_URL);
 
     // Assert
-    expect(status).toBe(404);
+    expect(status).toEqual(404);
   });
 
   it("returns a 400 error if a request body item is missing the 'reportId' property", async () => {
@@ -54,7 +54,7 @@ describe(`PUT ${BASE_URL}`, () => {
     const { status } = await testApi.put(requestBody).to(BASE_URL);
 
     // Assert
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
   });
 
   it("returns a 400 error if a request body item is missing the 'status' property", async () => {
@@ -73,7 +73,7 @@ describe(`PUT ${BASE_URL}`, () => {
     const { status } = await testApi.put(requestBody).to(BASE_URL);
 
     // Assert
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
   });
 
   it('returns a 200 if the request body is valid', async () => {
@@ -92,6 +92,6 @@ describe(`PUT ${BASE_URL}`, () => {
     const { status } = await testApi.put(requestBody).to(BASE_URL);
 
     // Assert
-    expect(status).toBe(200);
+    expect(status).toEqual(200);
   });
 });

--- a/dtfs-central-api/src/errors/invalid-environment-variable.error.test.ts
+++ b/dtfs-central-api/src/errors/invalid-environment-variable.error.test.ts
@@ -7,7 +7,7 @@ describe('InvalidEnvironmentVariableError', () => {
   it('exposes the message it was created with', () => {
     const exception = new InvalidEnvironmentVariableError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the 500 (Internal Server Error) status code', () => {
@@ -15,12 +15,12 @@ describe('InvalidEnvironmentVariableError', () => {
     const error = new InvalidEnvironmentVariableError(message);
 
     // Assert
-    expect(error.status).toBe(HttpStatusCode.InternalServerError);
+    expect(error.status).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidEnvironmentVariableError(message);
 
-    expect(exception.name).toBe('InvalidEnvironmentVariableError');
+    expect(exception.name).toEqual('InvalidEnvironmentVariableError');
   });
 });

--- a/dtfs-central-api/src/errors/invalid-payload.test.ts
+++ b/dtfs-central-api/src/errors/invalid-payload.test.ts
@@ -21,7 +21,7 @@ describe('InvalidPayloadError', () => {
     const error = new InvalidPayloadError(message);
 
     // Assert
-    expect(error.status).toBe(HttpStatusCode.BadRequest);
+    expect(error.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('exposes the name of the exception', () => {

--- a/dtfs-central-api/src/errors/invalid-state-machine-transition.error.test.ts
+++ b/dtfs-central-api/src/errors/invalid-state-machine-transition.error.test.ts
@@ -12,7 +12,7 @@ describe('InvalidStateMachineTransitionError', () => {
     const error = InvalidStateMachineTransitionError.forUninitialisedEntity(uninitialisedEntityParams);
 
     // Assert
-    expect(error.message).toBe("Event type 'DELETE_ENTITY' is invalid for uninitialised 'SomeEntity'");
+    expect(error.message).toEqual("Event type 'DELETE_ENTITY' is invalid for uninitialised 'SomeEntity'");
   });
 
   it('exposes a message when entity params are provided', () => {
@@ -27,7 +27,7 @@ describe('InvalidStateMachineTransitionError', () => {
     const error = InvalidStateMachineTransitionError.forEntity(entityParams);
 
     // Assert
-    expect(error.message).toBe("Event type 'DELETE_ENTITY' is invalid for 'SomeEntity' (ID: '123') in state 'COMPLETED'");
+    expect(error.message).toEqual("Event type 'DELETE_ENTITY' is invalid for 'SomeEntity' (ID: '123') in state 'COMPLETED'");
   });
 
   it('exposes the 400 (Bad Request) status code', () => {
@@ -35,7 +35,7 @@ describe('InvalidStateMachineTransitionError', () => {
     const error = InvalidStateMachineTransitionError.forUninitialisedEntity(uninitialisedEntityParams);
 
     // Assert
-    expect(error.status).toBe(HttpStatusCode.BadRequest);
+    expect(error.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('exposes the name of the error', () => {
@@ -43,6 +43,6 @@ describe('InvalidStateMachineTransitionError', () => {
     const error = InvalidStateMachineTransitionError.forUninitialisedEntity(uninitialisedEntityParams);
 
     // Assert
-    expect(error.name).toBe('InvalidStateMachineTransitionError');
+    expect(error.name).toEqual('InvalidStateMachineTransitionError');
   });
 });

--- a/dtfs-central-api/src/errors/not-found.error.test.ts
+++ b/dtfs-central-api/src/errors/not-found.error.test.ts
@@ -21,7 +21,7 @@ describe('NotFoundError', () => {
     const error = new NotFoundError(message);
 
     // Assert
-    expect(error.status).toBe(HttpStatusCode.NotFound);
+    expect(error.status).toEqual(HttpStatusCode.NotFound);
   });
 
   it('exposes the name of the exception', () => {

--- a/dtfs-central-api/src/errors/not-implemented.error.test.ts
+++ b/dtfs-central-api/src/errors/not-implemented.error.test.ts
@@ -7,7 +7,7 @@ describe('NotImplementedError', () => {
     const error = new NotImplementedError();
 
     // Assert
-    expect(error.status).toBe(HttpStatusCode.NotImplemented);
+    expect(error.status).toEqual(HttpStatusCode.NotImplemented);
   });
 
   it('exposes the name of the error', () => {
@@ -15,6 +15,6 @@ describe('NotImplementedError', () => {
     const error = new NotImplementedError();
 
     // Assert
-    expect(error.name).toBe('NotImplementedError');
+    expect(error.name).toEqual('NotImplementedError');
   });
 });

--- a/dtfs-central-api/src/helpers/calculate-total-currency-and-amount.test.ts
+++ b/dtfs-central-api/src/helpers/calculate-total-currency-and-amount.test.ts
@@ -31,7 +31,7 @@ describe('calculateTotalCurrencyAndAmount', () => {
     const totalCurrencyAndAmount = calculateTotalCurrencyAndAmount(currencyAndAmountList);
 
     // Assert
-    expect(totalCurrencyAndAmount.currency).toBe('JPY');
+    expect(totalCurrencyAndAmount.currency).toEqual('JPY');
   });
 
   it('returns an object with the sum total of the supplied list amount as the amount', () => {
@@ -46,6 +46,6 @@ describe('calculateTotalCurrencyAndAmount', () => {
     const totalCurrencyAndAmount = calculateTotalCurrencyAndAmount(currencyAndAmountList);
 
     // Assert
-    expect(totalCurrencyAndAmount.amount).toBe(350);
+    expect(totalCurrencyAndAmount.amount).toEqual(350);
   });
 });

--- a/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.test.ts
+++ b/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.test.ts
@@ -33,7 +33,7 @@ describe('fee-record-helpers', () => {
       });
 
       // Assert
-      expect(feeRecordEntity instanceof FeeRecordEntity).toBe(true);
+      expect(feeRecordEntity instanceof FeeRecordEntity).toEqual(true);
       expect(feeRecordEntity).toEqual(
         expect.objectContaining<Partial<FeeRecordEntity>>({
           facilityId: rawCsvData['ukef facility id'],
@@ -64,7 +64,7 @@ describe('fee-record-helpers', () => {
       });
 
       // Assert
-      expect(feeRecordEntity instanceof FeeRecordEntity).toBe(true);
+      expect(feeRecordEntity instanceof FeeRecordEntity).toEqual(true);
       expect(feeRecordEntity.status).toEqual<FeeRecordStatus>('TO_DO');
     });
 
@@ -77,7 +77,7 @@ describe('fee-record-helpers', () => {
       });
 
       // Assert
-      expect(feeRecordEntity instanceof FeeRecordEntity).toBe(true);
+      expect(feeRecordEntity instanceof FeeRecordEntity).toEqual(true);
       expect(feeRecordEntity.status).toEqual<FeeRecordStatus>('MATCH');
     });
 

--- a/dtfs-central-api/src/helpers/fee-record-matching.test.ts
+++ b/dtfs-central-api/src/helpers/fee-record-matching.test.ts
@@ -106,7 +106,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         },
       );
 
@@ -130,7 +130,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(false);
+          expect(result).toEqual(false);
         },
       );
 
@@ -154,7 +154,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(false);
+          expect(result).toEqual(false);
         },
       );
 
@@ -169,7 +169,7 @@ describe('fee-record-matching', () => {
         const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
 
       it('returns false if fee record payment amount is non-zero and there are no payments', async () => {
@@ -183,7 +183,7 @@ describe('fee-record-matching', () => {
         const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
         // Assert
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
 
       describe('and when the payment currency and fees paid currency do not match', () => {
@@ -232,7 +232,7 @@ describe('fee-record-matching', () => {
             const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toEqual(expected);
           },
         );
 
@@ -263,7 +263,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         });
 
         it('returns false if fee record payment amount is zero after conversion to payment currency and there are no payments', async () => {
@@ -293,7 +293,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(false);
+          expect(result).toEqual(false);
         });
       });
     });
@@ -320,7 +320,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         },
       );
 
@@ -345,7 +345,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         },
       );
 
@@ -370,7 +370,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(false);
+          expect(result).toEqual(false);
         },
       );
 
@@ -395,7 +395,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(false);
+          expect(result).toEqual(false);
         },
       );
 
@@ -420,7 +420,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         },
       );
 
@@ -445,7 +445,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         },
       );
 
@@ -461,7 +461,7 @@ describe('fee-record-matching', () => {
         const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
 
       it('returns false if fee record payment amount exceeds the tolerance and there are no payments', async () => {
@@ -476,7 +476,7 @@ describe('fee-record-matching', () => {
         const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
         // Assert
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
 
       describe('and when the payment currency and fees paid to ukef currency do not match', () => {
@@ -508,7 +508,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(true);
+          expect(result).toEqual(true);
         });
 
         it('returns false if fee record payment amount exceeds the tolerance after conversion to payment currency and there are no payments', async () => {
@@ -539,7 +539,7 @@ describe('fee-record-matching', () => {
           const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
           // Assert
-          expect(result).toBe(false);
+          expect(result).toEqual(false);
         });
 
         it.each`
@@ -590,7 +590,7 @@ describe('fee-record-matching', () => {
             const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toEqual(expected);
           },
         );
 
@@ -642,7 +642,7 @@ describe('fee-record-matching', () => {
             const result = await feeRecordsAndPaymentsMatch(feeRecords, payments, mockEntityManager);
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toEqual(expected);
           },
         );
       });

--- a/dtfs-central-api/src/helpers/isNumber.test.ts
+++ b/dtfs-central-api/src/helpers/isNumber.test.ts
@@ -2,46 +2,46 @@ import { isNumber } from './isNumber';
 
 describe('isNumber', () => {
   it('should correctly identify a single digit number', () => {
-    expect(isNumber(5)).toBe(true);
+    expect(isNumber(5)).toEqual(true);
   });
 
   it('should correctly identify a single digit number as a string', () => {
-    expect(isNumber('5')).toBe(true);
+    expect(isNumber('5')).toEqual(true);
   });
 
   it('should correctly identify a multi-digit number', () => {
-    expect(isNumber(201, 3)).toBe(true);
+    expect(isNumber(201, 3)).toEqual(true);
   });
 
   it('should correctly identify a number with the default number of digits', () => {
-    expect(isNumber(7)).toBe(true);
+    expect(isNumber(7)).toEqual(true);
   });
 
   it('should correctly identify a number with more digits than specified', () => {
-    expect(isNumber(1234, 3)).toBe(false);
+    expect(isNumber(1234, 3)).toEqual(false);
   });
 
   it('should correctly identify a number with fewer digits than specified', () => {
-    expect(isNumber(5, 2)).toBe(false);
+    expect(isNumber(5, 2)).toEqual(false);
   });
 
   it('should correctly identify a number with fewer digits than specified', () => {
-    expect(isNumber(5.3, 1)).toBe(false);
+    expect(isNumber(5.3, 1)).toEqual(false);
   });
 
   it('should correctly identify a non-numeric value', () => {
-    expect(isNumber('abc')).toBe(false);
+    expect(isNumber('abc')).toEqual(false);
   });
 
   it('should correctly identify a non-numeric value', () => {
-    expect(isNumber(null)).toBe(false);
+    expect(isNumber(null)).toEqual(false);
   });
 
   it('should correctly identify a non-numeric value', () => {
-    expect(isNumber([])).toBe(false);
+    expect(isNumber([])).toEqual(false);
   });
 
   it('should correctly identify a non-numeric value', () => {
-    expect(isNumber({})).toBe(false);
+    expect(isNumber({})).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/mapping/fee-record-mapper.test.ts
+++ b/dtfs-central-api/src/mapping/fee-record-mapper.test.ts
@@ -94,7 +94,7 @@ describe('fee record mapper', () => {
       const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
       // Assert
-      expect(feeRecord.id).toBe(10);
+      expect(feeRecord.id).toEqual(10);
     });
 
     it('maps the fee record entity facility id to the fee record facilityId', () => {
@@ -105,7 +105,7 @@ describe('fee record mapper', () => {
       const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
       // Assert
-      expect(feeRecord.facilityId).toBe('27182818');
+      expect(feeRecord.facilityId).toEqual('27182818');
     });
 
     it('maps the fee record entity exporter to the fee record exporter', () => {
@@ -116,7 +116,7 @@ describe('fee record mapper', () => {
       const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
       // Assert
-      expect(feeRecord.exporter).toBe('Test exporter');
+      expect(feeRecord.exporter).toEqual('Test exporter');
     });
 
     it('maps the fee record entity fees paid currency to the fee record reported fees currency', () => {
@@ -127,7 +127,7 @@ describe('fee record mapper', () => {
       const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
       // Assert
-      expect(feeRecord.reportedFees.currency).toBe('EUR');
+      expect(feeRecord.reportedFees.currency).toEqual('EUR');
     });
 
     it('maps the fee record entity fees paid to the fee record reported fees amount', () => {
@@ -138,7 +138,7 @@ describe('fee record mapper', () => {
       const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
       // Assert
-      expect(feeRecord.reportedFees.amount).toBe(314.59);
+      expect(feeRecord.reportedFees.amount).toEqual(314.59);
     });
 
     describe('when the fee record entity payment currency matches the fees paid currency', () => {
@@ -155,7 +155,7 @@ describe('fee record mapper', () => {
         const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
         // Assert
-        expect(feeRecord.reportedPayments.currency).toBe('EUR');
+        expect(feeRecord.reportedPayments.currency).toEqual('EUR');
       });
 
       it('maps the fee record entity fees paid to the fee record reported payment amount', () => {
@@ -170,7 +170,7 @@ describe('fee record mapper', () => {
         const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
         // Assert
-        expect(feeRecord.reportedPayments.amount).toBe(314.59);
+        expect(feeRecord.reportedPayments.amount).toEqual(314.59);
       });
     });
 
@@ -196,7 +196,7 @@ describe('fee record mapper', () => {
         const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
         // Assert
-        expect(feeRecord.reportedPayments.currency).toBe(paymentCurrency);
+        expect(feeRecord.reportedPayments.currency).toEqual(paymentCurrency);
       });
 
       it('maps the fee record entity fees paid to the fee record reported payment amount in the payment currency', () => {
@@ -212,7 +212,7 @@ describe('fee record mapper', () => {
         const feeRecord = mapFeeRecordEntityToFeeRecord(feeRecordEntity);
 
         // Assert
-        expect(feeRecord.reportedPayments.amount).toBe(feesPaidInPaymentCurrencyAmount);
+        expect(feeRecord.reportedPayments.amount).toEqual(feesPaidInPaymentCurrencyAmount);
       });
     });
   });

--- a/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
+++ b/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
@@ -51,9 +51,9 @@ describe('keying sheet mapping', () => {
       const keyingSheetRow = mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments(feeRecordEntity);
 
       // Assert
-      expect(keyingSheetRow.feeRecordId).toBe(123);
-      expect(keyingSheetRow.facilityId).toBe('12345678');
-      expect(keyingSheetRow.exporter).toBe('Test exporter');
+      expect(keyingSheetRow.feeRecordId).toEqual(123);
+      expect(keyingSheetRow.facilityId).toEqual('12345678');
+      expect(keyingSheetRow.exporter).toEqual('Test exporter');
       expect(keyingSheetRow.baseCurrency).toBe<Currency>('EUR');
     });
 
@@ -120,7 +120,7 @@ describe('keying sheet mapping', () => {
 
       // Assert
       expect(feePayment.currency).toBe<Currency>('GBP');
-      expect(feePayment.amount).toBe(123.45);
+      expect(feePayment.amount).toEqual(123.45);
       expect(feePayment.dateReceived).toEqual(new Date('2024-05-06'));
     });
   });

--- a/dtfs-central-api/src/mapping/payment-mapper.test.ts
+++ b/dtfs-central-api/src/mapping/payment-mapper.test.ts
@@ -13,7 +13,7 @@ describe('payment mapper', () => {
       const payment = mapPaymentEntityToPayment(paymentEntity);
 
       // Assert
-      expect(payment.currency).toBe(paymentCurrency);
+      expect(payment.currency).toEqual(paymentCurrency);
     });
 
     it('maps the payment entity amount to the payment amount', () => {
@@ -26,7 +26,7 @@ describe('payment mapper', () => {
       const payment = mapPaymentEntityToPayment(paymentEntity);
 
       // Assert
-      expect(payment.amount).toBe(paymentAmount);
+      expect(payment.amount).toEqual(paymentAmount);
     });
 
     it('maps the payment entity id to the payment id', () => {
@@ -39,7 +39,7 @@ describe('payment mapper', () => {
       const payment = mapPaymentEntityToPayment(paymentEntity);
 
       // Assert
-      expect(payment.id).toBe(paymentId);
+      expect(payment.id).toEqual(paymentId);
     });
 
     it('maps the payment entity dateReceived to the payment dateReceived', () => {
@@ -65,7 +65,7 @@ describe('payment mapper', () => {
       const payment = mapPaymentEntityToPayment(paymentEntity);
 
       // Assert
-      expect(payment.reference).toBe(reference);
+      expect(payment.reference).toEqual(reference);
     });
 
     it('maps the payment entity reference to the payment reference when the reference is not defined', () => {

--- a/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.deleteOne.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.deleteOne.test.ts
@@ -87,7 +87,7 @@ describe('tfm-deals-cancellation-repo', () => {
       const result = await TfmDealCancellationRepo.deleteOneDealCancellation(dealId, auditDetails);
 
       // Assert
-      expect(result).toBe(mockUpdateResult);
+      expect(result).toEqual(mockUpdateResult);
     });
   });
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -65,7 +65,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.fixedFeeAdjustment).toBe(999.99);
+      expect(feeRecord.fixedFeeAdjustment).toEqual(999.99);
       expect(calculateFixedFeeAdjustment).toHaveBeenCalledWith(feeRecord, feeRecord.facilityUtilisationData, reportPeriod);
     });
 
@@ -87,7 +87,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.principalBalanceAdjustment).toBe(200);
+      expect(feeRecord.principalBalanceAdjustment).toEqual(200);
       expect(calculatePrincipalBalanceAdjustment).toHaveBeenCalledWith(feeRecord, facilityUtilisationData);
     });
 
@@ -125,7 +125,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.READY_TO_KEY);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.READY_TO_KEY);
     });
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fixed fee adjustment is greater than zero`, async () => {
@@ -143,7 +143,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.READY_TO_KEY);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.READY_TO_KEY);
     });
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fixed fee adjustment is less than zero`, async () => {
@@ -161,7 +161,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.READY_TO_KEY);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.READY_TO_KEY);
     });
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the principal balance adjustment is greater than zero`, async () => {
@@ -179,7 +179,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.READY_TO_KEY);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.READY_TO_KEY);
     });
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the principal balance adjustment is less than zero`, async () => {
@@ -197,7 +197,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.READY_TO_KEY);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.READY_TO_KEY);
     });
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.RECONCILED}' if the principal balance adjustment, fixed fee adjustment and fees paid to ukef for the period are all zero`, async () => {
@@ -215,7 +215,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.RECONCILED);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.RECONCILED);
     });
 
     it("sets the fee record 'lastUpdatedByIsSystemUser' field to false", async () => {
@@ -231,7 +231,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
+      expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
     });
 
     it("sets the fee record 'lastUpdatedByPortalUserId' to null", async () => {
@@ -263,7 +263,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+      expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
     });
 
     it('updates the facility utilisation data entity attached to the fee record', async () => {
@@ -363,7 +363,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.READY_TO_KEY);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.READY_TO_KEY);
     });
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.RECONCILED}' if fees paid to ukef is equal to zero`, async () => {
@@ -379,7 +379,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(FEE_RECORD_STATUS.RECONCILED);
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.RECONCILED);
     });
 
     it("sets the fee record 'lastUpdatedByIsSystemUser' field to false", async () => {
@@ -395,7 +395,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
+      expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
     });
 
     it("sets the fee record 'lastUpdatedByPortalUserId' to null", async () => {
@@ -427,7 +427,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+      expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
     });
 
     it('does not update the facility utilisation data entity attached to the fee record', async () => {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.test.ts
@@ -77,7 +77,7 @@ describe('calculateFixedFeeAdjustment', () => {
       const result = await calculateFixedFeeAdjustment(feeRecord, facilityUtilisationData, reportPeriod);
 
       // Assert
-      expect(result).toBe(expected);
+      expect(result).toEqual(expected);
     },
   );
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee.test.ts
@@ -40,7 +40,7 @@ describe('calculateFixedFeeAdjustment', () => {
       });
 
       // Assert
-      expect(result).toBe(4536.99); // 100000 * (5 / 100) * 0.9 * 368 / 365 = 4,536.98630... = 4,536.99 (ROUNDED)
+      expect(result).toEqual(4536.99); // 100000 * (5 / 100) * 0.9 * 368 / 365 = 4,536.98630... = 4,536.99 (ROUNDED)
     });
   });
 
@@ -68,7 +68,7 @@ describe('calculateFixedFeeAdjustment', () => {
       });
 
       // Assert
-      expect(result).toBe(5326.03); // 100000 * (5 / 100) * 0.9 * 432 / 365 = 5,326.02739... = 5,326.03 (ROUNDED)
+      expect(result).toEqual(5326.03); // 100000 * (5 / 100) * 0.9 * 432 / 365 = 5,326.02739... = 5,326.03 (ROUNDED)
     });
   });
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.test.ts
@@ -35,7 +35,7 @@ describe('calculatePrincipalBalanceAdjustment', () => {
       const result = calculatePrincipalBalanceAdjustment(feeRecord, facilityUtilisationData);
 
       // Assert
-      expect(result).toBe(expectedDifference);
+      expect(result).toEqual(expectedDifference);
     },
   );
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
@@ -52,11 +52,11 @@ describe('updateFacilityUtilisationData', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, facilityUtilisationDataEntity);
-    expect(facilityUtilisationDataEntity.utilisation).toBe(9876543.21);
+    expect(facilityUtilisationDataEntity.utilisation).toEqual(9876543.21);
     expect(facilityUtilisationDataEntity.reportPeriod).toEqual(reportPeriod);
-    expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toBe('abc123');
+    expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toEqual('abc123');
     expect(facilityUtilisationDataEntity.lastUpdatedByPortalUserId).toBeNull();
-    expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toBe(false);
+    expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toEqual(false);
   });
 
   it('calculates the fixed fee using the supplied facility utilisation data id and utilisation and the supplied report period and updates the facility utilisation data fixed fee', async () => {
@@ -86,6 +86,6 @@ describe('updateFacilityUtilisationData', () => {
     });
 
     // Assert
-    expect(facilityUtilisationDataEntity.fixedFee).toBe(76543.21);
+    expect(facilityUtilisationDataEntity.fixedFee).toEqual(76543.21);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.test.ts
@@ -28,7 +28,7 @@ describe('handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(expectedStatus);
+      expect(feeRecord.status).toEqual(expectedStatus);
     },
   );
 
@@ -53,8 +53,8 @@ describe('handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
-    expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+    expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
+    expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
     expect(feeRecord.lastUpdatedByPortalUserId).toBeNull();
   });
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.test.ts
@@ -28,7 +28,7 @@ describe('handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(expectedStatus);
+      expect(feeRecord.status).toEqual(expectedStatus);
     },
   );
 
@@ -53,8 +53,8 @@ describe('handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
-    expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+    expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
+    expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
     expect(feeRecord.lastUpdatedByPortalUserId).toBeNull();
   });
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.test.ts
@@ -48,7 +48,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(expectedStatus);
+      expect(feeRecord.status).toEqual(expectedStatus);
     },
   );
 
@@ -64,7 +64,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
+    expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
   });
 
   it("sets the fee record 'lastUpdatedByPortalUserId' to null", async () => {
@@ -94,6 +94,6 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+    expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
@@ -24,7 +24,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toBe('MATCH');
+    expect(feeRecord.status).toEqual('MATCH');
   });
 
   it("sets the fee record status to 'DOES_NOT_MATCH' when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is true", async () => {
@@ -40,7 +40,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toBe('DOES_NOT_MATCH');
+    expect(feeRecord.status).toEqual('DOES_NOT_MATCH');
   });
 
   it("sets the fee record status to 'TO_DO' when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is false", async () => {
@@ -56,7 +56,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toBe('TO_DO');
+    expect(feeRecord.status).toEqual('TO_DO');
   });
 
   it("throws an error when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is false", async () => {
@@ -95,8 +95,8 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
-    expect(feeRecord.lastUpdatedByTfmUserId).toBe('123');
+    expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
+    expect(feeRecord.lastUpdatedByTfmUserId).toEqual('123');
     expect(feeRecord.lastUpdatedByPortalUserId).toBeNull();
   });
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.test.ts
@@ -48,7 +48,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
       });
 
       // Assert
-      expect(feeRecord.status).toBe(expectedStatus);
+      expect(feeRecord.status).toEqual(expectedStatus);
     },
   );
 
@@ -64,7 +64,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
+    expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
   });
 
   it("sets the fee record 'lastUpdatedByPortalUserId' to null", async () => {
@@ -94,6 +94,6 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+    expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
@@ -41,7 +41,7 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toBe('TO_DO');
+    expect(feeRecord.status).toEqual('TO_DO');
   });
 
   it('updates the last updated by fields to the request source', async () => {
@@ -64,8 +64,8 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.lastUpdatedByIsSystemUser).toBe(false);
-    expect(feeRecord.lastUpdatedByTfmUserId).toBe(userId);
+    expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
+    expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);
     expect(feeRecord.lastUpdatedByPortalUserId).toBeNull();
   });
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.test.ts
@@ -223,9 +223,9 @@ describe('handleUtilisationReportAddAPaymentEvent', () => {
     });
 
     // Assert
-    expect(reconciliationInProgressReport.lastUpdatedByIsSystemUser).toBe(false);
+    expect(reconciliationInProgressReport.lastUpdatedByIsSystemUser).toEqual(false);
     expect(reconciliationInProgressReport.lastUpdatedByPortalUserId).toBeNull();
-    expect(reconciliationInProgressReport.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(reconciliationInProgressReport.lastUpdatedByTfmUserId).toEqual(tfmUserId);
   });
 
   it(`updates the report audit fields and status if the report status is '${UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION}'`, async () => {
@@ -243,9 +243,9 @@ describe('handleUtilisationReportAddAPaymentEvent', () => {
     });
 
     // Assert
-    expect(pendingReconciliationReport.lastUpdatedByIsSystemUser).toBe(false);
+    expect(pendingReconciliationReport.lastUpdatedByIsSystemUser).toEqual(false);
     expect(pendingReconciliationReport.lastUpdatedByPortalUserId).toBeNull();
-    expect(pendingReconciliationReport.lastUpdatedByTfmUserId).toBe(tfmUserId);
-    expect(pendingReconciliationReport.status).toBe(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS);
+    expect(pendingReconciliationReport.lastUpdatedByTfmUserId).toEqual(tfmUserId);
+    expect(pendingReconciliationReport.status).toEqual(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.test.ts
@@ -75,9 +75,9 @@ describe('handleUtilisationReportAddAPaymentEvent', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(PaymentEntity, payment);
-    expect(payment.amount).toBe(newPaymentAmount);
-    expect(payment.dateReceived).toBe(newDatePaymentReceived);
-    expect(payment.reference).toBe(newPaymentReference);
+    expect(payment.amount).toEqual(newPaymentAmount);
+    expect(payment.dateReceived).toEqual(newDatePaymentReceived);
+    expect(payment.reference).toEqual(newPaymentReference);
   });
 
   it('calls the fee record state machine event handler for each fee record in the payload', async () => {
@@ -210,9 +210,9 @@ describe('handleUtilisationReportAddAPaymentEvent', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, utilisationReport);
-    expect(utilisationReport.lastUpdatedByIsSystemUser).toBe(false);
+    expect(utilisationReport.lastUpdatedByIsSystemUser).toEqual(false);
     expect(utilisationReport.lastUpdatedByPortalUserId).toBeNull();
-    expect(utilisationReport.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(utilisationReport.lastUpdatedByTfmUserId).toEqual(tfmUserId);
   });
 
   function aSetOfPayloadPaymentValues() {

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -226,9 +226,9 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, utilisationReport);
-    expect(utilisationReport.lastUpdatedByIsSystemUser).toBe(false);
+    expect(utilisationReport.lastUpdatedByIsSystemUser).toEqual(false);
     expect(utilisationReport.lastUpdatedByPortalUserId).toBeNull();
-    expect(utilisationReport.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(utilisationReport.lastUpdatedByTfmUserId).toEqual(tfmUserId);
   });
 
   it('updates and saves the report setting status to RECONCILIATION_IN_PROGRESS when the status is PENDING_RECONCILIATION', async () => {
@@ -247,8 +247,8 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
     // Assert
     expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, utilisationReport);
     expect(utilisationReport.status).toBe<UtilisationReportReconciliationStatus>('RECONCILIATION_IN_PROGRESS');
-    expect(utilisationReport.lastUpdatedByIsSystemUser).toBe(false);
+    expect(utilisationReport.lastUpdatedByIsSystemUser).toEqual(false);
     expect(utilisationReport.lastUpdatedByPortalUserId).toBeNull();
-    expect(utilisationReport.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(utilisationReport.lastUpdatedByTfmUserId).toEqual(tfmUserId);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/fee-records-match-attached-payments.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/fee-records-match-attached-payments.test.ts
@@ -43,7 +43,7 @@ describe('feeRecordsMatchAttachedPayments', () => {
 
     // Assert
     expect(feeRecordsAndPaymentsMatch).toHaveBeenCalledWith(feeRecordsWithoutTheirAttachedPayments, feeRecordOneWithPayments.payments, mockEntityManager);
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it('returns false when the payments attached to the fee records do not have the same total payments', async () => {
@@ -69,6 +69,6 @@ describe('feeRecordsMatchAttachedPayments', () => {
 
     // Assert
     expect(feeRecordsAndPaymentsMatch).toHaveBeenCalledWith(feeRecordsWithoutTheirAttachedPayments, feeRecordOneWithPayments.payments, mockEntityManager);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/get-keying-sheet-fee-payment-shares-for-fee-records.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/get-keying-sheet-fee-payment-shares-for-fee-records.test.ts
@@ -54,7 +54,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
       // Assert
       expect(result).toHaveLength(1);
-      expect(result[0].feeRecordId).toBe(feeRecordId);
+      expect(result[0].feeRecordId).toEqual(feeRecordId);
       expect(result[0]).toEqual<KeyingSheetFeePaymentShare>({ feeRecordId, paymentId, feePaymentAmount: paymentAmount });
     });
   });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.test.ts
@@ -26,9 +26,9 @@ describe('handleUtilisationReportManuallySetCompletedEvent', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, report);
-    expect(report.status).toBe(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
-    expect(report.lastUpdatedByIsSystemUser).toBe(false);
+    expect(report.status).toEqual(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
+    expect(report.lastUpdatedByIsSystemUser).toEqual(false);
     expect(report.lastUpdatedByPortalUserId).toBeNull();
-    expect(report.lastUpdatedByTfmUserId).toBe(requestSource.userId);
+    expect(report.lastUpdatedByTfmUserId).toEqual(requestSource.userId);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.test.ts
@@ -135,8 +135,8 @@ describe('handleUtilisationReportRemoveFeesFromPaymentGroupEvent', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, utilisationReport);
-    expect(utilisationReport.lastUpdatedByIsSystemUser).toBe(false);
+    expect(utilisationReport.lastUpdatedByIsSystemUser).toEqual(false);
     expect(utilisationReport.lastUpdatedByPortalUserId).toBeNull();
-    expect(utilisationReport.lastUpdatedByTfmUserId).toBe(tfmUserId);
+    expect(utilisationReport.lastUpdatedByTfmUserId).toEqual(tfmUserId);
   });
 });

--- a/dtfs-central-api/src/utils/report-period.test.ts
+++ b/dtfs-central-api/src/utils/report-period.test.ts
@@ -142,7 +142,7 @@ describe('report-period utils', () => {
       const result = isValidReportPeriod(validReportPeriod);
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
 
     const validStart = { month: 1, year: 2021 };
@@ -164,7 +164,7 @@ describe('report-period utils', () => {
       const result = isValidReportPeriod(reportPeriod);
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/bank/get-banks.controller.test.ts
+++ b/dtfs-central-api/src/v1/controllers/bank/get-banks.controller.test.ts
@@ -40,9 +40,9 @@ describe('getBanks', () => {
       await getBanks(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(res._getData()).toEqual(banks);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._isEndCalled()).toEqual(true);
       expect(findReportingYearsByBankIdSpy).not.toHaveBeenCalled();
     });
   });
@@ -81,9 +81,9 @@ describe('getBanks', () => {
       await getBanks(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(res._getData()).toEqual(banksWithReportingYears);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._isEndCalled()).toEqual(true);
       expect(findReportingYearsByBankIdSpy).not.toHaveBeenCalledWith('789');
     });
   });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.test.ts
@@ -88,7 +88,7 @@ describe('delete-payment.controller', () => {
           },
         },
       });
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     it('responds with a 404 (Not Found) error if a report with the supplied report and payment id cannot be found', async () => {
@@ -115,7 +115,7 @@ describe('delete-payment.controller', () => {
           },
         },
       });
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
       expect(res._getData()).toEqual(expect.stringContaining(`Failed to find a report with id '${reportId}' with attached payment with id '${paymentId}'`));
     });
 
@@ -134,7 +134,7 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if saving the report throws an 'ApiError'", async () => {
@@ -152,7 +152,7 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to delete payment with id ${paymentId}: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to delete payment with id ${paymentId}: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -169,7 +169,7 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -186,7 +186,7 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to delete payment with id ${paymentId}`);
+      expect(res._getData()).toEqual(`Failed to delete payment with id ${paymentId}`);
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.test.ts
@@ -25,7 +25,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
 
       // Assert
-      expect(feeRecordsToKey[0].id).toBe(id);
+      expect(feeRecordsToKey[0].id).toEqual(id);
     });
 
     it('maps the fee record facilityId to the fee record to key facilityId', () => {
@@ -37,7 +37,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
 
       // Assert
-      expect(feeRecordsToKey[0].facilityId).toBe(facilityId);
+      expect(feeRecordsToKey[0].facilityId).toEqual(facilityId);
     });
 
     it('maps the fee record exporter to the fee record to key exporter', () => {
@@ -49,7 +49,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
 
       // Assert
-      expect(feeRecordsToKey[0].exporter).toBe(exporter);
+      expect(feeRecordsToKey[0].exporter).toEqual(exporter);
     });
 
     it('maps the fee record status to the fee record to key status', () => {
@@ -61,7 +61,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
 
       // Assert
-      expect(feeRecordsToKey[0].status).toBe(status);
+      expect(feeRecordsToKey[0].status).toEqual(status);
     });
 
     it('maps the fee record fees to the fee record to key reported fees', () => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/index.test.ts
@@ -38,7 +38,7 @@ describe('get-fee-records-to-key.controller', () => {
 
       // Assert
       expect(findOneByIdWithFeeRecordsFilteredByStatusWithPaymentsSpy).toHaveBeenCalledWith(1, [FEE_RECORD_STATUS.MATCH]);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
     });
 
     it('responds with a 404 when no bank with the utilisation report bank id can be found', async () => {
@@ -58,7 +58,7 @@ describe('get-fee-records-to-key.controller', () => {
 
       // Assert
       expect(getBankNameById).toHaveBeenCalledWith(bankId);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
     });
 
     it('responds with a 200', async () => {
@@ -74,7 +74,7 @@ describe('get-fee-records-to-key.controller', () => {
       await getFeeRecordsToKey(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     it('responds with a body containing the report id', async () => {
@@ -94,7 +94,7 @@ describe('get-fee-records-to-key.controller', () => {
 
       // Assert
       const responseBody = res._getData() as GetFeeRecordsToKeyResponseBody;
-      expect(responseBody.reportId).toBe(1);
+      expect(responseBody.reportId).toEqual(1);
     });
 
     it('responds with a body containing the report session bank', async () => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-payment-details-by-id.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-payment-details-by-id.controller/index.test.ts
@@ -56,7 +56,7 @@ describe('get-payment-details-by-id.controller', () => {
       await getPaymentDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
     });
 
     it('responds with a 200', async () => {
@@ -77,7 +77,7 @@ describe('get-payment-details-by-id.controller', () => {
       await getPaymentDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     it('responds with the payment details', async () => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/index.test.ts
@@ -41,7 +41,7 @@ describe('get selected fee records details controller', () => {
     // Assert
     expect(findReportSpy).toHaveBeenCalledTimes(1);
     expect(findReportSpy).toHaveBeenCalledWith(REPORT_ID, [1, 2]);
-    expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
   });
 
   it('responds with a 400 when the requested fee records have differing payment currencies', async () => {
@@ -57,7 +57,7 @@ describe('get selected fee records details controller', () => {
     await getSelectedFeeRecordDetails(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     expect(res._getData()).toEqual(expect.stringContaining('Selected fee records must all have the same payment currency'));
   });
 
@@ -69,7 +69,7 @@ describe('get selected fee records details controller', () => {
     await getSelectedFeeRecordDetails(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     expect(res._getData()).toEqual(expect.stringContaining('No fee records selected'));
   });
 
@@ -85,7 +85,7 @@ describe('get selected fee records details controller', () => {
     await getSelectedFeeRecordDetails(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     expect(res._getData()).toEqual(expect.stringContaining('All selected fee records must belong to the requested report'));
   });
 
@@ -129,7 +129,7 @@ describe('get selected fee records details controller', () => {
     // Assert
     expect(getBankNameById).toHaveBeenCalledWith('999');
     expect(findReportSpy).toHaveBeenCalledWith(REPORT_ID, [1, 2]);
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     expect(res._getData()).toEqual<SelectedFeeRecordsDetails>({
       reportPeriod,
       totalReportedPayments: { currency: 'GBP', amount: 300 },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/filter-fee-record-payment-entity-groups.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/filter-fee-record-payment-entity-groups.test.ts
@@ -301,7 +301,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -320,7 +320,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -339,7 +339,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
   });
@@ -360,7 +360,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -379,7 +379,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
   });
@@ -403,7 +403,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -425,7 +425,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -447,7 +447,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller helpers
         const result = filterer(group);
 
         // Assert
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
   });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
@@ -107,11 +107,11 @@ describe('getKeyingSheetForReportId', () => {
 
     // Assert
     expect(keyingSheet).toHaveLength(1);
-    expect(keyingSheet[0].feeRecordId).toBe(12);
-    expect(keyingSheet[0].status).toBe(KEYING_SHEET_ROW_STATUS.TO_DO);
-    expect(keyingSheet[0].facilityId).toBe('11111111');
-    expect(keyingSheet[0].exporter).toBe('Test exporter 1');
-    expect(keyingSheet[0].baseCurrency).toBe('GBP');
+    expect(keyingSheet[0].feeRecordId).toEqual(12);
+    expect(keyingSheet[0].status).toEqual(KEYING_SHEET_ROW_STATUS.TO_DO);
+    expect(keyingSheet[0].facilityId).toEqual('11111111');
+    expect(keyingSheet[0].exporter).toEqual('Test exporter 1');
+    expect(keyingSheet[0].baseCurrency).toEqual('GBP');
     expect(keyingSheet[0].fixedFeeAdjustment).toEqual({ change: 'INCREASE', amount: 1234.56 });
     expect(keyingSheet[0].principalBalanceAdjustment).toEqual({ change: 'INCREASE', amount: 9876543.21 });
   });
@@ -201,9 +201,9 @@ describe('getKeyingSheetForReportId', () => {
     // Assert
     expect(keyingSheet).toHaveLength(1);
     expect(keyingSheet[0].feePayments).toHaveLength(3);
-    expect(keyingSheet[0].feePayments[0].amount).toBe(1000);
-    expect(keyingSheet[0].feePayments[1].amount).toBe(2000);
-    expect(keyingSheet[0].feePayments[2].amount).toBe(3000);
+    expect(keyingSheet[0].feePayments[0].amount).toEqual(1000);
+    expect(keyingSheet[0].feePayments[1].amount).toEqual(2000);
+    expect(keyingSheet[0].feePayments[2].amount).toEqual(3000);
   });
 
   it('sets the keying sheet row fee payment currency and date received to the corresponding payment value', async () => {
@@ -242,11 +242,11 @@ describe('getKeyingSheetForReportId', () => {
     // Assert
     expect(keyingSheet).toHaveLength(1);
     expect(keyingSheet[0].feePayments).toHaveLength(3);
-    expect(keyingSheet[0].feePayments[0].currency).toBe('GBP');
+    expect(keyingSheet[0].feePayments[0].currency).toEqual('GBP');
     expect(keyingSheet[0].feePayments[0].dateReceived).toEqual(new Date('2021'));
-    expect(keyingSheet[0].feePayments[1].currency).toBe('USD');
+    expect(keyingSheet[0].feePayments[1].currency).toEqual('USD');
     expect(keyingSheet[0].feePayments[1].dateReceived).toEqual(new Date('2022'));
-    expect(keyingSheet[0].feePayments[2].currency).toBe('EUR');
+    expect(keyingSheet[0].feePayments[2].currency).toEqual('EUR');
     expect(keyingSheet[0].feePayments[2].dateReceived).toEqual(new Date('2023'));
   });
 
@@ -284,8 +284,8 @@ describe('getKeyingSheetForReportId', () => {
     // Assert
     expect(keyingSheet).toHaveLength(1);
     expect(keyingSheet[0].feePayments).toHaveLength(1);
-    expect(keyingSheet[0].feePayments[0].currency).toBe('GBP');
-    expect(keyingSheet[0].feePayments[0].amount).toBe(1000);
+    expect(keyingSheet[0].feePayments[0].currency).toEqual('GBP');
+    expect(keyingSheet[0].feePayments[0].amount).toEqual(1000);
     expect(keyingSheet[0].feePayments[0].dateReceived).toEqual(new Date('2021'));
   });
 
@@ -324,8 +324,8 @@ describe('getKeyingSheetForReportId', () => {
         // Assert
         expect(keyingSheet).toHaveLength(1);
         expect(keyingSheet[0].feePayments).toHaveLength(1);
-        expect(keyingSheet[0].feePayments[0].currency).toBe('EUR');
-        expect(keyingSheet[0].feePayments[0].amount).toBe(0);
+        expect(keyingSheet[0].feePayments[0].currency).toEqual('EUR');
+        expect(keyingSheet[0].feePayments[0].amount).toEqual(0);
         expect(keyingSheet[0].feePayments[0].dateReceived).toBeNull();
       },
     );
@@ -371,7 +371,7 @@ describe('getKeyingSheetForReportId', () => {
         // Assert
         expect(keyingSheet).toHaveLength(1);
         expect(keyingSheet[0].feePayments).toHaveLength(1);
-        expect(keyingSheet[0].feePayments[0].currency).toBe('GBP');
+        expect(keyingSheet[0].feePayments[0].currency).toEqual('GBP');
         expect(keyingSheet[0].feePayments[0].dateReceived).toEqual(new Date('2021'));
       },
     );
@@ -409,9 +409,9 @@ describe('getKeyingSheetForReportId', () => {
       // Assert
       expect(keyingSheet).toHaveLength(1);
       expect(keyingSheet[0].feePayments).toHaveLength(1);
-      expect(keyingSheet[0].feePayments[0].currency).toBe('GBP');
+      expect(keyingSheet[0].feePayments[0].currency).toEqual('GBP');
       expect(keyingSheet[0].feePayments[0].dateReceived).toBeNull();
-      expect(keyingSheet[0].feePayments[0].amount).toBe(0);
+      expect(keyingSheet[0].feePayments[0].amount).toEqual(0);
     });
   });
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/parse-filters.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/parse-filters.test.ts
@@ -237,28 +237,28 @@ describe('parse-filters helper', () => {
     describe('when payment reference is less than 4 characters', () => {
       it('should return false', () => {
         const result = isPaymentReferenceBetweenFourAndFiftyCharacters('123');
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
 
     describe('when payment reference is exactly 4 characters', () => {
       it('should return true', () => {
         const result = isPaymentReferenceBetweenFourAndFiftyCharacters('1234');
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
     describe('when payment reference is between 4 and 50 characters', () => {
       it('should return true', () => {
         const result = isPaymentReferenceBetweenFourAndFiftyCharacters('This is a string with exactly 44 characters.');
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
     describe('when payment reference is exactly 50 characters', () => {
       it('should return true', () => {
         const result = isPaymentReferenceBetweenFourAndFiftyCharacters('This is a string with exactly 50 characters.......');
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -268,7 +268,7 @@ describe('parse-filters helper', () => {
 
         const result = isPaymentReferenceBetweenFourAndFiftyCharacters(paymentReference);
 
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
   });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/index.test.ts
@@ -46,7 +46,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to get utilisation report reconciliation for report with id '${reportId}': ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to get utilisation report reconciliation for report with id '${reportId}': ${errorMessage}`);
     });
 
     it('responds with a 500 if an unknown error occurs', async () => {
@@ -59,7 +59,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -72,7 +72,7 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to get utilisation report reconciliation for report with id '${reportId}'`);
+      expect(res._getData()).toEqual(`Failed to get utilisation report reconciliation for report with id '${reportId}'`);
     });
 
     it('fetches details and responds with 200 when there are no filters provided', async () => {
@@ -92,8 +92,8 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._getData()).toBe(reportDetails);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._getData()).toEqual(reportDetails);
       expect(getUtilisationReportReconciliationDetails).toHaveBeenCalledTimes(1);
       expect(getUtilisationReportReconciliationDetails).toHaveBeenCalledWith(
         utilisationReport,
@@ -124,8 +124,8 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._getData()).toBe(reportDetails);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._getData()).toEqual(reportDetails);
       expect(getUtilisationReportReconciliationDetails).toHaveBeenCalledTimes(1);
       expect(getUtilisationReportReconciliationDetails).toHaveBeenCalledWith(
         utilisationReport,

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report.controller/index.test.ts
@@ -87,7 +87,7 @@ describe('getUtilisationReport', () => {
 
       // Assert
       expect(findOneBySpy).toHaveBeenCalledWith({ id: reportId });
-      expect(res._getStatusCode()).toBe(500);
+      expect(res._getStatusCode()).toEqual(500);
       expect(errorSpy).toHaveBeenCalledWith('Failed to map data - report seems to have been uploaded but is missing some required fields');
     });
 
@@ -117,7 +117,7 @@ describe('getUtilisationReport', () => {
       expect(findOneBySpy).toHaveBeenCalledWith({ id: reportId });
       expect(getUserById).toHaveBeenCalledWith(mockUtilisationReport.uploadedByUserId);
 
-      expect(res._getStatusCode()).toBe(200);
+      expect(res._getStatusCode()).toEqual(200);
 
       expect(res._getData()).toEqual<GetUtilisationReportResponse>({
         id: reportId,
@@ -152,7 +152,7 @@ describe('getUtilisationReport', () => {
       expect(findOneBySpy).toHaveBeenCalledWith({ id: reportId });
       expect(getUserById).not.toHaveBeenCalled();
 
-      expect(res._getStatusCode()).toBe(200);
+      expect(res._getStatusCode()).toEqual(200);
 
       expect(res._getData()).toEqual<GetUtilisationReportResponse>({
         id: reportId,

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/index.test.ts
@@ -223,7 +223,7 @@ describe('getReconciliationSummary', () => {
       // Assert
       expect(findSubmittedReportsForBankIdWithReportPeriodEndInYearMock).toHaveBeenCalledWith(bankId, Number(year));
 
-      expect(res._getStatusCode()).toBe(200);
+      expect(res._getStatusCode()).toEqual(200);
       expect(res._getData()).toEqual<{
         bankName: string;
         year: string;

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports.controller/index.test.ts
@@ -231,7 +231,7 @@ describe('getUtilisationReports', () => {
         excludeNotReceived: true,
       });
 
-      expect(res._getStatusCode()).toBe(200);
+      expect(res._getStatusCode()).toEqual(200);
       expect(res._getData()).toHaveLength(1);
       expect(res._getData()).toEqual<GetUtilisationReportResponse[]>([
         {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/patch-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/patch-payment.controller/index.test.ts
@@ -67,7 +67,7 @@ describe('patch-payment.controller', () => {
 
       // Assert
       expect(paymentRepoFindSpy).toHaveBeenCalledWith(paymentId, reportId);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
     });
 
     it('responds with a 500 (Internal Server Error) when an unexpected error occurs', async () => {
@@ -80,7 +80,7 @@ describe('patch-payment.controller', () => {
       await patchPayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a 200 and updates the payment', async () => {
@@ -121,7 +121,7 @@ describe('patch-payment.controller', () => {
           },
         },
       });
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     function aPatchPaymentRequestBody(): PatchPaymentPayload {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/index.test.ts
@@ -92,7 +92,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     it("responds with a '404' if no payments are found with the supplied payment IDs", async () => {
@@ -109,7 +109,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
     });
 
     it("responds with a '400' if no fee records belong to the first payment in the payment group", async () => {
@@ -129,7 +129,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     });
 
     it("responds with a '400' if all of the supplied fee record ids already belong to the payment group.", async () => {
@@ -149,7 +149,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     });
 
     it("responds with a '400' if the fee records payment currency does not equal the payment group currency", async () => {
@@ -181,7 +181,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
       expect(res._getData()).toContain('The selected fee records payment currency does not match that of the payment group.');
     });
 
@@ -200,7 +200,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if saving the report throws an 'ApiError'", async () => {
@@ -218,7 +218,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to add fees to an existing payment group: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to add fees to an existing payment group: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -235,7 +235,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -252,7 +252,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       await postAddFeesToAnExistingPaymentGroup(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to add fees to an existing payment group');
+      expect(res._getData()).toEqual('Failed to add fees to an existing payment group');
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
@@ -64,8 +64,8 @@ describe('post-keying-data.controller', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a 500 (Internal Server Error) if the returned fee records have an undefined report', async () => {
@@ -84,8 +84,8 @@ describe('post-keying-data.controller', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a 200 and generates the keying data', async () => {
@@ -106,8 +106,8 @@ describe('post-keying-data.controller', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toEqual(true);
       expect(mockEventHandler).toHaveBeenCalledWith({
         type: 'GENERATE_KEYING_DATA',
         payload: {
@@ -132,7 +132,7 @@ describe('post-keying-data.controller', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to generate keying data: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to generate keying data: ${errorMessage}`);
     });
 
     it('responds with a 500 if an unknown error occurs', async () => {
@@ -145,7 +145,7 @@ describe('post-keying-data.controller', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -158,7 +158,7 @@ describe('post-keying-data.controller', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to generate keying data');
+      expect(res._getData()).toEqual('Failed to generate keying data');
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/index.test.ts
@@ -78,7 +78,7 @@ describe('post-payment.controller', () => {
       await postPayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     it("responds with the specific error status if saving the report throws an 'ApiError'", async () => {
@@ -96,7 +96,7 @@ describe('post-payment.controller', () => {
       await postPayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if saving the report throws an 'ApiError'", async () => {
@@ -114,7 +114,7 @@ describe('post-payment.controller', () => {
       await postPayment(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to add a new payment: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to add a new payment: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -131,7 +131,7 @@ describe('post-payment.controller', () => {
       await postPayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -148,7 +148,7 @@ describe('post-payment.controller', () => {
       await postPayment(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to add a new payment');
+      expect(res._getData()).toEqual('Failed to add a new payment');
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-remove-fees-from-payment-group.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-remove-fees-from-payment-group.controller/index.test.ts
@@ -80,7 +80,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
     });
 
     it("responds with a '400' if no matching fee records are found on the payment", async () => {
@@ -98,7 +98,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     });
 
     it("responds with a '400' if all of the payments fee records are selected", async () => {
@@ -116,7 +116,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     });
 
     it("responds with the specific error status if saving the report throws an 'ApiError'", async () => {
@@ -134,7 +134,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if saving the report throws an 'ApiError'", async () => {
@@ -152,7 +152,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to remove fees from payment with id ${paymentId}: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to remove fees from payment with id ${paymentId}: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -169,7 +169,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -186,7 +186,7 @@ describe('post-remove-fees-from-payment-group.controller', () => {
       await postRemoveFeesFromPaymentGroup(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to remove fees from payment with id ${paymentId}`);
+      expect(res._getData()).toEqual(`Failed to remove fees from payment with id ${paymentId}`);
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-report-data-validation.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-report-data-validation.controller/index.test.ts
@@ -34,7 +34,7 @@ describe('post-report-data-validation.controller', () => {
 
       // Assert
       expect(validateUtilisationReportCsvData).toHaveBeenCalledWith(reportData);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(res._getData()).toEqual({ csvValidationErrors: [{ errorMessage: 'Data invalid!' }] });
     });
 
@@ -54,7 +54,7 @@ describe('post-report-data-validation.controller', () => {
       await postReportDataValidation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if saving the report throws an 'ApiError'", async () => {
@@ -73,7 +73,7 @@ describe('post-report-data-validation.controller', () => {
       await postReportDataValidation(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to validate report data: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to validate report data: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -91,7 +91,7 @@ describe('post-report-data-validation.controller', () => {
       await postReportDataValidation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -109,7 +109,7 @@ describe('post-report-data-validation.controller', () => {
       await postReportDataValidation(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to validate report data');
+      expect(res._getData()).toEqual('Failed to validate report data');
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-upload-utilisation-report.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-upload-utilisation-report.controller/index.test.ts
@@ -71,7 +71,7 @@ describe('post-upload-utilisation-report controller', () => {
       await postUploadUtilisationReport(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
       expect(res._getData()).toEqual(`Failed to save utilisation report: ${errorMessage}`);
     });
 
@@ -90,7 +90,7 @@ describe('post-upload-utilisation-report controller', () => {
         // Assert
         expect(mockEventHandler).toHaveBeenCalled();
 
-        expect(res._getStatusCode()).toBe(HttpStatusCode.Created);
+        expect(res._getStatusCode()).toEqual(HttpStatusCode.Created);
         expect(res._getData()).toEqual({ dateUploaded: mockDate });
       });
 
@@ -105,7 +105,7 @@ describe('post-upload-utilisation-report controller', () => {
 
         // Assert
         expect(res._getData()).toEqual(expect.stringContaining('Failed to save utilisation report'));
-        expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+        expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
       });
     });
   });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-done.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-done.controller/index.test.ts
@@ -67,7 +67,7 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if marking keying data throws an 'ApiError'", async () => {
@@ -85,7 +85,7 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as DONE: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as DONE: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -102,7 +102,7 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -119,7 +119,7 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as DONE`);
+      expect(res._getData()).toEqual(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as DONE`);
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-to-do.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-to-do.controller/index.test.ts
@@ -67,7 +67,7 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
 
     it("responds with the specific error message if marking keying data throws an 'ApiError'", async () => {
@@ -85,7 +85,7 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as TO DO: ${errorMessage}`);
+      expect(res._getData()).toEqual(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as TO DO: ${errorMessage}`);
     });
 
     it(`responds with a ${HttpStatusCode.InternalServerError} if an unknown error occurs`, async () => {
@@ -102,7 +102,7 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
     });
 
     it('responds with a generic error message if an unknown error occurs', async () => {
@@ -119,7 +119,7 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getData()).toBe(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as TO DO`);
+      expect(res._getData()).toEqual(`Failed to mark keying data with fee record ids ${feeRecordId} from report with id ${reportId} as TO DO`);
     });
   });
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-utilisation-report-status.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-utilisation-report-status.controller/index.test.ts
@@ -64,7 +64,7 @@ describe('put-utilisation-report-status.controller', () => {
     await putUtilisationReportStatus(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     expect(res._getData()).toEqual("Failed to update utilisation report statuses: Request body item 'user' supplied does not match required format");
     expect(executeWithSqlTransaction).not.toHaveBeenCalled();
   });
@@ -83,7 +83,7 @@ describe('put-utilisation-report-status.controller', () => {
     await putUtilisationReportStatus(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     expect(res._getData()).toEqual(
       "Failed to update utilisation report statuses: Request body item 'reportsWithStatus' supplied does not match required format",
     );
@@ -117,14 +117,14 @@ describe('put-utilisation-report-status.controller', () => {
       await putUtilisationReportStatus(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(mockSave).toHaveBeenCalledTimes(reportsWithStatusForMarkingAsCompleted.length);
 
       existingReports.forEach((report) => {
-        expect(report.status).toBe(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
-        expect(report.lastUpdatedByIsSystemUser).toBe(false);
+        expect(report.status).toEqual(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_COMPLETED);
+        expect(report.lastUpdatedByIsSystemUser).toEqual(false);
         expect(report.lastUpdatedByPortalUserId).toBeNull();
-        expect(report.lastUpdatedByTfmUserId).toBe(userId);
+        expect(report.lastUpdatedByTfmUserId).toEqual(userId);
         expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, report);
       });
     });
@@ -149,7 +149,7 @@ describe('put-utilisation-report-status.controller', () => {
         await putUtilisationReportStatus(req, res);
 
         // Assert
-        expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+        expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
         expect(res._getData()).toEqual(
           `Failed to update utilisation report statuses: Event type 'MANUALLY_SET_COMPLETED' is invalid for 'UtilisationReportEntity' (ID: '${reportWithStatus.reportId}') in state '${reportStatus}'`,
         );
@@ -193,15 +193,15 @@ describe('put-utilisation-report-status.controller', () => {
       await putUtilisationReportStatus(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(mockSave).toHaveBeenCalledTimes(reportsWithStatusForMarkingAsNotCompleted.length);
 
       existingReports.forEach((report, index) => {
         const expectedStatus = reportsWithStatusForMarkingAsNotCompleted[index].status;
-        expect(report.status).toBe(expectedStatus);
-        expect(report.lastUpdatedByIsSystemUser).toBe(false);
+        expect(report.status).toEqual(expectedStatus);
+        expect(report.lastUpdatedByIsSystemUser).toEqual(false);
         expect(report.lastUpdatedByPortalUserId).toBeNull();
-        expect(report.lastUpdatedByTfmUserId).toBe(userId);
+        expect(report.lastUpdatedByTfmUserId).toEqual(userId);
         expect(mockSave).toHaveBeenCalledWith(UtilisationReportEntity, report);
       });
     });
@@ -226,7 +226,7 @@ describe('put-utilisation-report-status.controller', () => {
         await putUtilisationReportStatus(req, res);
 
         // Assert
-        expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+        expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
         expect(res._getData()).toEqual(
           `Failed to update utilisation report statuses: Event type 'MANUALLY_SET_INCOMPLETE' is invalid for 'UtilisationReportEntity' (ID: '${reportWithStatus.reportId}') in state '${reportStatus}'`,
         );

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/amendment-status.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/amendment-status.schema.test.ts
@@ -8,7 +8,7 @@ describe('amendment-status.schema', () => {
       const { success } = AmendmentStatusSchema.safeParse(status);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the amendment status is invalid", () => {
@@ -19,7 +19,7 @@ describe('amendment-status.schema', () => {
       const { success } = AmendmentStatusSchema.safeParse(invalidStatus);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'data' property to the parsed amendment status", () => {
@@ -30,7 +30,7 @@ describe('amendment-status.schema', () => {
       const { data } = AmendmentStatusSchema.safeParse(status);
 
       // Assert
-      expect(data).toBe(status);
+      expect(data).toEqual(status);
     });
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/audit-details.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/audit-details.schema.test.ts
@@ -13,7 +13,7 @@ describe('audit-details.schema', () => {
         const { success } = AuditDetailsSchema.safeParse(auditDetails);
 
         // Assert
-        expect(success).toBe(true);
+        expect(success).toEqual(true);
       });
 
       it("sets the 'data' property to the parsed auditDetails when the auditDetails object is valid", () => {
@@ -35,7 +35,7 @@ describe('audit-details.schema', () => {
         const { success } = AuditDetailsSchema.safeParse(auditDetails);
 
         // Assert
-        expect(success).toBe(false);
+        expect(success).toEqual(false);
       });
     });
 
@@ -50,7 +50,7 @@ describe('audit-details.schema', () => {
         const { success } = AuditDetailsSchema.safeParse(auditDetails);
 
         // Assert
-        expect(success).toBe(true);
+        expect(success).toEqual(true);
       });
 
       it("sets the 'data' property to the parsed auditDetails when the auditDetails object is valid", () => {
@@ -75,7 +75,7 @@ describe('audit-details.schema', () => {
         const { success } = AuditDetailsSchema.safeParse(auditDetails);
 
         // Assert
-        expect(success).toBe(false);
+        expect(success).toEqual(false);
       });
 
       it("sets the 'success' property to false when the auditDetails 'id' is invalid", () => {
@@ -86,7 +86,7 @@ describe('audit-details.schema', () => {
         const { success } = AuditDetailsSchema.safeParse(auditDetails);
 
         // Assert
-        expect(success).toBe(false);
+        expect(success).toEqual(false);
       });
     });
   });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/currency.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/currency.schema.test.ts
@@ -8,7 +8,7 @@ describe('currency.schema', () => {
       const { success } = CurrencySchema.safeParse(currency);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the currency is invalid", () => {
@@ -19,7 +19,7 @@ describe('currency.schema', () => {
       const { success } = CurrencySchema.safeParse(invalidCurrency);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'data' property to the parsed currency", () => {
@@ -30,7 +30,7 @@ describe('currency.schema', () => {
       const { data } = CurrencySchema.safeParse(currency);
 
       // Assert
-      expect(data).toBe(currency);
+      expect(data).toEqual(currency);
     });
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/dateFromIsoString.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/dateFromIsoString.schema.test.ts
@@ -10,7 +10,7 @@ describe('dateFromIsoString.schema', () => {
       const { success } = dateFromIsoStringSchema.safeParse(validIsoString);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the ISO string is invalid", () => {
@@ -21,7 +21,7 @@ describe('dateFromIsoString.schema', () => {
       const { success } = dateFromIsoStringSchema.safeParse(invalidIsoString);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'data' property to the parsed date", () => {

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/mongo-object-id.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/mongo-object-id.schema.test.ts
@@ -11,7 +11,7 @@ describe('mongo-object-id.schema', () => {
       const { success } = MongoObjectIdSchema.safeParse(validObjectId);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to true when the value is a valid object id object", () => {
@@ -22,7 +22,7 @@ describe('mongo-object-id.schema', () => {
       const { success } = MongoObjectIdSchema.safeParse(validObjectId);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the value is not a valid object id", () => {
@@ -33,7 +33,7 @@ describe('mongo-object-id.schema', () => {
       const { success } = MongoObjectIdSchema.safeParse(invalidObjectId);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'data' property to the string representation of the object id", () => {
@@ -44,7 +44,7 @@ describe('mongo-object-id.schema', () => {
       const { data } = MongoObjectIdSchema.safeParse(objectId);
 
       // Assert
-      expect(data).toBe(objectId.toString());
+      expect(data).toEqual(objectId.toString());
     });
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/tfm-session-user.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/tfm-session-user.schema.test.ts
@@ -14,7 +14,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'username' is not a string", () => {
@@ -26,7 +26,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to true when the user 'email' is a valid email string", () => {
@@ -38,7 +38,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'email' is a string but not an email", () => {
@@ -50,7 +50,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to false when the user 'email' is not a string", () => {
@@ -62,7 +62,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to true when the user 'timezone' is a string", () => {
@@ -74,7 +74,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'timezone' is not a string", () => {
@@ -86,7 +86,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to true when the user 'firstName' is a string", () => {
@@ -98,7 +98,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'firstName' is not a string", () => {
@@ -110,7 +110,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to true when the user 'lastName' is a string", () => {
@@ -122,7 +122,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'lastName' is not a string", () => {
@@ -134,7 +134,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to true when the user 'status' is a string", () => {
@@ -146,7 +146,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'status' is not a string", () => {
@@ -158,7 +158,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'success' property to true when the user 'lastLogin' is undefined", () => {
@@ -170,7 +170,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to true when the user 'lastLogin' is a number", () => {
@@ -182,7 +182,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the user 'lastLogin' is not a number", () => {
@@ -194,7 +194,7 @@ describe('tfm-session-user.schema', () => {
       const { success } = TfmSessionUserSchema.safeParse(user);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("sets the 'data' property to the parsed user", () => {

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/tfm-team.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/tfm-team.schema.test.ts
@@ -8,7 +8,7 @@ describe('tfm-team.schema', () => {
       const { success } = TfmTeamSchema.safeParse(team);
 
       // Assert
-      expect(success).toBe(true);
+      expect(success).toEqual(true);
     });
 
     it("sets the 'success' property to false when the team is not a valid team", () => {
@@ -19,7 +19,7 @@ describe('tfm-team.schema', () => {
       const { success } = TfmTeamSchema.safeParse(invalidTeam);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it("set the 'data' property to the parsed team", () => {
@@ -30,7 +30,7 @@ describe('tfm-team.schema', () => {
       const { data } = TfmTeamSchema.safeParse(team);
 
       // Assert
-      expect(data).toBe(team);
+      expect(data).toEqual(team);
     });
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/utilisation-report-csv-row-data.schema.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/schemas/utilisation-report-csv-row-data.schema.test.ts
@@ -16,7 +16,7 @@ describe('utilisation-report-raw-csv-cell-data-with-location.schema', () => {
       const { success } = UtilisationReportCsvRowDataSchema.safeParse(invalidRowData);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it.each`
@@ -34,7 +34,7 @@ describe('utilisation-report-raw-csv-cell-data-with-location.schema', () => {
       const { success } = UtilisationReportCsvRowDataSchema.safeParse(invalidRowData);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it.each`
@@ -51,7 +51,7 @@ describe('utilisation-report-raw-csv-cell-data-with-location.schema', () => {
       const { success } = UtilisationReportCsvRowDataSchema.safeParse(invalidRowData);
 
       // Assert
-      expect(success).toBe(false);
+      expect(success).toEqual(false);
     });
 
     it.each`
@@ -70,7 +70,7 @@ describe('utilisation-report-raw-csv-cell-data-with-location.schema', () => {
         const result = UtilisationReportCsvRowDataSchema.safeParse(validRowData);
 
         // Assert
-        expect(result.success).toBe(true);
+        expect(result.success).toEqual(true);
       },
     );
 

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-delete-deal-cancellation-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-delete-deal-cancellation-payload.test.ts
@@ -61,8 +61,8 @@ describe('validateDeleteDealCancellationPayload', () => {
     validateDeleteDealCancellationPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -78,6 +78,6 @@ describe('validateDeleteDealCancellationPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-payment-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-payment-payload.test.ts
@@ -30,8 +30,8 @@ describe('validatePatchPaymentPayload', () => {
     validatePatchPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -50,8 +50,8 @@ describe('validatePatchPaymentPayload', () => {
     validatePatchPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -75,7 +75,7 @@ describe('validatePatchPaymentPayload', () => {
     // Assert
     expect(datePaymentReceived).toEqual(new Date(dateAsString));
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 
   it(`responds with a '${HttpStatusCode.BadRequest}' if the 'datePaymentReceived' field is an invalid date string`, () => {
@@ -93,8 +93,8 @@ describe('validatePatchPaymentPayload', () => {
     validatePatchPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -114,10 +114,10 @@ describe('validatePatchPaymentPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
 
     const requestBody = req.body as PatchPaymentPayload;
-    expect('paymentReference' in requestBody).toBe(true);
+    expect('paymentReference' in requestBody).toEqual(true);
     expect(requestBody.paymentReference).toBeUndefined();
   });
 
@@ -137,9 +137,9 @@ describe('validatePatchPaymentPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
 
     const requestBody = req.body as PatchPaymentPayload;
-    expect(requestBody.paymentReference).toBe('Some payment reference');
+    expect(requestBody.paymentReference).toEqual('Some payment reference');
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-add-fees-to-an-existing-payment-group-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-add-fees-to-an-existing-payment-group-payload.test.ts
@@ -34,8 +34,8 @@ describe('validatePostAddFeesToAnExistingPaymentGroupPayload', () => {
     validatePostAddFeesToAnExistingPaymentGroupPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -54,8 +54,8 @@ describe('validatePostAddFeesToAnExistingPaymentGroupPayload', () => {
     validatePostAddFeesToAnExistingPaymentGroupPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -74,8 +74,8 @@ describe('validatePostAddFeesToAnExistingPaymentGroupPayload', () => {
     validatePostAddFeesToAnExistingPaymentGroupPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-payment-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-payment-payload.test.ts
@@ -33,8 +33,8 @@ describe('validatePostPaymentPayload', () => {
     validatePostPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -53,8 +53,8 @@ describe('validatePostPaymentPayload', () => {
     validatePostPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -73,8 +73,8 @@ describe('validatePostPaymentPayload', () => {
     validatePostPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -93,8 +93,8 @@ describe('validatePostPaymentPayload', () => {
     validatePostPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -114,7 +114,7 @@ describe('validatePostPaymentPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 
   it("coerces the 'datePaymentReceived' field to a date if it is a valid date string and calls the next function", () => {
@@ -137,7 +137,7 @@ describe('validatePostPaymentPayload', () => {
     // Assert
     expect(datePaymentReceived).toEqual(new Date(dateAsString));
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 
   it(`responds with a '${HttpStatusCode.BadRequest}' if the 'datePaymentReceived' field is an invalid date string`, () => {
@@ -155,8 +155,8 @@ describe('validatePostPaymentPayload', () => {
     validatePostPaymentPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -176,6 +176,6 @@ describe('validatePostPaymentPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-remove-fees-from-payment-group-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-remove-fees-from-payment-group-payload.test.ts
@@ -28,8 +28,8 @@ describe('validatePostRemoveFeesFromPaymentGroupPayload', () => {
     validatePostRemoveFeesFromPaymentGroupPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -48,8 +48,8 @@ describe('validatePostRemoveFeesFromPaymentGroupPayload', () => {
     validatePostRemoveFeesFromPaymentGroupPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -68,8 +68,8 @@ describe('validatePostRemoveFeesFromPaymentGroupPayload', () => {
     validatePostRemoveFeesFromPaymentGroupPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-report-data-validation-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-report-data-validation-payload.test.ts
@@ -15,8 +15,8 @@ describe('validatePostReportDataValidationPayload', () => {
     validatePostReportDataValidationPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -38,8 +38,8 @@ describe('validatePostReportDataValidationPayload', () => {
     validatePostReportDataValidationPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -54,8 +54,8 @@ describe('validatePostReportDataValidationPayload', () => {
     validatePostReportDataValidationPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -76,6 +76,6 @@ describe('validatePostReportDataValidationPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-upload-utilisation-report-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-post-upload-utilisation-report-payload.test.ts
@@ -92,7 +92,7 @@ describe('validate-post-upload-utilisation-report-payload', () => {
 
       // Assert
       expect(mockNext).toHaveBeenCalled();
-      expect(res._isEndCalled()).toBe(false);
+      expect(res._isEndCalled()).toEqual(false);
     });
 
     const propertyNamesWithInvalidValues = [
@@ -121,7 +121,7 @@ describe('validate-post-upload-utilisation-report-payload', () => {
 
       // Assert
       expect(mockNext).not.toHaveBeenCalled();
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     });
 
     it.each`
@@ -142,7 +142,7 @@ describe('validate-post-upload-utilisation-report-payload', () => {
 
       // Assert
       expect(mockNext).not.toHaveBeenCalled();
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     });
 
     it('responds with an error if the reportData contains validation errors', async () => {
@@ -160,7 +160,7 @@ describe('validate-post-upload-utilisation-report-payload', () => {
 
       // Assert
       expect(mockNext).not.toHaveBeenCalled();
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
       expect(res._getData()).toEqual([{ errorMessage: 'That is not valid report data', value: '300', row: 3 }]);
     });
   });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-deal-cancellation-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-deal-cancellation-payload.test.ts
@@ -106,8 +106,8 @@ describe('validatePutDealCancellationPayload', () => {
     validatePutDealCancellationPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -123,6 +123,6 @@ describe('validatePutDealCancellationPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-keying-data-mark-as-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-keying-data-mark-as-payload.test.ts
@@ -28,8 +28,8 @@ describe('validatePutKeyingDataMarkAsPayload', () => {
     validatePutKeyingDataMarkAsPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -48,8 +48,8 @@ describe('validatePutKeyingDataMarkAsPayload', () => {
     validatePutKeyingDataMarkAsPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -68,8 +68,8 @@ describe('validatePutKeyingDataMarkAsPayload', () => {
     validatePutKeyingDataMarkAsPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/dtfs-central-api/src/v1/validation/utilisation-report-service/utilisation-report-validator.test.js
+++ b/dtfs-central-api/src/v1/validation/utilisation-report-service/utilisation-report-validator.test.js
@@ -88,7 +88,7 @@ describe('utilisation-report-validator', () => {
         mimetype: 1,
       });
 
-      expect(validationErrors.length).toBe(5);
+      expect(validationErrors.length).toEqual(5);
       expect(validationErrors).toContain('Folder name from file info must be a string');
       expect(validationErrors).toContain('Filename from file info must be a string');
       expect(validationErrors).toContain('Full path from file info must be a string');
@@ -99,7 +99,7 @@ describe('utilisation-report-validator', () => {
     it('returns an error if a file info property is not provided', async () => {
       const validationErrors = validateFileInfo({});
 
-      expect(validationErrors.length).toBe(5);
+      expect(validationErrors.length).toEqual(5);
       expect(validationErrors).toContain('Folder name from file info is required');
       expect(validationErrors).toContain('Filename from file info is required');
       expect(validationErrors).toContain('Full path from file info is required');

--- a/external-api/api-tests/v1/countries.api-test.ts
+++ b/external-api/api-tests/v1/countries.api-test.ts
@@ -28,7 +28,7 @@ describe('/countries', () => {
       expect(body.countries[0]).toEqual(gbr);
 
       for (let i = 2; i < body.countries.length; i += 1) {
-        expect(body.countries[i - 1].name < body.countries[i].name).toBe(true);
+        expect(body.countries[i - 1].name < body.countries[i].name).toEqual(true);
       }
     });
   });

--- a/external-api/api-tests/v1/currencies.api-test.ts
+++ b/external-api/api-tests/v1/currencies.api-test.ts
@@ -27,7 +27,7 @@ describe('/currencies', () => {
       expect(status).toEqual(200);
       expect(body.currencies.length).toBeGreaterThan(1);
       for (let i = 1; i < body.currencies.length; i += 1) {
-        expect(body.currencies[i - 1].id < body.currencies[i].id).toBe(true);
+        expect(body.currencies[i - 1].id < body.currencies[i].id).toEqual(true);
       }
     });
   });

--- a/external-api/api-tests/v1/healthcheck.api-test.ts
+++ b/external-api/api-tests/v1/healthcheck.api-test.ts
@@ -19,6 +19,6 @@ describe('Healthcheck', () => {
   it('returns 200 if server is healthy', async () => {
     const res = await get(`/healthcheck`);
     expect(res.body.uptime).toBeGreaterThan(0);
-    expect(res.status).toBe(200);
+    expect(res.status).toEqual(200);
   });
 });

--- a/external-api/api-tests/v1/middleware/api-rate-limiting.api-test.ts
+++ b/external-api/api-tests/v1/middleware/api-rate-limiting.api-test.ts
@@ -69,7 +69,7 @@ describe('api rate limiting', () => {
 
     const responseAfterRateLimitExceeded = await sendRequestTimes(1);
 
-    expect(responseAfterRateLimitExceeded[0].value.status).toBe(429);
+    expect(responseAfterRateLimitExceeded[0].value.status).toEqual(429);
   });
 
   it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -77,6 +77,6 @@ describe('api rate limiting', () => {
 
     const responseThatMeetsRateLimit = await sendRequestTimes(1);
 
-    expect(responseThatMeetsRateLimit[0].value.status).toBe(200);
+    expect(responseThatMeetsRateLimit[0].value.status).toEqual(200);
   });
 });

--- a/external-api/src/errors/invalid-environment-variable.error.test.ts
+++ b/external-api/src/errors/invalid-environment-variable.error.test.ts
@@ -6,12 +6,12 @@ describe('InvalidEnvironmentVariableError', () => {
   it('exposes the message it was created with', () => {
     const exception = new InvalidEnvironmentVariableError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidEnvironmentVariableError(message);
 
-    expect(exception.name).toBe('InvalidEnvironmentVariableError');
+    expect(exception.name).toEqual('InvalidEnvironmentVariableError');
   });
 });

--- a/external-api/src/helpers/date.test.ts
+++ b/external-api/src/helpers/date.test.ts
@@ -8,7 +8,7 @@ describe('getNowAsEpoch', () => {
 
   it('should return as EPOCH representing the current time in milliseconds', () => {
     const result = getNowAsEpoch();
-    expect(typeof result).toBe('number');
+    expect(typeof result).toEqual('number');
   });
 
   it('should return a value greater than or equal to the previous value', () => {
@@ -19,7 +19,7 @@ describe('getNowAsEpoch', () => {
 
   it('should return a number', () => {
     const result = getNowAsEpoch();
-    expect(typeof result).toBe('number');
+    expect(typeof result).toEqual('number');
   });
 
   it('should return a number greater than 0', () => {
@@ -40,6 +40,6 @@ describe('getNowAsEpoch', () => {
   it('should return EPOCH as 0', () => {
     jest.useFakeTimers().setSystemTime(new Date('1970-01-01 01:00:00'));
     const result = getNowAsEpoch();
-    expect(result).toBe(0);
+    expect(result).toEqual(0);
   });
 });

--- a/external-api/src/helpers/errors/estore-internal-server-error.test.ts
+++ b/external-api/src/helpers/errors/estore-internal-server-error.test.ts
@@ -16,14 +16,14 @@ describe('estoreInternalServerError', () => {
     const message = 'Mock error';
     const result = estoreInternalServerError(message);
 
-    expect(result.status).toBe(HttpStatusCode.InternalServerError);
+    expect(result.status).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it('should set the data.status property to 500', () => {
     const message = 'Mock error';
     const result = estoreInternalServerError(message);
 
-    expect(result.data.status).toBe(HttpStatusCode.InternalServerError);
+    expect(result.data.status).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it('should return an object with an empty string as the message property', () => {

--- a/external-api/src/helpers/validIds.test.ts
+++ b/external-api/src/helpers/validIds.test.ts
@@ -24,7 +24,7 @@ describe('areValidUkefIds', () => {
   it('should return true when dealIdentifier and facilityIdentifiers are present and do not contain temporary IDs and match 10 digit format', () => {
     const result = areValidUkefIds(eStoreData);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it('should return false when dealIdentifier and facilityIdentifiers are present and do not contain temporary IDs and do not match 10 digit format', () => {
@@ -35,7 +35,7 @@ describe('areValidUkefIds', () => {
     };
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when dealIdentifier is empty', () => {
@@ -46,7 +46,7 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilityIdentifiers is falsy', () => {
@@ -57,7 +57,7 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when dealIdentifier contains temporary (pending) ID', () => {
@@ -68,7 +68,7 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when dealIdentifier contains test ID', () => {
@@ -79,7 +79,7 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilityIdentifiers contain test ID and a valid ID', () => {
@@ -90,7 +90,7 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilityIdentifiers contain temporary (pending) ID', () => {
@@ -101,7 +101,7 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilityIdentifiers contain test and pending ID', () => {
@@ -112,6 +112,6 @@ describe('areValidUkefIds', () => {
 
     const result = areValidUkefIds(eStoreDataModified);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });

--- a/external-api/src/helpers/validUkefId.api-test.ts
+++ b/external-api/src/helpers/validUkefId.api-test.ts
@@ -3,56 +3,56 @@ import { validUkefId } from './validUkefId';
 describe('validUkefId function', () => {
   // Tests that a valid UKEF ID with 10 digits returns the same ID
   it('should test  valid ukef id with 10 digits', () => {
-    expect(validUkefId('1234567890')).toBe('1234567890');
+    expect(validUkefId('1234567890')).toEqual('1234567890');
   });
 
   // Tests that a valid UKEF ID with leading zeros returns the same ID
   it('should test  valid ukef id with leading zeros', () => {
-    expect(validUkefId('0000123456')).toBe('0000123456');
+    expect(validUkefId('0000123456')).toEqual('0000123456');
   });
 
   // Tests that an empty string returns false
   it('should test  empty string', () => {
-    expect(validUkefId('')).toBe(false);
+    expect(validUkefId('')).toEqual(false);
   });
 
   // Tests that a non-numeric UKEF ID returns false
   it('should test  non numeric ukef id', () => {
-    expect(validUkefId('1234a67890')).toBe(false);
+    expect(validUkefId('1234a67890')).toEqual(false);
   });
 
   // Tests that a UKEF ID with less than 10 digits returns false
   it('should test  ukef id with less than 10 digits', () => {
-    expect(validUkefId('123456789')).toBe(false);
+    expect(validUkefId('123456789')).toEqual(false);
   });
 
   // Tests that a UKEF ID with more than 10 digits returns false
   it('should test  ukef id with more than 10 digits', () => {
-    expect(validUkefId('12345678901')).toBe(false);
+    expect(validUkefId('12345678901')).toEqual(false);
   });
 
   // Tests that a UKEF ID with negative value returns false
   it('should test  negative value ukef id', () => {
-    expect(validUkefId('-1234567890')).toBe(false);
+    expect(validUkefId('-1234567890')).toEqual(false);
   });
 
   // Tests that a UKEF ID with decimal value returns false
   it('should test  decimal value ukef id', () => {
-    expect(validUkefId('1234.567890')).toBe(false);
+    expect(validUkefId('1234.567890')).toEqual(false);
   });
 
   // Tests that a UKEF ID with scientific notation returns false
   it('should test  scientific notation ukef id', () => {
-    expect(validUkefId('1.234e+9')).toBe(false);
+    expect(validUkefId('1.234e+9')).toEqual(false);
   });
 
   // Tests that a UKEF ID with non-numeric characters returns false
   it('should test  non numeric characters ukef id', () => {
-    expect(validUkefId('1234-567890')).toBe(false);
+    expect(validUkefId('1234-567890')).toEqual(false);
   });
 
   // Tests that a UKEF ID with injection returns false
   it('should test  non numeric characters ukef id', () => {
-    expect(validUkefId('{u: { $rg: `` }}}')).toBe(false);
+    expect(validUkefId('{u: { $rg: `` }}}')).toEqual(false);
   });
 });

--- a/external-api/src/v1/errors/invalid-entity-type.error.test.ts
+++ b/external-api/src/v1/errors/invalid-entity-type.error.test.ts
@@ -9,7 +9,7 @@ describe('InvalidEntityTypeError', () => {
     const exception = new InvalidEntityTypeError(entityType);
 
     // Assert
-    expect(exception.message).toBe(ERRORS.ENTITY_TYPE.INVALID);
+    expect(exception.message).toEqual(ERRORS.ENTITY_TYPE.INVALID);
   });
 
   it('exposes the expected cause', () => {
@@ -19,7 +19,7 @@ describe('InvalidEntityTypeError', () => {
     const exception = new InvalidEntityTypeError(entityType);
 
     // Assert
-    expect(exception.cause).toBe(expectedCause);
+    expect(exception.cause).toEqual(expectedCause);
   });
 
   it('exposes the name of the exception', () => {

--- a/gef-ui/api-tests/api-rate-limiting.api-test.js
+++ b/gef-ui/api-tests/api-rate-limiting.api-test.js
@@ -27,7 +27,7 @@ describe('api rate limiting', () => {
 
       const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-      expect(responseAfterRateLimitExceeded.status).toBe(429);
+      expect(responseAfterRateLimitExceeded.status).toEqual(429);
     });
 
     it('returns a successful response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -35,7 +35,7 @@ describe('api rate limiting', () => {
 
       const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-      expect(responseThatMeetsRateLimit.status).toBe(302);
+      expect(responseThatMeetsRateLimit.status).toEqual(302);
     });
   });
 
@@ -47,7 +47,7 @@ describe('api rate limiting', () => {
 
       const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-      expect(responseAfterRateLimitExceeded.status).toBe(200);
+      expect(responseAfterRateLimitExceeded.status).toEqual(200);
     });
 
     it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -55,7 +55,7 @@ describe('api rate limiting', () => {
 
       const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-      expect(responseThatMeetsRateLimit.status).toBe(200);
+      expect(responseThatMeetsRateLimit.status).toEqual(200);
     });
   });
 });

--- a/gef-ui/api-tests/bank-review-date.get.api-test.js
+++ b/gef-ui/api-tests/bank-review-date.get.api-test.js
@@ -79,7 +79,7 @@ describe('bank review date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(200);
+        expect(response.status).toEqual(200);
       });
 
       it('redirects the user to the previous page if the deal is version 0', async () => {
@@ -91,8 +91,8 @@ describe('bank review date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(previousPageUrl);
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual(previousPageUrl);
       });
 
       it('redirects the user to the previous page if version is 1 & isUsingFacilityEndDate is null', async () => {
@@ -104,8 +104,8 @@ describe('bank review date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(previousPageUrl);
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual(previousPageUrl);
       });
 
       it('redirects the user to the previous page if version is 1 & isUsingFacilityEndDate is true', async () => {
@@ -117,8 +117,8 @@ describe('bank review date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(previousPageUrl);
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual(previousPageUrl);
       });
     });
   });

--- a/gef-ui/api-tests/bank-review-date.post.api-test.js
+++ b/gef-ui/api-tests/bank-review-date.post.api-test.js
@@ -93,7 +93,7 @@ describe('bank review date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Ok);
+          expect(response.status).toEqual(HttpStatusCode.Ok);
           expect(api.updateFacility).toHaveBeenCalledTimes(0);
         });
 
@@ -105,8 +105,8 @@ describe('bank review date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Found);
-          expect(response.headers.location).toBe(nextPageUrl);
+          expect(response.status).toEqual(HttpStatusCode.Found);
+          expect(response.headers.location).toEqual(nextPageUrl);
         });
 
         it('updates the facility if request body is valid', async () => {
@@ -178,7 +178,7 @@ describe('bank review date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Ok);
+          expect(response.status).toEqual(HttpStatusCode.Ok);
           expect(api.updateFacility).toHaveBeenCalledTimes(0);
         });
 
@@ -190,8 +190,8 @@ describe('bank review date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Found);
-          expect(response.headers.location).toBe(saveAndReturnRedirectUrl);
+          expect(response.status).toEqual(HttpStatusCode.Found);
+          expect(response.headers.location).toEqual(saveAndReturnRedirectUrl);
         });
 
         it('does not update the database if the bank review date is blank', async () => {
@@ -213,8 +213,8 @@ describe('bank review date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Found);
-          expect(response.headers.location).toBe(saveAndReturnRedirectUrl);
+          expect(response.status).toEqual(HttpStatusCode.Found);
+          expect(response.headers.location).toEqual(saveAndReturnRedirectUrl);
         });
 
         it('updates the facility if request body is valid', async () => {

--- a/gef-ui/api-tests/common-tests/role-validation-api-tests.js
+++ b/gef-ui/api-tests/common-tests/role-validation-api-tests.js
@@ -51,11 +51,11 @@ const withRoleValidationApiTests = ({
             Cookie: [`dtfs-session=${encodeURIComponent(sessionCookie)}`],
           });
 
-          expect(response.status).toBe(successCode);
+          expect(response.status).toEqual(successCode);
 
           if (successHeaders) {
             Object.entries(successHeaders).forEach(([key, value]) => {
-              expect(response.headers[key]).toBe(value);
+              expect(response.headers[key]).toEqual(value);
             });
           }
         });
@@ -71,9 +71,9 @@ const withRoleValidationApiTests = ({
             Cookie: [`dtfs-session=${encodeURIComponent(sessionCookie)}`],
           });
 
-          expect(response.status).toBe(302);
+          expect(response.status).toEqual(302);
           const redirectUrl = redirectUrlForInvalidRoles ?? '/';
-          expect(response.headers.location).toBe(redirectUrl);
+          expect(response.headers.location).toEqual(redirectUrl);
         });
       });
     }

--- a/gef-ui/api-tests/facility-end-date.get.api-test.js
+++ b/gef-ui/api-tests/facility-end-date.get.api-test.js
@@ -79,7 +79,7 @@ describe('facility end date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(200);
+        expect(response.status).toEqual(200);
       });
 
       it('redirects the user to the previous page if the deal is version 0', async () => {
@@ -91,8 +91,8 @@ describe('facility end date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(previousPageUrl);
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual(previousPageUrl);
       });
 
       it('redirects the user to the previous page if version is 1 & isUsingFacilityEndDate is null ', async () => {
@@ -104,8 +104,8 @@ describe('facility end date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(previousPageUrl);
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual(previousPageUrl);
       });
 
       it('redirects the user to the previous page if version is 1 & isUsingFacilityEndDate is false', async () => {
@@ -117,8 +117,8 @@ describe('facility end date routes', () => {
         const response = await getWithSessionCookie(url, sessionCookie);
 
         // Assert
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe(previousPageUrl);
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual(previousPageUrl);
       });
     });
   });

--- a/gef-ui/api-tests/facility-end-date.post.api-test.js
+++ b/gef-ui/api-tests/facility-end-date.post.api-test.js
@@ -93,7 +93,7 @@ describe('facility end date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Ok);
+          expect(response.status).toEqual(HttpStatusCode.Ok);
           expect(api.updateFacility).toHaveBeenCalledTimes(0);
         });
 
@@ -105,8 +105,8 @@ describe('facility end date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Found);
-          expect(response.headers.location).toBe(nextPageUrl);
+          expect(response.status).toEqual(HttpStatusCode.Found);
+          expect(response.headers.location).toEqual(nextPageUrl);
         });
 
         it('updates the facility if request body is valid', async () => {
@@ -178,7 +178,7 @@ describe('facility end date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Ok);
+          expect(response.status).toEqual(HttpStatusCode.Ok);
           expect(api.updateFacility).toHaveBeenCalledTimes(0);
         });
 
@@ -190,8 +190,8 @@ describe('facility end date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Found);
-          expect(response.headers.location).toBe(saveAndReturnRedirectUrl);
+          expect(response.status).toEqual(HttpStatusCode.Found);
+          expect(response.headers.location).toEqual(saveAndReturnRedirectUrl);
         });
 
         it('does not update the database if the facility end date is blank', async () => {
@@ -213,8 +213,8 @@ describe('facility end date routes', () => {
           const response = await makeRequest(body);
 
           // Assert
-          expect(response.status).toBe(HttpStatusCode.Found);
-          expect(response.headers.location).toBe(saveAndReturnRedirectUrl);
+          expect(response.status).toEqual(HttpStatusCode.Found);
+          expect(response.headers.location).toEqual(saveAndReturnRedirectUrl);
         });
 
         it('updates the facility if request body is valid', async () => {

--- a/gef-ui/scripts/correspondence-address.test.js
+++ b/gef-ui/scripts/correspondence-address.test.js
@@ -25,7 +25,7 @@ describe('correspondence-address.js', () => {
 
     runCorrespondenceAddressScript();
 
-    expect(conditionalCorrespondenceElement().className).toBe('');
+    expect(conditionalCorrespondenceElement().className).toEqual('');
   });
 
   it('sets a class to hide the conditional correspondence element on load if the no correspondence radio is checked', () => {
@@ -37,7 +37,7 @@ describe('correspondence-address.js', () => {
 
     runCorrespondenceAddressScript();
 
-    expect(conditionalCorrespondenceElement().className).toBe(classNameToHideElement);
+    expect(conditionalCorrespondenceElement().className).toEqual(classNameToHideElement);
   });
 
   it('sets a class to hide the conditional correspondence element on load if neither of the correspondence radios are checked', () => {
@@ -49,6 +49,6 @@ describe('correspondence-address.js', () => {
 
     runCorrespondenceAddressScript();
 
-    expect(conditionalCorrespondenceElement().className).toBe(classNameToHideElement);
+    expect(conditionalCorrespondenceElement().className).toEqual(classNameToHideElement);
   });
 });

--- a/gef-ui/server/controllers/application-details/canUpdateUnissuedFacilitiesCheck.test.js
+++ b/gef-ui/server/controllers/application-details/canUpdateUnissuedFacilitiesCheck.test.js
@@ -11,7 +11,7 @@ describe('canUpdateUnissuedFacilitiesCheck', () => {
 
       const result = canUpdateUnissuedFacilitiesCheck(application, true, [], null);
 
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 
@@ -26,22 +26,22 @@ describe('canUpdateUnissuedFacilitiesCheck', () => {
 
       it('returns true if unissuedFacilities and no facilitiesChanged to issued', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, true, [], null);
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
 
       it('returns false if unissuedFacilities and facilitiesChanged to issued', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, true, ['mock1'], null);
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
 
       it('returns false if no unissuedFacilities and no facilitiesChanged to issued', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, false, [], null);
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
 
       it('returns false if no unissuedFacilities and facilitiesChanged to issued', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, false, ['mock1'], null);
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
 
@@ -53,22 +53,22 @@ describe('canUpdateUnissuedFacilitiesCheck', () => {
 
       it('returns true if unissuedFacilities and no facilitiesChanged to issued and ukefDecisionAccepted is true', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, true, [], true);
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
 
       it('returns false if no unissuedFacilities and no facilitiesChanged to issued and ukefDecisionAccepted is true', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, false, [], true);
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
 
       it('returns false if unissuedFacilities and facilitiesChanged to issued and ukefDecisionAccepted is true', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, true, ['mock1'], true);
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
 
       it('returns false if unissuedFacilities and no facilitiesChanged to issued and ukefDecisionAccepted is false', () => {
         const result = canUpdateUnissuedFacilitiesCheck(application, true, [], false);
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
   });

--- a/gef-ui/server/services/__tests__/api.test.js
+++ b/gef-ui/server/services/__tests__/api.test.js
@@ -338,14 +338,14 @@ describe('getCompanyByRegistrationNumber()', () => {
     };
     Axios.get.mockRejectedValueOnce(axiosError);
 
-    await expect(api.getCompanyByRegistrationNumber({ registrationNumber, userToken })).rejects.toBe(axiosError);
+    await expect(api.getCompanyByRegistrationNumber({ registrationNumber, userToken })).rejects.toEqual(axiosError);
   });
 
   it('rethrows the error if making the request to Portal API throws an unhandled error', async () => {
     const error = new Error();
     Axios.get.mockRejectedValueOnce(error);
 
-    await expect(api.getCompanyByRegistrationNumber({ registrationNumber, userToken })).rejects.toBe(error);
+    await expect(api.getCompanyByRegistrationNumber({ registrationNumber, userToken })).rejects.toEqual(error);
   });
 });
 

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -96,12 +96,12 @@ describe('userToken()', () => {
 
 describe('isObject()', () => {
   it('returns the correct boolean', () => {
-    expect(isObject({})).toBe(true);
-    expect(isObject([])).toBe(false);
-    expect(isObject('')).toBe(false);
-    expect(isObject(1)).toBe(false);
-    expect(isObject(true)).toBe(false);
-    expect(isObject(false)).toBe(false);
+    expect(isObject({})).toEqual(true);
+    expect(isObject([])).toEqual(false);
+    expect(isObject('')).toEqual(false);
+    expect(isObject(1)).toEqual(false);
+    expect(isObject(true)).toEqual(false);
+    expect(isObject(false)).toEqual(false);
   });
 });
 
@@ -978,20 +978,20 @@ describe('mapSummaryList()', () => {
 
 describe('isTrueSet()', () => {
   it('returns null if value is not a string', () => {
-    expect(isTrueSet(null)).toBe(null);
-    expect(isTrueSet(10)).toBe(null);
-    expect(isTrueSet('')).toBe(null);
-    expect(isTrueSet(true)).toBe(null);
-    expect(isTrueSet(false)).toBe(null);
-    expect(isTrueSet(undefined)).toBe(null);
+    expect(isTrueSet(null)).toEqual(null);
+    expect(isTrueSet(10)).toEqual(null);
+    expect(isTrueSet('')).toEqual(null);
+    expect(isTrueSet(true)).toEqual(null);
+    expect(isTrueSet(false)).toEqual(null);
+    expect(isTrueSet(undefined)).toEqual(null);
   });
 
   it('returns true boolean if string value is equal to `true`', () => {
-    expect(isTrueSet('true')).toBe(true);
+    expect(isTrueSet('true')).toEqual(true);
   });
 
   it('returns false boolean if string value is equal to `false`', () => {
-    expect(isTrueSet('false')).toBe(false);
+    expect(isTrueSet('false')).toEqual(false);
   });
 });
 

--- a/libs/common/src/change-stream/test-helpers/with-delete-many.api-tests.ts
+++ b/libs/common/src/change-stream/test-helpers/with-delete-many.api-tests.ts
@@ -61,13 +61,13 @@ export const withDeleteManyTests = ({ makeRequest, collectionName, auditRecord, 
           const collection = await mongoDbClient.getCollection(collectionName);
           const deletedDocuments = await collection.find({ _id: { $in: getDeletedDocumentIds() } }).toArray();
 
-          expect(deletedDocuments.length).toBe(0);
+          expect(deletedDocuments.length).toEqual(0);
         });
 
         it('should return 200', async () => {
           const { status, body } = await makeRequest();
 
-          expect(status).toBe(200);
+          expect(status).toEqual(200);
           expect(body).toEqual(expectedSuccessResponseBody);
         });
       });
@@ -123,7 +123,7 @@ export const withDeleteManyTests = ({ makeRequest, collectionName, auditRecord, 
         const collection = await mongoDbClient.getCollection(collectionName);
         const deletedDocuments = await collection.find({ _id: { $in: getDeletedDocumentIds() } }).toArray();
 
-        expect(deletedDocuments.length).toBe(0);
+        expect(deletedDocuments.length).toEqual(0);
       });
     }
 
@@ -141,13 +141,13 @@ export const withDeleteManyTests = ({ makeRequest, collectionName, auditRecord, 
         const collection = await mongoDbClient.getCollection(collectionName);
         const deletedDocuments = await collection.find({ _id: { $in: getDeletedDocumentIds() } }).toArray();
 
-        expect(deletedDocuments.length).toBe(getDeletedDocumentIds().length);
+        expect(deletedDocuments.length).toEqual(getDeletedDocumentIds().length);
       });
 
       it('should return a 500', async () => {
         const { status } = await makeRequest();
 
-        expect(status).toBe(500);
+        expect(status).toEqual(500);
       });
     }
   });

--- a/libs/common/src/change-stream/test-helpers/with-delete-one.api-tests.ts
+++ b/libs/common/src/change-stream/test-helpers/with-delete-one.api-tests.ts
@@ -67,13 +67,13 @@ export const withDeleteOneTests = ({ makeRequest, collectionName, auditRecord, g
           const collection = await mongoDbClient.getCollection(collectionName);
           const deletedDocument = await collection.findOne({ _id: { $eq: getDeletedDocumentId() } });
 
-          expect(deletedDocument).toBe(null);
+          expect(deletedDocument).toEqual(null);
         });
 
         it('should return 200', async () => {
           const { status } = await makeRequest();
 
-          expect(status).toBe(200);
+          expect(status).toEqual(200);
         });
       });
 
@@ -97,7 +97,7 @@ export const withDeleteOneTests = ({ makeRequest, collectionName, auditRecord, g
         it('should return 500', async () => {
           const { status } = await makeRequest();
 
-          expect(status).toBe(500);
+          expect(status).toEqual(500);
         });
       });
 
@@ -121,7 +121,7 @@ export const withDeleteOneTests = ({ makeRequest, collectionName, auditRecord, g
         it('should return 500', async () => {
           const { status } = await makeRequest();
 
-          expect(status).toBe(500);
+          expect(status).toEqual(500);
         });
       });
     } else {
@@ -131,13 +131,13 @@ export const withDeleteOneTests = ({ makeRequest, collectionName, auditRecord, g
         const collection = await mongoDbClient.getCollection(collectionName);
         const deletedDocument = await collection.findOne({ _id: { $eq: getDeletedDocumentId() } });
 
-        expect(deletedDocument).toBe(null);
+        expect(deletedDocument).toEqual(null);
       });
 
       it('should return 200', async () => {
         const { status } = await makeRequest();
 
-        expect(status).toBe(200);
+        expect(status).toEqual(200);
       });
     }
 

--- a/libs/common/src/errors/database.error.test.ts
+++ b/libs/common/src/errors/database.error.test.ts
@@ -8,7 +8,7 @@ describe('DatabaseError', () => {
     const exception = new DatabaseError(message);
 
     // Assert
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('is an instance of DatabaseError', () => {

--- a/libs/common/src/errors/deal-version.error.test.ts
+++ b/libs/common/src/errors/deal-version.error.test.ts
@@ -20,7 +20,7 @@ describe('InvalidAuditDetailsError', () => {
     const error = new DealVersionError(message);
 
     // Assert
-    expect(error.status).toBe(400);
+    expect(error.status).toEqual(400);
   });
 
   it('exposes the name of the exception', () => {

--- a/libs/common/src/errors/invalid-audit-details.error.test.ts
+++ b/libs/common/src/errors/invalid-audit-details.error.test.ts
@@ -20,7 +20,7 @@ describe('InvalidAuditDetailsError', () => {
     const error = new InvalidAuditDetailsError(message);
 
     // Assert
-    expect(error.status).toBe(400);
+    expect(error.status).toEqual(400);
   });
 
   it('exposes the name of the exception', () => {

--- a/libs/common/src/errors/invalid-environment-variable.error.test.ts
+++ b/libs/common/src/errors/invalid-environment-variable.error.test.ts
@@ -6,12 +6,12 @@ describe('InvalidEnvironmentVariableError', () => {
   it('exposes the message it was created with', () => {
     const exception = new InvalidEnvironmentVariableError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidEnvironmentVariableError(message);
 
-    expect(exception.name).toBe('InvalidEnvironmentVariableError');
+    expect(exception.name).toEqual('InvalidEnvironmentVariableError');
   });
 });

--- a/libs/common/src/errors/invalid-parameter-error.test.ts
+++ b/libs/common/src/errors/invalid-parameter-error.test.ts
@@ -72,7 +72,7 @@ describe('InvalidParameterError', () => {
     const error = new InvalidParameterError(parameterName, parameterValue);
 
     // Assert
-    expect(error.status).toBe(HttpStatusCode.BadRequest);
+    expect(error.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('exposes the name of the exception', () => {

--- a/libs/common/src/errors/invalid-payload-error.test.ts
+++ b/libs/common/src/errors/invalid-payload-error.test.ts
@@ -18,7 +18,7 @@ describe('InvalidPayloadError', () => {
     const exception = new InvalidPayloadError(message);
 
     // Assert
-    expect(exception.status).toBe(HttpStatusCode.BadRequest);
+    expect(exception.status).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('is an instance of InvalidFacilityIdError', () => {

--- a/libs/common/src/errors/user-session-not-defined.test.ts
+++ b/libs/common/src/errors/user-session-not-defined.test.ts
@@ -17,7 +17,7 @@ describe('UserSessionNotDefinedError', () => {
     const exception = new UserSessionNotDefinedError();
 
     // Assert
-    expect(exception.status).toBe(HttpStatusCode.Unauthorized);
+    expect(exception.status).toEqual(HttpStatusCode.Unauthorized);
   });
 
   it('exposes the INVALID_USER_SESSION code', () => {
@@ -25,7 +25,7 @@ describe('UserSessionNotDefinedError', () => {
     const exception = new UserSessionNotDefinedError();
 
     // Assert
-    expect(exception.code).toBe('INVALID_USER_SESSION');
+    expect(exception.code).toEqual('INVALID_USER_SESSION');
   });
 
   it('is an instance of UserSessionNotDefinedError', () => {

--- a/libs/common/src/errors/user-token-not-defined.test.ts
+++ b/libs/common/src/errors/user-token-not-defined.test.ts
@@ -17,7 +17,7 @@ describe('UserTokenNotDefinedError', () => {
     const exception = new UserTokenNotDefinedError();
 
     // Assert
-    expect(exception.status).toBe(HttpStatusCode.Unauthorized);
+    expect(exception.status).toEqual(HttpStatusCode.Unauthorized);
   });
 
   it('exposes the INVALID_USER_SESSION code', () => {
@@ -25,7 +25,7 @@ describe('UserTokenNotDefinedError', () => {
     const exception = new UserTokenNotDefinedError();
 
     // Assert
-    expect(exception.code).toBe('INVALID_USER_SESSION');
+    expect(exception.code).toEqual('INVALID_USER_SESSION');
   });
 
   it('is an instance of UserTokenNotDefinedError', () => {

--- a/libs/common/src/helpers/currency.test.ts
+++ b/libs/common/src/helpers/currency.test.ts
@@ -16,7 +16,7 @@ describe('currency helpers', () => {
       const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);
 
       // Assert
-      expect(formattedCurrencyAndAmount).toBe(expectedFormattedCurrencyAndAmount);
+      expect(formattedCurrencyAndAmount).toEqual(expectedFormattedCurrencyAndAmount);
     });
 
     it('gets the formatted the current and amount string with 2 decimal places when the amount has more than 2 decimal places', () => {
@@ -32,7 +32,7 @@ describe('currency helpers', () => {
       const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);
 
       // Assert
-      expect(formattedCurrencyAndAmount).toBe(expectedFormattedCurrencyAndAmount);
+      expect(formattedCurrencyAndAmount).toEqual(expectedFormattedCurrencyAndAmount);
     });
 
     it('gets the formatted the current and amount string with 2 decimal places when the amount has no decimal places', () => {
@@ -48,7 +48,7 @@ describe('currency helpers', () => {
       const formattedCurrencyAndAmount = getFormattedCurrencyAndAmount(currencyAndAmount);
 
       // Assert
-      expect(formattedCurrencyAndAmount).toBe(expectedFormattedCurrencyAndAmount);
+      expect(formattedCurrencyAndAmount).toEqual(expectedFormattedCurrencyAndAmount);
     });
   });
 });

--- a/libs/common/src/helpers/custom-axios-validate-status.test.ts
+++ b/libs/common/src/helpers/custom-axios-validate-status.test.ts
@@ -12,12 +12,12 @@ describe('customValidateStatus', () => {
   it.each(falseCodes)('should return false for HTTP status code %s', (code) => {
     const result = customValidateStatus(code);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it.each(trueCodes)('should return true for HTTP status code %s', (code) => {
     const result = customValidateStatus(code);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 });

--- a/libs/common/src/helpers/gef-deal-versioning.test.ts
+++ b/libs/common/src/helpers/gef-deal-versioning.test.ts
@@ -14,7 +14,7 @@ describe('is-deal-feature-enabled helpers', () => {
 
       const result = getCurrentGefDealVersion();
 
-      expect(result).toBe(1);
+      expect(result).toEqual(1);
     });
 
     it("returns 0 when deal version set to '0'", () => {
@@ -22,7 +22,7 @@ describe('is-deal-feature-enabled helpers', () => {
 
       const result = getCurrentGefDealVersion();
 
-      expect(result).toBe(0);
+      expect(result).toEqual(0);
     });
 
     it('returns 0 when deal version set to empty string', () => {
@@ -30,7 +30,7 @@ describe('is-deal-feature-enabled helpers', () => {
 
       const result = getCurrentGefDealVersion();
 
-      expect(result).toBe(0);
+      expect(result).toEqual(0);
     });
 
     it('returns 0 when deal version undefined', () => {
@@ -38,7 +38,7 @@ describe('is-deal-feature-enabled helpers', () => {
 
       const result = getCurrentGefDealVersion();
 
-      expect(result).toBe(0);
+      expect(result).toEqual(0);
     });
 
     it('throws an error when deal version is invalid', () => {
@@ -52,19 +52,19 @@ describe('is-deal-feature-enabled helpers', () => {
     it('returns true when deal version set to 1', () => {
       const result = isFacilityEndDateEnabledOnGefVersion(1);
 
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
 
     it('returns true when deal version greater than 1', () => {
       const result = isFacilityEndDateEnabledOnGefVersion(2);
 
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
 
     it('returns false when deal version less than 1', () => {
       const result = isFacilityEndDateEnabledOnGefVersion(0);
 
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 });

--- a/libs/common/src/helpers/payload-verification/is-verified-payload-by-type.test.ts
+++ b/libs/common/src/helpers/payload-verification/is-verified-payload-by-type.test.ts
@@ -52,11 +52,11 @@ describe('isVerifiedPayloadByType', () => {
 
   it.each(successTestCases)('should return true $description', ({ payload, template }) => {
     const result = isVerifiedPayloadByType({ payload, template });
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it.each(failureTestCases)('should return false $description', ({ payload, template }) => {
     const result = isVerifiedPayloadByType({ payload, template });
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });

--- a/libs/common/src/helpers/payload-verification/is-verified-payload-by-zod.test.ts
+++ b/libs/common/src/helpers/payload-verification/is-verified-payload-by-zod.test.ts
@@ -62,11 +62,11 @@ describe('isVerifiedPayloadByZod', () => {
 
   it.each(successTestCases)('should return true $description', ({ payload, template }) => {
     const result = isVerifiedPayloadByZod({ payload, template });
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it.each(failureTestCases)('should return false $description', ({ payload, template }) => {
     const result = isVerifiedPayloadByZod({ payload, template });
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });

--- a/libs/common/src/helpers/schema/z-boolean-strict-coerce.test.ts
+++ b/libs/common/src/helpers/schema/z-boolean-strict-coerce.test.ts
@@ -5,7 +5,7 @@ describe('zBooleanStrictCoerce', () => {
   describe('when parsing a value with zBooleanStrictCoerce', () => {
     describe('when the provided value can be coerced to a boolean', () => {
       it.each(getSuccessTestCases())('should return $result when the provided value is $description', ({ value, result }) => {
-        expect(zBooleanStrictCoerce.parse(value)).toBe(result);
+        expect(zBooleanStrictCoerce.parse(value)).toEqual(result);
       });
     });
 
@@ -19,13 +19,13 @@ describe('zBooleanStrictCoerce', () => {
   describe('when parsing a value with zBooleanStrictCoerce and additional chaining', () => {
     describe('when chaining with .optional()', () => {
       it('should return undefined when the provided value is undefined', () => {
-        expect(zBooleanStrictCoerce.optional().parse(undefined)).toBe(undefined);
+        expect(zBooleanStrictCoerce.optional().parse(undefined)).toEqual(undefined);
       });
     });
 
     describe('when chaining with .nullable()', () => {
       it('should return null when the provided value is null', () => {
-        expect(zBooleanStrictCoerce.nullable().parse(null)).toBe(null);
+        expect(zBooleanStrictCoerce.nullable().parse(null)).toEqual(null);
       });
     });
   });

--- a/libs/common/src/helpers/string.test.ts
+++ b/libs/common/src/helpers/string.test.ts
@@ -13,7 +13,7 @@ describe('string helpers', () => {
       ${''}                                 | ${true}
       ${'a string'}                         | ${true}
     `('returns $expected when the value is $value', ({ value, expected }: { value: unknown; expected: boolean }) => {
-      expect(isString(value)).toBe(expected);
+      expect(isString(value)).toEqual(expected);
     });
   });
 
@@ -28,7 +28,7 @@ describe('string helpers', () => {
       ${' string'} | ${false}
       ${'string '} | ${false}
     `('returns $expected when the value is $value', ({ value, expected }: { value: unknown; expected: boolean }) => {
-      expect(isNullUndefinedOrEmptyString(value)).toBe(expected);
+      expect(isNullUndefinedOrEmptyString(value)).toEqual(expected);
     });
   });
 
@@ -43,7 +43,7 @@ describe('string helpers', () => {
       ${' string'} | ${true}
       ${'string '} | ${true}
     `('returns $expected when the value is $value', ({ value, expected }: { value: unknown; expected: boolean }) => {
-      expect(isNonEmptyString(value)).toBe(expected);
+      expect(isNonEmptyString(value)).toEqual(expected);
     });
   });
 });

--- a/libs/common/src/helpers/validation.test.ts
+++ b/libs/common/src/helpers/validation.test.ts
@@ -25,8 +25,8 @@ describe('validation helpers', () => {
       const stringValue = asString(value, 'value');
 
       // Assert
-      expect(typeof stringValue).toBe('string');
-      expect(stringValue).toBe(value);
+      expect(typeof stringValue).toEqual('string');
+      expect(stringValue).toEqual(value);
     });
 
     it.each`

--- a/libs/common/src/helpers/with-boolean-feature-flag.tests.ts
+++ b/libs/common/src/helpers/with-boolean-feature-flag.tests.ts
@@ -16,7 +16,7 @@ export const withBooleanFeatureFlagTests = ({ featureFlagName, getFeatureFlagVal
       const result = getFeatureFlagValue();
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
 
     it("returns true when the feature flag is set to 'true'", () => {
@@ -27,7 +27,7 @@ export const withBooleanFeatureFlagTests = ({ featureFlagName, getFeatureFlagVal
       const result = getFeatureFlagValue();
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
 
     it('defaults to false when the flag is not defined', () => {
@@ -38,7 +38,7 @@ export const withBooleanFeatureFlagTests = ({ featureFlagName, getFeatureFlagVal
       const result = getFeatureFlagValue();
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 };

--- a/libs/common/src/middleware/create-validation-middleware-for-schema.test.ts
+++ b/libs/common/src/middleware/create-validation-middleware-for-schema.test.ts
@@ -62,8 +62,8 @@ describe('createValidationMiddleware', () => {
 
       // Assert
       expect(next).not.toHaveBeenCalled();
-      expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('formats and logs the validation errors', () => {
@@ -109,7 +109,7 @@ describe('createValidationMiddleware', () => {
 
       // Assert
       expect(next).toHaveBeenCalled();
-      expect(res._isEndCalled()).toBe(false);
+      expect(res._isEndCalled()).toEqual(false);
       expect(req.body).toEqual(parsedData);
     });
   });

--- a/libs/common/src/schemas/with-schema-validation.tests.ts
+++ b/libs/common/src/schemas/with-schema-validation.tests.ts
@@ -13,12 +13,12 @@ export const withSchemaValidationTests = ({
 }) => {
   describe('when validating a valid input', () => {
     it.each(successTestCases)(`should validate $description as a valid ${schemaName}`, ({ testCase }) => {
-      expect(schema.safeParse(testCase).success).toBe(true);
+      expect(schema.safeParse(testCase).success).toEqual(true);
     });
   });
   describe('when validating an invalid input', () => {
     it.each(failureTestCases)(`should not validate $description as a valid ${schemaName}`, ({ testCase }) => {
-      expect(schema.safeParse(testCase).success).toBe(false);
+      expect(schema.safeParse(testCase).success).toEqual(false);
     });
   });
 };

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
@@ -27,15 +27,15 @@ describe('FacilityUtilisationDataEntity', () => {
       });
 
       // Assert
-      expect(facilityUtilisationDataEntity.fixedFee).toBe(543.21);
-      expect(facilityUtilisationDataEntity.utilisation).toBe(876543.21);
+      expect(facilityUtilisationDataEntity.fixedFee).toEqual(543.21);
+      expect(facilityUtilisationDataEntity.utilisation).toEqual(876543.21);
       expect(facilityUtilisationDataEntity.reportPeriod).toEqual({
         start: { month: 3, year: 2023 },
         end: { month: 4, year: 2024 },
       });
-      expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toBe(false);
+      expect(facilityUtilisationDataEntity.lastUpdatedByIsSystemUser).toEqual(false);
       expect(facilityUtilisationDataEntity.lastUpdatedByPortalUserId).toBeNull();
-      expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toBe(userId);
+      expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toEqual(userId);
     });
   });
 });

--- a/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.test.ts
+++ b/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.test.ts
@@ -41,8 +41,8 @@ describe('UtilisationReportEntity', () => {
       expect(report.azureFileInfo).toEqual(azureFileInfo);
       expect(report.status).toEqual(UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION);
 
-      expect(report.lastUpdatedByIsSystemUser).toBe(false);
-      expect(report.lastUpdatedByPortalUserId).toBe(uploadedByUserId);
+      expect(report.lastUpdatedByIsSystemUser).toEqual(false);
+      expect(report.lastUpdatedByPortalUserId).toEqual(uploadedByUserId);
       expect(report.lastUpdatedByTfmUserId).toBeNull();
     });
   });
@@ -62,10 +62,10 @@ describe('UtilisationReportEntity', () => {
       report.updateWithStatus({ status, requestSource });
 
       // Assert
-      expect(report.status).toBe(status);
-      expect(report.lastUpdatedByIsSystemUser).toBe(false);
+      expect(report.status).toEqual(status);
+      expect(report.lastUpdatedByIsSystemUser).toEqual(false);
       expect(report.lastUpdatedByPortalUserId).toBeNull();
-      expect(report.lastUpdatedByTfmUserId).toBe(requestSource.userId);
+      expect(report.lastUpdatedByTfmUserId).toEqual(requestSource.userId);
     });
   });
 });

--- a/libs/common/src/test-helpers/test-cases-backend/with-mongo-id-path-parameter-validation-tests.ts
+++ b/libs/common/src/test-helpers/test-cases-backend/with-mongo-id-path-parameter-validation-tests.ts
@@ -34,7 +34,7 @@ export const withMongoIdPathParameterValidationTests = ({ baseUrl, makeRequest }
       const { status } = await makeRequest(testUrl);
 
       // Assert
-      expect(status).toBe(HttpStatusCode.BadRequest);
+      expect(status).toEqual(HttpStatusCode.BadRequest);
     });
 
     it(`sets the response body 'code' field to ${API_ERROR_CODE.INVALID_MONGO_ID_PATH_PARAMETER}`, async () => {
@@ -42,7 +42,7 @@ export const withMongoIdPathParameterValidationTests = ({ baseUrl, makeRequest }
       const { body } = await makeRequest(testUrl);
 
       // Assert
-      expect(body.code).toBe(API_ERROR_CODE.INVALID_MONGO_ID_PATH_PARAMETER);
+      expect(body.code).toEqual(API_ERROR_CODE.INVALID_MONGO_ID_PATH_PARAMETER);
     });
   });
 };

--- a/libs/common/src/test-helpers/test-cases-backend/with-sql-id-path-parameter-validation-tests.ts
+++ b/libs/common/src/test-helpers/test-cases-backend/with-sql-id-path-parameter-validation-tests.ts
@@ -34,7 +34,7 @@ export const withSqlIdPathParameterValidationTests = ({ baseUrl, makeRequest }: 
       const { status } = await makeRequest(testUrl);
 
       // Assert
-      expect(status).toBe(HttpStatusCode.BadRequest);
+      expect(status).toEqual(HttpStatusCode.BadRequest);
     });
 
     it(`sets the response body 'code' field to ${API_ERROR_CODE.INVALID_SQL_ID_PATH_PARAMETER}`, async () => {
@@ -42,7 +42,7 @@ export const withSqlIdPathParameterValidationTests = ({ baseUrl, makeRequest }: 
       const { body } = await makeRequest(testUrl);
 
       // Assert
-      expect(body.code).toBe(API_ERROR_CODE.INVALID_SQL_ID_PATH_PARAMETER);
+      expect(body.code).toEqual(API_ERROR_CODE.INVALID_SQL_ID_PATH_PARAMETER);
     });
   });
 };

--- a/libs/common/src/utils/date.test.ts
+++ b/libs/common/src/utils/date.test.ts
@@ -24,12 +24,12 @@ describe('date utils', () => {
     it.each(['2023-11-01', '2023-13', '202-11', 'invalid', '', 202311, undefined, null, ['2023-11'], { date: '2023-11' }])(
       'returns false when the value is %p',
       (value) => {
-        expect(isValidIsoMonth(value)).toBe(false);
+        expect(isValidIsoMonth(value)).toEqual(false);
       },
     );
 
     it('returns true when a valid ISO month value is provided', () => {
-      expect(isValidIsoMonth('2023-11')).toBe(true);
+      expect(isValidIsoMonth('2023-11')).toEqual(true);
     });
   });
 
@@ -40,7 +40,7 @@ describe('date utils', () => {
       { date: new Date('2023-03'), expectedIsoMonthStamp: '2023-03' },
       { date: new Date('2023-03-31'), expectedIsoMonthStamp: '2023-03' },
     ])(`converts Date object '$date' to IsoMonthStamp '$expectedIsoMonthStamp'`, ({ date, expectedIsoMonthStamp }) => {
-      expect(toIsoMonthStamp(date)).toBe(expectedIsoMonthStamp);
+      expect(toIsoMonthStamp(date)).toEqual(expectedIsoMonthStamp);
     });
   });
 
@@ -48,12 +48,12 @@ describe('date utils', () => {
     it.each(['2023-11-01', '2023-11', '202', 'invalid', '', 2023, undefined, null, ['2023'], { date: '2023' }])(
       'returns false when the value is %p',
       (value) => {
-        expect(isValidIsoYear(value)).toBe(false);
+        expect(isValidIsoYear(value)).toEqual(false);
       },
     );
 
     it('returns true when a valid ISO month value is provided', () => {
-      expect(isValidIsoYear('2023')).toBe(true);
+      expect(isValidIsoYear('2023')).toEqual(true);
     });
   });
 });

--- a/libs/common/src/utils/report-period.test.ts
+++ b/libs/common/src/utils/report-period.test.ts
@@ -398,7 +398,7 @@ describe('report-period utils', () => {
       const result = isEqualReportPeriod(reportPeriod1, reportPeriod2);
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
 
     it('returns false when the two supplied report periods are not equal', () => {
@@ -416,7 +416,7 @@ describe('report-period utils', () => {
       const result = isEqualReportPeriod(reportPeriod1, reportPeriod2);
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 });

--- a/portal-api/api-tests/common-tests/client-authentication-tests.js
+++ b/portal-api/api-tests/common-tests/client-authentication-tests.js
@@ -1,5 +1,5 @@
 const expectNotAuthenticatedResponse = ({ status, body }) => {
-  expect(status).toBe(401);
+  expect(status).toEqual(401);
   expect(body).toStrictEqual({});
 };
 

--- a/portal-api/api-tests/common-tests/role-authorisation-tests.js
+++ b/portal-api/api-tests/common-tests/role-authorisation-tests.js
@@ -1,7 +1,7 @@
 const ROLES = require('../../src/v1/roles/roles');
 
 const expectNotAuthorisedResponse = ({ status, body }) => {
-  expect(status).toBe(401);
+  expect(status).toEqual(401);
   expect(body).toStrictEqual({
     success: false,
     msg: "You don't have access to this page",
@@ -24,7 +24,7 @@ const withRoleAuthorisationTests = ({ allowedRoles, getUserWithRole, makeRequest
   it.each(allowedRoles)(`returns a ${successStatusCode} response for requests from a user with role %s`, async (role) => {
     const userWithRole = getUserWithRole(role);
     const { status } = await makeRequestAsUser(userWithRole);
-    expect(status).toBe(successStatusCode);
+    expect(status).toEqual(successStatusCode);
   });
 };
 

--- a/portal-api/api-tests/v1/countries/countries.api-test.js
+++ b/portal-api/api-tests/v1/countries/countries.api-test.js
@@ -53,7 +53,7 @@ describe('/v1/countries', () => {
       expect(body.countries[0]).toEqual(gbr);
 
       for (let i = 2; i < body.countries.length; i += 1) {
-        expect(body.countries[i - 1].name < body.countries[i].name).toBe(true);
+        expect(body.countries[i - 1].name < body.countries[i].name).toEqual(true);
       }
     });
   });

--- a/portal-api/api-tests/v1/currencies/currencies.api-test.js
+++ b/portal-api/api-tests/v1/currencies/currencies.api-test.js
@@ -39,7 +39,7 @@ describe('/v1/currencies', () => {
       expect(status).toEqual(200);
       expect(body.currencies.length).toBeGreaterThan(1);
       for (let i = 1; i < body.currencies.length; i += 1) {
-        expect(body.currencies[i - 1].id < body.currencies[i].id).toBe(true);
+        expect(body.currencies[i - 1].id < body.currencies[i].id).toEqual(true);
       }
     });
   });

--- a/portal-api/api-tests/v1/gef/application-submit.api-test.js
+++ b/portal-api/api-tests/v1/gef/application-submit.api-test.js
@@ -89,7 +89,7 @@ describe('submissionPortalActivity()', () => {
 
     const { status: dealStatus, body: dealBody } = await as(aMaker).post(MOCK_APPLICATION_FACILITIES).to(applicationBaseUrl);
 
-    expect(dealStatus).toBe(201);
+    expect(dealStatus).toEqual(201);
 
     const req = {
       body: {
@@ -115,7 +115,7 @@ describe('submissionPortalActivity()', () => {
 
     const { status: dealStatus, body: dealBody } = await as(aMaker).post(MOCK_APPLICATION_FACILITIES).to(applicationBaseUrl);
 
-    expect(dealStatus).toBe(201);
+    expect(dealStatus).toEqual(201);
 
     const req = {
       body: {

--- a/portal-api/api-tests/v1/gef/facilities/facilities.delete.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities/facilities.delete.api-test.js
@@ -100,8 +100,8 @@ describe(baseUrl, () => {
     it('returns 200 if there are no facilities to delete', async () => {
       const { status: firstStatus } = await as(aMaker).remove(`${baseUrl}?dealId=${mockApplication.body._id}`);
       const { status: secondStatus } = await as(aMaker).remove(`${baseUrl}?dealId=${mockApplication.body._id}`);
-      expect(firstStatus).toBe(200);
-      expect(secondStatus).toBe(200);
+      expect(firstStatus).toEqual(200);
+      expect(secondStatus).toEqual(200);
     });
   });
 });

--- a/portal-api/api-tests/v1/gef/facilities/facilities.post.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities/facilities.post.api-test.js
@@ -67,13 +67,13 @@ describe(baseUrl, () => {
 
       it('returns a 400 if the dealId is invalid', async () => {
         const { body, status } = await as(aMaker).post({ dealId: 'test', type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
         expect(body).toEqual({ status: 400, message: 'Invalid deal ID: test' });
       });
 
       it('returns a 404 if the dealId is valid but does not exist', async () => {
         const { body, status } = await as(aMaker).post({ dealId: 'abcdef123456abcdef123456', type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-        expect(status).toBe(404);
+        expect(status).toEqual(404);
         expect(body).toEqual({ status: 404, message: 'Deal not found: abcdef123456abcdef123456' });
       });
 
@@ -144,7 +144,7 @@ describe(baseUrl, () => {
           .to(baseUrl);
 
         expect(body).toEqual({ status: 400, message: 'Cannot add facility end date to deal version 0' });
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
       });
 
       it('returns 400 when payload contains bankReviewDate', async () => {
@@ -153,7 +153,7 @@ describe(baseUrl, () => {
           .to(baseUrl);
 
         expect(body).toEqual({ status: 400, message: 'Cannot add facility end date to deal version 0' });
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
       });
 
       it('returns 400 when payload contains facilityEndDate', async () => {
@@ -162,7 +162,7 @@ describe(baseUrl, () => {
           .to(baseUrl);
 
         expect(body).toEqual({ status: 400, message: 'Cannot add facility end date to deal version 0' });
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
       });
     });
 
@@ -181,7 +181,7 @@ describe(baseUrl, () => {
           .post({ dealId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false, isUsingFacilityEndDate: true })
           .to(baseUrl);
 
-        expect(status).toBe(201);
+        expect(status).toEqual(201);
       });
 
       it('returns 201 when payload is valid & contains bankReviewDate', async () => {
@@ -189,7 +189,7 @@ describe(baseUrl, () => {
           .post({ dealId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false, bankReviewDate: new Date().toISOString() })
           .to(baseUrl);
 
-        expect(status).toBe(201);
+        expect(status).toEqual(201);
       });
 
       it('returns 201 when payload is valid & contains facilityEndDate', async () => {
@@ -197,7 +197,7 @@ describe(baseUrl, () => {
           .post({ dealId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false, facilityEndDate: new Date().toISOString() })
           .to(baseUrl);
 
-        expect(status).toBe(201);
+        expect(status).toEqual(201);
       });
 
       it('returns 400 when isUsingFacilityEndDate is not a boolean', async () => {

--- a/portal-api/api-tests/v1/gef/facilities/facilities.put.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities/facilities.put.api-test.js
@@ -451,7 +451,7 @@ describe(baseUrl, () => {
         const { status, body } = await as(aMaker).put({ isUsingFacilityEndDate: true }).to(`${baseUrl}/${facilityBody.details._id}`);
 
         expect(body).toEqual({ status: 400, message: 'Cannot add facility end date to deal version 0' });
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
       });
 
       it('returns 400 when payload contains bankReviewDate', async () => {
@@ -459,7 +459,7 @@ describe(baseUrl, () => {
         const { status, body } = await as(aMaker).put({ bankReviewDate: new Date().toISOString() }).to(`${baseUrl}/${facilityBody.details._id}`);
 
         expect(body).toEqual({ status: 400, message: 'Cannot add facility end date to deal version 0' });
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
       });
 
       it('returns 400 when payload contains facilityEndDate', async () => {
@@ -467,7 +467,7 @@ describe(baseUrl, () => {
         const { status, body } = await as(aMaker).put({ bankReviewDate: new Date().toISOString() }).to(`${baseUrl}/${facilityBody.details._id}`);
 
         expect(body).toEqual({ status: 400, message: 'Cannot add facility end date to deal version 0' });
-        expect(status).toBe(400);
+        expect(status).toEqual(400);
       });
     });
 
@@ -486,7 +486,7 @@ describe(baseUrl, () => {
 
         const { status } = await as(aMaker).put({ isUsingFacilityEndDate: true }).to(`${baseUrl}/${facilityBody.details._id}`);
 
-        expect(status).toBe(HttpStatusCode.Ok);
+        expect(status).toEqual(HttpStatusCode.Ok);
       });
 
       it('returns 200 when payload is valid & contains bankReviewDate', async () => {
@@ -494,7 +494,7 @@ describe(baseUrl, () => {
 
         const { status } = await as(aMaker).put({ bankReviewDate: new Date().toISOString() }).to(`${baseUrl}/${facilityBody.details._id}`);
 
-        expect(status).toBe(HttpStatusCode.Ok);
+        expect(status).toEqual(HttpStatusCode.Ok);
       });
 
       it('returns 200 when payload is valid & contains facilityEndDate', async () => {
@@ -502,7 +502,7 @@ describe(baseUrl, () => {
 
         const { status } = await as(aMaker).put({ facilityEndDate: new Date().toISOString() }).to(`${baseUrl}/${facilityBody.details._id}`);
 
-        expect(status).toBe(HttpStatusCode.Ok);
+        expect(status).toEqual(HttpStatusCode.Ok);
       });
 
       it('returns 200 when facilityEndDate & bankReviewDate are both null', async () => {
@@ -510,7 +510,7 @@ describe(baseUrl, () => {
 
         const { status } = await as(aMaker).put({ facilityEndDate: null, bankReviewDate: null }).to(`${baseUrl}/${facilityBody.details._id}`);
 
-        expect(status).toBe(HttpStatusCode.Ok);
+        expect(status).toEqual(HttpStatusCode.Ok);
       });
 
       it('returns 400 when isUsingFacilityEndDate is not a boolean', async () => {

--- a/portal-api/api-tests/v1/middleware/api-rate-limiting.api-test.js
+++ b/portal-api/api-tests/v1/middleware/api-rate-limiting.api-test.js
@@ -27,7 +27,7 @@ describe('api rate limiting', () => {
 
     const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-    expect(responseAfterRateLimitExceeded.status).toBe(429);
+    expect(responseAfterRateLimitExceeded.status).toEqual(429);
   });
 
   it('returns a 401 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -35,6 +35,6 @@ describe('api rate limiting', () => {
 
     const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-    expect(responseThatMeetsRateLimit.status).toBe(401);
+    expect(responseThatMeetsRateLimit.status).toEqual(401);
   });
 });

--- a/portal-api/api-tests/v1/users/login-with-sign-in-link.api-test.js
+++ b/portal-api/api-tests/v1/users/login-with-sign-in-link.api-test.js
@@ -83,7 +83,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         userToken: partiallyLoggedInUserToken,
       });
 
-      expect(status).toBe(400);
+      expect(status).toEqual(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
         errors: [
@@ -105,7 +105,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         userToken: partiallyLoggedInUserToken,
       });
 
-      expect(status).toBe(400);
+      expect(status).toEqual(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
         errors: [
@@ -127,7 +127,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         userToken: partiallyLoggedInUserToken,
       });
 
-      expect(status).toBe(400);
+      expect(status).toEqual(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
         errors: [
@@ -149,7 +149,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         userToken: partiallyLoggedInUserToken,
       });
 
-      expect(status).toBe(400);
+      expect(status).toEqual(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
         errors: [
@@ -172,7 +172,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         userToken: partiallyLoggedInUserToken,
       });
 
-      expect(status).toBe(400);
+      expect(status).toEqual(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
         errors: [
@@ -214,7 +214,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
         userToken: anotherPartiallyLoggedInUserToken,
       });
 
-      expect(status).toBe(400);
+      expect(status).toEqual(400);
       expect(body).toStrictEqual({
         message: 'Bad Request',
         errors: [
@@ -235,7 +235,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
           userToken: partiallyLoggedInUserToken,
         });
 
-        expect(status).toBe(404);
+        expect(status).toEqual(404);
         expect(body).toStrictEqual({
           message: 'Not Found',
           errors: [
@@ -275,7 +275,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
             userToken: partiallyLoggedInUserToken,
           });
 
-          expect(status).toBe(404);
+          expect(status).toEqual(404);
           expect(body).toStrictEqual({
             message: 'Not Found',
             errors: [
@@ -311,7 +311,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
               signInToken: validSignInToken,
               userToken: partiallyLoggedInUserToken,
             });
-            expect(status).toBe(403);
+            expect(status).toEqual(403);
             expect(body).toStrictEqual({
               message: 'Forbidden',
               errors: [
@@ -347,7 +347,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
               signInToken: validSignInToken,
               userToken: partiallyLoggedInUserToken,
             });
-            expect(status).toBe(403);
+            expect(status).toEqual(403);
             expect(body).toStrictEqual({
               message: 'Forbidden',
               errors: [
@@ -382,7 +382,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
               signInToken: validSignInToken,
               userToken: partiallyLoggedInUserToken,
             });
-            expect(status).toBe(403);
+            expect(status).toEqual(403);
             expect(body).toStrictEqual({
               message: 'Forbidden',
               errors: [
@@ -418,7 +418,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
               signInToken: validSignInToken,
               userToken: partiallyLoggedInUserToken,
             });
-            expect(status).toBe(403);
+            expect(status).toEqual(403);
             expect(body).toStrictEqual({
               message: 'Forbidden',
               errors: [
@@ -474,7 +474,7 @@ describe('POST /users/:userId/sign-in-link/:signInToken/login', () => {
             });
 
             const testUserInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-            expect(testUserInDb.signInTokens).toBe(undefined);
+            expect(testUserInDb.signInTokens).toEqual(undefined);
           });
         });
       });

--- a/portal-api/api-tests/v1/users/post-sign-in-link.api-test.js
+++ b/portal-api/api-tests/v1/users/post-sign-in-link.api-test.js
@@ -133,7 +133,7 @@ describe('POST /users/me/sign-in-link', () => {
       await sendSignInLink();
 
       const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-      expect(userInDb.signInLinkSendCount).toBe(initialSignInLinkSendCount + 1);
+      expect(userInDb.signInLinkSendCount).toEqual(initialSignInLinkSendCount + 1);
     });
 
     it('does not email a new sign in link', async () => {
@@ -168,7 +168,7 @@ describe('POST /users/me/sign-in-link', () => {
       await sendSignInLink();
 
       const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-      expect(userInDb.signInLinkSendCount).toBe(initialSignInLinkSendCount + 1);
+      expect(userInDb.signInLinkSendCount).toEqual(initialSignInLinkSendCount + 1);
     });
 
     it('does not email a new sign in link', async () => {
@@ -211,7 +211,7 @@ describe('POST /users/me/sign-in-link', () => {
       await sendSignInLink();
 
       const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-      expect(userInDb.signInLinkSendCount).toBe(4);
+      expect(userInDb.signInLinkSendCount).toEqual(4);
     });
 
     it('keeps any existing sign in token data', async () => {
@@ -346,14 +346,14 @@ describe('POST /users/me/sign-in-link', () => {
             it('should return a 201 response', async () => {
               const { status } = await sendSignInLink();
 
-              expect(status).toBe(201);
+              expect(status).toEqual(201);
             });
 
             it('increments the signInLinkSendCount', async () => {
               await sendSignInLink();
 
               const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-              expect(userInDb.signInLinkSendCount).toBe(1);
+              expect(userInDb.signInLinkSendCount).toEqual(1);
             });
 
             describe('when the user has not been sent a sign in link before', () => {
@@ -375,7 +375,7 @@ describe('POST /users/me/sign-in-link', () => {
                 await sendSignInLink();
 
                 const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-                expect(userInDb.signInLinkSendCount).toBe(1);
+                expect(userInDb.signInLinkSendCount).toEqual(1);
               });
 
               it('adds the signInToken to the end of saved signInTokens array', async () => {
@@ -420,7 +420,7 @@ describe('POST /users/me/sign-in-link', () => {
                   await sendSignInLink();
 
                   const userInDb = await databaseHelper.getUserById(partiallyLoggedInUserId);
-                  expect(userInDb.signInLinkSendCount).toBe(initialSignInLinkSendCount + 1);
+                  expect(userInDb.signInLinkSendCount).toEqual(initialSignInLinkSendCount + 1);
                 });
 
                 it('adds the signInToken to the end of saved signInTokens array', async () => {
@@ -493,14 +493,14 @@ describe('POST /users/me/sign-in-link', () => {
   });
 
   function expect403ErrorWithUserBlockedMessage({ status, body }) {
-    expect(status).toBe(403);
+    expect(status).toEqual(403);
     expect(body).toStrictEqual({
       error: 'Forbidden',
       message: `User blocked: ${partiallyLoggedInUserId}`,
     });
   }
   function expect500ErrorWithFailedToCreateCodeMessage({ status, body }) {
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(body).toStrictEqual({
       error: 'Internal Server Error',
       message: 'Failed to create a sign in token',
@@ -508,7 +508,7 @@ describe('POST /users/me/sign-in-link', () => {
   }
 
   function expect500ErrorWithFailedToSaveCodeMessage({ status, body }) {
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(body).toStrictEqual({
       error: 'Internal Server Error',
       message: 'Failed to save the sign in token',
@@ -516,7 +516,7 @@ describe('POST /users/me/sign-in-link', () => {
   }
 
   function expect500ErrorWithFailedToSendEmailMessage({ status, body }) {
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(body).toStrictEqual({
       error: 'Internal Server Error',
       message: 'Failed to email the sign in token',

--- a/portal-api/api-tests/v1/validate/validate-partial-2fa-token.api-test.js
+++ b/portal-api/api-tests/v1/validate/validate-partial-2fa-token.api-test.js
@@ -25,6 +25,6 @@ describe(`GET ${url}`, () => {
 
     const { status } = await get(url, { headers: { Authorization: token } });
 
-    expect(status).toBe(200);
+    expect(status).toEqual(200);
   });
 });

--- a/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.test.ts
+++ b/portal-api/src/cron-scheduler-jobs/helpers/utilisation-report-helpers.test.ts
@@ -198,7 +198,7 @@ describe('utilisation-report-helpers', () => {
       expect(api.getUtilisationReports).toHaveBeenCalledWith(BANK_ID, {
         reportPeriod,
       });
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
 
     it.each(Object.values(UTILISATION_REPORT_RECONCILIATION_STATUS).filter((status) => status !== 'REPORT_NOT_RECEIVED'))(
@@ -221,7 +221,7 @@ describe('utilisation-report-helpers', () => {
         expect(api.getUtilisationReports).toHaveBeenCalledWith(BANK_ID, {
           reportPeriod,
         });
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       },
     );
   });

--- a/portal-api/src/crypto/cryptographically-strong-generator.test.js
+++ b/portal-api/src/crypto/cryptographically-strong-generator.test.js
@@ -23,7 +23,7 @@ describe('CryptographicallyStrongGenerator', () => {
 
       const randomHexString = generator.randomHexString(numberOfBytes);
 
-      expect(randomHexString).toBe(hexStringOfTheRandomBytes);
+      expect(randomHexString).toEqual(hexStringOfTheRandomBytes);
     });
   });
 
@@ -37,7 +37,7 @@ describe('CryptographicallyStrongGenerator', () => {
 
       const randomHexString = generator.randomHexString(numberOfBytes);
 
-      expect(randomHexString).toBe(hexStringOfTheRandomBytes);
+      expect(randomHexString).toEqual(hexStringOfTheRandomBytes);
     });
   });
 });

--- a/portal-api/src/crypto/hasher.test.js
+++ b/portal-api/src/crypto/hasher.test.js
@@ -33,12 +33,12 @@ describe('Hasher', () => {
 
     it('returns the salt generated from the hash strategy', () => {
       const { salt } = hasher.hash(valueToHash);
-      expect(salt).toBe(saltFromStrategy);
+      expect(salt).toEqual(saltFromStrategy);
     });
 
     it('returns the hash generated from the target and salt from the hash strategy', () => {
       const { hash } = hasher.hash(valueToHash);
-      expect(hash).toBe(hashFromStrategy);
+      expect(hash).toEqual(hashFromStrategy);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Hasher', () => {
           salt: saltFromStrategy,
           hash: matchingHashFromStrategy,
         });
-        expect(result).toBe(true);
+        expect(result).toEqual(true);
       });
     });
 
@@ -85,7 +85,7 @@ describe('Hasher', () => {
           salt: saltFromStrategy,
           hash: matchingHashFromStrategy,
         });
-        expect(result).toBe(false);
+        expect(result).toEqual(false);
       });
     });
   });

--- a/portal-api/src/crypto/utils.test.js
+++ b/portal-api/src/crypto/utils.test.js
@@ -103,8 +103,8 @@ describe('crypto utils', () => {
       it('should return a token with the expected payload', () => {
         const { token, sessionIdentifier } = issueValidUsernameAndPasswordJWT(USER);
         const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
-        expect(decodedToken.iat).toBe(DATE_NOW_IN_UNIX_TIME);
-        expect(decodedToken.exp).toBe(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_105_MINUTES);
+        expect(decodedToken.iat).toEqual(DATE_NOW_IN_UNIX_TIME);
+        expect(decodedToken.exp).toEqual(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_105_MINUTES);
         expect(decodedToken.username).toEqual(USER.username);
         expect(decodedToken.loginStatus).toEqual(PORTAL_LOGIN_STATUS.VALID_USERNAME_AND_PASSWORD);
         expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);
@@ -130,8 +130,8 @@ describe('crypto utils', () => {
       it('should return a token with the expected payload', () => {
         const { token, sessionIdentifier } = issueValid2faJWT(USER_WITH_EXISTING_SESSION_IDENTIFIER);
         const decodedToken = jsonwebtoken.decode(token.replace('Bearer ', ''));
-        expect(decodedToken.iat).toBe(DATE_NOW_IN_UNIX_TIME);
-        expect(decodedToken.exp).toBe(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_12_HOURS);
+        expect(decodedToken.iat).toEqual(DATE_NOW_IN_UNIX_TIME);
+        expect(decodedToken.exp).toEqual(DATE_NOW_IN_UNIX_TIME + SECONDS_IN_12_HOURS);
         expect(decodedToken.username).toEqual(USER.username);
         expect(decodedToken.loginStatus).toEqual(PORTAL_LOGIN_STATUS.VALID_2FA);
         expect(decodedToken.sessionIdentifier).toEqual(sessionIdentifier);

--- a/portal-api/src/utils/date.test.js
+++ b/portal-api/src/utils/date.test.js
@@ -52,7 +52,7 @@ describe('date', () => {
         const result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
 
         const firstBusinessDay = new Date('2023-11-01');
-        expect(isSameDay(result, firstBusinessDay)).toBe(true);
+        expect(isSameDay(result, firstBusinessDay)).toEqual(true);
       });
 
       it('should return Monday 2nd October when the month is October', () => {
@@ -61,7 +61,7 @@ describe('date', () => {
         const result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
 
         const firstBusinessDay = new Date('2023-10-02');
-        expect(isSameDay(result, firstBusinessDay)).toBe(true);
+        expect(isSameDay(result, firstBusinessDay)).toEqual(true);
       });
     });
 
@@ -75,7 +75,7 @@ describe('date', () => {
         const result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
 
         const firstBusinessDay = new Date('2023-10-03');
-        expect(isSameDay(result, firstBusinessDay)).toBe(true);
+        expect(isSameDay(result, firstBusinessDay)).toEqual(true);
       });
     });
   });
@@ -111,7 +111,7 @@ describe('date', () => {
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         const firstBusinessDay = new Date('2023-11-01');
-        expect(isSameDay(result, firstBusinessDay)).toBe(true);
+        expect(isSameDay(result, firstBusinessDay)).toEqual(true);
       });
 
       it('should return the same day next week as the sixth business day', () => {
@@ -120,7 +120,7 @@ describe('date', () => {
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         const sixthBusinessDay = new Date('2023-11-08');
-        expect(isSameDay(result, sixthBusinessDay)).toBe(true);
+        expect(isSameDay(result, sixthBusinessDay)).toEqual(true);
       });
     });
 
@@ -134,7 +134,7 @@ describe('date', () => {
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         const firstBusinessDay = new Date('2023-10-05');
-        expect(isSameDay(result, firstBusinessDay)).toBe(true);
+        expect(isSameDay(result, firstBusinessDay)).toEqual(true);
       });
 
       it('should return 9th October as the second business day', () => {
@@ -143,7 +143,7 @@ describe('date', () => {
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         const secondBusinessDay = new Date('2023-10-09');
-        expect(isSameDay(result, secondBusinessDay)).toBe(true);
+        expect(isSameDay(result, secondBusinessDay)).toEqual(true);
       });
     });
   });

--- a/portal-api/src/utils/string.test.js
+++ b/portal-api/src/utils/string.test.js
@@ -31,84 +31,84 @@ describe('isValidEmail function', () => {
   // Tests that a valid email returns true
   it('should test valid email', () => {
     const email = 'test@example.com';
-    expect(isValidEmail(email)).toBe(true);
+    expect(isValidEmail(email)).toEqual(true);
   });
 
   // Tests that a valid email with uppercase letters returns true
   it('should test valid email uppercase', () => {
     const email = 'Test@Example.com';
-    expect(isValidEmail(email)).toBe(true);
+    expect(isValidEmail(email)).toEqual(true);
   });
 
   // Tests that a valid email with numbers returns true
   it('should test valid email numbers', () => {
     const email = 'test123@example.com';
-    expect(isValidEmail(email)).toBe(true);
+    expect(isValidEmail(email)).toEqual(true);
   });
 
   // Tests that an empty string input returns false
   it('should test empty string input', () => {
     const email = '';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that a non-string input returns false
   it('should test non string input', () => {
     const email = 123;
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that an invalid email returns false
   it('should test invalid email', () => {
     const email = 'example.com';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that an invalid email without an @ symbol returns false
   it('should test invalid email no at symbol', () => {
     const email = 'testexample.com';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that an invalid email without a domain returns false
   it('should test invalid email no domain', () => {
     const email = 'test@';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that an invalid email without a username returns false
   it('should test invalid email no username', () => {
     const email = '@example.com';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that an invalid email without a top-level domain returns false
   it('should test invalid email no tld', () => {
     const email = 'test@example';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 
   // Tests that a valid email address returns true
   it('should test valid email', () => {
     const email = 'abc@ukexportfinance.gov.uk';
-    expect(isValidEmail(email)).toBe(true);
+    expect(isValidEmail(email)).toEqual(true);
   });
 
   // Tests that a valid email address with uppercase letters returns true
   it('should test valid email uppercase', () => {
     const email = 'ABC@UKEXPORTFINANCE.GOV.UK';
-    expect(isValidEmail(email)).toBe(true);
+    expect(isValidEmail(email)).toEqual(true);
   });
 
   // Tests that a valid email address with numbers returns true
   it('should test valid email numbers', () => {
     const email = 'abc123@ukexportfinance.gov.uk';
-    expect(isValidEmail(email)).toBe(true);
+    expect(isValidEmail(email)).toEqual(true);
   });
 
   // Tests that an invalid email address input returns false
   it('should test invalid email input', () => {
     const email = 'abc@ukexportfinance';
-    expect(isValidEmail(email)).toBe(false);
+    expect(isValidEmail(email)).toEqual(false);
   });
 });

--- a/portal-api/src/v1/controllers/utilisation-report-service/due-report-periods.controller.test.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/due-report-periods.controller.test.js
@@ -70,7 +70,7 @@ describe('controllers/utilisation-report-service/due-report-periods', () => {
 
       // Assert
       // eslint-disable-next-line no-underscore-dangle
-      expect(res._getStatusCode()).toBe(200);
+      expect(res._getStatusCode()).toEqual(200);
       // eslint-disable-next-line no-underscore-dangle
       expect(res._getData()).toEqual([]);
     });
@@ -91,7 +91,7 @@ describe('controllers/utilisation-report-service/due-report-periods', () => {
 
       // Assert
       // eslint-disable-next-line no-underscore-dangle
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
   });
 });

--- a/portal-api/src/v1/controllers/utilisation-report-service/last-uploaded.controller.test.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/last-uploaded.controller.test.js
@@ -128,7 +128,7 @@ describe('controllers/utilisation-report-service/last-uploaded', () => {
       expect(api.getUtilisationReports).toHaveBeenCalledWith(bankId, { excludeNotReceived });
 
       // eslint-disable-next-line no-underscore-dangle
-      expect(res._getStatusCode()).toBe(errorStatusCode);
+      expect(res._getStatusCode()).toEqual(errorStatusCode);
     });
 
     it('should return an error response if the api does not find any uploaded reports', async () => {
@@ -143,7 +143,7 @@ describe('controllers/utilisation-report-service/last-uploaded', () => {
       expect(api.getUtilisationReports).toHaveBeenCalledWith(bankId, { excludeNotReceived });
 
       // eslint-disable-next-line no-underscore-dangle
-      expect(res._getStatusCode()).toBe(500);
+      expect(res._getStatusCode()).toEqual(500);
     });
 
     it('should return the last uploaded report', async () => {
@@ -162,7 +162,7 @@ describe('controllers/utilisation-report-service/last-uploaded', () => {
       expect(api.getUtilisationReports).toHaveBeenCalledWith(bankId, { excludeNotReceived });
 
       // eslint-disable-next-line no-underscore-dangle
-      expect(res._getStatusCode()).toBe(200);
+      expect(res._getStatusCode()).toEqual(200);
       // eslint-disable-next-line no-underscore-dangle
       expect(res._getData()).toEqual(lastUploadedReport);
     });

--- a/portal-api/src/v1/controllers/utilisation-report-service/next-report-period.controller.test.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/next-report-period.controller.test.js
@@ -53,7 +53,7 @@ describe('controllers/utilisation-report-service/next-report-period', () => {
 
       // Assert
       // eslint-disable-next-line no-underscore-dangle
-      expect(res._getStatusCode()).toBe(errorStatus);
+      expect(res._getStatusCode()).toEqual(errorStatus);
     });
   });
 });

--- a/portal-api/src/v1/controllers/utilisation-report-service/utilisation-report-upload.controller.test.js
+++ b/portal-api/src/v1/controllers/utilisation-report-service/utilisation-report-upload.controller.test.js
@@ -53,7 +53,7 @@ describe('controllers/utilisation-report-service/utilisation-report-upload', () 
     await uploadReportAndSendNotification(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
   });
 
   it('does not upload report and returns a 500 if there are no reports for period', async () => {
@@ -66,7 +66,7 @@ describe('controllers/utilisation-report-service/utilisation-report-upload', () 
 
     // Assert
     expect(saveUtilisationReportFileToAzure).not.toHaveBeenCalled();
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it('does not upload report and returns a 500 if there are more than one reports for period', async () => {
@@ -79,7 +79,7 @@ describe('controllers/utilisation-report-service/utilisation-report-upload', () 
 
     // Assert
     expect(saveUtilisationReportFileToAzure).not.toHaveBeenCalled();
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
   });
 
   it('does not upload report and returns a 500 with error message if report has already been received', async () => {
@@ -92,8 +92,8 @@ describe('controllers/utilisation-report-service/utilisation-report-upload', () 
 
     // Assert
     expect(saveUtilisationReportFileToAzure).not.toHaveBeenCalled();
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-    expect(res._getData()).toBe(
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._getData()).toEqual(
       `Expected report to be in '${UTILISATION_REPORT_RECONCILIATION_STATUS.REPORT_NOT_RECEIVED}' state (was actually in '${UTILISATION_REPORT_RECONCILIATION_STATUS.PENDING_RECONCILIATION}' state)`,
     );
   });
@@ -130,7 +130,7 @@ describe('controllers/utilisation-report-service/utilisation-report-upload', () 
     await uploadReportAndSendNotification(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Created);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Created);
     expect(res._getData()).toEqual({ paymentOfficerEmails: ['email'] });
   });
 
@@ -147,7 +147,7 @@ describe('controllers/utilisation-report-service/utilisation-report-upload', () 
     await uploadReportAndSendNotification(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Created);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Created);
     expect(res._getData()).toEqual({ paymentOfficerEmails: ['email'] });
   });
 });

--- a/portal-api/src/v1/controllers/utilisation-report-service/validate-utilisation-report-data.controller.test.ts
+++ b/portal-api/src/v1/controllers/utilisation-report-service/validate-utilisation-report-data.controller.test.ts
@@ -52,8 +52,8 @@ describe('controllers/utilisation-report-service/validate-utilisation-report-dat
       await validateUtilisationReportData(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -69,8 +69,8 @@ describe('controllers/utilisation-report-service/validate-utilisation-report-dat
       await validateUtilisationReportData(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message', async () => {
@@ -83,8 +83,8 @@ describe('controllers/utilisation-report-service/validate-utilisation-report-dat
       await validateUtilisationReportData(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to validate utilisation report data');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to validate utilisation report data');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/portal-api/src/v1/errors/invalid-database-query.error.test.js
+++ b/portal-api/src/v1/errors/invalid-database-query.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidDatabaseQueryError', () => {
   it('exposes the message it was created with', () => {
     const exception = new InvalidDatabaseQueryError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidDatabaseQueryError(message);
 
-    expect(exception.name).toBe('InvalidDatabaseQueryError');
+    expect(exception.name).toEqual('InvalidDatabaseQueryError');
   });
 });

--- a/portal-api/src/v1/errors/invalid-email-address.error.test.js
+++ b/portal-api/src/v1/errors/invalid-email-address.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidEmailAddressError', () => {
   it('exposes the email in a formatted message', () => {
     const exception = new InvalidEmailAddressError(email);
 
-    expect(exception.message).toBe(`Invalid email address: ${email}`);
+    expect(exception.message).toEqual(`Invalid email address: ${email}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidEmailAddressError(email);
 
-    expect(exception.name).toBe('InvalidEmailAddressError');
+    expect(exception.name).toEqual('InvalidEmailAddressError');
   });
 });

--- a/portal-api/src/v1/errors/invalid-report-status.error.test.ts
+++ b/portal-api/src/v1/errors/invalid-report-status.error.test.ts
@@ -6,12 +6,12 @@ describe('InvalidReportStatusError', () => {
   it('exposes the message it was created with', () => {
     const exception = new InvalidReportStatusError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidReportStatusError(message);
 
-    expect(exception.name).toBe('InvalidReportStatusError');
+    expect(exception.name).toEqual('InvalidReportStatusError');
   });
 });

--- a/portal-api/src/v1/errors/invalid-session-identifier.error.test.js
+++ b/portal-api/src/v1/errors/invalid-session-identifier.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidSessionIdentifierError', () => {
   it('exposes the sessionIdentier in a formatted message', () => {
     const exception = new InvalidSessionIdentifierError(sessionIdentier);
 
-    expect(exception.message).toBe(`Invalid sessionIdentier: ${sessionIdentier}`);
+    expect(exception.message).toEqual(`Invalid sessionIdentier: ${sessionIdentier}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidSessionIdentifierError(sessionIdentier);
 
-    expect(exception.name).toBe('InvalidSessionIdentifierError');
+    expect(exception.name).toEqual('InvalidSessionIdentifierError');
   });
 });

--- a/portal-api/src/v1/errors/invalid-sign-in-token.error.test.js
+++ b/portal-api/src/v1/errors/invalid-sign-in-token.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidSignInToken', () => {
   it('exposes the signInToken in a formatted message', () => {
     const exception = new InvalidSignInToken(signInToken);
 
-    expect(exception.message).toBe(`Invalid signInToken: ${signInToken}`);
+    expect(exception.message).toEqual(`Invalid signInToken: ${signInToken}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidSignInToken(signInToken);
 
-    expect(exception.name).toBe('InvalidSignInTokenError');
+    expect(exception.name).toEqual('InvalidSignInTokenError');
   });
 });

--- a/portal-api/src/v1/errors/invalid-user-id.error.test.js
+++ b/portal-api/src/v1/errors/invalid-user-id.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidUserIdError', () => {
   it('exposes the userId in a formatted message', () => {
     const exception = new InvalidUserIdError(userId);
 
-    expect(exception.message).toBe(`Invalid user ID: ${userId}`);
+    expect(exception.message).toEqual(`Invalid user ID: ${userId}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidUserIdError(userId);
 
-    expect(exception.name).toBe('InvalidUserIdError');
+    expect(exception.name).toEqual('InvalidUserIdError');
   });
 });

--- a/portal-api/src/v1/errors/invalid-username.error.test.js
+++ b/portal-api/src/v1/errors/invalid-username.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidUsernameError', () => {
   it('exposes the username in a formatted message', () => {
     const exception = new InvalidUsernameError(username);
 
-    expect(exception.message).toBe(`Invalid username: ${username}`);
+    expect(exception.message).toEqual(`Invalid username: ${username}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidUsernameError(username);
 
-    expect(exception.name).toBe('InvalidUsernameError');
+    expect(exception.name).toEqual('InvalidUsernameError');
   });
 });

--- a/portal-api/src/v1/errors/user-blocked.error.test.js
+++ b/portal-api/src/v1/errors/user-blocked.error.test.js
@@ -6,12 +6,12 @@ describe('UserBlockedError', () => {
   it('exposes the userId in a formatted message', () => {
     const exception = new UserBlockedError(userId);
 
-    expect(exception.message).toBe(`User blocked: ${userId}`);
+    expect(exception.message).toEqual(`User blocked: ${userId}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new UserBlockedError(userId);
 
-    expect(exception.name).toBe('UserBlockedError');
+    expect(exception.name).toEqual('UserBlockedError');
   });
 });

--- a/portal-api/src/v1/errors/user-disabled.error.test.js
+++ b/portal-api/src/v1/errors/user-disabled.error.test.js
@@ -6,12 +6,12 @@ describe('UserDisabledError', () => {
   it('exposes the userId in a formatted message', () => {
     const exception = new UserDisabledError(userId);
 
-    expect(exception.message).toBe(`User disabled: ${userId}`);
+    expect(exception.message).toEqual(`User disabled: ${userId}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new UserDisabledError(userId);
 
-    expect(exception.name).toBe('UserDisabledError');
+    expect(exception.name).toEqual('UserDisabledError');
   });
 });

--- a/portal-api/src/v1/errors/user-not-found.error.test.js
+++ b/portal-api/src/v1/errors/user-not-found.error.test.js
@@ -6,20 +6,20 @@ describe('UserNotFoundError', () => {
   it('exposes the userIdentifier in a formatted message', () => {
     const exception = new UserNotFoundError({ userIdentifier });
 
-    expect(exception.message).toBe(`Failed to find user: ${userIdentifier}`);
+    expect(exception.message).toEqual(`Failed to find user: ${userIdentifier}`);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new UserNotFoundError({ userIdentifier });
 
-    expect(exception.name).toBe('UserNotFoundError');
+    expect(exception.name).toEqual('UserNotFoundError');
   });
 
   it('exposes the cause if a cause is provided', () => {
     const cause = 'exampleCause';
     const exception = new UserNotFoundError({ userIdentifier, cause });
 
-    expect(exception.cause).toBe(cause);
+    expect(exception.cause).toEqual(cause);
   });
 
   it('does not expose a cause if a cause is not provided', () => {

--- a/portal-api/src/v1/helpers/date.test.ts
+++ b/portal-api/src/v1/helpers/date.test.ts
@@ -10,7 +10,7 @@ import {
 describe('getNowAsEpoch', () => {
   it('should return as EPOCH representing the current time in milliseconds', () => {
     const result = getNowAsEpoch();
-    expect(typeof result).toBe('number');
+    expect(typeof result).toEqual('number');
   });
 
   it('should return EPOCH from getNowAsEpoch function call, whose subsequent value will be either equal or greater than the previous call', () => {
@@ -21,7 +21,7 @@ describe('getNowAsEpoch', () => {
 
   it('should return a number', () => {
     const result = getNowAsEpoch();
-    expect(typeof result).toBe('number');
+    expect(typeof result).toEqual('number');
   });
 
   it('should return a number greater than 0', () => {
@@ -43,7 +43,7 @@ describe('getNowAsEpoch', () => {
     jest.useFakeTimers().setSystemTime(new Date('1970-01-01 01:00:00'));
 
     const result = getNowAsEpoch();
-    expect(result).toBe(0);
+    expect(result).toEqual(0);
   });
 });
 
@@ -288,6 +288,6 @@ describe('getLongFormattedDate', () => {
 
     const result = getLongFormattedDate(mockDate);
 
-    expect(result).toBe('15th July 2024');
+    expect(result).toEqual('15th July 2024');
   });
 });

--- a/portal-api/src/v1/roles/user-has-at-least-one-allowed-role.test.js
+++ b/portal-api/src/v1/roles/user-has-at-least-one-allowed-role.test.js
@@ -13,7 +13,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [] },
       });
 
-      expect(allowed).toBe(false);
+      expect(allowed).toEqual(false);
     });
 
     it.each(allRoles)('returns false if the user has the %s role', (userRole) => {
@@ -22,7 +22,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [userRole] },
       });
 
-      expect(allowed).toBe(false);
+      expect(allowed).toEqual(false);
     });
   });
 
@@ -35,7 +35,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [] },
       });
 
-      expect(allowed).toBe(false);
+      expect(allowed).toEqual(false);
     });
 
     const nonMatchingRoles = allRoles.filter((role) => role !== allowedRole);
@@ -45,7 +45,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [userRole] },
       });
 
-      expect(allowed).toBe(false);
+      expect(allowed).toEqual(false);
     });
 
     it(`returns true if the user has the ${allowedRole} role only`, () => {
@@ -54,7 +54,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [allowedRole] },
       });
 
-      expect(allowed).toBe(true);
+      expect(allowed).toEqual(true);
     });
 
     it.each(nonMatchingRoles)(`returns true if the user has the ${allowedRole} role and the %s role in either order`, (userRole) => {
@@ -67,8 +67,8 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [userRole, allowedRole] },
       });
 
-      expect(allowedWithAllowedRoleFirst).toBe(true);
-      expect(allowedWithAllowedRoleSecond).toBe(true);
+      expect(allowedWithAllowedRoleFirst).toEqual(true);
+      expect(allowedWithAllowedRoleSecond).toEqual(true);
     });
   });
 
@@ -82,7 +82,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [] },
       });
 
-      expect(allowed).toBe(false);
+      expect(allowed).toEqual(false);
     });
 
     it('returns false if the user has none of the allowed roles', () => {
@@ -91,7 +91,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [notAllowedRole] },
       });
 
-      expect(allowed).toBe(false);
+      expect(allowed).toEqual(false);
     });
 
     it('returns true if the user has one of the allowed roles', () => {
@@ -100,7 +100,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [allowedRoles[0]] },
       });
 
-      expect(allowed).toBe(true);
+      expect(allowed).toEqual(true);
     });
 
     it('returns true if the user has multiple of the allowed roles', () => {
@@ -109,7 +109,7 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [allowedRoles[0], allowedRoles[1]] },
       });
 
-      expect(allowed).toBe(true);
+      expect(allowed).toEqual(true);
     });
 
     it('returns true if the user has an allowed role and another role in either order', () => {
@@ -122,8 +122,8 @@ describe('userHasAtLeastOneAllowedRole', () => {
         user: { roles: [notAllowedRole, allowedRoles[1]] },
       });
 
-      expect(allowedWithAllowedRoleFirst).toBe(true);
-      expect(allowedWithAllowedRoleSecond).toBe(true);
+      expect(allowedWithAllowedRoleFirst).toEqual(true);
+      expect(allowedWithAllowedRoleSecond).toEqual(true);
     });
   });
 });

--- a/portal-api/src/v1/users/routes.test.js
+++ b/portal-api/src/v1/users/routes.test.js
@@ -123,7 +123,7 @@ describe('users routes', () => {
 
       const result = await loginWithSignInLink(req, res);
 
-      expect(result).toBe('mock result');
+      expect(result).toEqual('mock result');
     });
   });
 

--- a/portal-api/src/v1/users/sign-in-link.service.create-and-email-sign-in-link.test.js
+++ b/portal-api/src/v1/users/sign-in-link.service.create-and-email-sign-in-link.test.js
@@ -226,7 +226,7 @@ describe('SignInLinkService', () => {
                 it('resolves and returns numberOfSendSignInLinkAttemptsRemaining', async () => {
                   const createAndEmailSignInLinkPromise = service.createAndEmailSignInLink(user);
 
-                  await expect(createAndEmailSignInLinkPromise).resolves.toBe(numberOfSendSignInLinkAttemptsRemaining);
+                  await expect(createAndEmailSignInLinkPromise).resolves.toEqual(numberOfSendSignInLinkAttemptsRemaining);
                 });
 
                 it('increments signInLinkSendCount', async () => {

--- a/portal-api/src/v1/users/sign-in-link.service.get-sign-in-token-status.test.js
+++ b/portal-api/src/v1/users/sign-in-link.service.get-sign-in-token-status.test.js
@@ -311,7 +311,7 @@ describe('getSignInTokenStatus', () => {
 
   function itReturnsTheStatus(expectedStatus) {
     it(`returns ${expectedStatus}`, async () => {
-      await expect(service.getSignInTokenStatus({ userId: testUserFromDatabase._id, signInToken: aTokenProvidedByUser })).resolves.toBe(expectedStatus);
+      await expect(service.getSignInTokenStatus({ userId: testUserFromDatabase._id, signInToken: aTokenProvidedByUser })).resolves.toEqual(expectedStatus);
     });
   }
 

--- a/portal-api/src/v1/users/user.service.test.js
+++ b/portal-api/src/v1/users/user.service.test.js
@@ -31,7 +31,7 @@ describe('UserService', () => {
 
     it('checking a user is blocked or disabled returns true', async () => {
       const result = userService.isUserBlockedOrDisabled(blockedUser);
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
   });
 
@@ -49,7 +49,7 @@ describe('UserService', () => {
 
     it('checking a user is blocked or disabled returns true', async () => {
       const result = userService.isUserBlockedOrDisabled(disabledUser);
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
   });
 
@@ -67,7 +67,7 @@ describe('UserService', () => {
 
     it('checking a user is blocked or disabled returns true', async () => {
       const result = userService.isUserBlockedOrDisabled(disabledAndBlockedUser);
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
   });
 
@@ -78,7 +78,7 @@ describe('UserService', () => {
 
     it('checking a user is blocked or disabled returns false', async () => {
       const result = userService.isUserBlockedOrDisabled(testUser._id);
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 
@@ -96,7 +96,7 @@ describe('UserService', () => {
 
     it('checking a user is blocked or disabled returns false', async () => {
       const result = userService.isUserBlockedOrDisabled(disabledSetToFalseUser._id);
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
   });
 });

--- a/portal-api/src/v1/validation/fields/country.test.js
+++ b/portal-api/src/v1/validation/fields/country.test.js
@@ -30,6 +30,6 @@ describe('isCountryDisabled ', () => {
     ${undefined} | ${true}
   `('Should return $expected for specified country code $code', async ({ code, expected }) => {
     const response = await isCountryDisabled(code);
-    expect(response).toBe(expected);
+    expect(response).toEqual(expected);
   });
 });

--- a/portal/api-tests/admin-routes.api-test.js
+++ b/portal/api-tests/admin-routes.api-test.js
@@ -90,8 +90,8 @@ describe('user routes', () => {
       it("redirects to '/admin/users' if the Portal API call to update the user returns a 200", async () => {
         const response = await post({}, { Cookie: [sessionCookie] }).to(`/admin/users/edit/${_id}`);
 
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe('/admin/users');
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual('/admin/users');
       });
     });
 
@@ -101,7 +101,7 @@ describe('user routes', () => {
 
         const response = await post({}, { Cookie: [sessionCookie] }).to(`/admin/users/edit/${_id}`);
 
-        expect(response.status).toBe(200);
+        expect(response.status).toEqual(200);
       });
     });
   });

--- a/portal/api-tests/api-rate-limiting.api-test.js
+++ b/portal/api-tests/api-rate-limiting.api-test.js
@@ -27,7 +27,7 @@ describe('api rate limiting', () => {
 
       const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-      expect(responseAfterRateLimitExceeded.status).toBe(429);
+      expect(responseAfterRateLimitExceeded.status).toEqual(429);
     });
 
     it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -35,7 +35,7 @@ describe('api rate limiting', () => {
 
       const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-      expect(responseThatMeetsRateLimit.status).toBe(200);
+      expect(responseThatMeetsRateLimit.status).toEqual(200);
     });
   });
 
@@ -47,7 +47,7 @@ describe('api rate limiting', () => {
 
       const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-      expect(responseAfterRateLimitExceeded.status).toBe(200);
+      expect(responseAfterRateLimitExceeded.status).toEqual(200);
     });
 
     it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -55,7 +55,7 @@ describe('api rate limiting', () => {
 
       const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-      expect(responseThatMeetsRateLimit.status).toBe(200);
+      expect(responseThatMeetsRateLimit.status).toEqual(200);
     });
   });
 });

--- a/portal/api-tests/common-tests/partial-2fa-auth-validation-api-tests.js
+++ b/portal/api-tests/common-tests/partial-2fa-auth-validation-api-tests.js
@@ -22,8 +22,8 @@ const withPartial2faAuthValidationApiTests = ({ makeRequestWithHeaders, validate
 
     it('redirects to /login if the user does not have a session', async () => {
       const response = await makeRequestWithHeaders();
-      expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/login');
+      expect(response.status).toEqual(302);
+      expect(response.headers.location).toEqual('/login');
     });
 
     it('redirects to /login if the user has a session with an invalid partial auth token', async () => {
@@ -31,8 +31,8 @@ const withPartial2faAuthValidationApiTests = ({ makeRequestWithHeaders, validate
 
       const response = await makeRequestWithHeaders({ Cookie: sessionCookie });
 
-      expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/login');
+      expect(response.status).toEqual(302);
+      expect(response.headers.location).toEqual('/login');
     });
 
     it('succeeds if the user has a session with a valid partial auth token', async () => {

--- a/portal/api-tests/common-tests/role-validation-api-tests.js
+++ b/portal/api-tests/common-tests/role-validation-api-tests.js
@@ -36,11 +36,11 @@ const withRoleValidationApiTests = ({
             await get('/login/sign-in-link', { t: token, u: userId }, { Cookie: sessionCookie });
             const response = await makeRequestWithHeaders({ Cookie: sessionCookie });
 
-            expect(response.status).toBe(successCode);
+            expect(response.status).toEqual(successCode);
 
             if (successHeaders) {
               for (const [key, value] of Object.entries(successHeaders)) {
-                expect(response.headers[key]).toBe(value);
+                expect(response.headers[key]).toEqual(value);
               }
             }
           });
@@ -58,9 +58,9 @@ const withRoleValidationApiTests = ({
           await get('/login/sign-in-link', { t: token, u: userId }, { Cookie: sessionCookie });
           const response = await makeRequestWithHeaders({ Cookie: sessionCookie });
 
-          expect(response.status).toBe(302);
+          expect(response.status).toEqual(302);
           const redirectUrl = redirectUrlForInvalidRoles ?? '/';
-          expect(response.headers.location).toBe(redirectUrl);
+          expect(response.headers.location).toEqual(redirectUrl);
         });
       });
     }

--- a/portal/api-tests/login/get-check-your-email.api-test.js
+++ b/portal/api-tests/login/get-check-your-email.api-test.js
@@ -18,6 +18,6 @@ const { withPartial2faAuthValidationApiTests } = require('../common-tests/partia
 describe('GET /login/check-your-email', () => {
   withPartial2faAuthValidationApiTests({
     makeRequestWithHeaders: (headers) => get('/login/check-your-email', {}, headers),
-    validateResponseWasSuccessful: (response) => expect(response.status).toBe(200),
+    validateResponseWasSuccessful: (response) => expect(response.status).toEqual(200),
   });
 });

--- a/portal/api-tests/login/get-sign-in-link-expired.api-test.js
+++ b/portal/api-tests/login/get-sign-in-link-expired.api-test.js
@@ -10,6 +10,6 @@ jest.mock('../../server/api', () => ({
 describe('GET /login/sign-in-link-expired', () => {
   withPartial2faAuthValidationApiTests({
     makeRequestWithHeaders: (headers) => get('/login/sign-in-link-expired', {}, headers),
-    validateResponseWasSuccessful: (response) => expect(response.status).toBe(302),
+    validateResponseWasSuccessful: (response) => expect(response.status).toEqual(302),
   });
 });

--- a/portal/api-tests/login/login-with-sign-in-link.api-test.js
+++ b/portal/api-tests/login/login-with-sign-in-link.api-test.js
@@ -36,7 +36,7 @@ describe('GET /login/sign-in-link?t={signInToken}&u={userId}', () => {
 
     const { status } = await getSignInLinkLoginPage({ u: validUserId, t: validSignInToken });
 
-    expect(status).toBe(200);
+    expect(status).toEqual(200);
   });
 
   it('redirects to /login/sign-in-link-expired if the login API request fails with a token expired 403', async () => {
@@ -48,8 +48,8 @@ describe('GET /login/sign-in-link?t={signInToken}&u={userId}', () => {
 
     const { status, headers } = await getSignInLinkLoginPage({ u: validUserId, t: validSignInToken });
 
-    expect(status).toBe(302);
-    expect(headers.location).toBe('/login/sign-in-link-expired');
+    expect(status).toEqual(302);
+    expect(headers.location).toEqual('/login/sign-in-link-expired');
   });
 
   it('redirects to /login/sign-in-link-expired if the login API request fails with a user blocked 403', async () => {
@@ -61,7 +61,7 @@ describe('GET /login/sign-in-link?t={signInToken}&u={userId}', () => {
 
     const { status, text } = await getSignInLinkLoginPage({ u: validUserId, t: validSignInToken });
 
-    expect(status).toBe(403);
+    expect(status).toEqual(403);
     expect(text).toContain('This account has been temporarily suspended');
   });
 
@@ -72,8 +72,8 @@ describe('GET /login/sign-in-link?t={signInToken}&u={userId}', () => {
 
     const { status, headers } = await getSignInLinkLoginPage({ u: validUserId, t: validSignInToken });
 
-    expect(status).toBe(302);
-    expect(headers.location).toBe('/login');
+    expect(status).toEqual(302);
+    expect(headers.location).toEqual('/login');
   });
 
   it('redirects to /login if the login API request fails with a 404', async () => {
@@ -83,8 +83,8 @@ describe('GET /login/sign-in-link?t={signInToken}&u={userId}', () => {
 
     const { status, headers } = await getSignInLinkLoginPage({ u: validUserId, t: validSignInToken });
 
-    expect(status).toBe(302);
-    expect(headers.location).toBe('/login');
+    expect(status).toEqual(302);
+    expect(headers.location).toEqual('/login');
   });
 
   it('returns a 500 response if the login API request has an unexpected error', async () => {
@@ -92,49 +92,49 @@ describe('GET /login/sign-in-link?t={signInToken}&u={userId}', () => {
 
     const { status, text } = await getSignInLinkLoginPage({ u: validUserId, t: validSignInToken });
 
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(text).toContain('Problem with the service');
   });
 
   it('returns a 400 response if the u query string is not a valid ObjectId', async () => {
     const { status, text } = await getSignInLinkLoginPage({ u: '123', t: validSignInToken });
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(text).toContain('Problem with the service');
   });
 
   it('returns a 400 response if the u query string is not provided', async () => {
     const { status, text } = await getSignInLinkLoginPage({ t: validSignInToken });
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(text).toContain('Problem with the service');
   });
 
   it('returns a 400 response if the u query string is empty', async () => {
     const { status, text } = await getSignInLinkLoginPage({ t: validSignInToken, u: '' });
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(text).toContain('Problem with the service');
   });
 
   it('returns a 400 response if the t query string is not a string of hex characters', async () => {
     const { status, text } = await getSignInLinkLoginPage({ u: validUserId, t: 'not-a-hex-string' });
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(text).toContain('Problem with the service');
   });
 
   it('returns a 400 response if the t query string is not provided', async () => {
     const { status, text } = await getSignInLinkLoginPage({ u: validUserId });
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(text).toContain('Problem with the service');
   });
 
   it('returns a 400 response if the t query string is empty', async () => {
     const { status, text } = await getSignInLinkLoginPage({ u: validUserId, t: '' });
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(text).toContain('Problem with the service');
   });
 });

--- a/portal/api-tests/login/post-login.api-test.js
+++ b/portal/api-tests/login/post-login.api-test.js
@@ -84,7 +84,7 @@ describe('POST /login', () => {
 
     it('returns a 403', async () => {
       const { status } = await loginWith({ email: anEmail, password: aPassword });
-      expect(status).toBe(403);
+      expect(status).toEqual(403);
     });
   });
 
@@ -107,7 +107,7 @@ describe('POST /login', () => {
     it('redirects the user to the check-your-email page if the sign in link is sent successfully', async () => {
       const { status, headers } = await loginWith({ email: anEmail, password: aPassword });
 
-      expect(status).toBe(302);
+      expect(status).toEqual(302);
       expect(headers).toHaveProperty('location', '/login/check-your-email');
     });
 
@@ -116,7 +116,7 @@ describe('POST /login', () => {
 
       const { status, headers } = await loginWith({ email: anEmail, password: aPassword });
 
-      expect(status).toBe(302);
+      expect(status).toEqual(302);
       expect(headers).toHaveProperty('location', '/login/check-your-email');
     });
 
@@ -127,7 +127,7 @@ describe('POST /login', () => {
 
       const { status } = await loginWith({ email: anEmail, password: aPassword });
 
-      expect(status).toBe(403);
+      expect(status).toEqual(403);
     });
   });
 });

--- a/portal/api-tests/login/send-new-sign-in-link-api-tests.js
+++ b/portal/api-tests/login/send-new-sign-in-link-api-tests.js
@@ -36,8 +36,8 @@ const withSendNewSignInLinkApiTests = (endpoint) => {
     withPartial2faAuthValidationApiTests({
       makeRequestWithHeaders: (headers) => post({}, headers).to(`/login/${endpoint}`),
       validateResponseWasSuccessful: (response) => {
-        expect(response.status).toBe(302);
-        expect(response.headers.location).toBe('/login/check-your-email');
+        expect(response.status).toEqual(302);
+        expect(response.headers.location).toEqual('/login/check-your-email');
       },
     });
 
@@ -70,8 +70,8 @@ const withSendNewSignInLinkApiTests = (endpoint) => {
         it('redirects the user to /login', async () => {
           const { status, headers } = await post().to(`/login/${endpoint}`);
 
-          expect(status).toBe(302);
-          expect(headers.location).toBe('/login');
+          expect(status).toEqual(302);
+          expect(headers.location).toEqual('/login');
         });
       });
 
@@ -107,8 +107,8 @@ const withSendNewSignInLinkApiTests = (endpoint) => {
         it('redirects the user to /login/check-your-email', async () => {
           const { status, headers } = await post({}, { Cookie: sessionCookie }).to('/login/check-your-email');
 
-          expect(status).toBe(302);
-          expect(headers.location).toBe('/login/check-your-email');
+          expect(status).toEqual(302);
+          expect(headers.location).toEqual('/login/check-your-email');
         });
       }
 

--- a/portal/server/api.test.js
+++ b/portal/server/api.test.js
@@ -45,7 +45,7 @@ describe('api.login', () => {
 
     const loginPromise = api.login(username, password);
 
-    await expect(loginPromise).rejects.toBe(error);
+    await expect(loginPromise).rejects.toEqual(error);
   });
 });
 
@@ -87,6 +87,6 @@ describe('api.loginWithSignInLink', () => {
 
     const loginPromise = api.loginWithSignInLink({ token: token2fa, signInToken, userId });
 
-    await expect(loginPromise).rejects.toBe(error);
+    await expect(loginPromise).rejects.toEqual(error);
   });
 });

--- a/portal/server/controllers/dashboard/filters/helpers.test.js
+++ b/portal/server/controllers/dashboard/filters/helpers.test.js
@@ -105,29 +105,29 @@ describe('controllers/dashboard/filters - helpers', () => {
     });
 
     it('handles boolean values', () => {
-      expect(formatFieldValue(true)).toBe('true');
-      expect(formatFieldValue(false)).toBe('false');
+      expect(formatFieldValue(true)).toEqual('true');
+      expect(formatFieldValue(false)).toEqual('false');
     });
 
     it('returns null for null or undefined values', () => {
-      expect(formatFieldValue(null)).toBe(null);
-      expect(formatFieldValue(undefined)).toBe(null);
+      expect(formatFieldValue(null)).toEqual(null);
+      expect(formatFieldValue(undefined)).toEqual(null);
     });
 
     it('returns null for empty string', () => {
-      expect(formatFieldValue('')).toBe(null);
+      expect(formatFieldValue('')).toEqual(null);
     });
 
     it('returns null for numeric zero', () => {
-      expect(formatFieldValue(0)).toBe(null);
+      expect(formatFieldValue(0)).toEqual(null);
     });
 
     it('handles numeric non-zero values', () => {
-      expect(formatFieldValue(123)).toBe('123');
+      expect(formatFieldValue(123)).toEqual('123');
     });
 
     it('handles NaN values', () => {
-      expect(formatFieldValue(NaN)).toBe(null);
+      expect(formatFieldValue(NaN)).toEqual(null);
     });
   });
 

--- a/portal/server/controllers/login/check-your-email.test.js
+++ b/portal/server/controllers/login/check-your-email.test.js
@@ -106,7 +106,7 @@ describe('sendNewSignInLink', () => {
 
       await sendNewSignInLink(req, res);
 
-      expect(req.session.numberOfSendSignInLinkAttemptsRemaining).toBe(numberOfSendSignInLinkAttemptsRemaining);
+      expect(req.session.numberOfSendSignInLinkAttemptsRemaining).toEqual(numberOfSendSignInLinkAttemptsRemaining);
     });
 
     it('redirects to the check your email page', async () => {
@@ -142,7 +142,7 @@ describe('sendNewSignInLink', () => {
 
       await sendNewSignInLink(req, res);
 
-      expect(req.session.numberOfSendSignInLinkAttemptsRemaining).toBe(-1);
+      expect(req.session.numberOfSendSignInLinkAttemptsRemaining).toEqual(-1);
     });
   });
 

--- a/portal/server/controllers/login/login-with-sign-in-link.test.js
+++ b/portal/server/controllers/login/login-with-sign-in-link.test.js
@@ -49,10 +49,10 @@ describe('loginWithSignInLink', () => {
 
     await loginWithSignInLink(req, res);
 
-    expect(session.userToken).toBe(loginResponseUserToken);
+    expect(session.userToken).toEqual(loginResponseUserToken);
     expect(session.user).toEqual(user);
-    expect(session.loginStatus).toBe(loginStatus);
-    expect(session.dashboardFilters).toBe(CONSTANTS.DASHBOARD.DEFAULT_FILTERS);
+    expect(session.loginStatus).toEqual(loginStatus);
+    expect(session.dashboardFilters).toEqual(CONSTANTS.DASHBOARD.DEFAULT_FILTERS);
   });
 
   it('deletes the numberOfSendSignInLinkAttemptsRemaining from the session', async () => {
@@ -60,7 +60,7 @@ describe('loginWithSignInLink', () => {
 
     await loginWithSignInLink(req, res);
 
-    expect(session.numberOfSendSignInLinkAttemptsRemaining).toBe(undefined);
+    expect(session.numberOfSendSignInLinkAttemptsRemaining).toEqual(undefined);
   });
 
   it('deletes the userEmail from the session', async () => {
@@ -68,7 +68,7 @@ describe('loginWithSignInLink', () => {
 
     await loginWithSignInLink(req, res);
 
-    expect(session.userEmail).toBe(undefined);
+    expect(session.userEmail).toEqual(undefined);
   });
 
   it.each`

--- a/portal/server/controllers/utilisation-report-service/previous-reports/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/previous-reports/index.test.ts
@@ -56,7 +56,7 @@ describe('previous-reports controller', () => {
       expect(apiGetPreviousReportsSpy).toHaveBeenCalledTimes(1);
       expect(apiGetPreviousReportsSpy).toHaveBeenCalledWith(USER_TOKEN, BANK_ID);
       expect(mapToPreviousReportsViewModelSpy).toHaveBeenCalledWith('2024', mockUser, responseBody);
-      expect(res._getRenderView()).toBe('utilisation-report-service/previous-reports/previous-reports.njk');
+      expect(res._getRenderView()).toEqual('utilisation-report-service/previous-reports/previous-reports.njk');
       expect(res._getRenderData()).toEqual(viewModel);
     });
 
@@ -71,7 +71,7 @@ describe('previous-reports controller', () => {
       // Assert
       expect(apiGetPreviousReportsSpy).toHaveBeenCalledTimes(1);
       expect(apiGetPreviousReportsSpy).toHaveBeenCalledWith(USER_TOKEN, BANK_ID);
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: mockUser });
     });
   });

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-details.test.js
@@ -48,16 +48,16 @@ describe('utilisation-report-details', () => {
   it('should return the correct full name, date format and report period for a report uploaded in the morning', () => {
     const { uploadedByFullName, formattedDateAndTimeUploaded, lastUploadedReportPeriod } = getReportAndUserDetails(morningReport);
 
-    expect(uploadedByFullName).toBe('John Smith');
-    expect(formattedDateAndTimeUploaded).toBe('8 April 2023 at 10:35am');
-    expect(lastUploadedReportPeriod).toBe('April 2023');
+    expect(uploadedByFullName).toEqual('John Smith');
+    expect(formattedDateAndTimeUploaded).toEqual('8 April 2023 at 10:35am');
+    expect(lastUploadedReportPeriod).toEqual('April 2023');
   });
 
   it('should return the correct full name, date format and report period for a report uploaded in the afternoon', () => {
     const { uploadedByFullName, formattedDateAndTimeUploaded, lastUploadedReportPeriod } = getReportAndUserDetails(afternoonReport);
 
-    expect(uploadedByFullName).toBe('John Smith');
-    expect(formattedDateAndTimeUploaded).toBe('8 April 2023 at 3:23pm');
-    expect(lastUploadedReportPeriod).toBe('April 2023');
+    expect(uploadedByFullName).toEqual('John Smith');
+    expect(formattedDateAndTimeUploaded).toEqual('8 April 2023 at 3:23pm');
+    expect(lastUploadedReportPeriod).toEqual('April 2023');
   });
 });

--- a/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-filename-validator.test.ts
+++ b/portal/server/controllers/utilisation-report-service/utilisation-report-upload/utilisation-report-filename-validator.test.ts
@@ -17,7 +17,7 @@ describe('utilisation-report-validator', () => {
       const { filenameError } = validateFilenameFormat(filename, dueReportPeriod);
 
       // Assert
-      expect(filenameError).toBe(`Report filename must not contain '${FILE_UPLOAD.FILENAME_SUBMITTED_INDICATOR}'`);
+      expect(filenameError).toEqual(`Report filename must not contain '${FILE_UPLOAD.FILENAME_SUBMITTED_INDICATOR}'`);
     });
 
     describe('when the due report period is a monthly report period', () => {
@@ -53,7 +53,9 @@ describe('utilisation-report-validator', () => {
           const { filenameError } = validateFilenameFormat(filename, dueReportPeriod);
 
           // Assert
-          expect(filenameError).toBe(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
+          expect(filenameError).toEqual(
+            `The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`,
+          );
         });
 
         it('should return an error with an example filename when the filename contains an incorrect year', () => {
@@ -67,7 +69,9 @@ describe('utilisation-report-validator', () => {
           const { filenameError } = validateFilenameFormat(filename, dueReportPeriod);
 
           // Assert
-          expect(filenameError).toBe(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
+          expect(filenameError).toEqual(
+            `The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`,
+          );
         });
       });
 
@@ -83,7 +87,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueReportPeriod);
 
         // Assert
-        expect(filenameError).toBe("The selected file must contain the word 'monthly'");
+        expect(filenameError).toEqual("The selected file must contain the word 'monthly'");
       });
     });
 
@@ -123,7 +127,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueQuarterlyReportPeriod);
 
         // Assert
-        expect(filenameError).toBe(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
+        expect(filenameError).toEqual(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
       });
 
       it('should return an error with an example filename when the filename contains an incorrect year', () => {
@@ -137,7 +141,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueQuarterlyReportPeriod);
 
         // Assert
-        expect(filenameError).toBe(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
+        expect(filenameError).toEqual(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
       });
 
       it("should return an error when the filename does not contain the word 'quarterly'", () => {
@@ -148,7 +152,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueQuarterlyReportPeriod);
 
         // Assert
-        expect(filenameError).toBe("The selected file must contain the word 'quarterly'");
+        expect(filenameError).toEqual("The selected file must contain the word 'quarterly'");
       });
     });
 
@@ -189,7 +193,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueQuarterlyReportPeriod);
 
         // Assert
-        expect(filenameError).toBe(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
+        expect(filenameError).toEqual(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
       });
 
       it('should return an error with an example filename when the filename contains an incorrect end year', () => {
@@ -203,7 +207,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueQuarterlyReportPeriod);
 
         // Assert
-        expect(filenameError).toBe(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
+        expect(filenameError).toEqual(`The selected file must contain the reporting period as part of its name, for example '${exampleFilenameReportPeriod}'`);
       });
 
       it("should return an error when the filename does not contain the word 'quarterly'", () => {
@@ -214,7 +218,7 @@ describe('utilisation-report-validator', () => {
         const { filenameError } = validateFilenameFormat(filename, dueQuarterlyReportPeriod);
 
         // Assert
-        expect(filenameError).toBe("The selected file must contain the word 'quarterly'");
+        expect(filenameError).toEqual("The selected file must contain the word 'quarterly'");
       });
     });
   });

--- a/portal/server/helpers/convertUserFormDataToRequest.test.js
+++ b/portal/server/helpers/convertUserFormDataToRequest.test.js
@@ -25,19 +25,19 @@ describe('convertUserFormDataToRequest', () => {
     it('should return true when isTrusted is "true"', () => {
       const user = { isTrusted: 'true' };
       const result = convertUserFormDataToRequest(user);
-      expect(result.isTrusted).toBe(true);
+      expect(result.isTrusted).toEqual(true);
     });
 
     it('should return false when isTrusted is "false"', () => {
       const user = { isTrusted: 'false' };
       const result = convertUserFormDataToRequest(user);
-      expect(result.isTrusted).toBe(false);
+      expect(result.isTrusted).toEqual(false);
     });
 
     it('should return undefined when isTrusted is undefined', () => {
       const user = {};
       const result = convertUserFormDataToRequest(user);
-      expect(result.isTrusted).toBe(undefined);
+      expect(result.isTrusted).toEqual(undefined);
     });
   });
 
@@ -45,13 +45,13 @@ describe('convertUserFormDataToRequest', () => {
     it('should return username as email', () => {
       const user = { email: 'example@ukexportfinance.gov.uk' };
       const result = convertUserFormDataToRequest(user);
-      expect(result.username).toBe('example@ukexportfinance.gov.uk');
+      expect(result.username).toEqual('example@ukexportfinance.gov.uk');
     });
 
     it('should return username as undefined when email is undefined', () => {
       const user = {};
       const result = convertUserFormDataToRequest(user);
-      expect(result.email).toBe(undefined);
+      expect(result.email).toEqual(undefined);
     });
   });
 });

--- a/portal/server/helpers/date.test.ts
+++ b/portal/server/helpers/date.test.ts
@@ -20,8 +20,8 @@ describe('helpers - date', () => {
       const nowAsEpoch = getNowAsEpoch();
 
       // Assert
-      expect(nowAsEpoch).toBe(now);
-      expect(nowAsEpoch.toString().length).toBe(13);
+      expect(nowAsEpoch).toEqual(now);
+      expect(nowAsEpoch.toString().length).toEqual(13);
     });
   });
 });

--- a/portal/server/helpers/dealFormsCompleted.test.js
+++ b/portal/server/helpers/dealFormsCompleted.test.js
@@ -462,7 +462,7 @@ describe('isEligibilityComplete', () => {
       },
     };
     const result = isEligibilityComplete(deal);
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it("should return false when eligibility status is not 'completed'", () => {
@@ -472,7 +472,7 @@ describe('isEligibilityComplete', () => {
       },
     };
     const result = isEligibilityComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when eligibility status is undefined', () => {
@@ -480,18 +480,18 @@ describe('isEligibilityComplete', () => {
       eligibility: {},
     };
     const result = isEligibilityComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is undefined', () => {
     const result = isEligibilityComplete(undefined);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when eligibility object is undefined', () => {
     const deal = {};
     const result = isEligibilityComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when status property of eligibility object is undefined', () => {
@@ -499,7 +499,7 @@ describe('isEligibilityComplete', () => {
       eligibility: {},
     };
     const result = isEligibilityComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });
 
@@ -511,7 +511,7 @@ describe('isSubmissionDetailComplete', () => {
       },
     };
     const result = isSubmissionDetailComplete(deal);
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it("should return false when submissionDetails status is not 'completed'", () => {
@@ -521,7 +521,7 @@ describe('isSubmissionDetailComplete', () => {
       },
     };
     const result = isSubmissionDetailComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when submissionDetails status is undefined', () => {
@@ -529,18 +529,18 @@ describe('isSubmissionDetailComplete', () => {
       submissionDetails: {},
     };
     const result = isSubmissionDetailComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is undefined', () => {
     const result = isSubmissionDetailComplete(undefined);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when submissionDetails object is undefined', () => {
     const deal = {};
     const result = isSubmissionDetailComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when status property of submissionDetails object is undefined', () => {
@@ -548,6 +548,6 @@ describe('isSubmissionDetailComplete', () => {
       submissionDetails: {},
     };
     const result = isSubmissionDetailComplete(deal);
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });

--- a/portal/server/helpers/getBusinessDayOfMonth.test.js
+++ b/portal/server/helpers/getBusinessDayOfMonth.test.js
@@ -51,7 +51,7 @@ describe('getFirstBusinessDayOfMonth', () => {
       const result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
 
       const firstBusinessDay = new Date('2023-11-01');
-      expect(isSameDay(result, firstBusinessDay)).toBe(true);
+      expect(isSameDay(result, firstBusinessDay)).toEqual(true);
     });
 
     it('should return Monday 2nd October when the month is October', () => {
@@ -60,7 +60,7 @@ describe('getFirstBusinessDayOfMonth', () => {
       const result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
 
       const firstBusinessDay = new Date('2023-10-02');
-      expect(isSameDay(result, firstBusinessDay)).toBe(true);
+      expect(isSameDay(result, firstBusinessDay)).toEqual(true);
     });
   });
 
@@ -74,7 +74,7 @@ describe('getFirstBusinessDayOfMonth', () => {
       const result = getFirstBusinessDayOfMonth(dateInMonth, holidays);
 
       const firstBusinessDay = new Date('2023-10-03');
-      expect(isSameDay(result, firstBusinessDay)).toBe(true);
+      expect(isSameDay(result, firstBusinessDay)).toEqual(true);
     });
   });
 });
@@ -110,7 +110,7 @@ describe('getBusinessDayOfMonth', () => {
       const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
       const firstBusinessDay = new Date('2023-11-01');
-      expect(isSameDay(result, firstBusinessDay)).toBe(true);
+      expect(isSameDay(result, firstBusinessDay)).toEqual(true);
     });
 
     it('should return the same day next week as the sixth business day', () => {
@@ -119,7 +119,7 @@ describe('getBusinessDayOfMonth', () => {
       const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
       const sixthBusinessDay = new Date('2023-11-08');
-      expect(isSameDay(result, sixthBusinessDay)).toBe(true);
+      expect(isSameDay(result, sixthBusinessDay)).toEqual(true);
     });
   });
 
@@ -133,7 +133,7 @@ describe('getBusinessDayOfMonth', () => {
       const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
       const firstBusinessDay = new Date('2023-10-05');
-      expect(isSameDay(result, firstBusinessDay)).toBe(true);
+      expect(isSameDay(result, firstBusinessDay)).toEqual(true);
     });
 
     it('should return 9th October as the second business day', () => {
@@ -142,7 +142,7 @@ describe('getBusinessDayOfMonth', () => {
       const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
       const secondBusinessDay = new Date('2023-10-09');
-      expect(isSameDay(result, secondBusinessDay)).toBe(true);
+      expect(isSameDay(result, secondBusinessDay)).toEqual(true);
     });
   });
 });

--- a/portal/server/helpers/isFacilityComplete.test.js
+++ b/portal/server/helpers/isFacilityComplete.test.js
@@ -8,7 +8,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilities is undefined', () => {
@@ -16,7 +16,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when all facilities are incomplete', () => {
@@ -28,7 +28,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when all facilities are not started', () => {
@@ -40,7 +40,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when all facilities are not started and are incomplete', () => {
@@ -55,7 +55,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return true when atleast one facility is completed', () => {
@@ -67,7 +67,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it('should return true when facilities is complete', () => {
@@ -79,7 +79,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it('should return false when a single facility is incomplete', () => {
@@ -91,7 +91,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when multiple facilities are in `Incomplete` status', () => {
@@ -116,7 +116,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilities has acknowledged items but not all are complete', () => {
@@ -128,7 +128,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilities has acknowledged items and all are complete with missing properties', () => {
@@ -141,7 +141,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when facilities has acknowledged items but not all have requestedCoverStartDate and coverDateConfirmed', () => {
@@ -153,7 +153,7 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return true when facilities has acknowledged items and all have requestedCoverStartDate and coverDateConfirmed', () => {
@@ -174,6 +174,6 @@ describe('isEveryFacilityComplete', () => {
 
     const result = isEveryFacilityComplete(facilities);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 });

--- a/portal/server/helpers/isObject.test.js
+++ b/portal/server/helpers/isObject.test.js
@@ -2,12 +2,12 @@ import isObject from './isObject';
 
 describe('isObject()', () => {
   it('returns the correct boolean', () => {
-    expect(isObject({})).toBe(true);
-    expect(isObject({ foo: 'bar' })).toBe(true);
-    expect(isObject([])).toBe(false);
-    expect(isObject('')).toBe(false);
-    expect(isObject(1)).toBe(false);
-    expect(isObject(true)).toBe(false);
-    expect(isObject(false)).toBe(false);
+    expect(isObject({})).toEqual(true);
+    expect(isObject({ foo: 'bar' })).toEqual(true);
+    expect(isObject([])).toEqual(false);
+    expect(isObject('')).toEqual(false);
+    expect(isObject(1)).toEqual(false);
+    expect(isObject(true)).toEqual(false);
+    expect(isObject(false)).toEqual(false);
   });
 });

--- a/portal/server/routes/contract/eligibility/submittedDocumentationMatchesOriginalData.test.js
+++ b/portal/server/routes/contract/eligibility/submittedDocumentationMatchesOriginalData.test.js
@@ -89,7 +89,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, originalData);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal parameter is null', () => {
@@ -101,7 +101,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal parameter is undefined', () => {
@@ -113,7 +113,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal parameter is an empty object', () => {
@@ -125,7 +125,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal.securityDetails property does not exist', () => {
@@ -149,7 +149,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal.securityDetails is null', () => {
@@ -163,7 +163,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal.securityDetails is undefined', () => {
@@ -177,7 +177,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when savedDeal.securityDetails is an empty object', () => {
@@ -191,7 +191,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when form data is null', () => {
@@ -205,7 +205,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when form data is undefined', () => {
@@ -219,7 +219,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when form data is an empty object', () => {
@@ -233,7 +233,7 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return true when security field in form data matches security field in the saved deal data and no files have been submitted', () => {
@@ -249,6 +249,6 @@ describe('submittedDocumentationMatchesOriginalData', () => {
 
     const result = submittedDocumentationMatchesOriginalData(formData, formFiles, savedDeal);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 });

--- a/portal/server/routes/middleware/validateSqlId/index.test.ts
+++ b/portal/server/routes/middleware/validateSqlId/index.test.ts
@@ -17,7 +17,7 @@ describe('validateSqlId', () => {
 
     // Assert
     expect(mockNext).not.toHaveBeenCalled();
-    expect(mockRes._getRedirectUrl()).toBe('/not-found');
+    expect(mockRes._getRedirectUrl()).toEqual('/not-found');
   });
 
   it('calls the next middleware function when an integer id is provided', () => {

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -15,13 +15,13 @@ describe('csv-utils', () => {
     it('returns the correct column for an index below 26', async () => {
       const excelColumnIndex = columnIndexToExcelColumn(2);
 
-      expect(excelColumnIndex).toBe('C');
+      expect(excelColumnIndex).toEqual('C');
     });
 
     it('returns the correct column for an index above 26', async () => {
       const excelColumnIndex = columnIndexToExcelColumn(30);
 
-      expect(excelColumnIndex).toBe('AE');
+      expect(excelColumnIndex).toEqual('AE');
     });
   });
 
@@ -29,13 +29,13 @@ describe('csv-utils', () => {
     it('returns the correct index for a column below 26', async () => {
       const columnIndex = excelColumnToColumnIndex('C');
 
-      expect(columnIndex).toBe(2);
+      expect(columnIndex).toEqual(2);
     });
 
     it('returns the correct index for a column above 26', async () => {
       const columnIndex = excelColumnToColumnIndex('AE');
 
-      expect(columnIndex).toBe(30);
+      expect(columnIndex).toEqual(30);
     });
   });
 
@@ -299,15 +299,15 @@ describe('csv-utils', () => {
       { input: 987654321.1200005, expected: 987654321.12 },
       { input: 987654321.1200006, expected: 987654321.120001 },
     ])('should return $expected for $input', ({ input, expected }) => {
-      expect(handleFloatingPointRoundingErrors(input)).toBe(expected);
+      expect(handleFloatingPointRoundingErrors(input)).toEqual(expected);
     });
 
     it.each([123.456, 0.1, 1.230001])('should return %f unchanged (already rounded to required decimal places)', (value) => {
-      expect(handleFloatingPointRoundingErrors(value)).toBe(value);
+      expect(handleFloatingPointRoundingErrors(value)).toEqual(value);
     });
 
     it.each([456, 1234567, Number.MAX_SAFE_INTEGER])('should return integer %d unchanged', (value) => {
-      expect(handleFloatingPointRoundingErrors(value)).toBe(value);
+      expect(handleFloatingPointRoundingErrors(value)).toEqual(value);
     });
 
     it.each([
@@ -317,7 +317,7 @@ describe('csv-utils', () => {
       { input: -987654321.1200006, expected: -987654321.120001 },
       { input: Number.MIN_SAFE_INTEGER, expected: Number.MIN_SAFE_INTEGER },
     ])('should return $expected for negative number $input', ({ input, expected }) => {
-      expect(handleFloatingPointRoundingErrors(input)).toBe(expected);
+      expect(handleFloatingPointRoundingErrors(input)).toEqual(expected);
     });
 
     it.each(['123.456', null, undefined])('should throw TypeError for non-number input %o', (input) => {

--- a/portal/server/utils/obscure-email.test.js
+++ b/portal/server/utils/obscure-email.test.js
@@ -30,12 +30,12 @@ describe('obscureEmail', () => {
     'returns the first character before the @, 3 stars, the last character before the @, then the rest of the original string ($original -> $expected)',
     ({ original, expected }) => {
       const obscured = obscureEmail(original);
-      expect(obscured).toBe(expected);
+      expect(obscured).toEqual(expected);
     },
   );
 
   it('removes any characters after and including a second @ sign', () => {
     const obscured = obscureEmail('2-@-signs@example.com');
-    expect(obscured).toBe('2***-@-signs');
+    expect(obscured).toEqual('2***-@-signs');
   });
 });

--- a/trade-finance-manager-api/api-tests/common-tests/client-authentication-tests.js
+++ b/trade-finance-manager-api/api-tests/common-tests/client-authentication-tests.js
@@ -1,5 +1,5 @@
 const expectNotAuthenticatedResponse = ({ status, body }) => {
-  expect(status).toBe(401);
+  expect(status).toEqual(401);
   expect(body).toStrictEqual({});
 };
 

--- a/trade-finance-manager-api/api-tests/common-tests/with-team-authorisation.api-tests.ts
+++ b/trade-finance-manager-api/api-tests/common-tests/with-team-authorisation.api-tests.ts
@@ -12,7 +12,7 @@ type WithTeamAuthorisationTestsParams = {
 };
 
 const expectForbiddenResponse = ({ status, body }: ResponseObject) => {
-  expect(status).toBe(HttpStatusCode.Forbidden);
+  expect(status).toEqual(HttpStatusCode.Forbidden);
   expect(body).toStrictEqual({
     success: false,
     msg: "You don't have access to this page",
@@ -43,6 +43,6 @@ export const withTeamAuthorisationTests = ({ allowedTeams, getUserWithTeam, make
   it.each(allowedTeams)(`returns a ${successStatusCode} response for requests from a user with team %s`, async (team) => {
     const userWithTeam = getUserWithTeam(team);
     const { status } = await makeRequestAsUser(userWithTeam);
-    expect(status).toBe(successStatusCode);
+    expect(status).toEqual(successStatusCode);
   });
 };

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-update-lead-underwriter.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-update-lead-underwriter.api-test.js
@@ -48,7 +48,7 @@ describe('PUT /deals/:dealId/underwriting/lead-underwriter', () => {
 
     const { status, body } = await as(tokenUser).put(VALID_LEAD_UNDERWRITER_UPDATE).to(VALID_URL_TO_UPDATE_LEAD_UNDERWRITER);
 
-    expect(status).toBe(200);
+    expect(status).toEqual(200);
     expect(body).toEqual({
       leadUnderwriter: VALID_USER_ID,
     });
@@ -61,7 +61,7 @@ describe('PUT /deals/:dealId/underwriting/lead-underwriter', () => {
 
     const { status, body } = await as(tokenUser).put(VALID_LEAD_UNDERWRITER_UPDATE).to(`/v1/deals/${INVALID_DEAL_ID}/underwriting/lead-underwriter`);
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(body).toEqual({
       errors: [
         {
@@ -85,7 +85,7 @@ describe('PUT /deals/:dealId/underwriting/lead-underwriter', () => {
 
     const { status, body } = await as(tokenUser).put(VALID_LEAD_UNDERWRITER_UPDATE).to(VALID_URL_TO_UPDATE_LEAD_UNDERWRITER);
 
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(body).toEqual({ data: 'Unable to update lead underwriter' });
   });
 });

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-update-underwriter-managers-decision.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-update-underwriter-managers-decision.api-test.js
@@ -159,7 +159,7 @@ describe('PUT /deals/:dealId/underwriting/managers-decision', () => {
       }
       const { status, body } = await as(tokenUser).put(VALID_UNDERWRITER_MANAGERS_DECISION).to(`/v1/deals/${VALID_DEAL_ID}/underwriting/managers-decision`);
 
-      expect(status).toBe(500);
+      expect(status).toEqual(500);
       expect(body).toEqual({
         data: "Unable to update the underwriter manager's decision",
       });
@@ -218,7 +218,7 @@ describe('PUT /deals/:dealId/underwriting/managers-decision', () => {
   it('should return a 400 if deal id is invalid', async () => {
     const { status, body } = await as(tokenUser).put(VALID_UNDERWRITER_MANAGERS_DECISION).to(`/v1/deals/${INVALID_DEAL_ID}/underwriting/managers-decision`);
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(body).toEqual({
       errors: [
         {
@@ -244,7 +244,7 @@ describe('PUT /deals/:dealId/underwriting/managers-decision', () => {
 
     const { status, body } = await as(tokenUser).put(VALID_UNDERWRITER_MANAGERS_DECISION).to(`/v1/deals/${VALID_DEAL_ID}/underwriting/managers-decision`);
 
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(body).toEqual({
       data: "Unable to update the underwriter manager's decision",
     });

--- a/trade-finance-manager-api/api-tests/v1/middleware/api-rate-limiting.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/middleware/api-rate-limiting.api-test.js
@@ -27,7 +27,7 @@ describe('api rate limiting', () => {
 
     const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-    expect(responseAfterRateLimitExceeded.status).toBe(429);
+    expect(responseAfterRateLimitExceeded.status).toEqual(429);
   });
 
   it('returns a 400 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -35,6 +35,6 @@ describe('api rate limiting', () => {
 
     const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-    expect(responseThatMeetsRateLimit.status).toBe(400);
+    expect(responseThatMeetsRateLimit.status).toEqual(400);
   });
 });

--- a/trade-finance-manager-api/api-tests/v1/tasks/tasks-update-task.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/tasks/tasks-update-task.api-test.js
@@ -71,7 +71,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
       history: expect.any(Array),
     };
 
-    expect(status).toBe(200);
+    expect(status).toEqual(200);
     expect(body).toEqual(expectedUpdatedTask);
   });
 
@@ -84,7 +84,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
     const invalidDealId = 'invalid-deal-id';
     const { status, body } = await as(tokenUser).put(taskUpdate).to(`/v1/deals/${invalidDealId}/tasks/${groupId}/${taskId}`);
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(body).toEqual({
       errors: [
         {
@@ -108,7 +108,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
     const invalidGroupId = 'invalid-group-id';
     const { status, body } = await as(tokenUser).put(taskUpdate).to(`/v1/deals/${taskDealId}/tasks/${invalidGroupId}/${taskId}`);
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(body).toEqual({
       errors: [
         {
@@ -132,7 +132,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
     const invalidTaskId = 'invalid-task-id';
     const { status, body } = await as(tokenUser).put(taskUpdate).to(`/v1/deals/${taskDealId}/tasks/${groupId}/${invalidTaskId}`);
 
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(body).toEqual({
       errors: [
         {
@@ -155,7 +155,7 @@ describe('PUT /deals/:dealId/tasks/:groupId/:taskId', () => {
 
     const { status, body } = await as(tokenUser).put(taskUpdate).to(validUrlToUpdateTask);
 
-    expect(status).toBe(500);
+    expect(status).toEqual(500);
     expect(body).toEqual({ data: 'Unable to update the task' });
   });
 });

--- a/trade-finance-manager-api/api-tests/v1/teams/get-team-members.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/teams/get-team-members.api-test.js
@@ -35,7 +35,7 @@ describe('GET /teams/:teamId/members', () => {
     const allTeamsSeparatedByComma = Object.values(TEAMS)
       .map((team) => team.id)
       .join(', ');
-    expect(status).toBe(400);
+    expect(status).toEqual(400);
     expect(body).toStrictEqual({
       status: 400,
       errors: [
@@ -60,7 +60,7 @@ describe('GET /teams/:teamId/members', () => {
 
     const { status, body } = await as(tokenUser).get(validUrlToGetTeamMembers);
 
-    expect(status).toBe(statusFromDtfsCentralApiCall);
+    expect(status).toEqual(statusFromDtfsCentralApiCall);
     expect(body).toStrictEqual({
       status: statusFromDtfsCentralApiCall,
       data: dataFromDtfsCentralApiCall,
@@ -106,7 +106,7 @@ describe('GET /teams/:teamId/members', () => {
 
       const { status, body } = await as(tokenUser).get(`/v1/teams/${teamId}/members`);
 
-      expect(status).toBe(200);
+      expect(status).toEqual(200);
       expect(body).toStrictEqual({ teamMembers: expectedTeamMemberDataToReturn });
     });
 
@@ -115,7 +115,7 @@ describe('GET /teams/:teamId/members', () => {
 
       const { status, body } = await as(tokenUser).get(`/v1/teams/${teamId}/members`);
 
-      expect(status).toBe(200);
+      expect(status).toEqual(200);
       expect(body).toStrictEqual({ teamMembers: [] });
     });
   });

--- a/trade-finance-manager-api/api-tests/v1/utilisation-reports/update-utilisation-report-service.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/utilisation-reports/update-utilisation-report-service.api-test.ts
@@ -23,7 +23,7 @@ describe('/v1/utilisation-reports/set-status', () => {
     const response = await as(tokenUser).put(payload).to(url);
 
     // Assert
-    expect(response.status).toBe(400);
+    expect(response.status).toEqual(400);
   });
 
   it('should return a 400 status code if the body does not contain a user object', async () => {
@@ -36,7 +36,7 @@ describe('/v1/utilisation-reports/set-status', () => {
     const response = await as(tokenUser).put(payload).to(url);
 
     // Assert
-    expect(response.status).toBe(400);
+    expect(response.status).toEqual(400);
   });
 
   it('should return a 400 status code if reportsWithStatus is not an array', async () => {
@@ -50,7 +50,7 @@ describe('/v1/utilisation-reports/set-status', () => {
     const response = await as(tokenUser).put(payload).to(url);
 
     // Assert
-    expect(response.status).toBe(400);
+    expect(response.status).toEqual(400);
   });
 
   it('should return a 400 status code if reportsWithStatus array is empty', async () => {
@@ -64,7 +64,7 @@ describe('/v1/utilisation-reports/set-status', () => {
     const response = await as(tokenUser).put(payload).to(url);
 
     // Assert
-    expect(response.status).toBe(400);
+    expect(response.status).toEqual(400);
   });
 
   it('should return a 400 status code if the reportsWithStatus array does not match the expected format', async () => {
@@ -82,7 +82,7 @@ describe('/v1/utilisation-reports/set-status', () => {
     const response = await as(tokenUser).put(payload).to(url);
 
     // Assert
-    expect(response.status).toBe(400);
+    expect(response.status).toEqual(400);
   });
 
   it('should return a 204 if the payload has the correct format', async () => {
@@ -101,6 +101,6 @@ describe('/v1/utilisation-reports/set-status', () => {
     const response = await as(tokenUser).put(payload).to(url);
 
     // Assert
-    expect(response.status).toBe(204);
+    expect(response.status).toEqual(204);
   });
 });

--- a/trade-finance-manager-api/src/drivers/fileshare/error-helper.test.ts
+++ b/trade-finance-manager-api/src/drivers/fileshare/error-helper.test.ts
@@ -10,7 +10,7 @@ describe('error-helper', () => {
     const result = isParentNotFoundError(error);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it.each`
@@ -27,7 +27,7 @@ describe('error-helper', () => {
     const result = isParentNotFoundError(error);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it(`returns true when errorCode is '${AZURE_STORAGE_SHARE_ERROR_CODE.PARENT_NOT_FOUND}'`, () => {
@@ -39,6 +39,6 @@ describe('error-helper', () => {
     const result = isParentNotFoundError(error);
 
     // Assert
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 });

--- a/trade-finance-manager-api/src/utils/date.test.js
+++ b/trade-finance-manager-api/src/utils/date.test.js
@@ -47,7 +47,7 @@ describe('utils - date', () => {
 
       const result = getIsoStringWithOffset(date);
 
-      expect(result).toBe('2024-03-02T00:00:00+00:00');
+      expect(result).toEqual('2024-03-02T00:00:00+00:00');
     });
 
     it('returns an ISO-8601 string with offset when timezone is BST', () => {
@@ -55,7 +55,7 @@ describe('utils - date', () => {
 
       const result = getIsoStringWithOffset(date);
 
-      expect(result).toBe('2024-07-02T01:00:00+01:00');
+      expect(result).toEqual('2024-07-02T01:00:00+01:00');
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.test.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.test.js
@@ -346,7 +346,7 @@ describe('createACBS', () => {
     const result = await createACBS(dealId);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false if the deal is not found', async () => {
@@ -357,7 +357,7 @@ describe('createACBS', () => {
     const result = await createACBS(MOCK_DEAL_ACBS._id);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false if the deal does not have `dealSnapshot` property', async () => {
@@ -370,7 +370,7 @@ describe('createACBS', () => {
     const result = await createACBS(MOCK_DEAL_ACBS._id);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false if the deal does not have `dealSnapshot.bank` property', async () => {
@@ -384,7 +384,7 @@ describe('createACBS', () => {
     const result = await createACBS(MOCK_DEAL_ACBS._id);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false if the deal does not have `tfm` property', async () => {
@@ -404,7 +404,7 @@ describe('createACBS', () => {
     const result = await createACBS(MOCK_DEAL_ACBS._id);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorMock).toHaveBeenCalledWith('Invalid ACBS deal payload, terminating API call for deal %s', MOCK_DEAL_ACBS._id);
   });
@@ -426,7 +426,7 @@ describe('createACBS', () => {
     const result = await createACBS(MOCK_DEAL_ACBS._id);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
     expect(consoleErrorMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorMock).toHaveBeenCalledWith('Invalid ACBS bank payload, terminating API call for deal %s', MOCK_DEAL_ACBS._id);
   });

--- a/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/dealStage.test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal-add-tfm-data/dealStage.test.js
@@ -8,7 +8,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 
   it('should return DEAL_STAGE_TFM.CONFIRMED when status is PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED and submissionType is AIN', () => {
@@ -17,7 +17,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.CONFIRMED);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.CONFIRMED);
   });
 
   it('should return DEAL_STAGE_TFM.CONFIRMED when status is PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED and submissionType is MIN', () => {
@@ -26,7 +26,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.CONFIRMED);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.CONFIRMED);
   });
 
   it('should return DEAL_STAGE_TFM.APPLICATION when status is PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED and submissionType is not AIN or MIN', () => {
@@ -35,7 +35,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 
   it('should return `Application` when status is not PORTAL_DEAL_STATUS.UKEF_ACKNOWLEDGED and submissionType is not AIN or MIN', () => {
@@ -46,7 +46,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
     expect(console.info).toHaveBeenCalledWith(
       'Invalid deal stage with status %s and submission type %s, setting status to Application',
       status,
@@ -60,7 +60,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 
   it('should return `Application` when submissionType is null', () => {
@@ -69,7 +69,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 
   it('should return `Application` when status is not a string', () => {
@@ -78,7 +78,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 
   it('should return `Application` when submissionType is not a string', () => {
@@ -87,7 +87,7 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 
   it('should return `Application` when status is an empty string', () => {
@@ -96,6 +96,6 @@ describe('dealStage', () => {
 
     const result = dealStage(status, submissionType);
 
-    expect(result).toBe(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
+    expect(result).toEqual(CONSTANTS.DEALS.DEAL_STAGE_TFM.APPLICATION);
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/delete-deal-cancellation.controller.test.ts
@@ -46,7 +46,7 @@ describe('controllers - deal cancellation', () => {
       await deleteDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.NoContent);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NoContent);
     });
 
     it('should return an error when there is an API error', async () => {
@@ -64,7 +64,7 @@ describe('controllers - deal cancellation', () => {
       await deleteDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(testErrorStatus);
+      expect(res._getStatusCode()).toEqual(testErrorStatus);
       expect(res._getData()).toEqual({ message: `Failed to delete deal cancellation: ${testApiErrorMessage}`, status: testErrorStatus });
     });
 
@@ -81,7 +81,7 @@ describe('controllers - deal cancellation', () => {
       await deleteDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
       expect(res._getData()).toEqual({ message: 'Failed to delete deal cancellation', status: 500 });
     });
   });

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/get-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/get-deal-cancellation.controller.test.ts
@@ -46,7 +46,7 @@ describe('controllers - deal cancellation', () => {
       await getDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(res._getData()).toEqual(mockTfmDealCancellation);
     });
 
@@ -64,7 +64,7 @@ describe('controllers - deal cancellation', () => {
       await getDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(testErrorStatus);
+      expect(res._getStatusCode()).toEqual(testErrorStatus);
       expect(res._getData()).toEqual({ message: `Failed to get deal cancellation: ${testApiErrorMessage}`, status: testErrorStatus });
     });
 
@@ -80,7 +80,7 @@ describe('controllers - deal cancellation', () => {
       await getDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
       expect(res._getData()).toEqual({ message: 'Failed to get deal cancellation', status: 500 });
     });
   });

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/update-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/update-deal-cancellation.controller.test.ts
@@ -61,7 +61,7 @@ describe('controllers - deal cancellation', () => {
       await updateDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
       expect(res._getData()).toEqual(mockUpdateResult);
     });
 
@@ -81,7 +81,7 @@ describe('controllers - deal cancellation', () => {
       await updateDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(testErrorStatus);
+      expect(res._getStatusCode()).toEqual(testErrorStatus);
       expect(res._getData()).toEqual({ message: `Failed to update deal cancellation: ${testApiErrorMessage}`, status: testErrorStatus });
     });
 
@@ -99,7 +99,7 @@ describe('controllers - deal cancellation', () => {
       await updateDealCancellation(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
       expect(res._getData()).toEqual({ message: 'Failed to update deal cancellation', status: 500 });
     });
   });

--- a/trade-finance-manager-api/src/v1/controllers/should-update-deal-from-MIA-to-MIN.test.js
+++ b/trade-finance-manager-api/src/v1/controllers/should-update-deal-from-MIA-to-MIN.test.js
@@ -39,43 +39,43 @@ describe('shouldUpdateDealFromMIAtoMIN', () => {
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(null, null);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(miaDeal, null);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(minDeal, null);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(ainDeal, null);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(null, tfmDealApprovedWithConditions);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(null, tfmDealApprovedWithoutConditions);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal object is null', () => {
     const result = shouldUpdateDealFromMIAtoMIN(null, tfmDealDeclined);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should log an error message when deal does not exist either in Portal or in TFM', () => {
@@ -91,55 +91,55 @@ describe('shouldUpdateDealFromMIAtoMIN', () => {
   it('should return true when deal submission type is MIA and TFM deal object has an underwriter manager decision that is UKEF approved with or without conditions', () => {
     const result = shouldUpdateDealFromMIAtoMIN(miaDeal, tfmDealApprovedWithConditions);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it('should return true when deal submission type is MIA and TFM deal object has an underwriter manager decision that is UKEF approved with or without conditions', () => {
     const result = shouldUpdateDealFromMIAtoMIN(miaDeal, tfmDealApprovedWithoutConditions);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it('should return false when deal submission type is MIA and TFM deal object has an underwriter manager decision that is UKEF has declined', () => {
     const result = shouldUpdateDealFromMIAtoMIN(miaDeal, tfmDealDeclined);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal submission type is not MIA and TFM deal object has an underwriter manager decision that is UKEF approved with or without conditions', () => {
     const result = shouldUpdateDealFromMIAtoMIN(minDeal, tfmDealApprovedWithConditions);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal submission type is not MIA and TFM deal object has an underwriter manager decision that is UKEF approved with or without conditions', () => {
     const result = shouldUpdateDealFromMIAtoMIN(minDeal, tfmDealApprovedWithoutConditions);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal submission type is MIA and TFM deal object has an underwriter manager decision that is UKEF has declined', () => {
     const result = shouldUpdateDealFromMIAtoMIN(minDeal, tfmDealDeclined);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal submission type is not MIA and TFM deal object has an underwriter manager decision that is UKEF approved with or without conditions', () => {
     const result = shouldUpdateDealFromMIAtoMIN(ainDeal, tfmDealApprovedWithConditions);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal submission type is not MIA and TFM deal object has an underwriter manager decision that is UKEF approved with or without conditions', () => {
     const result = shouldUpdateDealFromMIAtoMIN(ainDeal, tfmDealApprovedWithoutConditions);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when deal submission type is MIA and TFM deal object has an underwriter manager decision that is UKEF has declined', () => {
     const result = shouldUpdateDealFromMIAtoMIN(ainDeal, tfmDealDeclined);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should log an info message for MIA deal after pre-condition check and before returning response back', () => {

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/delete-payment.controller.test.ts
@@ -41,8 +41,8 @@ describe('delete-payment.controller', () => {
 
       // Assert
       expect(api.deletePaymentById).toHaveBeenCalledWith(reportId, paymentId, user);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a 500 if an unknown error occurs', async () => {
@@ -55,8 +55,8 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -72,8 +72,8 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message', async () => {
@@ -86,8 +86,8 @@ describe('delete-payment.controller', () => {
       await deletePayment(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to delete payment');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to delete payment');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-fee-records-to-key.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-fee-records-to-key.controller.test.ts
@@ -64,8 +64,8 @@ describe('get-fee-records-to-key.controller', () => {
       await getFeeRecordsToKey(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -81,8 +81,8 @@ describe('get-fee-records-to-key.controller', () => {
       await getFeeRecordsToKey(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message', async () => {
@@ -95,8 +95,8 @@ describe('get-fee-records-to-key.controller', () => {
       await getFeeRecordsToKey(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to get fee records to key');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to get fee records to key');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-payment-details-by-id.controller.test.ts
@@ -113,8 +113,8 @@ describe('get-payment-details-by-id.controller', () => {
       await getPaymentDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -130,8 +130,8 @@ describe('get-payment-details-by-id.controller', () => {
       await getPaymentDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message', async () => {
@@ -144,8 +144,8 @@ describe('get-payment-details-by-id.controller', () => {
       await getPaymentDetailsById(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to get payment details');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to get payment details');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-selected-fee-records-details.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-selected-fee-records-details.controller.test.ts
@@ -119,8 +119,8 @@ describe('get-selected-fee-records-details.controller', () => {
       await getSelectedFeeRecordsDetails(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -136,8 +136,8 @@ describe('get-selected-fee-records-details.controller', () => {
       await getSelectedFeeRecordsDetails(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message when api call fails', async () => {
@@ -150,8 +150,8 @@ describe('get-selected-fee-records-details.controller', () => {
       await getSelectedFeeRecordsDetails(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to get selected fee records details');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to get selected fee records details');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-utilisation-report-reconciliation-details-by-id.controller/index.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/get-utilisation-report-reconciliation-details-by-id.controller/index.test.ts
@@ -38,8 +38,8 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._getData()).toBe(utilisationReportReconciliationDetailsResponse);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._getData()).toEqual(utilisationReportReconciliationDetailsResponse);
     });
 
     it('fetches report with the premium payments tab filters query param when provided', async () => {
@@ -74,8 +74,8 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._getData()).toBe(`Failed to get utilisation report reconciliation details for report with id '${reportId}': ${axiosError.message}`);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._getData()).toEqual(`Failed to get utilisation report reconciliation details for report with id '${reportId}': ${axiosError.message}`);
     });
 
     it('responds with a 500 when an unexpected error occurs', async () => {
@@ -88,8 +88,8 @@ describe('get-utilisation-report-reconciliation-details-by-id.controller', () =>
       await getUtilisationReportReconciliationDetailsById(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._getData()).toBe(`Failed to get utilisation report reconciliation details for report with id '${reportId}'`);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._getData()).toEqual(`Failed to get utilisation report reconciliation details for report with id '${reportId}'`);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/patch-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/patch-payment.controller.test.ts
@@ -47,8 +47,8 @@ describe('patch-payment.controller', () => {
 
       // Assert
       expect(api.editPayment).toHaveBeenCalledWith(reportId.toString(), paymentId.toString(), paymentAmount, datePaymentReceived, paymentReference, user);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message if an error occurs', async () => {
@@ -61,7 +61,7 @@ describe('patch-payment.controller', () => {
       await patchPayment(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to edit payment');
+      expect(res._getData()).toEqual('Failed to edit payment');
     });
 
     it('responds with a 500 (Internal Server Error) if an unknown error occurs', async () => {
@@ -74,8 +74,8 @@ describe('patch-payment.controller', () => {
       await patchPayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -91,8 +91,8 @@ describe('patch-payment.controller', () => {
       await patchPayment(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     function aPatchPaymentRequestBody(): PatchPaymentRequest['body'] {

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-fees-to-an-existing-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-fees-to-an-existing-payment.controller.test.ts
@@ -61,8 +61,8 @@ describe('postFeesToAnExistingPayment', () => {
     await postFeesToAnExistingPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a 500 if an unknown error occurs', async () => {
@@ -75,8 +75,8 @@ describe('postFeesToAnExistingPayment', () => {
     await postFeesToAnExistingPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a specific error code if an axios error is thrown', async () => {
@@ -92,8 +92,8 @@ describe('postFeesToAnExistingPayment', () => {
     await postFeesToAnExistingPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(errorStatus);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(errorStatus);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with an error message when api call fails', async () => {
@@ -106,7 +106,7 @@ describe('postFeesToAnExistingPayment', () => {
     await postFeesToAnExistingPayment(req, res);
 
     // Assert
-    expect(res._getData()).toBe('Failed to add fees to an existing payment');
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getData()).toEqual('Failed to add fees to an existing payment');
+    expect(res._isEndCalled()).toEqual(true);
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-keying-data.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-keying-data.controller.test.ts
@@ -47,8 +47,8 @@ describe('postKeyingData', () => {
     await postKeyingData(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a 500 if an unknown error occurs', async () => {
@@ -61,8 +61,8 @@ describe('postKeyingData', () => {
     await postKeyingData(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a specific error code if an axios error is thrown', async () => {
@@ -78,8 +78,8 @@ describe('postKeyingData', () => {
     await postKeyingData(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(errorStatus);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(errorStatus);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with an error message', async () => {
@@ -92,7 +92,7 @@ describe('postKeyingData', () => {
     await postKeyingData(req, res);
 
     // Assert
-    expect(res._getData()).toBe('Failed to generate keying data');
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getData()).toEqual('Failed to generate keying data');
+    expect(res._isEndCalled()).toEqual(true);
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-payment.controller.test.ts
@@ -71,8 +71,8 @@ describe('postPayment', () => {
     await postPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a 500 if an unknown error occurs', async () => {
@@ -85,8 +85,8 @@ describe('postPayment', () => {
     await postPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a specific error code if an axios error is thrown', async () => {
@@ -102,8 +102,8 @@ describe('postPayment', () => {
     await postPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(errorStatus);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(errorStatus);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with an error message', async () => {
@@ -116,7 +116,7 @@ describe('postPayment', () => {
     await postPayment(req, res);
 
     // Assert
-    expect(res._getData()).toBe('Failed to add payment');
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getData()).toEqual('Failed to add payment');
+    expect(res._isEndCalled()).toEqual(true);
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-remove-fees-from-payment.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/post-remove-fees-from-payment.controller.test.ts
@@ -60,8 +60,8 @@ describe('postRemoveFeesFromPayment', () => {
     await postRemoveFeesFromPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a 500 if an unknown error occurs', async () => {
@@ -74,8 +74,8 @@ describe('postRemoveFeesFromPayment', () => {
     await postRemoveFeesFromPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with a specific error code if an axios error is thrown', async () => {
@@ -91,8 +91,8 @@ describe('postRemoveFeesFromPayment', () => {
     await postRemoveFeesFromPayment(req, res);
 
     // Assert
-    expect(res._getStatusCode()).toBe(errorStatus);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(errorStatus);
+    expect(res._isEndCalled()).toEqual(true);
   });
 
   it('responds with an error message when api call fails', async () => {
@@ -105,7 +105,7 @@ describe('postRemoveFeesFromPayment', () => {
     await postRemoveFeesFromPayment(req, res);
 
     // Assert
-    expect(res._getData()).toBe('Failed to remove fees from payment group');
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getData()).toEqual('Failed to remove fees from payment group');
+    expect(res._isEndCalled()).toEqual(true);
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-done.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-done.controller.test.ts
@@ -36,8 +36,8 @@ describe('put-keying-data-mark-as-done.controller', () => {
 
       // Assert
       expect(api.markKeyingDataAsDone).toHaveBeenCalledWith(reportId, feeRecordIds, user);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a 500 if an unknown error occurs', async () => {
@@ -50,8 +50,8 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -67,8 +67,8 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message', async () => {
@@ -81,8 +81,8 @@ describe('put-keying-data-mark-as-done.controller', () => {
       await putKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to mark keying data as done');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to mark keying data as done');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/put-keying-data-mark-as-to-do.controller.test.ts
@@ -36,8 +36,8 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
 
       // Assert
       expect(api.markKeyingDataAsToDo).toHaveBeenCalledWith(reportId, feeRecordIds, user);
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a 500 if an unknown error occurs', async () => {
@@ -50,8 +50,8 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.InternalServerError);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with a specific error code if an axios error is thrown', async () => {
@@ -67,8 +67,8 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getStatusCode()).toBe(errorStatus);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('responds with an error message', async () => {
@@ -81,8 +81,8 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       await putKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getData()).toBe('Failed to mark keying data as to do');
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getData()).toEqual('Failed to mark keying data as to do');
+      expect(res._isEndCalled()).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.test.js
+++ b/trade-finance-manager-api/src/v1/emails/AIN-MIN-confirmation/gef-facilities-list.test.js
@@ -64,25 +64,25 @@ describe('generate AIN/MIN confirmation email facilities list email variable/str
     it('maps true to `Yes`', () => {
       const result = mapBooleanToYesOrNo(true);
 
-      expect(result).toBe('Yes');
+      expect(result).toEqual('Yes');
     });
 
     it('maps false to `No`', () => {
       const result = mapBooleanToYesOrNo(false);
 
-      expect(result).toBe('No');
+      expect(result).toEqual('No');
     });
 
     it('maps undefined to undefined', () => {
       const result = mapBooleanToYesOrNo(undefined);
 
-      expect(result).toBe(undefined);
+      expect(result).toEqual(undefined);
     });
 
     it('maps null to undefined', () => {
       const result = mapBooleanToYesOrNo(null);
 
-      expect(result).toBe(undefined);
+      expect(result).toEqual(undefined);
     });
   });
 

--- a/trade-finance-manager-api/src/v1/helpers/dealHasAllUkefIds.api-test.js
+++ b/trade-finance-manager-api/src/v1/helpers/dealHasAllUkefIds.api-test.js
@@ -101,8 +101,8 @@ describe('dealHasAllValidUkefIds function', () => {
   // Tests that the function returns false if deal not found
   it('should test deal not found', async () => {
     const result = await dealHasAllValidUkefIds('invalid deal id');
-    expect(result.status).toBe(false);
-    expect(result.message).toBe('TFM Deal not found');
+    expect(result.status).toEqual(false);
+    expect(result.message).toEqual('TFM Deal not found');
   });
 
   // Tests that the function returns false if dealSnapshot or facilities are missing
@@ -118,13 +118,13 @@ describe('dealHasAllValidUkefIds function', () => {
 
     const result = await dealHasAllValidUkefIds(mockDeal._id);
 
-    expect(result.status).toBe(false);
+    expect(result.status).toEqual(false);
   });
 
   // Tests that the function returns false if  DEAL_TYPE is not GEF and ukefDealId is missing
   it('should test missing ukef deal id', async () => {
     const result = await dealHasAllValidUkefIds(MOCK_DEAL._id);
 
-    expect(result.status).toBe(true);
+    expect(result.status).toEqual(true);
   });
 });

--- a/trade-finance-manager-api/src/v1/middleware/validate-put-deal-cancellation-payload.test.ts
+++ b/trade-finance-manager-api/src/v1/middleware/validate-put-deal-cancellation-payload.test.ts
@@ -58,8 +58,8 @@ describe('validatePutDealCancellationPayload', () => {
     validatePutDealCancellationPayload(req, res, next);
 
     // Assert
-    expect(res._getStatusCode()).toBe(HttpStatusCode.BadRequest);
-    expect(res._isEndCalled()).toBe(true);
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -75,6 +75,6 @@ describe('validatePutDealCancellationPayload', () => {
 
     // Assert
     expect(next).toHaveBeenCalled();
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/trade-finance-manager-api/src/v1/middleware/validate-user-is-in-at-least-one-allowed-team.test.ts
+++ b/trade-finance-manager-api/src/v1/middleware/validate-user-is-in-at-least-one-allowed-team.test.ts
@@ -27,7 +27,7 @@ describe('validateUserHasAtLeastOneAllowedTeam', () => {
       middleware(req, res, next);
 
       // Assert
-      expect(res._getStatusCode()).toBe(HttpStatusCode.Forbidden);
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Forbidden);
       expect(res._getData()).toEqual({ success: false, msg: "You don't have access to this page" });
     });
 
@@ -76,8 +76,8 @@ describe('validateUserHasAtLeastOneAllowedTeam', () => {
       middleware(req, res, next);
 
       // Assert
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getData()).toBe('');
+      expect(res._getStatusCode()).toEqual(200);
+      expect(res._getData()).toEqual('');
     });
   });
 });

--- a/trade-finance-manager-ui/api-tests/api-rate-limiting.api-test.js
+++ b/trade-finance-manager-ui/api-tests/api-rate-limiting.api-test.js
@@ -27,7 +27,7 @@ describe('api rate limiting', () => {
 
       const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-      expect(responseAfterRateLimitExceeded.status).toBe(429);
+      expect(responseAfterRateLimitExceeded.status).toEqual(429);
     });
 
     it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -35,7 +35,7 @@ describe('api rate limiting', () => {
 
       const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-      expect(responseThatMeetsRateLimit.status).toBe(200);
+      expect(responseThatMeetsRateLimit.status).toEqual(200);
     });
   });
 
@@ -47,7 +47,7 @@ describe('api rate limiting', () => {
 
       const responseAfterRateLimitExceeded = (await sendRequestTimes(1))[0].value;
 
-      expect(responseAfterRateLimitExceeded.status).toBe(200);
+      expect(responseAfterRateLimitExceeded.status).toEqual(200);
     });
 
     it('returns a 200 response if exactly RATE_LIMIT_THRESHOLD requests are made from the same IP to the same endpoint in 1 minute', async () => {
@@ -55,7 +55,7 @@ describe('api rate limiting', () => {
 
       const responseThatMeetsRateLimit = (await sendRequestTimes(1))[0].value;
 
-      expect(responseThatMeetsRateLimit.status).toBe(200);
+      expect(responseThatMeetsRateLimit.status).toEqual(200);
     });
   });
 });

--- a/trade-finance-manager-ui/server/api.test.js
+++ b/trade-finance-manager-ui/server/api.test.js
@@ -48,7 +48,7 @@ describe('getDeals()', () => {
 
     const response = await api.getDeals(queryParams, token);
 
-    expect(mockAxios.history.get.length).toBe(1);
+    expect(mockAxios.history.get.length).toEqual(1);
     expect(response).toEqual({
       deals: [
         { _id: 1, name: 'Deal 1' },
@@ -71,7 +71,7 @@ describe('getDeals()', () => {
 
     const errorResponse = api.getDeals(queryParams, token);
 
-    expect(mockAxios.history.get.length).toBe(1);
+    expect(mockAxios.history.get.length).toEqual(1);
     await expect(errorResponse).rejects.toThrow(new PageOutOfBoundsError('Requested page number exceeds the maximum page number'));
   });
 });
@@ -107,7 +107,7 @@ describe('getFacilities()', () => {
 
     const response = await api.getFacilities(queryParams, token);
 
-    expect(mockAxios.history.get.length).toBe(1);
+    expect(mockAxios.history.get.length).toEqual(1);
     expect(response).toEqual({
       facilities: [
         { facilityId: 1, name: 'Facility 1' },
@@ -130,7 +130,7 @@ describe('getFacilities()', () => {
 
     const errorResponse = api.getFacilities(queryParams, token);
 
-    expect(mockAxios.history.get.length).toBe(1);
+    expect(mockAxios.history.get.length).toEqual(1);
     await expect(errorResponse).rejects.toThrow(new PageOutOfBoundsError('Requested page number exceeds the maximum page number'));
   });
 });

--- a/trade-finance-manager-ui/server/configs/entra-id.config.test.ts
+++ b/trade-finance-manager-ui/server/configs/entra-id.config.test.ts
@@ -58,7 +58,7 @@ describe('EntraIdConfig', () => {
     });
 
     it('should configure the authorityMetaDataUrl', () => {
-      expect(config.authorityMetadataUrl).toBe(`${mockEntraIdCloudInstance}/${mockEntraIdTenantId}/v2.0/.well-known/openid-configuration`);
+      expect(config.authorityMetadataUrl).toEqual(`${mockEntraIdCloudInstance}/${mockEntraIdTenantId}/v2.0/.well-known/openid-configuration`);
     });
 
     it('should configure the scopes', () => {
@@ -66,7 +66,7 @@ describe('EntraIdConfig', () => {
     });
 
     it('should configure the redirectUri', () => {
-      expect(config.redirectUri).toBe(mockEntraIdRedirectUrl);
+      expect(config.redirectUri).toEqual(mockEntraIdRedirectUrl);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.get.test.ts
@@ -37,7 +37,7 @@ describe('getBankRequestDate', () => {
     await getBankRequestDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -56,7 +56,7 @@ describe('getBankRequestDate', () => {
     await getBankRequestDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -75,7 +75,7 @@ describe('getBankRequestDate', () => {
     await getBankRequestDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/bank-request-date.controller.post.test.ts
@@ -45,7 +45,7 @@ describe('postBankRequestDate', () => {
     await postBankRequestDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -64,7 +64,7 @@ describe('postBankRequestDate', () => {
     await postBankRequestDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -83,7 +83,7 @@ describe('postBankRequestDate', () => {
     await postBankRequestDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
@@ -230,7 +230,7 @@ describe('postBankRequestDate', () => {
         await postBankRequestDate(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/case/${dealId}/cancellation/effective-from-date`);
+        expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/cancellation/effective-from-date`);
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/cancel-cancellation.controller.get.test.ts
@@ -35,7 +35,7 @@ describe('getCancelCancellation', () => {
     await getCancelCancellation(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -54,7 +54,7 @@ describe('getCancelCancellation', () => {
     await getCancelCancellation(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -73,7 +73,7 @@ describe('getCancelCancellation', () => {
     await getCancelCancellation(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
@@ -37,7 +37,7 @@ describe('getDealCancellationDetails', () => {
     await getDealCancellationDetails(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -56,7 +56,7 @@ describe('getDealCancellationDetails', () => {
     await getDealCancellationDetails(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -75,7 +75,7 @@ describe('getDealCancellationDetails', () => {
     await getDealCancellationDetails(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
@@ -33,7 +33,7 @@ describe('postBankRequestDate', () => {
     await postDealCancellationDetails(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -52,7 +52,7 @@ describe('postBankRequestDate', () => {
     await postDealCancellationDetails(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -71,7 +71,7 @@ describe('postBankRequestDate', () => {
     await postDealCancellationDetails(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
@@ -95,7 +95,7 @@ describe('postBankRequestDate', () => {
       await postDealCancellationDetails(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+      expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.get.test.ts
@@ -37,7 +37,7 @@ describe('getEffectiveFromDate', () => {
     await getEffectiveFromDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -56,7 +56,7 @@ describe('getEffectiveFromDate', () => {
     await getEffectiveFromDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -75,7 +75,7 @@ describe('getEffectiveFromDate', () => {
     await getEffectiveFromDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/effective-from-date.controller.post.test.ts
@@ -45,7 +45,7 @@ describe('postEffectiveFromDate', () => {
     await postEffectiveFromDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -64,7 +64,7 @@ describe('postEffectiveFromDate', () => {
     await postEffectiveFromDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -83,7 +83,7 @@ describe('postEffectiveFromDate', () => {
     await postEffectiveFromDate(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
@@ -233,7 +233,7 @@ describe('postEffectiveFromDate', () => {
         await postEffectiveFromDate(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/case/${dealId}/cancellation/check-details`);
+        expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/cancellation/check-details`);
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.get.test.ts
@@ -36,7 +36,7 @@ describe('getReasonForCancelling', () => {
     await getReasonForCancelling(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -55,7 +55,7 @@ describe('getReasonForCancelling', () => {
     await getReasonForCancelling(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -74,7 +74,7 @@ describe('getReasonForCancelling', () => {
     await getReasonForCancelling(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/reason-for-cancelling.controller.post.test.ts
@@ -50,7 +50,7 @@ describe('postReasonForCancelling', () => {
     await postReasonForCancelling(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to not found if the dealId is invalid', async () => {
@@ -72,7 +72,7 @@ describe('postReasonForCancelling', () => {
     await postReasonForCancelling(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/not-found`);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
   it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
@@ -94,7 +94,7 @@ describe('postReasonForCancelling', () => {
     await postReasonForCancelling(req, res);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe(`/case/${dealId}/deal`);
+    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
   });
 
   describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
@@ -233,7 +233,7 @@ describe('postReasonForCancelling', () => {
         await postReasonForCancelling(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/case/${dealId}/cancellation/bank-request-date`);
+        expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/cancellation/bank-request-date`);
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/helpers/deal-cancellation-enabled.helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/helpers/deal-cancellation-enabled.helper.test.ts
@@ -31,12 +31,12 @@ describe('canSubmissionTypeBeCancelled', () => {
   it.each([AIN, MIN])('returns true when deal submission type is %s', (submissionType) => {
     const result = canSubmissionTypeBeCancelled(submissionType);
 
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 
   it(`returns false when deal submission type is ${MIA}`, () => {
     const result = canSubmissionTypeBeCancelled(MIA);
 
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/login/loginNonSso/index.get-login.test.ts
+++ b/trade-finance-manager-ui/server/controllers/login/loginNonSso/index.get-login.test.ts
@@ -27,7 +27,7 @@ describe('controllers - login (sso)', () => {
         getLogin(req, res);
 
         // Assert
-        expect(res._getRenderView()).toBe('login.njk');
+        expect(res._getRenderView()).toEqual('login.njk');
         expect(res._getRenderData()).toStrictEqual({ user: requestSession.user });
       });
     });
@@ -50,7 +50,7 @@ describe('controllers - login (sso)', () => {
         getLogin(req, res);
 
         // Assert
-        expect(res._getRenderView()).toBe('login.njk');
+        expect(res._getRenderView()).toEqual('login.njk');
         expect(res._getRenderData()).toStrictEqual({ user: requestSession.user });
       });
     });

--- a/trade-finance-manager-ui/server/controllers/login/loginNonSso/index.logout.test.ts
+++ b/trade-finance-manager-ui/server/controllers/login/loginNonSso/index.logout.test.ts
@@ -20,7 +20,7 @@ describe('controllers - login (sso)', () => {
       logout(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe('/');
+      expect(res._getRedirectUrl()).toEqual('/');
     });
 
     it('destroys the session', () => {

--- a/trade-finance-manager-ui/server/controllers/login/loginNonSso/index.post-login.test.ts
+++ b/trade-finance-manager-ui/server/controllers/login/loginNonSso/index.post-login.test.ts
@@ -30,7 +30,7 @@ describe('controllers - login (sso)', () => {
       await postLogin(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('login.njk');
+      expect(res._getRenderView()).toEqual('login.njk');
       expect(res._getRenderData()).toStrictEqual({
         errors: {
           errorSummary: [
@@ -66,7 +66,7 @@ describe('controllers - login (sso)', () => {
       await postLogin(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe('/home');
+      expect(res._getRedirectUrl()).toEqual('/home');
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/login/loginSso/login.controller.get-login.test.ts
+++ b/trade-finance-manager-ui/server/controllers/login/loginSso/login.controller.get-login.test.ts
@@ -44,7 +44,7 @@ describe('controllers - login (sso)', () => {
         await loginController.getLogin(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe('/home');
+        expect(res._getRedirectUrl()).toEqual('/home');
       });
     });
 
@@ -57,7 +57,7 @@ describe('controllers - login (sso)', () => {
         await loginController.getLogin(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(mockAuthCodeUrl);
+        expect(res._getRedirectUrl()).toEqual(mockAuthCodeUrl);
       });
 
       it('overrides session login data if present', async () => {

--- a/trade-finance-manager-ui/server/controllers/login/loginSso/login.controller.get-logout.test.ts
+++ b/trade-finance-manager-ui/server/controllers/login/loginSso/login.controller.get-logout.test.ts
@@ -21,7 +21,7 @@ describe('controllers - login (sso)', () => {
       loginController.getLogout(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe('/');
+      expect(res._getRedirectUrl()).toEqual('/');
     });
 
     it('destroys the session', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.test.ts
@@ -712,7 +712,7 @@ describe('controllers/utilisation-reports/add-payment', () => {
         await addPayment(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}`);
+        expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}`);
       });
 
       it("should render the add payment page if 'addAnotherPayment' is set to 'true'", async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-to-an-existing-payment/get-link-to-premium-payments-tab.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-to-an-existing-payment/get-link-to-premium-payments-tab.test.ts
@@ -13,7 +13,7 @@ describe('getLinkToPremiumPaymentsTab', () => {
     const result = getLinkToPremiumPaymentsTab(reportId, selectedFeeRecordIds);
 
     // Assert
-    expect(result).toBe(`/utilisation-reports/${reportId}`);
+    expect(result).toEqual(`/utilisation-reports/${reportId}`);
   });
 
   it('returns URL without params when total length exceeds limit', () => {
@@ -24,7 +24,7 @@ describe('getLinkToPremiumPaymentsTab', () => {
     const result = getLinkToPremiumPaymentsTab(reportId, selectedFeeRecordIds);
 
     // Assert
-    expect(result).toBe(`/utilisation-reports/${reportId}`);
+    expect(result).toEqual(`/utilisation-reports/${reportId}`);
   });
 
   it('returns URL with params when selectedFeeRecordIds array has one element', () => {
@@ -35,7 +35,7 @@ describe('getLinkToPremiumPaymentsTab', () => {
     const result = getLinkToPremiumPaymentsTab(reportId, selectedFeeRecordIds);
 
     // Assert
-    expect(result).toBe(`/utilisation-reports/${reportId}?selectedFeeRecordIds=1`);
+    expect(result).toEqual(`/utilisation-reports/${reportId}?selectedFeeRecordIds=1`);
   });
 
   it('returns URL with params when total length is within limit', () => {
@@ -46,6 +46,6 @@ describe('getLinkToPremiumPaymentsTab', () => {
     const result = getLinkToPremiumPaymentsTab(reportId, selectedFeeRecordIds);
 
     // Assert
-    expect(result).toBe(`/utilisation-reports/${reportId}?selectedFeeRecordIds=1%2C22%2C333`);
+    expect(result).toEqual(`/utilisation-reports/${reportId}?selectedFeeRecordIds=1%2C22%2C333`);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-to-an-existing-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-to-an-existing-payment/index.test.ts
@@ -59,7 +59,7 @@ describe('controllers/utilisation-reports/add-to-an-existing-payment', () => {
       await addToAnExistingPayment(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
     });
 
     it("should render the 'problem-with-service' page when there are no available payment groups", async () => {
@@ -79,7 +79,7 @@ describe('controllers/utilisation-reports/add-to-an-existing-payment', () => {
       await addToAnExistingPayment(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
     });
 
     it('should fetch and map selected fee record details', async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/check-keying-data/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/check-keying-data/index.test.ts
@@ -36,7 +36,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
       await postCheckKeyingData(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: requestSession.user });
     });
 
@@ -59,7 +59,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
         await postCheckKeyingData(req, res);
 
         // Assert
-        expect(req.session.generateKeyingDataErrorKey).toBe('no-matching-fee-records');
+        expect(req.session.generateKeyingDataErrorKey).toEqual('no-matching-fee-records');
       });
 
       it("redirects to '/utilisation-reports/:reportId'", async () => {
@@ -74,8 +74,8 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
         await postCheckKeyingData(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}`);
-        expect(res._isEndCalled()).toBe(true);
+        expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}`);
+        expect(res._isEndCalled()).toEqual(true);
       });
     });
 
@@ -108,7 +108,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
         await postCheckKeyingData(req, res);
 
         // Assert
-        expect(res._getRenderView()).toBe('utilisation-reports/check-keying-data.njk');
+        expect(res._getRenderView()).toEqual('utilisation-reports/check-keying-data.njk');
       });
 
       it('renders the page with the bank', async () => {
@@ -159,7 +159,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
 
         // Assert
         const viewModel = res._getRenderData() as CheckKeyingDataViewModel;
-        expect(viewModel.formattedReportPeriod).toBe('January 2024');
+        expect(viewModel.formattedReportPeriod).toEqual('January 2024');
       });
 
       it('renders the page with the mapped fee records', async () => {
@@ -228,7 +228,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
         // Assert
         const viewModel = res._getRenderData() as CheckKeyingDataViewModel;
         expect(viewModel.feeRecords).toHaveLength(3);
-        expect(viewModel.numberOfMatchingFacilities).toBe(3);
+        expect(viewModel.numberOfMatchingFacilities).toEqual(3);
       });
 
       it('sets the view model report id to path parameter report id', async () => {
@@ -244,7 +244,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
 
         // Assert
         const viewModel = res._getRenderData() as CheckKeyingDataViewModel;
-        expect(viewModel.reportId).toBe(reportId);
+        expect(viewModel.reportId).toEqual(reportId);
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/confirm-delete-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/confirm-delete-payment/index.test.ts
@@ -46,7 +46,7 @@ describe('controllers/utilisation-reports/confirm-delete-payment', () => {
 
       // Assert
       expect(api.getPaymentDetailsWithoutFeeRecords).toHaveBeenCalledWith(reportId, paymentId, requestSession.userToken);
-      expect(res._getRenderView()).toBe('utilisation-reports/confirm-delete-payment.njk');
+      expect(res._getRenderView()).toEqual('utilisation-reports/confirm-delete-payment.njk');
     });
 
     it('renders the confirm delete payment page with the payment summary list rows', async () => {
@@ -174,7 +174,7 @@ describe('controllers/utilisation-reports/confirm-delete-payment', () => {
         await postConfirmDeletePayment(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}`);
+        expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}`);
       });
     });
 
@@ -209,7 +209,7 @@ describe('controllers/utilisation-reports/confirm-delete-payment', () => {
         await postConfirmDeletePayment(req, res);
 
         // Assert
-        expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}/edit-payment/${paymentId}?redirectTab=premium-payments`);
+        expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}/edit-payment/${paymentId}?redirectTab=premium-payments`);
       });
     });
 
@@ -227,7 +227,7 @@ describe('controllers/utilisation-reports/confirm-delete-payment', () => {
       await postConfirmDeletePayment(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: requestSession.user });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/edit-payment/index.test.ts
@@ -58,7 +58,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       await getEditPayment(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('utilisation-reports/edit-payment.njk');
+      expect(res._getRenderView()).toEqual('utilisation-reports/edit-payment.njk');
     });
 
     it('sets the render view model reportId to the request params reportId', async () => {
@@ -70,7 +70,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
-      expect(viewModel.reportId).toBe(reportId);
+      expect(viewModel.reportId).toEqual(reportId);
     });
 
     it('sets the render view model paymentId to the request params paymentId', async () => {
@@ -82,7 +82,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
-      expect(viewModel.paymentId).toBe(paymentId);
+      expect(viewModel.paymentId).toEqual(paymentId);
     });
 
     describe('when the remove fees from payment error key is set in the session data', () => {
@@ -104,8 +104,8 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         expect(res._getRenderView()).toEqual('utilisation-reports/edit-payment.njk');
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.errors.errorSummary).toBeDefined();
-        expect((viewModel.errors.errorSummary as [ErrorSummaryViewModel])[0].href).toBe('#added-reported-fees-details-header');
-        expect((viewModel.errors.errorSummary as [ErrorSummaryViewModel])[0].text).toBe('Select fee or fees to remove from the payment');
+        expect((viewModel.errors.errorSummary as [ErrorSummaryViewModel])[0].href).toEqual('#added-reported-fees-details-header');
+        expect((viewModel.errors.errorSummary as [ErrorSummaryViewModel])[0].text).toEqual('Select fee or fees to remove from the payment');
       });
 
       it("sets the render view model feeRecords isChecked to false for every fee record when the key is 'no-fee-records-selected'", async () => {
@@ -128,7 +128,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecords.length);
-        viewModel.feeRecords.forEach(({ isChecked }) => expect(isChecked).toBe(false));
+        viewModel.feeRecords.forEach(({ isChecked }) => expect(isChecked).toEqual(false));
       });
 
       it("sets the render view model feeRecords isChecked to false for every fee record when the key is 'all-fee-records-selected'", async () => {
@@ -151,7 +151,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecords.length);
-        viewModel.feeRecords.forEach(({ isChecked }) => expect(isChecked).toBe(true));
+        viewModel.feeRecords.forEach(({ isChecked }) => expect(isChecked).toEqual(true));
       });
     });
 
@@ -174,7 +174,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
-      expect(viewModel.paymentCurrency).toBe(paymentCurrency);
+      expect(viewModel.paymentCurrency).toEqual(paymentCurrency);
     });
 
     it('sets the render view model bank to the edit payment details response bank', async () => {
@@ -237,7 +237,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
       expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-      viewModel.feeRecords.forEach(({ id }, index) => expect(id).toBe(feeRecordIds[index]));
+      viewModel.feeRecords.forEach(({ id }, index) => expect(id).toEqual(feeRecordIds[index]));
     });
 
     it('sets the render view model feeRecords facilityId to the edit payment details response feeRecords facilityId', async () => {
@@ -258,7 +258,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
       expect(viewModel.feeRecords).toHaveLength(feeRecordFacilityIds.length);
-      viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toBe(feeRecordFacilityIds[index]));
+      viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toEqual(feeRecordFacilityIds[index]));
     });
 
     it('sets the render view model feeRecords exporter to the edit payment details response feeRecords exporter', async () => {
@@ -279,7 +279,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
       expect(viewModel.feeRecords).toHaveLength(feeRecordExporters.length);
-      viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toBe(feeRecordExporters[index]));
+      viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toEqual(feeRecordExporters[index]));
     });
 
     it('sets the render view model feeRecords reportedFees to the edit payment details response feeRecords sorted and formatted reportedFees', async () => {
@@ -356,7 +356,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
       expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-      viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toBe(`feeRecordId-${feeRecordIds[index]}`));
+      viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toEqual(`feeRecordId-${feeRecordIds[index]}`));
     });
 
     it('sets the render view model feeRecords isChecked to false for every fee record', async () => {
@@ -376,7 +376,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
       expect(viewModel.feeRecords).toHaveLength(feeRecords.length);
-      viewModel.feeRecords.forEach(({ isChecked }) => expect(isChecked).toBe(false));
+      viewModel.feeRecords.forEach(({ isChecked }) => expect(isChecked).toEqual(false));
     });
 
     it('sets the render view model totalReportedPayments to the edit payment details response formatted totalReportedPayments', async () => {
@@ -394,7 +394,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
       // Assert
       const viewModel = res._getRenderData() as EditPaymentViewModel;
-      expect(viewModel.totalReportedPayments).toBe('USD 314.59');
+      expect(viewModel.totalReportedPayments).toEqual('USD 314.59');
     });
 
     it('sets the render view model errors to the empty errors', async () => {
@@ -459,7 +459,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentAmount).toBe(paymentAmount.toString());
+        expect(viewModel.formValues.paymentAmount).toEqual(paymentAmount.toString());
       });
 
       it('sets the render view model formValues paymentDate day to the edit payment details response payment dateReceived day', async () => {
@@ -481,7 +481,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentDate.day).toBe(day);
+        expect(viewModel.formValues.paymentDate.day).toEqual(day);
       });
 
       it('sets the render view model formValues paymentDate month to the edit payment details response payment dateReceived month', async () => {
@@ -503,7 +503,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentDate.month).toBe(month);
+        expect(viewModel.formValues.paymentDate.month).toEqual(month);
       });
 
       it('sets the render view model formValues paymentDate year to the edit payment details response payment dateReceived year', async () => {
@@ -525,7 +525,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentDate.year).toBe(year);
+        expect(viewModel.formValues.paymentDate.year).toEqual(year);
       });
 
       it('sets the render view model formValues paymentReference to the edit payment details response payment reference', async () => {
@@ -546,7 +546,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentReference).toBe(reference);
+        expect(viewModel.formValues.paymentReference).toEqual(reference);
       });
     });
   });
@@ -639,7 +639,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         await postEditPayment(req, res);
 
         // Assert
-        expect(res._getRenderView()).toBe('utilisation-reports/edit-payment.njk');
+        expect(res._getRenderView()).toEqual('utilisation-reports/edit-payment.njk');
       });
 
       it('sets the render view model reportId to the request params reportId', async () => {
@@ -651,7 +651,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.reportId).toBe(reportId);
+        expect(viewModel.reportId).toEqual(reportId);
       });
 
       it('sets the render view model paymentId to the request params paymentId', async () => {
@@ -663,7 +663,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.paymentId).toBe(paymentId);
+        expect(viewModel.paymentId).toEqual(paymentId);
       });
 
       it('sets the render view model paymentCurrency to the edit payment details response payment currency', async () => {
@@ -685,7 +685,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.paymentCurrency).toBe(paymentCurrency);
+        expect(viewModel.paymentCurrency).toEqual(paymentCurrency);
       });
 
       it('sets the render view model bank to the edit payment details response bank', async () => {
@@ -748,7 +748,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-        viewModel.feeRecords.forEach(({ id }, index) => expect(id).toBe(feeRecordIds[index]));
+        viewModel.feeRecords.forEach(({ id }, index) => expect(id).toEqual(feeRecordIds[index]));
       });
 
       it('sets the render view model feeRecords facilityId to the edit payment details response feeRecords facilityId', async () => {
@@ -769,7 +769,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecordFacilityIds.length);
-        viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toBe(feeRecordFacilityIds[index]));
+        viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toEqual(feeRecordFacilityIds[index]));
       });
 
       it('sets the render view model feeRecords exporter to the edit payment details response feeRecords exporter', async () => {
@@ -790,7 +790,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecordExporters.length);
-        viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toBe(feeRecordExporters[index]));
+        viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toEqual(feeRecordExporters[index]));
       });
 
       it('sets the render view model feeRecords reportedFees to the edit payment details response feeRecords sorted and formatted reportedFees', async () => {
@@ -867,7 +867,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-        viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toBe(`feeRecordId-${feeRecordIds[index]}`));
+        viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toEqual(`feeRecordId-${feeRecordIds[index]}`));
       });
 
       it('sets the render view model feeRecords isChecked based on whether the fee record was selected or not', async () => {
@@ -895,9 +895,9 @@ describe('controllers/utilisation-reports/edit-payment', () => {
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
         expect(viewModel.feeRecords).toHaveLength(feeRecords.length);
-        expect(viewModel.feeRecords[0].isChecked).toBe(true);
-        expect(viewModel.feeRecords[1].isChecked).toBe(false);
-        expect(viewModel.feeRecords[2].isChecked).toBe(true);
+        expect(viewModel.feeRecords[0].isChecked).toEqual(true);
+        expect(viewModel.feeRecords[1].isChecked).toEqual(false);
+        expect(viewModel.feeRecords[2].isChecked).toEqual(true);
       });
 
       it('sets the render view model totalReportedPayments to the edit payment details response formatted totalReportedPayments', async () => {
@@ -915,7 +915,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.totalReportedPayments).toBe('USD 314.59');
+        expect(viewModel.totalReportedPayments).toEqual('USD 314.59');
       });
 
       it('sets the render view model formValues paymentAmount to the request body paymentAmount', async () => {
@@ -928,7 +928,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentAmount).toBe('314.59');
+        expect(viewModel.formValues.paymentAmount).toEqual('314.59');
       });
 
       it('sets the render view model formValues paymentDate day to the request body paymentDate-day', async () => {
@@ -941,7 +941,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentDate.day).toBe('10');
+        expect(viewModel.formValues.paymentDate.day).toEqual('10');
       });
 
       it('sets the render view model formValues paymentDate month to the request body paymentDate-month', async () => {
@@ -954,7 +954,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentDate.month).toBe('5');
+        expect(viewModel.formValues.paymentDate.month).toEqual('5');
       });
 
       it('sets the render view model formValues paymentDate year to the request body paymentDate-year', async () => {
@@ -967,7 +967,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentDate.year).toBe('2024');
+        expect(viewModel.formValues.paymentDate.year).toEqual('2024');
       });
 
       it('sets the render view model formValues paymentReference to the edit payment details response payment reference', async () => {
@@ -980,7 +980,7 @@ describe('controllers/utilisation-reports/edit-payment', () => {
 
         // Assert
         const viewModel = res._getRenderData() as EditPaymentViewModel;
-        expect(viewModel.formValues.paymentReference).toBe('A payment reference');
+        expect(viewModel.formValues.paymentReference).toEqual('A payment reference');
       });
 
       it('populates the render view model errors errorSummary array', async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/find-reports-by-year/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/find-reports-by-year/index.test.ts
@@ -188,8 +188,8 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/find-utilisation-reports-by-year.njk');
       expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.errorSummary).toStrictEqual(expectedErrorSummary);
-      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.bankError).toBe(expectedBankError);
-      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.yearError).toBe(expectedYearError);
+      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.bankError).toEqual(expectedBankError);
+      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.yearError).toEqual(expectedYearError);
     });
 
     it("renders the 'find-utilisation-reports-by-year.njk' view with required data when there are query params with errors", async () => {
@@ -266,7 +266,7 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
 
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/find-utilisation-reports-by-year.njk');
-      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.selectedBank).toBe(BANK_ID_TWO);
+      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.selectedBank).toEqual(BANK_ID_TWO);
     });
 
     it("renders the 'find-utilisation-reports-by-year.njk' view with year pre-filled with year query param if there is an error with the bank", async () => {
@@ -284,7 +284,7 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
 
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/find-utilisation-reports-by-year.njk');
-      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.selectedYear).toBe('2024');
+      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.selectedYear).toEqual('2024');
     });
 
     it("renders the 'find-utilisation-reports-by-year.njk' view with year pre-filled with year query param if there is an error with the year", async () => {
@@ -302,7 +302,7 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
 
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/find-utilisation-reports-by-year.njk');
-      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.selectedYear).toBe('Nonsense');
+      expect((res._getRenderData() as FindUtilisationReportsByYearViewModel)?.selectedYear).toEqual('Nonsense');
     });
 
     it("renders the 'utilisation-reports-by-bank-and-year-results.njk' view with required data when there are valid query params", async () => {
@@ -359,8 +359,8 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
 
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-reports-by-bank-and-year-results.njk');
-      expect((res._getRenderData() as UtilisationReportsByBankAndYearViewModel)?.bankName).toBe(BANK_NAME_ONE);
-      expect((res._getRenderData() as UtilisationReportsByBankAndYearViewModel)?.year).toBe(yearQuery);
+      expect((res._getRenderData() as UtilisationReportsByBankAndYearViewModel)?.bankName).toEqual(BANK_NAME_ONE);
+      expect((res._getRenderData() as UtilisationReportsByBankAndYearViewModel)?.year).toEqual(yearQuery);
       expect((res._getRenderData() as UtilisationReportsByBankAndYearViewModel)?.reports).toStrictEqual([expectedReportItem]);
     });
   });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/add-to-an-existing-payment-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/add-to-an-existing-payment-helper.test.ts
@@ -11,7 +11,7 @@ describe('add-to-an-existing-payment-helper', () => {
       const result = getPaymentsHeading(paymentGroups);
 
       // Assert
-      expect(result).toBe('There is one existing payment that the reported fees will be added to');
+      expect(result).toEqual('There is one existing payment that the reported fees will be added to');
     });
 
     it('should return "one existing group of payments" heading for a single group of payments', () => {
@@ -24,7 +24,7 @@ describe('add-to-an-existing-payment-helper', () => {
       const result = getPaymentsHeading(paymentGroups);
 
       // Assert
-      expect(result).toBe('There is one existing group of payments that the reported fees will be added to');
+      expect(result).toEqual('There is one existing group of payments that the reported fees will be added to');
     });
 
     it('should return "which payment" heading for multiple single payments', () => {
@@ -39,7 +39,7 @@ describe('add-to-an-existing-payment-helper', () => {
       const result = getPaymentsHeading(paymentGroups);
 
       // Assert
-      expect(result).toBe('Which payment do you want to add the reported fees to?');
+      expect(result).toEqual('Which payment do you want to add the reported fees to?');
     });
 
     it('should return "group of payments" heading for multiple groups of payments', () => {
@@ -54,7 +54,7 @@ describe('add-to-an-existing-payment-helper', () => {
       const result = getPaymentsHeading(paymentGroups);
 
       // Assert
-      expect(result).toBe('Which group of payments do you want to add the reported fees to?');
+      expect(result).toEqual('Which group of payments do you want to add the reported fees to?');
     });
 
     it('should return "payment or group of payments" heading for mix of single payments and groups', () => {
@@ -70,7 +70,7 @@ describe('add-to-an-existing-payment-helper', () => {
       const result = getPaymentsHeading(paymentGroups);
 
       // Assert
-      expect(result).toBe('Which payment or group of payments do you want to add the reported fees to?');
+      expect(result).toEqual('Which payment or group of payments do you want to add the reported fees to?');
     });
 
     function aSelectedFeeRecordsAvailablePaymentDetails(): SelectedFeeRecordsAvailablePaymentDetails {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/edit-payment-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/edit-payment-helper.test.ts
@@ -23,7 +23,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.reportId).toBe(reportId);
+      expect(viewModel.reportId).toEqual(reportId);
     });
 
     it('sets the view model paymentId the supplied paymentId', () => {
@@ -34,7 +34,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.paymentId).toBe(paymentId);
+      expect(viewModel.paymentId).toEqual(paymentId);
     });
 
     it('sets the view model paymentCurrency to the edit payment response payment currency', () => {
@@ -51,7 +51,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.paymentCurrency).toBe('USD');
+      expect(viewModel.paymentCurrency).toEqual('USD');
     });
 
     it('sets the view model bank to the edit payment response bank', () => {
@@ -85,7 +85,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.formattedReportPeriod).toBe('January 2024');
+      expect(viewModel.formattedReportPeriod).toEqual('January 2024');
     });
 
     it('sets the view model paymentCurrency to the edit payment details response payment currency', () => {
@@ -104,7 +104,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.paymentCurrency).toBe(paymentCurrency);
+      expect(viewModel.paymentCurrency).toEqual(paymentCurrency);
     });
 
     it('sets the render view model feeRecords id to the edit payment details response feeRecords id', () => {
@@ -122,7 +122,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-      viewModel.feeRecords.forEach(({ id }, index) => expect(id).toBe(feeRecordIds[index]));
+      viewModel.feeRecords.forEach(({ id }, index) => expect(id).toEqual(feeRecordIds[index]));
     });
 
     it('sets the render view model feeRecords facilityId to the edit payment details response feeRecords facilityId', () => {
@@ -140,7 +140,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordFacilityIds.length);
-      viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toBe(feeRecordFacilityIds[index]));
+      viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toEqual(feeRecordFacilityIds[index]));
     });
 
     it('sets the render view model feeRecords exporter to the edit payment details response feeRecords exporter', () => {
@@ -158,7 +158,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordExporters.length);
-      viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toBe(feeRecordExporters[index]));
+      viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toEqual(feeRecordExporters[index]));
     });
 
     it('sets the render view model feeRecords reportedFees to the edit payment details response feeRecords sorted and formatted reportedFees', () => {
@@ -226,7 +226,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-      viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toBe(`feeRecordId-${feeRecordIds[index]}`));
+      viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toEqual(`feeRecordId-${feeRecordIds[index]}`));
     });
 
     it('sets the render view model feeRecords isChecked value using the provided isCheckboxChecked function for every fee record', () => {
@@ -250,8 +250,8 @@ describe('edit-payment-helper', () => {
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecords.length);
       expect(mockIsCheckboxChecked).toHaveBeenCalledTimes(feeRecords.length);
-      expect(viewModel.feeRecords[0].isChecked).toBe(true);
-      expect(viewModel.feeRecords[1].isChecked).toBe(false);
+      expect(viewModel.feeRecords[0].isChecked).toEqual(true);
+      expect(viewModel.feeRecords[1].isChecked).toEqual(false);
     });
 
     it('sets the render view model totalReportedPayments to the edit payment details response formatted totalReportedPayments', () => {
@@ -266,7 +266,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.totalReportedPayments).toBe('USD 314.59');
+      expect(viewModel.totalReportedPayments).toEqual('USD 314.59');
     });
 
     it('sets the render view model errors to the empty errors', () => {
@@ -292,7 +292,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.formValues.paymentAmount).toBe(paymentAmount.toString());
+      expect(viewModel.formValues.paymentAmount).toEqual(paymentAmount.toString());
     });
 
     it('sets the render view model formValues paymentDate day to the edit payment details response payment dateReceived day', () => {
@@ -311,7 +311,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.formValues.paymentDate.day).toBe(day);
+      expect(viewModel.formValues.paymentDate.day).toEqual(day);
     });
 
     it('sets the render view model formValues paymentDate month to the edit payment details response payment dateReceived month', () => {
@@ -330,7 +330,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.formValues.paymentDate.month).toBe(month);
+      expect(viewModel.formValues.paymentDate.month).toEqual(month);
     });
 
     it('sets the render view model formValues paymentDate year to the edit payment details response payment dateReceived year', () => {
@@ -349,7 +349,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.formValues.paymentDate.year).toBe(year);
+      expect(viewModel.formValues.paymentDate.year).toEqual(year);
     });
 
     it('sets the render view model formValues paymentReference to the edit payment details response payment reference', () => {
@@ -367,7 +367,7 @@ describe('edit-payment-helper', () => {
       const viewModel = getEditPaymentViewModel(editPaymentResponseBody, reportId, paymentId, isCheckboxChecked);
 
       // Assert
-      expect(viewModel.formValues.paymentReference).toBe(reference);
+      expect(viewModel.formValues.paymentReference).toEqual(reference);
     });
 
     it('sets the view model redirectTab to the supplied redirectTab', () => {
@@ -417,7 +417,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.reportId).toBe(reportId);
+      expect(viewModel.reportId).toEqual(reportId);
     });
 
     it('sets the view model paymentId the supplied paymentId', () => {
@@ -436,7 +436,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.paymentId).toBe(paymentId);
+      expect(viewModel.paymentId).toEqual(paymentId);
     });
 
     it('sets the view model paymentCurrency to the edit payment response payment currency', () => {
@@ -461,7 +461,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.paymentCurrency).toBe('USD');
+      expect(viewModel.paymentCurrency).toEqual('USD');
     });
 
     it('sets the view model bank to the edit payment response bank', () => {
@@ -511,7 +511,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.formattedReportPeriod).toBe('January 2024');
+      expect(viewModel.formattedReportPeriod).toEqual('January 2024');
     });
 
     it('sets the view model paymentCurrency to the edit payment details response payment currency', () => {
@@ -538,7 +538,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.paymentCurrency).toBe(paymentCurrency);
+      expect(viewModel.paymentCurrency).toEqual(paymentCurrency);
     });
 
     it('sets the render view model feeRecords id to the edit payment details response feeRecords id', () => {
@@ -564,7 +564,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-      viewModel.feeRecords.forEach(({ id }, index) => expect(id).toBe(feeRecordIds[index]));
+      viewModel.feeRecords.forEach(({ id }, index) => expect(id).toEqual(feeRecordIds[index]));
     });
 
     it('sets the render view model feeRecords facilityId to the edit payment details response feeRecords facilityId', () => {
@@ -590,7 +590,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordFacilityIds.length);
-      viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toBe(feeRecordFacilityIds[index]));
+      viewModel.feeRecords.forEach(({ facilityId }, index) => expect(facilityId).toEqual(feeRecordFacilityIds[index]));
     });
 
     it('sets the render view model feeRecords exporter to the edit payment details response feeRecords exporter', () => {
@@ -616,7 +616,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordExporters.length);
-      viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toBe(feeRecordExporters[index]));
+      viewModel.feeRecords.forEach(({ exporter }, index) => expect(exporter).toEqual(feeRecordExporters[index]));
     });
 
     it('sets the render view model feeRecords reportedFees to the edit payment details response feeRecords sorted and formatted reportedFees', () => {
@@ -708,7 +708,7 @@ describe('edit-payment-helper', () => {
 
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecordIds.length);
-      viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toBe(`feeRecordId-${feeRecordIds[index]}`));
+      viewModel.feeRecords.forEach(({ checkboxId }, index) => expect(checkboxId).toEqual(`feeRecordId-${feeRecordIds[index]}`));
     });
 
     it('sets the render view model feeRecords isChecked value using the provided isCheckboxChecked function for every fee record', () => {
@@ -741,8 +741,8 @@ describe('edit-payment-helper', () => {
       // Assert
       expect(viewModel.feeRecords).toHaveLength(feeRecords.length);
       expect(mockIsCheckboxChecked).toHaveBeenCalledTimes(feeRecords.length);
-      expect(viewModel.feeRecords[0].isChecked).toBe(true);
-      expect(viewModel.feeRecords[1].isChecked).toBe(false);
+      expect(viewModel.feeRecords[0].isChecked).toEqual(true);
+      expect(viewModel.feeRecords[1].isChecked).toEqual(false);
     });
 
     it('sets the render view model totalReportedPayments to the edit payment details response formatted totalReportedPayments', () => {
@@ -765,7 +765,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.totalReportedPayments).toBe('USD 314.59');
+      expect(viewModel.totalReportedPayments).toEqual('USD 314.59');
     });
 
     it('sets the render view model errors to the supplied errors', () => {
@@ -823,7 +823,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.formValues.paymentAmount).toBe('314.59');
+      expect(viewModel.formValues.paymentAmount).toEqual('314.59');
     });
 
     it('sets the render view model formValues paymentDate to the supplied formValues paymentDate object', () => {
@@ -875,7 +875,7 @@ describe('edit-payment-helper', () => {
       );
 
       // Assert
-      expect(viewModel.formValues.paymentReference).toBe('Some payment reference');
+      expect(viewModel.formValues.paymentReference).toEqual('Some payment reference');
     });
 
     it('sets the view model redirectTab to the supplied redirectTab', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-add-payment-error-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-add-payment-error-helper.test.ts
@@ -10,8 +10,8 @@ describe('get-add-payment-error-helper', () => {
       const addPaymentError = getAddPaymentError(addPaymentErrorKey);
 
       // Assert
-      expect(addPaymentError.text).toBe('Select a fee or fees to add a payment to');
-      expect(addPaymentError.href).toBe('#premium-payments-table');
+      expect(addPaymentError.text).toEqual('Select a fee or fees to add a payment to');
+      expect(addPaymentError.href).toEqual('#premium-payments-table');
     });
 
     it("returns the error text and href when the payment error key is 'different-fee-record-statuses'", () => {
@@ -22,8 +22,8 @@ describe('get-add-payment-error-helper', () => {
       const addPaymentError = getAddPaymentError(addPaymentErrorKey);
 
       // Assert
-      expect(addPaymentError.text).toBe('Select a fee or fees with the same status');
-      expect(addPaymentError.href).toBe('#premium-payments-table');
+      expect(addPaymentError.text).toEqual('Select a fee or fees with the same status');
+      expect(addPaymentError.href).toEqual('#premium-payments-table');
     });
 
     it("returns the error text and href when the payment error key is 'different-fee-record-payment-currencies'", () => {
@@ -34,8 +34,8 @@ describe('get-add-payment-error-helper', () => {
       const addPaymentError = getAddPaymentError(addPaymentErrorKey);
 
       // Assert
-      expect(addPaymentError.text).toBe('Select fees with the same Reported payment currency');
-      expect(addPaymentError.href).toBe('#premium-payments-table');
+      expect(addPaymentError.text).toEqual('Select fees with the same Reported payment currency');
+      expect(addPaymentError.href).toEqual('#premium-payments-table');
     });
 
     it("returns the error text and href when the payment error key is 'multiple-does-not-match-selected'", () => {
@@ -46,8 +46,8 @@ describe('get-add-payment-error-helper', () => {
       const addPaymentError = getAddPaymentError(addPaymentErrorKey);
 
       // Assert
-      expect(addPaymentError.text).toBe("Select only one fee or fee group at 'Does not match' status");
-      expect(addPaymentError.href).toBe('#premium-payments-table');
+      expect(addPaymentError.text).toEqual("Select only one fee or fee group at 'Does not match' status");
+      expect(addPaymentError.href).toEqual('#premium-payments-table');
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-fee-record-display-status.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-fee-record-display-status.test.ts
@@ -14,7 +14,7 @@ describe('get-fee-record-display-status-helper', () => {
       const displayStatus = getFeeRecordDisplayStatus(status);
 
       // Assert
-      expect(displayStatus).toBe(expectedDisplayStatus);
+      expect(displayStatus).toEqual(expectedDisplayStatus);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-generate-keying-data-error-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-generate-keying-data-error-helper.test.ts
@@ -10,8 +10,8 @@ describe('get-generate-keying-data-error-helper', () => {
       const generateKeyingDataError = getGenerateKeyingDataError(addPaymentErrorKey);
 
       // Assert
-      expect(generateKeyingDataError.text).toBe('No matched fees to generate keying data with');
-      expect(generateKeyingDataError.href).toBe('#premium-payments-table');
+      expect(generateKeyingDataError.text).toEqual('No matched fees to generate keying data with');
+      expect(generateKeyingDataError.href).toEqual('#premium-payments-table');
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-remove-fees-from-payment-error-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/get-remove-fees-from-payment-error-helper.test.ts
@@ -11,8 +11,8 @@ describe('get-remove-fees-from-payment-error-helper', () => {
 
       // Assert
       expect(errors.errorSummary).toHaveLength(1);
-      expect(errors.errorSummary[0].text).toBe('Select fee or fees to remove from the payment');
-      expect(errors.errorSummary[0].href).toBe('#added-reported-fees-details-header');
+      expect(errors.errorSummary[0].text).toEqual('Select fee or fees to remove from the payment');
+      expect(errors.errorSummary[0].href).toEqual('#added-reported-fees-details-header');
     });
 
     it("sets remove selected fees error message when the payment error key is 'no-fee-records-selected'", () => {
@@ -23,7 +23,7 @@ describe('get-remove-fees-from-payment-error-helper', () => {
       const errors = getRemoveFeesFromPaymentError(removeFeesFromPaymentErrorKey);
 
       // Assert
-      expect(errors.removeSelectedFeesErrorMessage).toBe('Select fee or fees to remove from the payment');
+      expect(errors.removeSelectedFeesErrorMessage).toEqual('Select fee or fees to remove from the payment');
     });
 
     it("sets error summary to a single error with text and href when the payment error key is 'all-fee-records-selected'", () => {
@@ -35,8 +35,8 @@ describe('get-remove-fees-from-payment-error-helper', () => {
 
       // Assert
       expect(errors.errorSummary).toHaveLength(1);
-      expect(errors.errorSummary[0].text).toBe('You cannot remove all the fees. Delete the payment instead.');
-      expect(errors.errorSummary[0].href).toBe('#added-reported-fees-details-header');
+      expect(errors.errorSummary[0].text).toEqual('You cannot remove all the fees. Delete the payment instead.');
+      expect(errors.errorSummary[0].href).toEqual('#added-reported-fees-details-header');
     });
 
     it("sets remove selected fees error message whe the payment error key is 'all-fee-records-selected'", () => {
@@ -47,7 +47,7 @@ describe('get-remove-fees-from-payment-error-helper', () => {
       const error = getRemoveFeesFromPaymentError(removeFeesFromPaymentErrorKey);
 
       // Assert
-      expect(error.removeSelectedFeesErrorMessage).toBe('You cannot remove all the fees. Delete the payment instead.');
+      expect(error.removeSelectedFeesErrorMessage).toEqual('You cannot remove all the fees. Delete the payment instead.');
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/parse-payment-form-values.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/parse-payment-form-values.test.ts
@@ -27,7 +27,7 @@ describe('parseValidatedAddPaymentFormValues', () => {
     const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
 
     // Assert
-    expect(parsedFormValues.paymentCurrency).toBe(paymentCurrency);
+    expect(parsedFormValues.paymentCurrency).toEqual(paymentCurrency);
   });
 
   it('returns an object containing the supplied payment reference', () => {
@@ -42,7 +42,7 @@ describe('parseValidatedAddPaymentFormValues', () => {
     const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
 
     // Assert
-    expect(parsedFormValues.paymentReference).toBe(paymentReference);
+    expect(parsedFormValues.paymentReference).toEqual(paymentReference);
   });
 
   it('parses the supplied payment date to a date object', () => {
@@ -80,7 +80,7 @@ describe('parseValidatedAddPaymentFormValues', () => {
     const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
 
     // Assert
-    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+    expect(parsedFormValues.paymentAmount).toEqual(paymentAmount);
   });
 
   it('parses the supplied payment amount to a number when the amount does not contain any commas but has decimals', () => {
@@ -97,7 +97,7 @@ describe('parseValidatedAddPaymentFormValues', () => {
     const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
 
     // Assert
-    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+    expect(parsedFormValues.paymentAmount).toEqual(paymentAmount);
   });
 
   it('parses the supplied payment amount to a number when the amount does not contain decimals but has commas', () => {
@@ -114,7 +114,7 @@ describe('parseValidatedAddPaymentFormValues', () => {
     const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
 
     // Assert
-    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+    expect(parsedFormValues.paymentAmount).toEqual(paymentAmount);
   });
 
   it('parses the supplied payment amount to a number when the amount contains commas and decimals', () => {
@@ -131,7 +131,7 @@ describe('parseValidatedAddPaymentFormValues', () => {
     const parsedFormValues = parseValidatedAddPaymentFormValues(formValues);
 
     // Assert
-    expect(parsedFormValues.paymentAmount).toBe(paymentAmount);
+    expect(parsedFormValues.paymentAmount).toEqual(paymentAmount);
   });
 });
 
@@ -147,7 +147,7 @@ describe('parseValidatedEditPaymentFormValues', () => {
     const result = parseValidatedEditPaymentFormValues(validatedFormValues);
 
     // Assert
-    expect(result.paymentAmount).toBe(314.59);
+    expect(result.paymentAmount).toEqual(314.59);
   });
 
   it('sets the datePaymentReceived field to a date matching the supplied paymentDate object', () => {
@@ -179,7 +179,7 @@ describe('parseValidatedEditPaymentFormValues', () => {
     const result = parseValidatedEditPaymentFormValues(validatedFormValues);
 
     // Assert
-    expect(result.paymentReference).toBe('A payment reference');
+    expect(result.paymentReference).toEqual('A payment reference');
   });
 
   it('sets the paymentReference field to null when the supplied paymentReference is undefined', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/payment-form-helpers.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/payment-form-helpers.test.ts
@@ -34,7 +34,7 @@ describe('payment-form-helpers', () => {
         const { isAddingPayment } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(isAddingPayment).toBe(false);
+        expect(isAddingPayment).toEqual(false);
       });
 
       it('sets the errors property to the empty payment errors view model', () => {
@@ -74,7 +74,7 @@ describe('payment-form-helpers', () => {
         const { isAddingPayment } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(isAddingPayment).toBe(true);
+        expect(isAddingPayment).toEqual(true);
       });
 
       it('sets the formValues paymentCurrency property to the requestBody paymentCurrency', () => {
@@ -89,7 +89,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.paymentCurrency).toBe('USD');
+        expect(formValues.paymentCurrency).toEqual('USD');
       });
 
       it('sets the formValues paymentAmount property to the requestBody paymentAmount', () => {
@@ -104,7 +104,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.paymentAmount).toBe('314.59');
+        expect(formValues.paymentAmount).toEqual('314.59');
       });
 
       it('sets the formValues paymentDate day property to the requestBody paymentDate-day', () => {
@@ -119,7 +119,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.paymentDate.day).toBe('10');
+        expect(formValues.paymentDate.day).toEqual('10');
       });
 
       it('sets the formValues paymentDate month property to the requestBody paymentDate-month', () => {
@@ -134,7 +134,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.paymentDate.month).toBe('6');
+        expect(formValues.paymentDate.month).toEqual('6');
       });
 
       it('sets the formValues paymentDate year property to the requestBody paymentDate-year', () => {
@@ -149,7 +149,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.paymentDate.year).toBe('2024');
+        expect(formValues.paymentDate.year).toEqual('2024');
       });
 
       it('sets the formValues paymentReference property to the requestBody paymentReference', () => {
@@ -164,7 +164,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.paymentReference).toBe('A payment reference');
+        expect(formValues.paymentReference).toEqual('A payment reference');
       });
 
       it('sets the formValues addAnotherPayment property to the requestBody addAnotherPayment', () => {
@@ -179,7 +179,7 @@ describe('payment-form-helpers', () => {
         const { formValues } = extractAddPaymentFormValuesAndValidateIfPresent(body, 'GBP');
 
         // Assert
-        expect(formValues.addAnotherPayment).toBe('true');
+        expect(formValues.addAnotherPayment).toEqual('true');
       });
 
       it('sets the errors property to the result of the validateAddPaymentRequestFormValues function', () => {
@@ -228,7 +228,7 @@ describe('payment-form-helpers', () => {
       const formValues = extractEditPaymentFormValues(body);
 
       // Assert
-      expect(formValues.paymentAmount).toBe('314.59');
+      expect(formValues.paymentAmount).toEqual('314.59');
     });
 
     it('sets the formValues paymentDate day property to the requestBody paymentDate-day', () => {
@@ -242,7 +242,7 @@ describe('payment-form-helpers', () => {
       const formValues = extractEditPaymentFormValues(body);
 
       // Assert
-      expect(formValues.paymentDate.day).toBe('10');
+      expect(formValues.paymentDate.day).toEqual('10');
     });
 
     it('sets the formValues paymentDate month property to the requestBody paymentDate-month', () => {
@@ -256,7 +256,7 @@ describe('payment-form-helpers', () => {
       const formValues = extractEditPaymentFormValues(body);
 
       // Assert
-      expect(formValues.paymentDate.month).toBe('6');
+      expect(formValues.paymentDate.month).toEqual('6');
     });
 
     it('sets the formValues paymentDate year property to the requestBody paymentDate-year', () => {
@@ -270,7 +270,7 @@ describe('payment-form-helpers', () => {
       const formValues = extractEditPaymentFormValues(body);
 
       // Assert
-      expect(formValues.paymentDate.year).toBe('2024');
+      expect(formValues.paymentDate.year).toEqual('2024');
     });
 
     it('sets the formValues paymentReference property to the requestBody paymentReference', () => {
@@ -284,7 +284,7 @@ describe('payment-form-helpers', () => {
       const formValues = extractEditPaymentFormValues(body);
 
       // Assert
-      expect(formValues.paymentReference).toBe('A payment reference');
+      expect(formValues.paymentReference).toEqual('A payment reference');
     });
 
     function aValidEditPaymentFormRequestBody(): EditPaymentFormRequestBody {
@@ -311,7 +311,7 @@ describe('payment-form-helpers', () => {
         const { isAddingToAnExistingPayment } = extractAddToAnExistingPaymentRadioPaymentIdsAndValidateIfPresent(requestBody);
 
         // Assert
-        expect(isAddingToAnExistingPayment).toBe(false);
+        expect(isAddingToAnExistingPayment).toEqual(false);
       });
 
       it('sets the errors property to the empty payment errors view model', () => {
@@ -342,7 +342,7 @@ describe('payment-form-helpers', () => {
         const { isAddingToAnExistingPayment } = extractAddToAnExistingPaymentRadioPaymentIdsAndValidateIfPresent(requestBody);
 
         // Assert
-        expect(isAddingToAnExistingPayment).toBe(true);
+        expect(isAddingToAnExistingPayment).toEqual(true);
       });
 
       it('sets the errors property to the result of the validateAddPaymentRequestFormValues function', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/validate-payment-form-values.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/validate-payment-form-values.test.ts
@@ -60,7 +60,7 @@ describe('validate-payment-form-values', () => {
       expect(errors.errorSummary).toEqual([
         { text: 'The new payment currency must be the same as the reported payment currency of the selected fees', href: '#paymentCurrency' },
       ]);
-      expect(errors.paymentCurrencyErrorMessage).toBe('The new payment currency must be the same as the reported payment currency of the selected fees');
+      expect(errors.paymentCurrencyErrorMessage).toEqual('The new payment currency must be the same as the reported payment currency of the selected fees');
     });
 
     it.each(Object.values(CURRENCY))('should not set payment currency error when payment currency value is %s', (currency: Currency) => {
@@ -872,7 +872,7 @@ describe('validate-payment-form-values', () => {
 
       // Assert
       expect(result.errorSummary).toEqual([{ text: 'Select a payment to add the fee or fees to', href: '#payment-groups' }]);
-      expect(result.paymentGroupErrorMessage).toBe('Select a payment to add the fee or fees to');
+      expect(result.paymentGroupErrorMessage).toEqual('Select a payment to add the fee or fees to');
     });
 
     it('should not return error when a payment radio is selected', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/keying-data/index.test.ts
@@ -51,8 +51,8 @@ describe('controllers/utilisation-reports/keying-data', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('renders the problem-with-service page when an error occurs', async () => {
@@ -68,7 +68,7 @@ describe('controllers/utilisation-reports/keying-data', () => {
       await postKeyingData(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: requestSession.user });
     });
   });
@@ -103,8 +103,8 @@ describe('controllers/utilisation-reports/keying-data', () => {
 
       // Assert
       expect(api.markKeyingDataAsDone).toHaveBeenCalledWith(reportId, [123, 456], user, userToken);
-      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('does not mark any fees as done and redirects to keying sheet when none of the selected checkboxes are for rows with status TO_DO', async () => {
@@ -121,8 +121,8 @@ describe('controllers/utilisation-reports/keying-data', () => {
 
       // Assert
       expect(api.markKeyingDataAsDone).not.toHaveBeenCalled();
-      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('renders the problem-with-service page when an error occurs', async () => {
@@ -139,7 +139,7 @@ describe('controllers/utilisation-reports/keying-data', () => {
       await postKeyingDataMarkAsDone(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: requestSession.user });
     });
   });
@@ -174,8 +174,8 @@ describe('controllers/utilisation-reports/keying-data', () => {
 
       // Assert
       expect(api.markKeyingDataAsToDo).toHaveBeenCalledWith(reportId, [123, 789], user, userToken);
-      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('does not mark any fees as to do and redirects to keying sheet when none of the selected checkboxes are for rows with status DONE', async () => {
@@ -192,8 +192,8 @@ describe('controllers/utilisation-reports/keying-data', () => {
 
       // Assert
       expect(api.markKeyingDataAsToDo).not.toHaveBeenCalled();
-      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}#keying-sheet`);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}#keying-sheet`);
+      expect(res._isEndCalled()).toEqual(true);
     });
 
     it('renders the problem-with-service page when an error occurs', async () => {
@@ -210,7 +210,7 @@ describe('controllers/utilisation-reports/keying-data', () => {
       await postKeyingDataMarkAsToDo(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: requestSession.user });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/remove-fees-from-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/remove-fees-from-payment/index.test.ts
@@ -77,8 +77,8 @@ describe('controllers/utilisation-reports/remove-fees-from-payment', () => {
           month: '8',
         },
       };
-      expect(res._getRedirectUrl()).toBe(`/utilisation-reports/${reportId}/edit-payment/${paymentId}?redirectTab=premium-payments`);
-      expect(res._isEndCalled()).toBe(true);
+      expect(res._getRedirectUrl()).toEqual(`/utilisation-reports/${reportId}/edit-payment/${paymentId}?redirectTab=premium-payments`);
+      expect(res._isEndCalled()).toEqual(true);
       expect(req.session.editPaymentFormValues).toEqual(expectedEditPaymentFormValues);
     });
 
@@ -95,7 +95,7 @@ describe('controllers/utilisation-reports/remove-fees-from-payment', () => {
       await postRemoveFeesFromPayment(req, res);
 
       // Assert
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user: requestSession.user });
     });
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/extract-query-and-session-data.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/extract-query-and-session-data.test.ts
@@ -29,7 +29,7 @@ describe('extractQueryAndSessionData', () => {
       const result = extractQueryAndSessionData(queryParams, sessionData, ORIGINAL_URL);
 
       // Assert
-      expect(result.premiumPaymentsFilters.facilityId).toBe(PREMIUM_PAYMENTS_FACILITY_ID_QUERY);
+      expect(result.premiumPaymentsFilters.facilityId).toEqual(PREMIUM_PAYMENTS_FACILITY_ID_QUERY);
     });
 
     it('validates premiumPaymentsFacilityId and returns any errors as premiumPaymentsFilterError', () => {
@@ -84,9 +84,9 @@ describe('extractQueryAndSessionData', () => {
     const result = extractQueryAndSessionData(queryParams, sessionData, ORIGINAL_URL);
 
     // Assert
-    expect(result.isCheckboxChecked([1])).toBe(true);
-    expect(result.isCheckboxChecked([2, 3])).toBe(true);
-    expect(result.isCheckboxChecked([4])).toBe(false);
+    expect(result.isCheckboxChecked([1])).toEqual(true);
+    expect(result.isCheckboxChecked([2, 3])).toEqual(true);
+    expect(result.isCheckboxChecked([4])).toEqual(false);
   });
 
   it('uses selectedFeeRecordIds from session data for isCheckboxChecked when present', () => {
@@ -105,8 +105,8 @@ describe('extractQueryAndSessionData', () => {
 
     // Assert
     expect(handleRedirectSessionData).toHaveBeenCalledWith({});
-    expect(result.isCheckboxChecked([1])).toBe(true);
-    expect(result.isCheckboxChecked([2, 3])).toBe(true);
-    expect(result.isCheckboxChecked([4])).toBe(false);
+    expect(result.isCheckboxChecked([1])).toEqual(true);
+    expect(result.isCheckboxChecked([2, 3])).toEqual(true);
+    expect(result.isCheckboxChecked([4])).toEqual(false);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/get-is-checkbox-checked.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/get-is-checkbox-checked.test.ts
@@ -11,7 +11,7 @@ describe('getIsCheckboxChecked', () => {
     const result = isCheckboxChecked(checkboxFeeRecordIds);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when checkbox fee record ids do not match any checked fee record ids', () => {
@@ -24,7 +24,7 @@ describe('getIsCheckboxChecked', () => {
     const result = isCheckboxChecked(checkboxFeeRecordIds);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return false when checkbox fee record ids only partially match checked fee record ids', () => {
@@ -37,7 +37,7 @@ describe('getIsCheckboxChecked', () => {
     const result = isCheckboxChecked(checkboxFeeRecordIds);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toEqual(false);
   });
 
   it('should return true when all checkbox fee record ids match a checked fee record ids', () => {
@@ -50,6 +50,6 @@ describe('getIsCheckboxChecked', () => {
     const result = isCheckboxChecked(checkboxFeeRecordIds);
 
     // Assert
-    expect(result).toBe(true);
+    expect(result).toEqual(true);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
@@ -57,7 +57,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
 
       // Assert
       expect(api.getUtilisationReportReconciliationDetailsById).toHaveBeenCalledWith(reportId, premiumPaymentsFilters, userToken);
-      expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
       expect(res._getRenderData()).toEqual({ user });
     });
 
@@ -195,9 +195,9 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
       expect(viewModel.premiumPaymentsTableDataError).toBeDefined();
-      expect(viewModel.premiumPaymentsTableDataError?.href).toBe('#premium-payments-table');
-      expect(viewModel.premiumPaymentsTableDataError?.text).toBe('Select a fee or fees with the same status');
-      expect(viewModel.premiumPayments[0].isChecked).toBe(true);
+      expect(viewModel.premiumPaymentsTableDataError?.href).toEqual('#premium-payments-table');
+      expect(viewModel.premiumPaymentsTableDataError?.text).toEqual('Select a fee or fees with the same status');
+      expect(viewModel.premiumPayments[0].isChecked).toEqual(true);
     });
 
     it("renders the page with 'enablePaymentsReceivedSorting' set to true if at least one fee record has a non-null 'paymentsReceived'", async () => {
@@ -226,7 +226,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.enablePaymentsReceivedSorting).toBe(true);
+      expect(viewModel.enablePaymentsReceivedSorting).toEqual(true);
     });
 
     it("renders the page with 'enablePaymentsReceivedSorting' set to false if all fee records have null 'paymentsReceived'", async () => {
@@ -248,7 +248,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.enablePaymentsReceivedSorting).toBe(false);
+      expect(viewModel.enablePaymentsReceivedSorting).toEqual(false);
     });
 
     it('sets facility ID query error when invalid facility ID query value used', async () => {
@@ -281,8 +281,8 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
       expect(viewModel.premiumPaymentsFilterError).toBeDefined();
-      expect(viewModel.premiumPaymentsFilterError?.href).toBe('#premium-payments-facility-id-filter');
-      expect(viewModel.premiumPaymentsFilterError?.text).toBe('Facility ID must be a number');
+      expect(viewModel.premiumPaymentsFilterError?.href).toEqual('#premium-payments-facility-id-filter');
+      expect(viewModel.premiumPaymentsFilterError?.text).toEqual('Facility ID must be a number');
     });
 
     it('checks selected checkboxes when selected fee record ids query param defined', async () => {
@@ -328,9 +328,9 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
 
       // Assert
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.premiumPayments[0].isChecked).toBe(true);
-      expect(viewModel.premiumPayments[1].isChecked).toBe(true);
-      expect(viewModel.premiumPayments[2].isChecked).toBe(false);
+      expect(viewModel.premiumPayments[0].isChecked).toEqual(true);
+      expect(viewModel.premiumPayments[1].isChecked).toEqual(true);
+      expect(viewModel.premiumPayments[2].isChecked).toEqual(false);
     });
 
     it('clears redirect session data', async () => {

--- a/trade-finance-manager-ui/server/errors/invalid-collection-name.error.test.js
+++ b/trade-finance-manager-ui/server/errors/invalid-collection-name.error.test.js
@@ -6,12 +6,12 @@ describe('InvalidCollectionNameError', () => {
   it('exposes the message it was created with', () => {
     const exception = new InvalidCollectionNameError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new InvalidCollectionNameError(message);
 
-    expect(exception.name).toBe('InvalidCollectionNameError');
+    expect(exception.name).toEqual('InvalidCollectionNameError');
   });
 });

--- a/trade-finance-manager-ui/server/errors/page-out-of-bounds.error.test.js
+++ b/trade-finance-manager-ui/server/errors/page-out-of-bounds.error.test.js
@@ -6,12 +6,12 @@ describe('PageOutOfBoundsError', () => {
   it('exposes the message it was created with', () => {
     const exception = new PageOutOfBoundsError(message);
 
-    expect(exception.message).toBe(message);
+    expect(exception.message).toEqual(message);
   });
 
   it('exposes the name of the exception', () => {
     const exception = new PageOutOfBoundsError(message);
 
-    expect(exception.name).toBe('PageOutOfBoundsError');
+    expect(exception.name).toEqual('PageOutOfBoundsError');
   });
 });

--- a/trade-finance-manager-ui/server/helpers/date.test.js
+++ b/trade-finance-manager-ui/server/helpers/date.test.js
@@ -43,7 +43,7 @@ describe('date', () => {
           const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
           // Assert
-          expect(isSameDay(result, expected)).toBe(true);
+          expect(isSameDay(result, expected)).toEqual(true);
         });
       });
 
@@ -59,7 +59,7 @@ describe('date', () => {
           const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
           // Assert
-          expect(isSameDay(result, expected)).toBe(true);
+          expect(isSameDay(result, expected)).toEqual(true);
         });
       });
     });
@@ -79,7 +79,7 @@ describe('date', () => {
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         // Assert
-        expect(isSameDay(result, expected)).toBe(true);
+        expect(isSameDay(result, expected)).toEqual(true);
       });
 
       it('takes into account both holidays and weekend dates', () => {
@@ -96,7 +96,7 @@ describe('date', () => {
         const result = getBusinessDayOfMonth(dateInMonth, holidays, businessDay);
 
         // Assert
-        expect(isSameDay(result, expected)).toBe(true);
+        expect(isSameDay(result, expected)).toEqual(true);
       });
     });
   });

--- a/trade-finance-manager-ui/server/helpers/user.test.ts
+++ b/trade-finance-manager-ui/server/helpers/user.test.ts
@@ -58,7 +58,7 @@ describe('user helpers', () => {
       const result = userIsOnlyInTeams(mockUser, teamIdList);
 
       // Assert
-      expect(result).toBe(false);
+      expect(result).toEqual(false);
     });
 
     it('should return true when the user teams match', () => {
@@ -71,7 +71,7 @@ describe('user helpers', () => {
       const result = userIsOnlyInTeams(mockUser, teamIdList);
 
       // Assert
-      expect(result).toBe(true);
+      expect(result).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-ui/server/middleware/validateMongoId/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validateMongoId/index.test.ts
@@ -16,7 +16,7 @@ describe('validateMongoId', () => {
 
     // Assert
     expect(mockNext).not.toHaveBeenCalled();
-    expect(mockRes._getRedirectUrl()).toBe('/not-found');
+    expect(mockRes._getRedirectUrl()).toEqual('/not-found');
   });
 
   it('calls the next middleware function when a valid MongoDB ID is provided', () => {

--- a/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.test.ts
@@ -34,7 +34,7 @@ describe('validatePostAddPaymentRequestBody', () => {
     addPaymentErrorKey: AddPaymentErrorKey,
     checkedCheckboxIdList: PremiumPaymentsTableCheckboxId[],
   ) => {
-    expect(req.session.addPaymentErrorKey).toBe(addPaymentErrorKey);
+    expect(req.session.addPaymentErrorKey).toEqual(addPaymentErrorKey);
 
     const expectedCheckedCheckboxIds = checkedCheckboxIdList.reduce((obj, checkboxId) => ({ ...obj, [checkboxId]: true }), {});
     expect(req.session.checkedCheckboxIds).toEqual(expectedCheckedCheckboxIds);
@@ -55,7 +55,7 @@ describe('validatePostAddPaymentRequestBody', () => {
     validatePostAddPaymentRequestBody(req, res, next);
 
     // Assert
-    expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+    expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
     expect(res._getRenderData()).toEqual({
       user: MOCK_TFM_SESSION_USER,
     });
@@ -74,7 +74,7 @@ describe('validatePostAddPaymentRequestBody', () => {
       validatePostAddPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(REDIRECT_URL);
+      expect(res._getRedirectUrl()).toEqual(REDIRECT_URL);
     });
 
     it(`populates the session with the 'no-fee-records-selected' error and no checked checkbox ids`, () => {
@@ -107,7 +107,7 @@ describe('validatePostAddPaymentRequestBody', () => {
       validatePostAddPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(REDIRECT_URL);
+      expect(res._getRedirectUrl()).toEqual(REDIRECT_URL);
     });
 
     it(`redirects to '${REDIRECT_URL}' with facility id filter if referer has one`, () => {
@@ -120,7 +120,7 @@ describe('validatePostAddPaymentRequestBody', () => {
       validatePostAddPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`${REDIRECT_URL}?premiumPaymentsFacilityId=1234`);
+      expect(res._getRedirectUrl()).toEqual(`${REDIRECT_URL}?premiumPaymentsFacilityId=1234`);
     });
 
     it(`populates the session with the 'different-fee-record-payment-currencies' error and the checked checkbox ids`, () => {
@@ -161,7 +161,7 @@ describe('validatePostAddPaymentRequestBody', () => {
       validatePostAddPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(REDIRECT_URL);
+      expect(res._getRedirectUrl()).toEqual(REDIRECT_URL);
     });
 
     it(`redirects to '${REDIRECT_URL}' with facility id filter if referer has one`, () => {
@@ -174,7 +174,7 @@ describe('validatePostAddPaymentRequestBody', () => {
       validatePostAddPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(`${REDIRECT_URL}?premiumPaymentsFacilityId=1234`);
+      expect(res._getRedirectUrl()).toEqual(`${REDIRECT_URL}?premiumPaymentsFacilityId=1234`);
     });
 
     it(`populates the session with the 'different-fee-record-statuses' error and the checked checkbox ids`, () => {
@@ -216,7 +216,7 @@ describe('validatePostAddPaymentRequestBody', () => {
       validatePostAddPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(REDIRECT_URL);
+      expect(res._getRedirectUrl()).toEqual(REDIRECT_URL);
     });
 
     it(`populates the session with the 'multiple-does-not-match-selected' error and the checked checkbox ids`, () => {

--- a/trade-finance-manager-ui/server/middleware/validatePostRemoveFeesFromPaymentRequestBody/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validatePostRemoveFeesFromPaymentRequestBody/index.test.ts
@@ -40,7 +40,7 @@ describe('validatePostRemoveFeesFromPaymentRequestBody', () => {
     removeFeesFromPaymentErrorKey: RemoveFeesFromPaymentErrorKey,
     editPaymentFormValues: EditPaymentFormValues,
   ) => {
-    expect(req.session.removeFeesFromPaymentErrorKey).toBe(removeFeesFromPaymentErrorKey);
+    expect(req.session.removeFeesFromPaymentErrorKey).toEqual(removeFeesFromPaymentErrorKey);
     expect(req.session.editPaymentFormValues).toEqual(editPaymentFormValues);
   };
 
@@ -59,7 +59,7 @@ describe('validatePostRemoveFeesFromPaymentRequestBody', () => {
     validatePostRemoveFeesFromPaymentRequestBody(req, res, next);
 
     // Assert
-    expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+    expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
     expect(res._getRenderData()).toEqual({
       user: MOCK_TFM_SESSION_USER,
     });
@@ -77,7 +77,7 @@ describe('validatePostRemoveFeesFromPaymentRequestBody', () => {
     validatePostRemoveFeesFromPaymentRequestBody(req, res, next);
 
     // Assert
-    expect(res._getRenderView()).toBe('_partials/problem-with-service.njk');
+    expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
     expect(res._getRenderData()).toEqual({
       user: MOCK_TFM_SESSION_USER,
     });
@@ -121,7 +121,7 @@ describe('validatePostRemoveFeesFromPaymentRequestBody', () => {
       validatePostRemoveFeesFromPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(REDIRECT_URL);
+      expect(res._getRedirectUrl()).toEqual(REDIRECT_URL);
     });
 
     it(`populates the session with the 'no-fee-records-selected' error and the extracted edit payment form values`, () => {
@@ -182,7 +182,7 @@ describe('validatePostRemoveFeesFromPaymentRequestBody', () => {
       validatePostRemoveFeesFromPaymentRequestBody(req, res, next);
 
       // Assert
-      expect(res._getRedirectUrl()).toBe(REDIRECT_URL);
+      expect(res._getRedirectUrl()).toEqual(REDIRECT_URL);
     });
 
     it(`populates the session with the 'all-fee-records-selected' error and the extracted edit payment form values`, () => {

--- a/trade-finance-manager-ui/server/middleware/validateSqlId/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validateSqlId/index.test.ts
@@ -17,7 +17,7 @@ describe('validateSqlId', () => {
 
     // Assert
     expect(mockNext).not.toHaveBeenCalled();
-    expect(mockRes._getRedirectUrl()).toBe('/not-found');
+    expect(mockRes._getRedirectUrl()).toEqual('/not-found');
   });
 
   it('calls the next middleware function when an integer id is provided', () => {

--- a/trade-finance-manager-ui/server/middleware/validateTfmPaymentReconciliationFeatureFlagIsEnabled/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validateTfmPaymentReconciliationFeatureFlagIsEnabled/index.test.ts
@@ -22,7 +22,7 @@ describe('validateTfmPaymentReconciliationFeatureFlagIsEnabled', () => {
     validateTfmPaymentReconciliationFeatureFlagIsEnabled(req, res, next);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe('/not-found');
+    expect(res._getRedirectUrl()).toEqual('/not-found');
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -37,7 +37,7 @@ describe('validateTfmPaymentReconciliationFeatureFlagIsEnabled', () => {
     validateTfmPaymentReconciliationFeatureFlagIsEnabled(req, res, next);
 
     // Assert
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
     expect(next).toHaveBeenCalled();
   });
 });

--- a/trade-finance-manager-ui/server/middleware/validateTfmPaymentReconciliationFeatureFlagIsNotEnabled/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validateTfmPaymentReconciliationFeatureFlagIsNotEnabled/index.test.ts
@@ -22,7 +22,7 @@ describe('validateTfmPaymentReconciliationFeatureFlagIsNotEnabled', () => {
     validateTfmPaymentReconciliationFeatureFlagIsNotEnabled(req, res, next);
 
     // Assert
-    expect(res._getRedirectUrl()).toBe('/not-found');
+    expect(res._getRedirectUrl()).toEqual('/not-found');
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -37,7 +37,7 @@ describe('validateTfmPaymentReconciliationFeatureFlagIsNotEnabled', () => {
     validateTfmPaymentReconciliationFeatureFlagIsNotEnabled(req, res, next);
 
     // Assert
-    expect(res._isEndCalled()).toBe(false);
+    expect(res._isEndCalled()).toEqual(false);
     expect(next).toHaveBeenCalled();
   });
 });

--- a/trade-finance-manager-ui/server/routes/login/configs/index.test.ts
+++ b/trade-finance-manager-ui/server/routes/login/configs/index.test.ts
@@ -26,7 +26,7 @@ describe('login router config', () => {
       jest.mocked(isTfmSsoFeatureFlagEnabled).mockReturnValue(true);
       jest.mocked(getLoginSsoRouter).mockReturnValue('loginSsoRouter' as unknown as Router);
 
-      expect(getLoginRouter()).toBe('loginSsoRouter');
+      expect(getLoginRouter()).toEqual('loginSsoRouter');
       expect(getLoginSsoRouter).toHaveBeenCalledTimes(1);
       expect(getLoginNonSsoRouter).not.toHaveBeenCalled();
     });
@@ -35,7 +35,7 @@ describe('login router config', () => {
       jest.mocked(isTfmSsoFeatureFlagEnabled).mockReturnValue(false);
       jest.mocked(getLoginNonSsoRouter).mockReturnValue('loginNonSsoRouter' as unknown as Router);
 
-      expect(getLoginRouter()).toBe('loginNonSsoRouter');
+      expect(getLoginRouter()).toEqual('loginNonSsoRouter');
       expect(getLoginNonSsoRouter).toHaveBeenCalledTimes(1);
       expect(getLoginSsoRouter).not.toHaveBeenCalled();
     });

--- a/trade-finance-manager-ui/server/routes/user/configs/index.test.ts
+++ b/trade-finance-manager-ui/server/routes/user/configs/index.test.ts
@@ -26,7 +26,7 @@ describe('user routes', () => {
       jest.mocked(isTfmSsoFeatureFlagEnabled).mockReturnValue(true);
       jest.mocked(getUserSsoRouter).mockReturnValue('userSsoRouter' as unknown as Router);
 
-      expect(getUserRouter()).toBe('userSsoRouter');
+      expect(getUserRouter()).toEqual('userSsoRouter');
       expect(getUserSsoRouter).toHaveBeenCalledTimes(1);
       expect(getUserNonSsoRouter).not.toHaveBeenCalled();
     });
@@ -35,7 +35,7 @@ describe('user routes', () => {
       jest.mocked(isTfmSsoFeatureFlagEnabled).mockReturnValue(false);
       jest.mocked(getUserNonSsoRouter).mockReturnValue('userNonSsoRouter' as unknown as Router);
 
-      expect(getUserRouter()).toBe('userNonSsoRouter');
+      expect(getUserRouter()).toEqual('userNonSsoRouter');
       expect(getUserNonSsoRouter).toHaveBeenCalledTimes(1);
       expect(getUserSsoRouter).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Introduction :pencil2:
- We have 5463 instances of `toEqual`.
- We have 1353 instances of `toBe`.
- `toEqual` is better thatn `toBe`.

## Resolution :heavy_check_mark:
- Replace all instances of `toBe` with `toEqual`