### PR TITLE
chore(DTFS2-NONE): fix flakey test

### DIFF
--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -3,6 +3,15 @@ import { getNowAsUtcISOString, getMonthName } from './date';
 
 describe('date helpers', () => {
   describe('getNowAsUtcISOString', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date());
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
     it('should return the current time as a UtcISOString', () => {
       const result = getNowAsUtcISOString();
 

--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -5,7 +5,6 @@ describe('date helpers', () => {
   describe('getNowAsUtcISOString', () => {
     beforeAll(() => {
       jest.useFakeTimers();
-      jest.setSystemTime(new Date());
     });
 
     afterAll(() => {


### PR DESCRIPTION
## Introduction :pencil2:
As reported in the flaky test reporting slack channel, this test has failed on a few different PRs recently. It relies heavily on consistent values of `new Date()`. 

## Resolution :heavy_check_mark:
Freeze the value of `new Date()` at the start of the test and unfreeze it at the end. 

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

