### PR TITLE
chore(DTFS2-7462): replace toBe instances with toEqual

### DIFF
--- a/trade-finance-manager-ui/server/controllers/auth/auth-sso/unauthenticated-auth.controller.post-sso-redirect.test.ts
+++ b/trade-finance-manager-ui/server/controllers/auth/auth-sso/unauthenticated-auth.controller.post-sso-redirect.test.ts
@@ -42,7 +42,7 @@ describe('controllers - unauthenticated auth (sso)', () => {
 
       unauthenticatedAuthController.postSsoRedirect(req, res);
 
-      expect(res._getRenderView()).toBe('sso/accept-sso-redirect.njk');
+      expect(res._getRenderView()).toEqual('sso/accept-sso-redirect.njk');
       expect(res._getRenderData()).toEqual({
         clientInfo: mockBody.client_info,
         state: mockBody.state,

--- a/trade-finance-manager-ui/server/routes/auth/configs/index.get-unauthenticated-auth-router.test.ts
+++ b/trade-finance-manager-ui/server/routes/auth/configs/index.get-unauthenticated-auth-router.test.ts
@@ -30,7 +30,7 @@ describe('auth router config', () => {
       });
       it('should return unauthenticatedAuthSsoRouter', () => {
         const result = getUnauthenticatedAuthRouter();
-        expect(result).toBe('unauthenticatedAuthSsoRouter');
+        expect(result).toEqual('unauthenticatedAuthSsoRouter');
       });
     });
 

--- a/trade-finance-manager-ui/test-helpers/with-schema.tests.ts
+++ b/trade-finance-manager-ui/test-helpers/with-schema.tests.ts
@@ -13,11 +13,11 @@ export const withSchemaTests = ({
 }) => {
   it.each(failureTestCases)('should fail parsing if $description', ({ aTestCase }) => {
     const { success } = schema.safeParse(aTestCase());
-    expect(success).toBe(false);
+    expect(success).toEqual(false);
   });
 
   it.each(successTestCases)('should pass parsing if $description', ({ aTestCase }) => {
     const { success } = schema.safeParse(aTestCase());
-    expect(success).toBe(true);
+    expect(success).toEqual(true);
   });
 };


### PR DESCRIPTION
## Introduction :pencil2:
- Somme `toBe` instances snuck in after merging [this PR](https://github.com/UK-Export-Finance/dtfs2/pull/3654)

## Resolution :heavy_check_mark:
- Replace remaining instances of `toBe` with `toEqual`