### PR TITLE
fix(FN-3502-3503): fix keying sheet adjustments UI

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/generate-keying-sheet.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/generate-keying-sheet.spec.js
@@ -168,7 +168,7 @@ context('PDC_RECONCILE users can generate keying data', () => {
      * difference between the current and previous
      * utilisation
      */
-    const expectedPrincipalBalanceAdjustment = 20000; // 200000 - 180000, DECREASE
+    const expectedPrincipalBalanceAdjustment = '20,000.00'; // 200000 - 180000, DECREASE
 
     /**
      * The fixed fee adjustment is the difference between
@@ -183,7 +183,7 @@ context('PDC_RECONCILE users can generate keying data', () => {
      * - number of days left in cover period divided by day count basis: 365 / 365 = 1
      * This yields a current utilisation value of 8100
      */
-    const expectedFixedFeeAdjustment = 7100; // 8100 - 1000, INCREASE
+    const expectedFixedFeeAdjustment = '7,100.00'; // 8100 - 1000, INCREASE
 
     pages.utilisationReportPage.keyingSheetTab.fixedFeeAdjustmentDecrease(FIRST_FEE_RECORD_ID).should('contain', '-');
     pages.utilisationReportPage.keyingSheetTab.fixedFeeAdjustmentIncrease(FIRST_FEE_RECORD_ID).should('contain', expectedFixedFeeAdjustment);

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/keying-sheet-table-row.component-test.ts
@@ -138,7 +138,7 @@ describe(component, () => {
   describe('when the keying sheet adjustment value change field is set to INCREASE', () => {
     const change = 'INCREASE';
 
-    it('renders the fixed fee adjustment amount in the increase column with the numeric cell class', () => {
+    it('renders the fixed fee adjustment amount in the increase column with the numeric cell class and does not use the text align right class', () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
@@ -147,9 +147,10 @@ describe(component, () => {
 
       wrapper.expectElement(`${getFixedFeeAdjustmentSelector('increase')}:contains("111.11")`).toExist();
       wrapper.expectElement(`${getFixedFeeAdjustmentSelector('increase')}:contains("111.11")`).hasClass('govuk-table__cell--numeric');
+      wrapper.expectElement(`${getFixedFeeAdjustmentSelector('increase')}:contains("111.11")`).doesNotHaveClass('govuk-!-text-align-right');
     });
 
-    it('renders the principal balance adjustment in the increase column with the numeric cell class', () => {
+    it('renders the principal balance adjustment in the increase column with the numeric cell class and does not use the text align right class', () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         principalBalanceAdjustment: { change, amount: '333.33' },
@@ -158,9 +159,10 @@ describe(component, () => {
 
       wrapper.expectElement(`${getPrincipalBalanceAdjustmentSelector('increase')}:contains("333.33")`).toExist();
       wrapper.expectElement(`${getPrincipalBalanceAdjustmentSelector('increase')}:contains("333.33")`).hasClass('govuk-table__cell--numeric');
+      wrapper.expectElement(`${getPrincipalBalanceAdjustmentSelector('increase')}:contains("333.33")`).doesNotHaveClass('govuk-!-text-align-right');
     });
 
-    it("sets all the decrease columns to the '-' character and does not use the numeric cell class", () => {
+    it("sets all the decrease columns to the '-' character with the text align right class and does not use the numeric cell class", () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
@@ -169,8 +171,10 @@ describe(component, () => {
       const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`tr ${getFixedFeeAdjustmentSelector('decrease')}:contains("-")`).toExist();
+      wrapper.expectElement(`tr ${getFixedFeeAdjustmentSelector('decrease')}:contains("-")`).hasClass('govuk-!-text-align-right');
       wrapper.expectElement(`tr ${getFixedFeeAdjustmentSelector('decrease')}:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
       wrapper.expectElement(`tr ${getPrincipalBalanceAdjustmentSelector('decrease')}:contains("-")`).toExist();
+      wrapper.expectElement(`tr ${getPrincipalBalanceAdjustmentSelector('decrease')}:contains("-")`).hasClass('govuk-!-text-align-right');
       wrapper.expectElement(`tr ${getPrincipalBalanceAdjustmentSelector('decrease')}:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
     });
   });
@@ -178,7 +182,7 @@ describe(component, () => {
   describe('when the keying sheet adjustment value change field is set to DECREASE', () => {
     const change = 'DECREASE';
 
-    it('renders the fixed fee adjustment amount in the decrease column with the numeric cell class', () => {
+    it('renders the fixed fee adjustment amount in the decrease column with the numeric cell class and does not use the text align right class', () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
@@ -187,9 +191,10 @@ describe(component, () => {
 
       wrapper.expectElement(`${getFixedFeeAdjustmentSelector('decrease')}:contains("111.11")`).toExist();
       wrapper.expectElement(`${getFixedFeeAdjustmentSelector('decrease')}:contains("111.11")`).hasClass('govuk-table__cell--numeric');
+      wrapper.expectElement(`${getFixedFeeAdjustmentSelector('decrease')}:contains("111.11")`).doesNotHaveClass('govuk-!-text-align-right');
     });
 
-    it('renders the principal balance adjustment in the decrease column with the numeric cell class', () => {
+    it('renders the principal balance adjustment in the decrease column with the numeric cell class and does not use the text align right class', () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         principalBalanceAdjustment: { change, amount: '333.33' },
@@ -198,9 +203,10 @@ describe(component, () => {
 
       wrapper.expectElement(`${getPrincipalBalanceAdjustmentSelector('decrease')}:contains("333.33")`).toExist();
       wrapper.expectElement(`${getPrincipalBalanceAdjustmentSelector('decrease')}:contains("333.33")`).hasClass('govuk-table__cell--numeric');
+      wrapper.expectElement(`${getPrincipalBalanceAdjustmentSelector('decrease')}:contains("333.33")`).doesNotHaveClass('govuk-!-text-align-right');
     });
 
-    it("sets all the increase columns to the '-' character and does not use the numeric cell class", () => {
+    it("sets all the increase columns to the '-' character with the text align right class and does not use the numeric cell class", () => {
       const keyingSheetRow: KeyingSheetTableRow = {
         ...aKeyingSheetTableRow(),
         fixedFeeAdjustment: { change, amount: '111.11' },
@@ -209,8 +215,10 @@ describe(component, () => {
       const wrapper = getWrapper({ keyingSheetRow });
 
       wrapper.expectElement(`tr ${getFixedFeeAdjustmentSelector('increase')}:contains("-")`).toExist();
+      wrapper.expectElement(`tr ${getFixedFeeAdjustmentSelector('increase')}:contains("-")`).hasClass('govuk-!-text-align-right');
       wrapper.expectElement(`tr ${getFixedFeeAdjustmentSelector('increase')}:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
       wrapper.expectElement(`tr ${getPrincipalBalanceAdjustmentSelector('increase')}:contains("-")`).toExist();
+      wrapper.expectElement(`tr ${getPrincipalBalanceAdjustmentSelector('increase')}:contains("-")`).hasClass('govuk-!-text-align-right');
       wrapper.expectElement(`tr ${getPrincipalBalanceAdjustmentSelector('increase')}:contains("-")`).doesNotHaveClass('govuk-table__cell--numeric');
     });
   });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -571,13 +571,13 @@ describe('reconciliation-for-report-helper', () => {
       { condition: 'has zero amount (no change)', value: { amount: 0, change: 'NONE' }, expectedMappedValue: { amount: '0.00', change: 'NONE' } },
       {
         condition: 'has a positive amount (increase)',
-        value: { amount: 100, change: 'INCREASE' },
-        expectedMappedValue: { amount: '100.00', change: 'INCREASE' },
+        value: { amount: 1234567.89, change: 'INCREASE' },
+        expectedMappedValue: { amount: '1,234,567.89', change: 'INCREASE' },
       },
       {
         condition: 'has a negative amount (decrease)',
-        value: { amount: 100, change: 'DECREASE' },
-        expectedMappedValue: { amount: '100.00', change: 'DECREASE' },
+        value: { amount: 1234567.89, change: 'DECREASE' },
+        expectedMappedValue: { amount: '1,234,567.89', change: 'DECREASE' },
       },
     ] as const)(
       'sets the view model fixedFeeAdjustment to $expectedMappedValue when the fee record entity fixedFeeAdjustment $condition',
@@ -604,13 +604,13 @@ describe('reconciliation-for-report-helper', () => {
       { condition: 'has zero amount (no change)', value: { amount: 0, change: 'NONE' }, expectedMappedValue: { amount: '0.00', change: 'NONE' } },
       {
         condition: 'has a positive amount (increase)',
-        value: { amount: 100, change: 'INCREASE' },
-        expectedMappedValue: { amount: '100.00', change: 'INCREASE' },
+        value: { amount: 1234567.89, change: 'INCREASE' },
+        expectedMappedValue: { amount: '1,234,567.89', change: 'INCREASE' },
       },
       {
         condition: 'has a negative amount (decrease)',
-        value: { amount: 100, change: 'DECREASE' },
-        expectedMappedValue: { amount: '100.00', change: 'DECREASE' },
+        value: { amount: 1234567.89, change: 'DECREASE' },
+        expectedMappedValue: { amount: '1,234,567.89', change: 'DECREASE' },
       },
     ] as const)(
       'sets the view model principalBalanceAdjustment to $expectedMappedValue when the keying sheet principalBalanceAdjustment $condition',

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
@@ -1,5 +1,12 @@
 import orderBy from 'lodash.orderby';
-import { FeeRecordStatus, getFormattedCurrencyAndAmount, IsoDateTimeStamp, KeyingSheetAdjustment, PaymentDetailsFilters } from '@ukef/dtfs2-common';
+import {
+  FeeRecordStatus,
+  getFormattedCurrencyAndAmount,
+  getFormattedMonetaryValue,
+  IsoDateTimeStamp,
+  KeyingSheetAdjustment,
+  PaymentDetailsFilters,
+} from '@ukef/dtfs2-common';
 import { format, parseISO } from 'date-fns';
 import { FeeRecord, FeeRecordPaymentGroup, KeyingSheet, KeyingSheetRow, Payment } from '../../../api-response-types';
 import {
@@ -155,7 +162,7 @@ const getKeyingSheetAdjustmentViewModel = (adjustment: KeyingSheetAdjustment | n
     return { amount: undefined, change: 'NONE' };
   }
   return {
-    amount: adjustment.amount.toFixed(2),
+    amount: getFormattedMonetaryValue(adjustment.amount),
     change: adjustment.change,
   };
 };

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/keying-sheet-table-row.njk
@@ -7,10 +7,10 @@
     {% set name = options.name %}
     {% set showBottomBorder = options.showBottomBorder %}
     {% set showValues = options.showValues %}
-    <td class="{{ ["govuk-table__cell", " govuk-table__cell--numeric" if change === "INCREASE", " no-border" if not showBottomBorder] | join }}" data-cy="{{ name }}--increase">
+    <td class="{{ ["govuk-table__cell", " govuk-table__cell--numeric" if change === "INCREASE" else " govuk-!-text-align-right", " no-border" if not showBottomBorder] | join }}" data-cy="{{ name }}--increase">
       {{ (amount if change === "INCREASE" else "-") if showValues }}
     </td>
-    <td class="{{ ["govuk-table__cell", " govuk-table__cell--numeric" if change === "DECREASE", " no-border" if not showBottomBorder] | join }}" data-cy="{{ name }}--decrease">
+    <td class="{{ ["govuk-table__cell", " govuk-table__cell--numeric" if change === "DECREASE" else " govuk-!-text-align-right", " no-border" if not showBottomBorder] | join }}" data-cy="{{ name }}--decrease">
       {{ (amount if change === "DECREASE" else "-") if showValues }}
     </td>
   {% endmacro %}


### PR DESCRIPTION
## Introduction :pencil2:
During a recent PDC demo, two issues were spotted with the keying sheet UI:
1. All cells in the adjustment columns aren't right aligned
2. Large numbers in the adjustment cells aren't comma separated

## Resolution :heavy_check_mark:
1. Right align all cell content in the adjustment columns
2. Use recently introduced `getFormattedMonetaryValue` helper to format monetary values with commas

Screenshot showing changes:
![Screenshot 2024-10-14 at 10 59 38](https://github.com/user-attachments/assets/457e1733-51de-4d0a-b8d1-cde103999162)

## Miscellaneous :heavy_plus_sign:
N/A

