### PR TITLE
feat(DTFS2-7489): create submit cancellation endpoint tfm api

### DIFF
--- a/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
@@ -1,0 +1,172 @@
+import { AnyObject, MAX_CHARACTER_COUNT, TEAM_IDS } from '@ukef/dtfs2-common';
+import { ObjectId, UpdateResult } from 'mongodb';
+import { createApi } from '../../api';
+import app from '../../../src/createApp';
+import { initialiseTestUsers } from '../../api-test-users';
+import { TestUser } from '../../types/test-user';
+import { withTeamAuthorisationTests } from '../../common-tests/with-team-authorisation.api-tests';
+import { PostSubmitDealCancellationPayload } from '../../../src/v1/middleware/validate-post-submit-deal-cancellation-payload';
+
+const updateDealCancellationMock = jest.fn() as jest.Mock<Promise<UpdateResult>>;
+
+jest.mock('../../../src/v1/api', () => ({
+  ...jest.requireActual<AnyObject>('../../../src/v1/api'),
+  updateDealCancellation: () => updateDealCancellationMock(),
+}));
+
+const originalProcessEnv = { ...process.env };
+const { as, post } = createApi(app);
+
+const validId = new ObjectId().toString();
+
+const mockUpdateResult: UpdateResult = {
+  acknowledged: true,
+  modifiedCount: 1,
+  matchedCount: 1,
+  upsertedCount: 1,
+  upsertedId: new ObjectId(validId),
+};
+
+const getSubmitTfmDealCancellationUrl = ({ id }: { id: string }) => `/v1/deals/${id}/cancellation/submit`;
+
+const aValidPayload = (): PostSubmitDealCancellationPayload => ({
+  reason: 'x'.repeat(MAX_CHARACTER_COUNT),
+  bankRequestDate: new Date().valueOf(),
+  effectiveFrom: new Date().valueOf(),
+});
+
+describe('POST /v1/deals/:id/cancellation/submit', () => {
+  let testUsers: Awaited<ReturnType<typeof initialiseTestUsers>>;
+  let aPimUser: TestUser;
+
+  beforeAll(async () => {
+    testUsers = await initialiseTestUsers(app);
+    aPimUser = testUsers().withTeam(TEAM_IDS.PIM).one();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(updateDealCancellationMock).mockResolvedValue(mockUpdateResult);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+    process.env = originalProcessEnv;
+  });
+
+  describe('when FF_TFM_DEAL_CANCELLATION_ENABLED is disabled', () => {
+    beforeEach(() => {
+      process.env.FF_TFM_DEAL_CANCELLATION_ENABLED = 'false';
+    });
+
+    afterAll(() => {
+      jest.resetAllMocks();
+    });
+
+    it('returns a 404 response for an authenticated user with a valid id path', async () => {
+      // Arrange
+      const url = getSubmitTfmDealCancellationUrl({ id: validId });
+
+      // Act
+      const response = await as(aPimUser).post(aValidPayload()).to(url);
+
+      // Assert
+      expect(response.status).toEqual(404);
+    });
+  });
+
+  describe('when FF_TFM_DEAL_CANCELLATION_ENABLED is enabled', () => {
+    beforeEach(() => {
+      process.env.FF_TFM_DEAL_CANCELLATION_ENABLED = 'true';
+    });
+
+    afterAll(() => {
+      jest.resetAllMocks();
+    });
+
+    withTeamAuthorisationTests({
+      allowedTeams: [TEAM_IDS.PIM],
+      getUserWithTeam: (team) => testUsers().withTeam(team).one(),
+      makeRequestAsUser: (user: TestUser) =>
+        as(user)
+          .post(aValidPayload())
+          .to(getSubmitTfmDealCancellationUrl({ id: validId })),
+      successStatusCode: 200,
+    });
+
+    it('returns a 401 response when user is not authenticated', async () => {
+      // Arrange
+      const url = getSubmitTfmDealCancellationUrl({ id: validId });
+
+      // Act
+      const response = await post(aValidPayload()).to(url);
+
+      // Assert
+      expect(response.status).toEqual(401);
+    });
+
+    it('returns a 400 response when the id path param is invalid', async () => {
+      // Arrange
+      const url = getSubmitTfmDealCancellationUrl({ id: 'invalid' });
+
+      // Act
+      const response = await as(aPimUser).post(aValidPayload()).to(url);
+
+      // Assert
+      expect(response.status).toEqual(400);
+    });
+
+    const invalidPayloads = [
+      {
+        description: 'the reason is not a string',
+        payload: { ...aValidPayload(), reason: 12 },
+      },
+      {
+        description: `the reason is over ${MAX_CHARACTER_COUNT} characters`,
+        payload: { ...aValidPayload(), reason: 'x'.repeat(MAX_CHARACTER_COUNT + 1) },
+      },
+      {
+        description: 'the reason is undefined',
+        payload: { ...aValidPayload(), reason: undefined },
+      },
+      {
+        description: 'the bankRequestDate is a string ',
+        payload: { ...aValidPayload(), bankRequestDate: new Date().toISOString() },
+      },
+      {
+        description: 'the bankRequestDate is undefined ',
+        payload: { ...aValidPayload(), bankRequestDate: undefined },
+      },
+      {
+        description: 'the effectiveFrom is a string ',
+        payload: { ...aValidPayload(), effectiveFrom: new Date().toISOString() },
+      },
+      {
+        description: 'the effectiveFrom is undefined ',
+        payload: { ...aValidPayload(), effectiveFrom: undefined },
+      },
+    ];
+
+    it.each(invalidPayloads)('returns a 400 response when $description', async ({ payload }) => {
+      // Arrange
+      const url = getSubmitTfmDealCancellationUrl({ id: validId });
+
+      // Act
+      const response = await as(aPimUser).post(payload).to(url);
+
+      // Assert
+      expect(response.status).toEqual(400);
+    });
+
+    it('returns 200 for an authenticated user', async () => {
+      // Arrange
+      const url = getSubmitTfmDealCancellationUrl({ id: validId });
+
+      // Act
+      const response = await as(aPimUser).post(aValidPayload()).to(url);
+
+      // Assert
+      expect(response.status).toEqual(200);
+    });
+  });
+});

--- a/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
@@ -98,43 +98,12 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
       expect(response.status).toEqual(400);
     });
 
-    const invalidPayloads = [
-      {
-        description: 'the reason is not a string',
-        payload: { ...aValidPayload(), reason: 12 },
-      },
-      {
-        description: `the reason is over ${MAX_CHARACTER_COUNT} characters`,
-        payload: { ...aValidPayload(), reason: 'x'.repeat(MAX_CHARACTER_COUNT + 1) },
-      },
-      {
-        description: 'the reason is undefined',
-        payload: { ...aValidPayload(), reason: undefined },
-      },
-      {
-        description: 'the bankRequestDate is a string ',
-        payload: { ...aValidPayload(), bankRequestDate: new Date().toISOString() },
-      },
-      {
-        description: 'the bankRequestDate is undefined ',
-        payload: { ...aValidPayload(), bankRequestDate: undefined },
-      },
-      {
-        description: 'the effectiveFrom is a string ',
-        payload: { ...aValidPayload(), effectiveFrom: new Date().toISOString() },
-      },
-      {
-        description: 'the effectiveFrom is undefined ',
-        payload: { ...aValidPayload(), effectiveFrom: undefined },
-      },
-    ];
-
-    it.each(invalidPayloads)('returns a 400 response when $description', async ({ payload }) => {
+    it('returns a 400 response when the payload is invalid', async () => {
       // Arrange
       const url = getSubmitTfmDealCancellationUrl({ id: validId });
 
       // Act
-      const response = await as(aPimUser).post(payload).to(url);
+      const response = await as(aPimUser).post({}).to(url);
 
       // Assert
       expect(response.status).toEqual(400);

--- a/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
@@ -19,14 +19,6 @@ const { as, post } = createApi(app);
 
 const validId = new ObjectId().toString();
 
-const mockUpdateResult: UpdateResult = {
-  acknowledged: true,
-  modifiedCount: 1,
-  matchedCount: 1,
-  upsertedCount: 1,
-  upsertedId: new ObjectId(validId),
-};
-
 const getSubmitTfmDealCancellationUrl = ({ id }: { id: string }) => `/v1/deals/${id}/cancellation/submit`;
 
 const aValidPayload = (): PostSubmitDealCancellationPayload => ({
@@ -44,23 +36,13 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
     aPimUser = testUsers().withTeam(TEAM_IDS.PIM).one();
   });
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-    jest.mocked(updateDealCancellationMock).mockResolvedValue(mockUpdateResult);
-  });
-
-  afterAll(() => {
-    jest.restoreAllMocks();
-    process.env = originalProcessEnv;
-  });
-
   describe('when FF_TFM_DEAL_CANCELLATION_ENABLED is disabled', () => {
     beforeEach(() => {
       process.env.FF_TFM_DEAL_CANCELLATION_ENABLED = 'false';
     });
 
     afterAll(() => {
-      jest.resetAllMocks();
+      process.env = originalProcessEnv;
     });
 
     it('returns a 404 response for an authenticated user with a valid id path', async () => {
@@ -81,7 +63,7 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
     });
 
     afterAll(() => {
-      jest.resetAllMocks();
+      process.env = originalProcessEnv;
     });
 
     withTeamAuthorisationTests({

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
@@ -1,0 +1,38 @@
+import { ObjectId } from 'mongodb';
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { submitDealCancellation, SubmitDealCancellationRequest } from './submit-deal-cancellation.controller';
+
+jest.mock('../../api');
+
+const dealCancellation = {
+  reason: 'test reason',
+  bankRequestDate: 1794418807,
+  effectiveFrom: 1794418808,
+};
+
+const mockDealId = new ObjectId();
+const mockUserId = new ObjectId();
+
+describe('controllers - deal cancellation', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('PUT - updateDealCancellation', () => {
+    it('should return 200', () => {
+      // Arrange
+      const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
+        params: { dealId: mockDealId },
+        body: dealCancellation,
+        user: { _id: mockUserId },
+      });
+
+      // Act
+      submitDealCancellation(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    });
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
@@ -19,7 +19,7 @@ describe('controllers - deal cancellation', () => {
     jest.resetAllMocks();
   });
 
-  describe('PUT - updateDealCancellation', () => {
+  describe('POST - submitDealCancellation', () => {
     it('should return 200', () => {
       // Arrange
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.ts
@@ -1,0 +1,40 @@
+import { HttpStatusCode } from 'axios';
+import { Response } from 'express';
+import { ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { PostSubmitDealCancellationPayload } from '../../middleware/validate-post-submit-deal-cancellation-payload';
+
+export type SubmitDealCancellationRequest = CustomExpressRequest<{
+  params: {
+    dealId: string;
+  };
+  reqBody: PostSubmitDealCancellationPayload;
+}>;
+
+/**
+ * Submits cancel deal
+ * @param req - request object
+ * @param res - response
+ */
+export const submitDealCancellation = (req: SubmitDealCancellationRequest, res: Response) => {
+  try {
+    // TODO: DTFS2-7298 - update cancellation in database
+    // TODO: DTFS2-7490 - send email
+    return res.status(HttpStatusCode.Ok).send();
+  } catch (error) {
+    const errorMessage = 'Failed to submit deal cancellation';
+    console.error(errorMessage, error);
+
+    if (error instanceof ApiError) {
+      return res.status(error.status).send({
+        status: error.status,
+        message: `${errorMessage}: ${error.message}`,
+        code: error.code,
+      });
+    }
+
+    return res.status(HttpStatusCode.InternalServerError).send({
+      status: HttpStatusCode.InternalServerError,
+      message: errorMessage,
+    });
+  }
+};

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/update-deal-cancellation.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/update-deal-cancellation.controller.ts
@@ -1,14 +1,15 @@
 import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
-import { ApiError, CustomExpressRequest, TfmDealCancellation } from '@ukef/dtfs2-common';
+import { ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import api from '../../api';
+import { PutDealCancellationPayload } from '../../middleware/validate-put-deal-cancellation-payload';
 
 export type UpdateDealCancellationRequest = CustomExpressRequest<{
   params: {
     dealId: string;
   };
-  reqBody: TfmDealCancellation;
+  reqBody: PutDealCancellationPayload;
 }>;
 
 /**

--- a/trade-finance-manager-api/src/v1/deals/routes.js
+++ b/trade-finance-manager-api/src/v1/deals/routes.js
@@ -6,11 +6,13 @@ const dealController = require('../controllers/deal.controller');
 const { getDealCancellation } = require('../controllers/deal-cancellation/get-deal-cancellation.controller');
 const { updateDealCancellation } = require('../controllers/deal-cancellation/update-deal-cancellation.controller');
 const { deleteDealCancellation } = require('../controllers/deal-cancellation/delete-deal-cancellation.controller');
+const { submitDealCancellation } = require('../controllers/deal-cancellation/submit-deal-cancellation.controller');
 const dealUnderwriterManagersDecisionController = require('../controllers/deal-underwriter-managers-decision.controller');
 const validation = require('../validation/route-validators/route-validators');
 const handleExpressValidatorResult = require('../validation/route-validators/express-validator-result-handler');
 const { validateUserHasAtLeastOneAllowedTeam } = require('../middleware/validate-user-is-in-at-least-one-allowed-team');
 const { validatePutDealCancellationPayload } = require('../middleware/validate-put-deal-cancellation-payload');
+const { validatePostSubmitDealCancellationPayload } = require('../middleware/validate-post-submit-deal-cancellation-payload');
 
 const dealsOpenRouter = express.Router();
 
@@ -88,6 +90,17 @@ dealsAuthRouter
   .put(validatePutDealCancellationPayload, updateDealCancellation)
   .get(getDealCancellation)
   .delete(deleteDealCancellation);
+
+dealsAuthRouter
+  .route('/deals/:dealId/cancellation/submit')
+  .post(
+    validateDealCancellationEnabled,
+    validateUserHasAtLeastOneAllowedTeam([TEAM_IDS.PIM]),
+    validation.dealIdValidation,
+    handleExpressValidatorResult,
+    validatePostSubmitDealCancellationPayload,
+    submitDealCancellation,
+  );
 
 dealsAuthRouter
   .route('/deals/:dealId/amendments/:status?/:type?')

--- a/trade-finance-manager-api/src/v1/middleware/validate-post-submit-deal-cancellation-payload.test.ts
+++ b/trade-finance-manager-api/src/v1/middleware/validate-post-submit-deal-cancellation-payload.test.ts
@@ -1,0 +1,101 @@
+import { MAX_CHARACTER_COUNT, TfmDealCancellation } from '@ukef/dtfs2-common';
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { validatePostSubmitDealCancellationPayload } from './validate-post-submit-deal-cancellation-payload';
+
+describe('validatePostSubmitDealCancellationPayload', () => {
+  const getHttpMocks = () => httpMocks.createMocks();
+
+  const aValidPayload = (): TfmDealCancellation => ({
+    reason: 'x'.repeat(MAX_CHARACTER_COUNT),
+    bankRequestDate: new Date().valueOf(),
+    effectiveFrom: new Date().valueOf(),
+  });
+
+  const invalidPayloads = [
+    {
+      description: 'the payload is undefined',
+      payload: undefined,
+    },
+    {
+      description: "the 'reason' is not a string",
+      payload: {
+        ...aValidPayload(),
+        reason: 1234,
+      },
+    },
+    {
+      description: `the 'reason' is over ${MAX_CHARACTER_COUNT} characters`,
+      payload: {
+        ...aValidPayload(),
+        reason: 'x'.repeat(MAX_CHARACTER_COUNT + 1),
+      },
+    },
+    {
+      description: "the 'reason' is undefined",
+      payload: {
+        ...aValidPayload(),
+        reason: undefined,
+      },
+    },
+    {
+      description: "the 'effectiveFrom' is a string",
+      payload: {
+        ...aValidPayload(),
+        effectiveFrom: new Date().toString(),
+      },
+    },
+    {
+      description: "the 'effectiveFrom' is undefined",
+      payload: {
+        ...aValidPayload(),
+        effectiveFrom: undefined,
+      },
+    },
+    {
+      description: "the 'bankRequestDate' is a string",
+      payload: {
+        ...aValidPayload(),
+        bankRequestDate: new Date().toString(),
+      },
+    },
+    {
+      description: "the 'bankRequestDate' is undefined",
+      payload: {
+        ...aValidPayload(),
+        bankRequestDate: undefined,
+      },
+    },
+  ];
+
+  it.each(invalidPayloads)(`responds with a '${HttpStatusCode.BadRequest}' if $description`, ({ payload }) => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    req.body = payload;
+
+    // Act
+    validatePostSubmitDealCancellationPayload(req, res, next);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls the 'next' function if the payload is valid", () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    req.body = aValidPayload();
+
+    // Act
+    validatePostSubmitDealCancellationPayload(req, res, next);
+
+    // Assert
+    expect(next).toHaveBeenCalled();
+    expect(res._isEndCalled()).toEqual(false);
+  });
+});

--- a/trade-finance-manager-api/src/v1/middleware/validate-post-submit-deal-cancellation-payload.ts
+++ b/trade-finance-manager-api/src/v1/middleware/validate-post-submit-deal-cancellation-payload.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+import { createValidationMiddlewareForSchema } from '@ukef/dtfs2-common';
+import { DEAL_CANCELLATION } from '@ukef/dtfs2-common/schemas';
+
+const PostSubmitDealCancellationSchema = DEAL_CANCELLATION;
+
+export type PostSubmitDealCancellationPayload = z.infer<typeof PostSubmitDealCancellationSchema>;
+
+export const validatePostSubmitDealCancellationPayload = createValidationMiddlewareForSchema(PostSubmitDealCancellationSchema);

--- a/trade-finance-manager-api/src/v1/middleware/validate-put-deal-cancellation-payload.ts
+++ b/trade-finance-manager-api/src/v1/middleware/validate-put-deal-cancellation-payload.ts
@@ -1,8 +1,8 @@
 import z from 'zod';
-import { TfmDealCancellation, createValidationMiddlewareForSchema } from '@ukef/dtfs2-common';
+import { createValidationMiddlewareForSchema } from '@ukef/dtfs2-common';
 import { DEAL_CANCELLATION } from '@ukef/dtfs2-common/schemas';
 
-const PutDealCancellationSchema: z.ZodType<Partial<TfmDealCancellation>> = DEAL_CANCELLATION.partial();
+const PutDealCancellationSchema = DEAL_CANCELLATION.partial();
 
 export type PutDealCancellationPayload = z.infer<typeof PutDealCancellationSchema>;
 


### PR DESCRIPTION
## Introduction :pencil2:
The user needs to be able to submit the cancellation. This endpoint provides the stub from which the database update & email can be sent from.

## Resolution :heavy_check_mark:
- Add submit cancellation endpoint with middleware validation
- Add api and unit test coverage

## Note ⚠️ 
This endpoint doesn't actually submit the cancellation yet, but merging this early will allow DTFS2-7298 and DTFS2-7364 to be completed in parallel
