### PR TITLE
fix(DTFS2-7492): await tfm deal update

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.submit.controller.js
@@ -107,7 +107,7 @@ const submitDealAfterUkefIds = async (dealId, dealType, checker, auditDetails) =
     }
 
     // Update the deal with all the above modifications
-    const tfmDeal = api.updateDeal({ dealId, dealUpdate, auditDetails });
+    const tfmDeal = await api.updateDeal({ dealId, dealUpdate, auditDetails });
 
     // Submit to ACBS
     const canSubmitDealToACBS = await canSubmitToACBS(tfmDeal);


### PR DESCRIPTION
## Introduction :pencil2:
When submitting a deal from portal to TFM, the deal is not shown in ACBS (on staging). The logs revealed an error that can be traced to not awaiting a deal update

## Resolution :heavy_check_mark:
Await the deal update in tfm-api


