### PR TITLE
feat(DTFS2-7528): submit cancellation in tfm-ui

### DIFF
--- a/trade-finance-manager-ui/component-tests/case/cancellation/check-details.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/case/cancellation/check-details.component-test.ts
@@ -32,7 +32,7 @@ describe(page, () => {
     wrapper.expectLink('[data-cy="return-link"]').toLinkTo(`/case/${dealId}/cancellation/cancel`, 'Return to deal summary');
   });
 
-  it('should render the delete account button', () => {
+  it('should render the cancel deal button', () => {
     // Arrange
     const checkDetailsViewModel: CheckDetailsViewModel = aCheckDetailsViewModel();
 
@@ -41,7 +41,7 @@ describe(page, () => {
 
     // Assert
     wrapper.expectElement('[data-cy="delete-button"]').toExist();
-    wrapper.expectText('[data-cy="delete-button"]').toRead('Delete account');
+    wrapper.expectText('[data-cy="delete-button"]').toRead('Cancel deal');
   });
 
   it('should display a warning message about cancelling the deal', () => {
@@ -71,7 +71,7 @@ describe(page, () => {
 
   it('should display a dash when the reason for cancelling a deal is empty', () => {
     // Arrange
-    const checkDetailsViewModel: CheckDetailsViewModel = aCheckDetailsViewModel();
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), cancellation: {} };
 
     // Act
     const wrapper = render(checkDetailsViewModel);
@@ -84,7 +84,7 @@ describe(page, () => {
   it('should display the reason for cancelling text when it exists', () => {
     // Arrange
     const reason = 'test reason';
-    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), reason };
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), cancellation: { reason } };
 
     // Act
     const wrapper = render(checkDetailsViewModel);
@@ -96,28 +96,30 @@ describe(page, () => {
 
   it('should display the received bank request date date string', () => {
     // Arrange
-    const receivedDateString = '1 January 2024';
-    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), bankRequestDate: receivedDateString };
+    const bankRequestDate = 1729007392441;
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), cancellation: { bankRequestDate } };
 
     // Act
     const wrapper = render(checkDetailsViewModel);
 
     // Assert
+    const expectedBankRequestDateString = '15 October 2024';
     wrapper.expectElement('[data-cy="bank-request-date-response"]').toExist();
-    wrapper.expectText('[data-cy="bank-request-date-response"]').toRead(receivedDateString);
+    wrapper.expectText('[data-cy="bank-request-date-response"]').toRead(expectedBankRequestDateString);
   });
 
   it('should display the received effective from date string', () => {
     // Arrange
-    const receivedDateString = '1 January 2024';
-    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), effectiveFromDate: receivedDateString };
+    const effectiveFrom = 1729007392441;
+    const checkDetailsViewModel: CheckDetailsViewModel = { ...aCheckDetailsViewModel(), cancellation: { effectiveFrom } };
 
     // Act
     const wrapper = render(checkDetailsViewModel);
 
     // Assert
+    const expectedEffectiveFromString = '15 October 2024';
     wrapper.expectElement('[data-cy="effective-from-response"]').toExist();
-    wrapper.expectText('[data-cy="effective-from-response"]').toRead(receivedDateString);
+    wrapper.expectText('[data-cy="effective-from-response"]').toRead(expectedEffectiveFromString);
   });
 
   it('should render the Change links', () => {

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1300,6 +1300,27 @@ const deleteDealCancellation = async (dealId, userToken) => {
   }
 };
 
+/**
+ * Submits the deal cancellation object on a TFM MIN or AIN deal
+ * @param {string} dealId - The deal ID
+ * @param {import('@ukef/dtfs2-common').TfmDealCancellation} cancellation - The deal cancellation object
+ * @param {string} userToken - The user token
+ * @returns {Promise<void>}
+ */
+const submitDealCancellation = async (dealId, cancellation, userToken) => {
+  try {
+    await axios({
+      method: 'post',
+      url: `${TFM_API_URL}/v1/deals/${dealId}/cancellation/submit`,
+      headers: generateHeaders(userToken),
+      data: cancellation,
+    });
+  } catch (error) {
+    console.error('Failed to submit deal cancellation', error);
+    throw error;
+  }
+};
+
 module.exports = {
   getDeal,
   getDeals,
@@ -1359,4 +1380,5 @@ module.exports = {
   updateDealCancellation,
   getDealCancellation,
   deleteDealCancellation,
+  submitDealCancellation,
 };

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
@@ -1,6 +1,5 @@
 import { createMocks } from 'node-mocks-http';
 import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
-import { format } from 'date-fns';
 import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { CheckDetailsViewModel } from '../../../types/view-models';
@@ -109,15 +108,13 @@ describe('getDealCancellationDetails', () => {
 
     it('renders the check details page with deal cancellation details', async () => {
       const reason = 'test reaspn';
-      const bankRequestDate = new Date('2024-01-01');
-      const effectiveFromDate = new Date('2024-03-03');
+      const bankRequestDate = new Date('2024-01-01').valueOf();
+      const effectiveFrom = new Date('2024-03-03').valueOf();
 
       const session = aRequestSession();
 
       // Arrange
-      jest
-        .mocked(api.getDealCancellation)
-        .mockResolvedValue({ reason, effectiveFrom: effectiveFromDate.valueOf(), bankRequestDate: bankRequestDate.valueOf() });
+      jest.mocked(api.getDealCancellation).mockResolvedValue({ reason, effectiveFrom, bankRequestDate });
 
       const { req, res } = createMocks<GetDealCancellationDetailsRequest>({
         params: { _id: dealId },
@@ -134,10 +131,7 @@ describe('getDealCancellationDetails', () => {
         user: session.user,
         ukefDealId,
         dealId,
-        reason,
-        bankRequestDate: format(bankRequestDate, 'd MMMM yyyy'),
-        effectiveFromDate: format(effectiveFromDate, 'd MMMM yyyy'),
-        cancellation: { reason, bankRequestDate, effectiveFrom: effectiveFromDate },
+        cancellation: { reason, bankRequestDate, effectiveFrom },
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.get.test.ts
@@ -3,7 +3,7 @@ import { DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
 import { aRequestSession } from '../../../../test-helpers';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
-import { BankRequestDateViewModel } from '../../../types/view-models';
+import { CheckDetailsViewModel } from '../../../types/view-models';
 import api from '../../../api';
 import { getDealCancellationDetails, GetDealCancellationDetailsRequest } from './check-details.controller';
 
@@ -129,7 +129,7 @@ describe('getDealCancellationDetails', () => {
 
       // Assert
       expect(res._getRenderView()).toEqual('case/cancellation/check-details.njk');
-      expect(res._getRenderData() as BankRequestDateViewModel).toEqual({
+      expect(res._getRenderData() as CheckDetailsViewModel).toEqual({
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
         user: session.user,
         ukefDealId,
@@ -137,6 +137,7 @@ describe('getDealCancellationDetails', () => {
         reason,
         bankRequestDate: format(bankRequestDate, 'd MMMM yyyy'),
         effectiveFromDate: format(effectiveFromDate, 'd MMMM yyyy'),
+        cancellation: { reason, bankRequestDate, effectiveFrom: effectiveFromDate },
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.post.test.ts
@@ -6,10 +6,15 @@ import { postDealCancellationDetails, PostDealCancellationDetailsRequest } from 
 
 jest.mock('../../../api', () => ({
   getDeal: jest.fn(),
+  submitDealCancellation: jest.fn(),
 }));
 
 const dealId = 'dealId';
 const ukefDealId = 'ukefDealId';
+
+const reason = 'reason';
+const bankRequestDate = new Date().valueOf();
+const effectiveFrom = new Date().valueOf();
 
 describe('postBankRequestDate', () => {
   beforeEach(() => {
@@ -23,6 +28,7 @@ describe('postBankRequestDate', () => {
     const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
       params: { _id: dealId },
       session: aRequestSession(),
+      body: { cancellation: { reason, bankRequestDate, effectiveFrom } },
     });
 
     // Act
@@ -39,6 +45,7 @@ describe('postBankRequestDate', () => {
     const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
       params: { _id: dealId },
       session: aRequestSession(),
+      body: { cancellation: { reason, bankRequestDate, effectiveFrom } },
     });
 
     // Act
@@ -48,34 +55,17 @@ describe('postBankRequestDate', () => {
     expect(res._getRedirectUrl()).toEqual(`/not-found`);
   });
 
-  it('redirects to deal summary page if the submission type is invalid (MIA)', async () => {
-    // Arrange
-    jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: DEAL_SUBMISSION_TYPE.MIA } });
-
-    const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
-      params: { _id: dealId },
-      session: aRequestSession(),
-    });
-
-    // Act
-    await postDealCancellationDetails(req, res);
-
-    // Assert
-    expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
-  });
-
-  describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
+  describe(`when the deal type is ${DEAL_SUBMISSION_TYPE.MIA}`, () => {
     beforeEach(() => {
-      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
+      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: DEAL_SUBMISSION_TYPE.MIA } });
     });
 
-    // TODO: DTFS2-7298 - test deal cancellation endpoints are called with correct payload
-
-    it('redirects to the effective from date page', async () => {
+    it('redirects to deal summary page', async () => {
       // Arrange
       const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
         params: { _id: dealId },
         session: aRequestSession(),
+        body: { cancellation: { reason, bankRequestDate, effectiveFrom } },
       });
 
       // Act
@@ -83,6 +73,110 @@ describe('postBankRequestDate', () => {
 
       // Assert
       expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
+    });
+
+    it('does not submit a deal cancellation', async () => {
+      // Arrange
+      const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+        params: { _id: dealId },
+        session: aRequestSession(),
+        body: { cancellation: { reason, bankRequestDate, effectiveFrom } },
+      });
+
+      // Act
+      await postDealCancellationDetails(req, res);
+
+      // Assert
+      expect(api.submitDealCancellation).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe.each([DEAL_SUBMISSION_TYPE.AIN, DEAL_SUBMISSION_TYPE.MIN])('when the deal type is %s', (validDealType) => {
+    beforeEach(() => {
+      jest.mocked(api.getDeal).mockResolvedValue({ dealSnapshot: { details: { ukefDealId }, submissionType: validDealType } });
+    });
+
+    const invalidTestCases = [
+      {
+        description: 'when the reason is undefined',
+        cancellation: { bankRequestDate, effectiveFrom },
+      },
+      {
+        description: 'when the bankRequestDate is undefined',
+        cancellation: { reason, effectiveFrom },
+      },
+      {
+        description: 'when the effectiveFrom is undefined',
+        cancellation: { reason, bankRequestDate },
+      },
+    ];
+
+    describe.each(invalidTestCases)('$description', ({ cancellation }) => {
+      it('does not submit the deal cancellation', async () => {
+        // Arrange
+        const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+          params: { _id: dealId },
+          session: aRequestSession(),
+          body: { cancellation },
+        });
+
+        // Act
+        await postDealCancellationDetails(req, res);
+
+        // Assert
+        expect(api.submitDealCancellation).toHaveBeenCalledTimes(0);
+      });
+
+      it('redirects to the deal summary', async () => {
+        // Arrange
+        const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+          params: { _id: dealId },
+          session: aRequestSession(),
+          body: { cancellation: { reason, bankRequestDate, effectiveFrom } },
+        });
+
+        // Act
+        await postDealCancellationDetails(req, res);
+
+        // Assert
+        expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
+      });
+    });
+
+    describe('when the cancellation is valid', () => {
+      it('submits the deal cancellation', async () => {
+        // Arrange
+        const cancellation = { reason, bankRequestDate, effectiveFrom };
+        const session = aRequestSession();
+
+        const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+          params: { _id: dealId },
+          session,
+          body: { cancellation },
+        });
+
+        // Act
+        await postDealCancellationDetails(req, res);
+
+        // Assert
+        expect(api.submitDealCancellation).toHaveBeenCalledTimes(1);
+        expect(api.submitDealCancellation).toHaveBeenCalledWith(dealId, cancellation, session.userToken);
+      });
+
+      it('redirects to the deal summary', async () => {
+        // Arrange
+        const { req, res } = createMocks<PostDealCancellationDetailsRequest>({
+          params: { _id: dealId },
+          session: aRequestSession(),
+          body: { cancellation: { reason, bankRequestDate, effectiveFrom } },
+        });
+
+        // Act
+        await postDealCancellationDetails(req, res);
+
+        // Assert
+        expect(res._getRedirectUrl()).toEqual(`/case/${dealId}/deal`);
+      });
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
+++ b/trade-finance-manager-ui/server/controllers/case/cancellation/check-details.controller.ts
@@ -1,7 +1,6 @@
 import { Response } from 'express';
 import { CustomExpressRequest, TfmDealCancellation } from '@ukef/dtfs2-common';
 import { isEmpty } from 'lodash';
-import { format } from 'date-fns';
 import { PRIMARY_NAVIGATION_KEYS } from '../../../constants';
 import { asUserSession } from '../../../helpers/express-session';
 import { canSubmissionTypeBeCancelled } from '../../helpers/deal-cancellation-enabled.helper';
@@ -38,19 +37,11 @@ export const getDealCancellationDetails = async (req: GetDealCancellationDetails
       return res.redirect(`/case/${_id}/deal`);
     }
 
-    const { reason, bankRequestDate, effectiveFrom } = cancellation;
-
-    const bankRequestDateFormatted = bankRequestDate ? format(new Date(bankRequestDate), 'd MMMM yyyy') : undefined;
-    const effectiveFromDateFormatted = effectiveFrom ? format(new Date(effectiveFrom), 'd MMMM yyyy') : undefined;
-
     const checkDetailsViewModel: CheckDetailsViewModel = {
       activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
       user,
       ukefDealId: deal.dealSnapshot.details.ukefDealId,
       dealId: _id,
-      reason,
-      bankRequestDate: bankRequestDateFormatted,
-      effectiveFromDate: effectiveFromDateFormatted,
       cancellation,
     };
     return res.render('case/cancellation/check-details.njk', checkDetailsViewModel);

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
@@ -5,7 +5,8 @@ const dashIfEmpty = (text) => {
 
   const textStr = String(text);
 
-  const isEmpty = !(textStr && textStr.trim().length > 0 && textStr !== 'NaN' && textStr !== 'Invalid date');
+  const isEmpty = !textStr || textStr.trim().length === 0 || textStr === 'NaN' || textStr === 'Invalid date';
+
   return isEmpty ? '-' : textStr;
 };
 

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.js
@@ -5,7 +5,7 @@ const dashIfEmpty = (text) => {
 
   const textStr = String(text);
 
-  const isEmpty = !textStr || textStr.trim().length === 0 || textStr === 'NaN' || textStr === 'Invalid date';
+  const isEmpty = !textStr || textStr.trim().length === 0 || textStr === 'NaN' || textStr === 'Invalid date' || textStr === 'Invalid Date';
 
   return isEmpty ? '-' : textStr;
 };

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.test.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-dashIfEmpty.test.js
@@ -1,33 +1,32 @@
 import dashIfEmpty from './filter-dashIfEmpty';
 
 describe('nunjuck filters - dashIfEmpty', () => {
-  it('should return string if text is number', () => {
+  it('should return string if text is non-zero number', () => {
     const result = dashIfEmpty(1234);
 
     const expected = '1234';
     expect(result).toEqual(expected);
   });
 
-  it('should return string', () => {
+  it('should return string, if its non-empty', () => {
     const result = dashIfEmpty('hello');
 
     expect(result).toEqual('hello');
   });
 
-  it('should return dash if nothing passed', () => {
-    const result = dashIfEmpty();
+  const returnDashCases = [
+    { argument: undefined, description: 'undefined' },
+    { argument: '', description: 'empty string' },
+    { argument: NaN, description: 'NaN' },
+    { argument: 'NaN', description: '"NaN"' },
+    { argument: '    ', description: 'whitespace' },
+    { argument: 'Invalid date', description: '`Invalid date`' },
+    { argument: new Date(NaN), description: 'an invalid Date' },
+    { argument: 0, description: '0' },
+  ];
 
-    expect(result).toEqual('-');
-  });
-
-  it('should return dash if empty string passed', () => {
-    const result = dashIfEmpty('');
-
-    expect(result).toEqual('-');
-  });
-
-  it('should return dash if NaN', () => {
-    const result = dashIfEmpty('NaN');
+  it.each(returnDashCases)('should return `-` when argument is $description', ({ argument }) => {
+    const result = dashIfEmpty(argument);
 
     expect(result).toEqual('-');
   });

--- a/trade-finance-manager-ui/server/nunjucks-configuration/filter-formatUnixTimestamp.ts
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/filter-formatUnixTimestamp.ts
@@ -1,0 +1,15 @@
+import { format, isValid, toDate } from 'date-fns';
+
+/**
+ * @param isoDateStr date string formatted as fromFormat
+ * @param toFormat date format using {@link https://date-fns.org/v3.3.1/docs/format | unicode tokens}
+ * @returns date formatted as toFormat or 'Invalid date' if can't parse isoDateStr
+ */
+export const formatUnixTimestamp = (timestamp: number, toFormat: string) => {
+  if (!timestamp) {
+    return 'Invalid date';
+  }
+
+  const date = toDate(timestamp);
+  return isValid(date) ? format(date, toFormat) : 'Invalid date';
+};

--- a/trade-finance-manager-ui/server/nunjucks-configuration/index.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/index.js
@@ -5,6 +5,7 @@ let mojFilters = require('@ministryofjustice/frontend/moj/filters/all')();
 const { localiseTimestamp } = require('./filter-localiseTimestamp');
 const { formatDateString } = require('./filter-formatDateString');
 const { formatIsoDateString } = require('./filter-formatIsoDateString');
+const { formatUnixTimestamp } = require('./filter-formatUnixTimestamp');
 const dashIfEmpty = require('./filter-dashIfEmpty');
 const formatBooleanAsString = require('./filter-formatOptionalBooleanAsString');
 const displayName = require('./filter-displayName');
@@ -42,6 +43,7 @@ const configureNunjucks = (opts) => {
   nunjucksEnvironment.addFilter('localiseTimestamp', localiseTimestamp);
   nunjucksEnvironment.addFilter('formatDateString', formatDateString);
   nunjucksEnvironment.addFilter('formatIsoDateString', formatIsoDateString);
+  nunjucksEnvironment.addFilter('formatUnixTimestamp', formatUnixTimestamp);
   nunjucksEnvironment.addFilter('dashIfEmpty', dashIfEmpty);
   nunjucksEnvironment.addFilter('formatBooleanAsString', formatBooleanAsString);
   nunjucksEnvironment.addFilter('displayName', displayName);

--- a/trade-finance-manager-ui/server/types/view-models/deal-cancellation/check-details-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/deal-cancellation/check-details-view-model.ts
@@ -1,3 +1,4 @@
+import { TfmDealCancellation } from '@ukef/dtfs2-common';
 import { BaseViewModel } from '../base-view-model';
 
 export type CheckDetailsViewModel = BaseViewModel & {
@@ -6,4 +7,5 @@ export type CheckDetailsViewModel = BaseViewModel & {
   reason?: string;
   bankRequestDate?: string;
   effectiveFromDate?: string;
+  cancellation: Partial<TfmDealCancellation>;
 };

--- a/trade-finance-manager-ui/server/types/view-models/deal-cancellation/check-details-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/deal-cancellation/check-details-view-model.ts
@@ -4,8 +4,5 @@ import { BaseViewModel } from '../base-view-model';
 export type CheckDetailsViewModel = BaseViewModel & {
   ukefDealId: string;
   dealId: string;
-  reason?: string;
-  bankRequestDate?: string;
-  effectiveFromDate?: string;
   cancellation: Partial<TfmDealCancellation>;
 };

--- a/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
@@ -14,12 +14,12 @@
 {% set rowLinkClasses = "govuk-!-padding-top-6 govuk-!-padding-bottom-6 govuk-!-text-align-right" %}
 
 {% set reasonForCancellingUrl %}
-  <a
+<a
     class="govuk-link"
     href="/case/{{ dealId }}/cancellation/reason?status=change"
     data-cy="reason-link">
     Change <span class="govuk-visually-hidden">reason</span>
-  </a>
+</a>
 {% endset %}
 {% set reasonForCancelling =
   [
@@ -31,12 +31,12 @@
 {% set optionsWithHTML = (optionsWithHTML.push(reasonForCancelling), optionsWithHTML) %}
 
 {% set bankRequestDateUrl %}
-  <a
+<a
     class="govuk-link"
     href="/case/{{ dealId }}/cancellation/bank-request-date?status=change"
     data-cy="bank-request-date-link">
     Change <span class="govuk-visually-hidden">bank request date</span>
-  </a>
+</a>
 {% endset %}
 {% set bankRequestDate =
   [
@@ -48,14 +48,14 @@
 {% set optionsWithHTML = (optionsWithHTML.push(bankRequestDate), optionsWithHTML) %}
 
 {% set effectiveFromDateUrl %}
-  <a
+<a
     class="govuk-link"
     href="/case/{{ dealId }}/cancellation/effective-from-date?status=change"
     data-cy="effective-from-link">
     Change <span class="govuk-visually-hidden">date effective from</span>
-  </a>
+</a>
 {% endset %}
-  {% set effectiveFromDate =
+{% set effectiveFromDate =
     [
       { text: 'Date effective from', attributes: { "data-cy": "effective-from-heading" }, classes: rowTextClasses },
       { text: effectiveFromDate | dashIfEmpty, attributes: { "data-cy": "effective-from-response" }, classes: rowTextClasses },
@@ -90,7 +90,7 @@
       }) }}
 
       <div class="govuk-!-margin-bottom-9">
-      {{ govukWarningText({
+        {{ govukWarningText({
         text: "When you cancel the deal it cannot be undone",
         iconFallbackText: "Warning",
         attributes: { 'data-cy': 'warning' }
@@ -99,9 +99,10 @@
 
       <form method="POST" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <input type="hidden" name="cancellation" value="{{ cancellation }}">
         <div class="govuk-!-margin-bottom-5">
           {{ govukButton({
-            text: "Delete account",
+            text: "Cancel deal",
             classes: "govuk-button--warning",
             attributes: { 'data-cy': 'delete-button' }
           }) }}

--- a/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
+++ b/trade-finance-manager-ui/templates/case/cancellation/check-details.njk
@@ -24,7 +24,7 @@
 {% set reasonForCancelling =
   [
     { text: 'Reason for cancelling deal', attributes: { "data-cy": "reason-heading" }, classes: rowTextClasses },
-    { text: reason | dashIfEmpty, attributes: { "data-cy": "reason-response" }, classes: rowTextClasses },
+    { text: cancellation.reason | dashIfEmpty, attributes: { "data-cy": "reason-response" }, classes: rowTextClasses },
     { html: reasonForCancellingUrl, classes: rowLinkClasses }
   ]
 %}
@@ -41,7 +41,7 @@
 {% set bankRequestDate =
   [
     { text: 'Bank request date', attributes: { "data-cy": "bank-request-date-heading" }, classes: rowTextClasses},
-    { text: bankRequestDate | dashIfEmpty, attributes: { "data-cy": "bank-request-date-response" }, classes: rowTextClasses },
+    { text: cancellation.bankRequestDate | formatUnixTimestamp('d MMMM yyyy') | dashIfEmpty, attributes: { "data-cy": "bank-request-date-response" }, classes: rowTextClasses },
     { html: bankRequestDateUrl, classes: rowLinkClasses }
   ]
 %}
@@ -58,7 +58,7 @@
 {% set effectiveFromDate =
     [
       { text: 'Date effective from', attributes: { "data-cy": "effective-from-heading" }, classes: rowTextClasses },
-      { text: effectiveFromDate | dashIfEmpty, attributes: { "data-cy": "effective-from-response" }, classes: rowTextClasses },
+      { text: cancellation.effectiveFrom | formatUnixTimestamp('d MMMM yyyy') | dashIfEmpty, attributes: { "data-cy": "effective-from-response" }, classes: rowTextClasses },
       { html: effectiveFromDateUrl, classes: rowLinkClasses }
     ]
 %}

--- a/trade-finance-manager-ui/test-helpers/test-data/check-answers-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/check-answers-view-model.ts
@@ -7,4 +7,5 @@ export const aCheckDetailsViewModel = (): CheckDetailsViewModel => ({
   activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.ALL_DEALS,
   ukefDealId: 'testUkefId',
   dealId: 'testId',
+  cancellation: { reason: 'a reason', effectiveFrom: 1729007392441, bankRequestDate: 1729007392441 },
 });


### PR DESCRIPTION
## Introduction :pencil2:
The check your details page currently does nothing when the button is pressed. It should send a submit request to tfm-api

## Resolution :heavy_check_mark:
- Send `POST` request to `cancellation/submit` in tfm-api, sending cancellation as payload.
- Refactor check-details page to take `cancellation` object, which is returned on the post request

## Miscellaneous :heavy_plus_sign:
- Take format dates in nunjucks template, not controller using new `formatUnixTimestamp` filter
- fix `delete account` typo in template
