### PR TITLE
feat(FN-3159): add keying sheet generation with amendments test

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/generate-fixed-fee-adjustment-with-amendments.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/generate-fixed-fee-adjustment-with-amendments.spec.js
@@ -1,0 +1,123 @@
+import {
+  FeeRecordEntityMockBuilder,
+  UTILISATION_REPORT_RECONCILIATION_STATUS,
+  UtilisationReportEntityMockBuilder,
+  FacilityUtilisationDataEntityMockBuilder,
+  PaymentEntityMockBuilder,
+  AMENDMENT_STATUS,
+  CURRENCY,
+  FEE_RECORD_STATUS,
+} from '@ukef/dtfs2-common';
+import pages from '../../pages';
+import USERS from '../../../fixtures/users';
+import { NODE_TASKS } from '../../../../../e2e-fixtures';
+import relative from '../../relativeURL';
+
+context('Fixed fee calculation uses effective amendment to cover end date at report period end', () => {
+  const bankId = '961';
+  const reportId = 1;
+  const facilityId = '12345678';
+  const feeRecordId = 2;
+
+  const reportPeriod = { start: { month: 12, year: 2023 }, end: { month: 2, year: 2024 } };
+  const dateBeforeReportPeriodEnd = new Date('2024-01-01');
+  const dateBeforeDateBeforeReportPeriodEnd = new Date('2023-12-01');
+  const dateAfterReportPeriodEnd = new Date('2024-03-01');
+
+  const report = UtilisationReportEntityMockBuilder.forStatus(UTILISATION_REPORT_RECONCILIATION_STATUS.RECONCILIATION_IN_PROGRESS)
+    .withId(reportId)
+    .withReportPeriod(reportPeriod)
+    .withBankId(bankId)
+    .build();
+
+  const facilityUtilisationData = FacilityUtilisationDataEntityMockBuilder.forId(facilityId).withFixedFee(700).build();
+
+  const paymentCurrency = CURRENCY.GBP;
+  const paymentAmount = 100;
+  const matchingPayment = PaymentEntityMockBuilder.forCurrency(paymentCurrency).withAmount(paymentAmount).build();
+  const feeRecord = FeeRecordEntityMockBuilder.forReport(report)
+    .withStatus(FEE_RECORD_STATUS.MATCH)
+    .withId(feeRecordId)
+    .withFacilityUtilisation(1)
+    .withFacilityUtilisationData(facilityUtilisationData)
+    .withPaymentCurrency(paymentCurrency)
+    .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
+    .withFeesPaidToUkefForThePeriod(paymentAmount)
+    .withPayments([matchingPayment])
+    .build();
+
+  const tfmFacility = {
+    facilitySnapshot: {
+      coverStartDate: new Date('2023-01-01').getTime(),
+      // 1095 days after report period end
+      coverEndDate: new Date('2027-03-01').getTime(),
+      interestPercentage: 100,
+      dayCountBasis: 1,
+      value: 700000,
+      coverPercentage: 100,
+      ukefFacilityId: facilityId,
+    },
+    amendments: [
+      {
+        status: AMENDMENT_STATUS.COMPLETED,
+        effectiveDate: dateAfterReportPeriodEnd.getTime(),
+        // 365 days after report period end
+        coverEndDate: new Date('2025-03-01').getTime(),
+      },
+      {
+        status: AMENDMENT_STATUS.IN_PROGRESS,
+        effectiveDate: dateBeforeReportPeriodEnd.getTime(),
+        // 370 days after report period end
+        coverEndDate: new Date('2025-03-06').getTime(),
+      },
+      {
+        status: AMENDMENT_STATUS.COMPLETED,
+        effectiveDate: dateBeforeDateBeforeReportPeriodEnd.getTime(),
+        // 730 days after report period end
+        coverEndDate: new Date('2026-03-01').getTime(),
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    cy.task(NODE_TASKS.DELETE_ALL_TFM_FACILITIES_FROM_DB);
+    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacility]);
+
+    cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+
+    pages.landingPage.visit();
+    cy.login(USERS.PDC_RECONCILE);
+
+    cy.visit(`utilisation-reports/${reportId}`);
+  });
+
+  it('should calculate the fixed fee adjustment using effective amendment at report period end', () => {
+    pages.utilisationReportPage.premiumPaymentsTab.generateKeyingDataButton().click();
+    pages.checkKeyingDataPage.generateKeyingSheetDataButton().click();
+
+    cy.url().should('eq', relative(`/utilisation-reports/${reportId}#keying-sheet`));
+
+    /**
+     * The fixed fee adjustment is the difference between
+     * the current fixed fee and the previous fixed fee,
+     * where the previous fixed fee is equal to the value
+     * stored on the FacilityUtilisationData table, and the
+     * current fixed fee is given by the product of the below
+     * values:
+     * - utilisation: 1
+     * - coverPercentage: 100 / 100 = 1
+     * - bank margin: 0.9 (this is a fixed, constant value)
+     * - interest percentage: 100 / 100 = 1
+     * - number of days left in cover period divided by day count basis: 730 / 1 = 730
+     * This yields a current utilisation value of 730 * 0.9 = 657
+     *
+     * The adjustment is therefore the difference between the previous
+     * fixed fee which was 700 and 657 which is a decrease of 43
+     */
+    cy.assertText(pages.utilisationReportPage.keyingSheetTab.fixedFeeAdjustmentDecrease(feeRecordId), '43.00');
+    cy.assertText(pages.utilisationReportPage.keyingSheetTab.fixedFeeAdjustmentIncrease(feeRecordId), '-');
+  });
+});


### PR DESCRIPTION
## Introduction :pencil2:
We don't have amendments on our facilities in our existing keying sheet generation tests.
Rather than adding to an already complex test file covering multiple other edge cases I have chosen to add a new e2e-test specific to this case so it is more readable and maintainable.

## Resolution :heavy_check_mark:
- Add e2e-test for a keying sheet generation journey where the facility in question has amendments to the cover end date

