### PR TITLE
feat(FN-3493): persist selected records on add payment screen

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
@@ -226,7 +226,7 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
       cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, matchingTfmFacilities);
     });
 
-    describe('by clicking the back button', () => {
+    describe('by clicking the back button with checkboxes for fee records 3 and 4 checked', () => {
       beforeEach(() => {
         pages.landingPage.visit();
         cy.login(USERS.PDC_RECONCILE);
@@ -254,7 +254,7 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
       });
     });
 
-    describe('by clicking the cancel button', () => {
+    describe('by clicking the cancel button with checkboxes for fee records 3 and 4 checked', () => {
       beforeEach(() => {
         pages.landingPage.visit();
         cy.login(USERS.PDC_RECONCILE);

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/add-payment.spec.js
@@ -5,6 +5,7 @@ import {
   PaymentMatchingToleranceEntityMockBuilder,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntityMockBuilder,
+  CURRENCY,
 } from '@ukef/dtfs2-common';
 import pages from '../../pages';
 import USERS from '../../../fixtures/users';
@@ -46,9 +47,9 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
     .withExporter('Exporter 1')
     .withPaymentCurrency(PAYMENT_CURRENCY)
     .withFeesPaidToUkefForThePeriod(100)
-    .withFeesPaidToUkefForThePeriodCurrency('JPY')
+    .withFeesPaidToUkefForThePeriodCurrency(CURRENCY.JPY)
     .withPaymentExchangeRate(2)
-    .withStatus('DOES_NOT_MATCH')
+    .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
     .withPayments([payment])
     .build();
   const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report)
@@ -56,10 +57,10 @@ context('PDC_RECONCILE users can add a payment to a report', () => {
     .withFacilityId('22222222')
     .withExporter('Exporter 2')
     .withFeesPaidToUkefForThePeriod(200)
-    .withFeesPaidToUkefForThePeriodCurrency('EUR')
+    .withFeesPaidToUkefForThePeriodCurrency(CURRENCY.EUR)
     .withPaymentCurrency(PAYMENT_CURRENCY)
     .withPaymentExchangeRate(0.5)
-    .withStatus('DOES_NOT_MATCH')
+    .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
     .withPayments([payment])
     .build();
 

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/add-payment.component-test.js
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/add-payment.component-test.js
@@ -281,24 +281,32 @@ describe(page, () => {
     wrapper.expectText('[id="addAnotherPayment-error"]').toContain('Please, tell us if you have more');
   });
 
-  it('cancel link should link to utilisation report page', () => {
+  it('cancel link should link to backLinkHref', () => {
     // Arrange
-    const addPaymentViewModel = anAddPaymentViewModel();
-    addPaymentViewModel.reportId = 123;
+    const backLinkHref = 'back-link-url';
+    const addPaymentViewModel = {
+      ...anAddPaymentViewModel(),
+      backLinkHref,
+    };
+
     const wrapper = render(addPaymentViewModel);
 
     // Assert
-    wrapper.expectLink('a:contains("Cancel")').toLinkTo('/utilisation-reports/123', 'Cancel');
+    wrapper.expectLink('a:contains("Cancel")').toLinkTo(backLinkHref, 'Cancel');
   });
 
-  it('back link should link to utilisation report page', () => {
+  it('back link should link to backLinkHref', () => {
     // Arrange
-    const addPaymentViewModel = anAddPaymentViewModel();
-    addPaymentViewModel.reportId = 123;
+    const backLinkHref = 'back-link-url';
+    const addPaymentViewModel = {
+      ...anAddPaymentViewModel(),
+      backLinkHref,
+    };
+
     const wrapper = render(addPaymentViewModel);
 
     // Assert
-    wrapper.expectLink('a:contains("Back")').toLinkTo('/utilisation-reports/123', 'Back');
+    wrapper.expectLink('a:contains("Back")').toLinkTo(backLinkHref, 'Back');
   });
 
   it('should display form heading as "New payment details" when payment number is 1', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.test.ts
@@ -101,6 +101,7 @@ describe('controllers/utilisation-reports/add-payment', () => {
         },
       ]);
       expect((res._getRenderData() as AddPaymentViewModel).canAddToExistingPayment).toEqual(true);
+      expect((res._getRenderData() as AddPaymentViewModel).backLinkHref).toEqual('/utilisation-reports/123?selectedFeeRecordIds=456');
     });
 
     it('should set payment number to number of payments plus 1', async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/add-payment/index.ts
@@ -20,6 +20,7 @@ import {
   mapToSelectedReportedFeesDetailsViewModel,
 } from '../helpers';
 import { SelectedFeeRecordsPaymentDetailsResponse } from '../../../api-response-types';
+import { getLinkToPremiumPaymentsTab } from '../add-to-an-existing-payment/get-link-to-premium-payments-tab';
 
 export type AddPaymentRequest = CustomExpressRequest<{
   reqBody: AddPaymentFormRequestBody;
@@ -82,6 +83,7 @@ export const addPayment = async (req: AddPaymentRequest, res: Response) => {
       recordedPaymentsDetails: selectedFeeRecordDetails.payments.map((payment) => mapToRecordedPaymentDetailsViewModel(payment)),
       multipleFeeRecordsSelected: selectedFeeRecordDetails.feeRecords.length > 1,
       canAddToExistingPayment: selectedFeeRecordDetails.canAddToExistingPayment,
+      backLinkHref: getLinkToPremiumPaymentsTab(reportId, feeRecordIds),
     });
   } catch (error) {
     console.error('Failed to add payment', error);

--- a/trade-finance-manager-ui/server/types/view-models/add-payment-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/add-payment-view-model.ts
@@ -23,4 +23,5 @@ export type AddPaymentViewModel = BaseViewModel & {
   errors: PaymentErrorsViewModel;
   multipleFeeRecordsSelected: boolean;
   canAddToExistingPayment: boolean;
+  backLinkHref: string;
 };

--- a/trade-finance-manager-ui/templates/utilisation-reports/add-payment.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/add-payment.njk
@@ -7,7 +7,7 @@
 {% import "./_macros/fee-record-details-table.njk" as feeRecordDetailsTable %}
 {% import "./_macros/payment-date-input.njk" as paymentDateInput %}
 {% extends "index.njk" %}
-{% set backLink = {"href": '/utilisation-reports/' + reportId} %}
+{% set backLink = { "href": backLinkHref } %}
 {% block pageTitle %}Add a payment{% endblock %}
 {% block content %}
   {% if errors.errorSummary | length %}
@@ -160,7 +160,7 @@
         text: "Continue",
         attributes: { 'data-cy': 'continue-button'}
       })}}
-      <a class="govuk-link" href="/utilisation-reports/{{ reportId }}">Cancel</a>
+      <a class="govuk-link" href="{{ backLinkHref }}" id="cancel-link" data-cy="cancel-link">Cancel</a>
     </div>
   </form>
 {% endblock %}

--- a/trade-finance-manager-ui/test-helpers/test-data/view-models/add-payment-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/view-models/add-payment-view-model.ts
@@ -31,6 +31,7 @@ export const anAddPaymentViewModel = (): AddPaymentViewModel => ({
   recordedPaymentsDetails: [],
   multipleFeeRecordsSelected: false,
   canAddToExistingPayment: false,
+  backLinkHref: '/utilisation-reports/12',
 });
 
 export const aRecordedPaymentDetailsViewModel = (): RecordedPaymentDetailsViewModel => ({


### PR DESCRIPTION
## Introduction :pencil2:
At present, clicking the back/cancel buttons on the add payment screen does not persist the selected fee records. This behaviour does not align with that of the 'add to an existing payment' screen.

## Resolution :heavy_check_mark:
- Update add payment screen template to accept a back link href
- Update add payment view model to accept back link href
- Update the add payment controller to use the existing back link href helper function
- Updates to the relevant unit/component/E2E tests

## Miscellaneous :heavy_plus_sign:
N/A

