### PR TITLE
feat(FN-3504): save ukefs share of utilisation

### DIFF
--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -2,7 +2,7 @@ import { EntityManager } from 'typeorm';
 import { DbRequestSource, FeeRecordEntity, FeeRecordStatus, ReportPeriod } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 import { calculatePrincipalBalanceAdjustment, calculateFixedFeeAdjustment, updateFacilityUtilisationData } from '../helpers';
-import { getLatestTfmFacilityValues } from '../../../../../helpers';
+import { calculateUkefShareOfUtilisation, getLatestTfmFacilityValues } from '../../../../../helpers';
 
 type GenerateKeyingDataEventPayload = {
   transactionEntityManager: EntityManager;
@@ -37,7 +37,9 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
 
   const fixedFeeAdjustment = await calculateFixedFeeAdjustment(feeRecord, feeRecord.facilityUtilisationData, reportPeriod);
 
-  const principalBalanceAdjustment = calculatePrincipalBalanceAdjustment(feeRecord, feeRecord.facilityUtilisationData, coverPercentage);
+  const ukefShareOfUtilisation = calculateUkefShareOfUtilisation(feeRecord.facilityUtilisation, coverPercentage);
+
+  const principalBalanceAdjustment = calculatePrincipalBalanceAdjustment(ukefShareOfUtilisation, feeRecord.facilityUtilisationData);
 
   const statusToUpdateTo = getStatusToUpdateTo(feeRecord.feesPaidToUkefForThePeriod, fixedFeeAdjustment, principalBalanceAdjustment);
 
@@ -54,6 +56,7 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
     reportPeriod,
     utilisation: feeRecord.facilityUtilisation,
     requestSource,
+    ukefShareOfUtilisation,
     entityManager: transactionEntityManager,
   });
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.test.ts
@@ -1,40 +1,34 @@
-import { FacilityUtilisationDataEntityMockBuilder, FeeRecordEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FacilityUtilisationDataEntityMockBuilder } from '@ukef/dtfs2-common';
 import { calculatePrincipalBalanceAdjustment } from './calculate-principal-balance-adjustment';
-import { aUtilisationReport } from '../../../../../../test-helpers';
 
 describe('calculatePrincipalBalanceAdjustment', () => {
-  const aFeeRecordEntityWithFacilityUtilisation = (facilityUtilisation: number) =>
-    FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withFacilityUtilisation(facilityUtilisation).build();
-
   const aFacilityUtilisationDataEntityWithUtilisation = (utilisation: number) =>
     FacilityUtilisationDataEntityMockBuilder.forId('11111111').withUtilisation(utilisation).build();
 
   it.each([
     {
       condition: 'the amounts are equal',
-      feeRecord: aFeeRecordEntityWithFacilityUtilisation(125),
-      facilityUtilisationData: aFacilityUtilisationDataEntityWithUtilisation(25),
+      ukefShareOfUtilisation: 250000,
+      facilityUtilisationData: aFacilityUtilisationDataEntityWithUtilisation(250000),
       expectedDifference: 0,
     },
     {
-      condition: 'the fee record facilityUtilisation is greater',
-      feeRecord: aFeeRecordEntityWithFacilityUtilisation(500),
-      facilityUtilisationData: aFacilityUtilisationDataEntityWithUtilisation(50),
-      expectedDifference: 50,
+      condition: 'the current utilisation is greater',
+      ukefShareOfUtilisation: 500000,
+      facilityUtilisationData: aFacilityUtilisationDataEntityWithUtilisation(450000),
+      expectedDifference: 50000,
     },
     {
-      condition: 'the facility utilisation is greater',
-      feeRecord: aFeeRecordEntityWithFacilityUtilisation(100),
-      facilityUtilisationData: aFacilityUtilisationDataEntityWithUtilisation(70),
-      expectedDifference: -50,
+      condition: 'the previous utilisation is greater',
+      ukefShareOfUtilisation: 100000,
+      facilityUtilisationData: aFacilityUtilisationDataEntityWithUtilisation(150000),
+      expectedDifference: -50000,
     },
   ])(
     'returns the difference between then facility utilisation and the fee record facilityUtilisation when $condition',
-    ({ feeRecord, facilityUtilisationData, expectedDifference }) => {
-      const coverPercentage = 20;
-
+    ({ ukefShareOfUtilisation, facilityUtilisationData, expectedDifference }) => {
       // Act
-      const result = calculatePrincipalBalanceAdjustment(feeRecord, facilityUtilisationData, coverPercentage);
+      const result = calculatePrincipalBalanceAdjustment(ukefShareOfUtilisation, facilityUtilisationData);
 
       // Assert
       expect(result).toEqual(expectedDifference);

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-principal-balance-adjustment.ts
@@ -1,20 +1,13 @@
 import Big from 'big.js';
-import { FacilityUtilisationDataEntity, FeeRecordEntity } from '@ukef/dtfs2-common';
-import { calculateUkefShareOfUtilisation } from '../../../../../helpers';
+import { FacilityUtilisationDataEntity } from '@ukef/dtfs2-common';
 
 /**
  * Calculates the principal balance adjustment for the given
  * UKEF share of utilisation from the fee record and facility utilisation data
- * @param feeRecord - The fee record
+ * @param ukefShareOfUtilisation - UKEF's share of the utilisation from the report
  * @param facilityUtilisationData - The facility utilisation data
  * @returns The principal balance adjustment
  */
-export const calculatePrincipalBalanceAdjustment = (
-  feeRecord: FeeRecordEntity,
-  facilityUtilisationData: FacilityUtilisationDataEntity,
-  coverPercentage: number,
-): number => {
-  const ukefShareOfUtilisation = calculateUkefShareOfUtilisation(feeRecord.facilityUtilisation, coverPercentage);
-
+export const calculatePrincipalBalanceAdjustment = (ukefShareOfUtilisation: number, facilityUtilisationData: FacilityUtilisationDataEntity): number => {
   return new Big(ukefShareOfUtilisation).sub(facilityUtilisationData.utilisation).toNumber();
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
@@ -54,7 +54,7 @@ describe('updateFacilityUtilisationData', () => {
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, facilityUtilisationDataEntity);
-    expect(facilityUtilisationDataEntity.utilisation).toEqual(1234567.77);
+    expect(facilityUtilisationDataEntity.utilisation).toEqual(ukefShareOfUtilisation);
     expect(facilityUtilisationDataEntity.reportPeriod).toEqual(reportPeriod);
     expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toEqual('abc123');
     expect(facilityUtilisationDataEntity.lastUpdatedByPortalUserId).toBeNull();

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
@@ -22,7 +22,7 @@ describe('updateFacilityUtilisationData', () => {
     jest.resetAllMocks();
   });
 
-  it('updates the facility utilisation data entity with the supplied report period, utilisation and request source and saves the entity', async () => {
+  it('updates the facility utilisation data entity with the supplied report period, ukef share of utilisation and request source and saves the entity', async () => {
     // Arrange
     const facilityUtilisationDataEntity = FacilityUtilisationDataEntityMockBuilder.forId('12345678')
       .withUtilisation(1234567.89)
@@ -37,6 +37,7 @@ describe('updateFacilityUtilisationData', () => {
       end: { month: 7, year: 2027 },
     };
     const utilisation = 9876543.21;
+    const ukefShareOfUtilisation = 1234567.77;
     const requestSource: DbRequestSource = {
       platform: 'TFM',
       userId: 'abc123',
@@ -47,12 +48,13 @@ describe('updateFacilityUtilisationData', () => {
       reportPeriod,
       utilisation,
       requestSource,
+      ukefShareOfUtilisation,
       entityManager: mockEntityManager,
     });
 
     // Assert
     expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, facilityUtilisationDataEntity);
-    expect(facilityUtilisationDataEntity.utilisation).toEqual(9876543.21);
+    expect(facilityUtilisationDataEntity.utilisation).toEqual(1234567.77);
     expect(facilityUtilisationDataEntity.reportPeriod).toEqual(reportPeriod);
     expect(facilityUtilisationDataEntity.lastUpdatedByTfmUserId).toEqual('abc123');
     expect(facilityUtilisationDataEntity.lastUpdatedByPortalUserId).toBeNull();
@@ -74,6 +76,7 @@ describe('updateFacilityUtilisationData', () => {
       end: { month: 7, year: 2027 },
     };
     const utilisation = 9876543.21;
+    const ukefShareOfUtilisation = 123;
 
     when(getFixedFeeForFacility).calledWith('12345678', utilisation, reportPeriod).mockResolvedValue(76543.21);
 
@@ -82,6 +85,7 @@ describe('updateFacilityUtilisationData', () => {
       reportPeriod,
       utilisation,
       requestSource: aDbRequestSource(),
+      ukefShareOfUtilisation,
       entityManager: mockEntityManager,
     });
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.ts
@@ -6,6 +6,7 @@ type UpdateFacilityUtilisationDataUpdate = {
   entityManager: EntityManager;
   reportPeriod: ReportPeriod;
   utilisation: number;
+  ukefShareOfUtilisation: number;
   requestSource: DbRequestSource;
 };
 
@@ -15,20 +16,21 @@ type UpdateFacilityUtilisationDataUpdate = {
  * @param facilityUtilisationDataEntity - The facility utilisation data entity to update
  * @param update - The values to update the entity with
  * @param update.reportPeriod - The report period to update with
- * @param update.utilisation - The utilisation to update with
+ * @param update.utilisation - The utilisation as reported by the bank
+ * @param update.ukefShareOfUtilisation - UKEF's share of the utilisation as reported by the bank
  * @param update.requestSource - The request source supplying the update
  * @param update.entityManager - The entity manager
  * @returns The updated entity
  */
 export const updateFacilityUtilisationData = async (
   facilityUtilisationDataEntity: FacilityUtilisationDataEntity,
-  { reportPeriod, utilisation, requestSource, entityManager }: UpdateFacilityUtilisationDataUpdate,
+  { reportPeriod, utilisation, requestSource, entityManager, ukefShareOfUtilisation }: UpdateFacilityUtilisationDataUpdate,
 ): Promise<FacilityUtilisationDataEntity> => {
   const nextReportPeriodFixedFee = await getFixedFeeForFacility(facilityUtilisationDataEntity.id, utilisation, reportPeriod);
 
   facilityUtilisationDataEntity.updateWithCurrentReportPeriodDetails({
     fixedFee: nextReportPeriodFixedFee,
-    utilisation,
+    utilisation: ukefShareOfUtilisation,
     reportPeriod,
     requestSource,
   });


### PR DESCRIPTION
## Introduction :pencil2:
We are currently saving the bank's reported utilisation but then comparing it to UKEF's share of utilisation for the next report period giving incorrect adjustment numbers.

## Resolution :heavy_check_mark:
- When saving utilisation to the facility utilisation data table save ukef's share of utilisation instead

## Miscellaneous :heavy_plus_sign:
Acknowledging this could do with further refactors for future maintainability since some values are being calculated multiple times rather than passed around - a separate tech debt ticket is being raised and worked on imminently by Zain which will be against main to do exactly this.

