### PR TITLE
fix(acbs-deployment): acbs dockerfile reference fix

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -279,10 +279,10 @@ jobs:
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: Artifacts 🗃️
-        working-directory: ./azure-functions/${{ matrix.functions }}
+        working-directory: .
         run: |
           # Build images
-          docker build . \
+          docker build -f ./azure-functions/${{ matrix.functions }}/Dockerfile . \
           -t ${{ env.ACR }}/${{ matrix.functions }}:${{ github.sha }} \
           -t ${{ env.ACR }}/${{ matrix.functions }}:${{ env.FROM }}
 


### PR DESCRIPTION
## Introduction :pencil2:
Deployment script is unable to reference the Dockerfile from correct context.

## Resolution :heavy_check_mark:
* Working directory changed to root.
* docker build will be executed with `-f` explicit dockerfile argument.

