### PR TITLE
fix(FN-3447): bold facility id and incorrect sorting fix on utilisation tab

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/view-utilisation.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/view-utilisation.spec.js
@@ -30,11 +30,21 @@ context('Users can view utilisation', () => {
   const secondUtilisationString = '199,999.99';
   const thirdUtilisationString = '90,000.00';
 
+  const firstValueString = '1,000,000.00';
+  const secondValueString = '300,000.00';
+  const thirdValueString = '1,050,000.00';
+
+  const firstExposureString = '400,000.00';
+  const secondExposureString = '169,999.99';
+  const thirdExposureString = '72,000.00';
+
   const reportPeriod = { start: { month: 12, year: 2023 }, end: { month: 2, year: 2024 } };
   const dateWithinReportPeriod = new Date('2024-01-01');
   const dateAfterReportPeriodEnd = new Date('2024-03-01');
 
-  beforeEach(() => {
+  const { utilisationTab } = pages.utilisationReportPage;
+
+  before(() => {
     cy.task(NODE_TASKS.DELETE_ALL_TFM_FACILITIES_FROM_DB);
 
     const tfmFacilityOne = {
@@ -80,7 +90,7 @@ context('Users can view utilisation', () => {
       facilitySnapshot: {
         ukefFacilityId: FACILITY_ID_THREE,
         coverPercentage: 80,
-        value: 1000000,
+        value: 1050000,
       },
     };
 
@@ -141,7 +151,9 @@ context('Users can view utilisation', () => {
       .build();
 
     cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecordOne, feeRecordTwo, feeRecordThree]);
+  });
 
+  beforeEach(() => {
     pages.landingPage.visit();
     cy.login(USERS.PDC_RECONCILE);
 
@@ -151,72 +163,116 @@ context('Users can view utilisation', () => {
   });
 
   it('should render the utilisation for each fee record', () => {
-    pages.utilisationReportPage.utilisationTab.table.row(FEE_RECORD_ID_ONE).within(() => {
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.facilityId(), FACILITY_ID_ONE);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), firstExporter);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.baseCurrency(), CURRENCY.GBP);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.value(), '1,000,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), firstUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.coverPercentage(), '80%');
+    utilisationTab.table.row(FEE_RECORD_ID_ONE).within(() => {
+      cy.assertText(utilisationTab.table.facilityId(), FACILITY_ID_ONE);
+      cy.assertText(utilisationTab.table.exporter(), firstExporter);
+      cy.assertText(utilisationTab.table.baseCurrency(), CURRENCY.GBP);
+      cy.assertText(utilisationTab.table.value(), '1,000,000.00');
+      cy.assertText(utilisationTab.table.utilisation(), firstUtilisationString);
+      cy.assertText(utilisationTab.table.coverPercentage(), '80%');
       // 80% of 500,000 is 400,000
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exposure(), '400,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 300.00`);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesPayable(), `${CURRENCY.JPY} 100.00`);
+      cy.assertText(utilisationTab.table.exposure(), '400,000.00');
+      cy.assertText(utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 300.00`);
+      cy.assertText(utilisationTab.table.feesPayable(), `${CURRENCY.JPY} 100.00`);
     });
 
-    pages.utilisationReportPage.utilisationTab.table.row(FEE_RECORD_ID_TWO).within(() => {
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.facilityId(), FACILITY_ID_TWO);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), secondExporter);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.baseCurrency(), CURRENCY.GBP);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.value(), '300,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), secondUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.coverPercentage(), '85%');
+    utilisationTab.table.row(FEE_RECORD_ID_TWO).within(() => {
+      cy.assertText(utilisationTab.table.facilityId(), FACILITY_ID_TWO);
+      cy.assertText(utilisationTab.table.exporter(), secondExporter);
+      cy.assertText(utilisationTab.table.baseCurrency(), CURRENCY.GBP);
+      cy.assertText(utilisationTab.table.value(), '300,000.00');
+      cy.assertText(utilisationTab.table.utilisation(), secondUtilisationString);
+      cy.assertText(utilisationTab.table.coverPercentage(), '85%');
       // 85% of 199,999.99 is 169,999.9915
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exposure(), '169,999.99');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 200.00`);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesPayable(), `${CURRENCY.GBP} 100.00`);
+      cy.assertText(utilisationTab.table.exposure(), '169,999.99');
+      cy.assertText(utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 200.00`);
+      cy.assertText(utilisationTab.table.feesPayable(), `${CURRENCY.GBP} 100.00`);
     });
 
-    pages.utilisationReportPage.utilisationTab.table.row(FEE_RECORD_ID_THREE).within(() => {
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.facilityId(), FACILITY_ID_THREE);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), thirdExporter);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.baseCurrency(), CURRENCY.GBP);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.value(), '1,000,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), thirdUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.coverPercentage(), '80%');
+    utilisationTab.table.row(FEE_RECORD_ID_THREE).within(() => {
+      cy.assertText(utilisationTab.table.facilityId(), FACILITY_ID_THREE);
+      cy.assertText(utilisationTab.table.exporter(), thirdExporter);
+      cy.assertText(utilisationTab.table.baseCurrency(), CURRENCY.GBP);
+      cy.assertText(utilisationTab.table.value(), '1,050,000.00');
+      cy.assertText(utilisationTab.table.utilisation(), thirdUtilisationString);
+      cy.assertText(utilisationTab.table.coverPercentage(), '80%');
       // 85% of 90,000 is 72,000
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exposure(), '72,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 200.00`);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesPayable(), `${CURRENCY.GBP} 100.00`);
+      cy.assertText(utilisationTab.table.exposure(), '72,000.00');
+      cy.assertText(utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 200.00`);
+      cy.assertText(utilisationTab.table.feesPayable(), `${CURRENCY.GBP} 100.00`);
     });
   });
 
   describe('when sorting by ascending utilisation', () => {
     it('should sort the reports correctly by utilisation', () => {
-      pages.utilisationReportPage.utilisationTab.table.utilisationHeader().click();
+      utilisationTab.table.utilisationHeader().click();
 
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(0), thirdUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(1), secondUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(2), firstUtilisationString);
+      cy.assertText(utilisationTab.table.utilisation().eq(0), thirdUtilisationString);
+      cy.assertText(utilisationTab.table.utilisation().eq(1), secondUtilisationString);
+      cy.assertText(utilisationTab.table.utilisation().eq(2), firstUtilisationString);
     });
   });
 
   describe('when sorting by descending utilisation', () => {
     it('should sort the reports correctly by utilisation', () => {
       // click twice for descending sort
-      pages.utilisationReportPage.utilisationTab.table.utilisationHeader().click();
-      pages.utilisationReportPage.utilisationTab.table.utilisationHeader().click();
+      utilisationTab.table.utilisationHeader().click();
+      utilisationTab.table.utilisationHeader().click();
 
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(0), firstUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(1), secondUtilisationString);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(2), thirdUtilisationString);
+      cy.assertText(utilisationTab.table.utilisation().eq(0), firstUtilisationString);
+      cy.assertText(utilisationTab.table.utilisation().eq(1), secondUtilisationString);
+      cy.assertText(utilisationTab.table.utilisation().eq(2), thirdUtilisationString);
+    });
+  });
+
+  describe('when sorting by ascending value', () => {
+    it('should sort the reports correctly by value', () => {
+      utilisationTab.table.valueHeader().click();
+
+      cy.assertText(utilisationTab.table.value().eq(0), secondValueString);
+      cy.assertText(utilisationTab.table.value().eq(1), firstValueString);
+      cy.assertText(utilisationTab.table.value().eq(2), thirdValueString);
+    });
+  });
+
+  describe('when sorting by descending value', () => {
+    it('should sort the reports correctly by value', () => {
+      // click twice for descending sort
+      utilisationTab.table.valueHeader().click();
+      utilisationTab.table.valueHeader().click();
+
+      cy.assertText(utilisationTab.table.value().eq(0), thirdValueString);
+      cy.assertText(utilisationTab.table.value().eq(1), firstValueString);
+      cy.assertText(utilisationTab.table.value().eq(2), secondValueString);
+    });
+  });
+
+  describe('when sorting by ascending exposure', () => {
+    it('should sort the reports correctly by exposure', () => {
+      utilisationTab.table.exposureHeader().click();
+
+      cy.assertText(utilisationTab.table.exposure().eq(0), thirdExposureString);
+      cy.assertText(utilisationTab.table.exposure().eq(1), secondExposureString);
+      cy.assertText(utilisationTab.table.exposure().eq(2), firstExposureString);
+    });
+  });
+
+  describe('when sorting by descending exposure', () => {
+    it('should sort the reports correctly by exposure', () => {
+      // click twice for descending sort
+      utilisationTab.table.exposureHeader().click();
+      utilisationTab.table.exposureHeader().click();
+
+      cy.assertText(utilisationTab.table.exposure().eq(0), firstExposureString);
+      cy.assertText(utilisationTab.table.exposure().eq(1), secondExposureString);
+      cy.assertText(utilisationTab.table.exposure().eq(2), thirdExposureString);
     });
   });
 
   it('should render a link to download the report', () => {
-    cy.assertText(pages.utilisationReportPage.utilisationTab.downloadReportLink(), 'Download the report submitted by the bank as a CSV');
+    cy.assertText(utilisationTab.downloadReportLink(), 'Download the report submitted by the bank as a CSV');
 
-    pages.utilisationReportPage.utilisationTab.downloadReportLink().click();
+    utilisationTab.downloadReportLink().click();
     cy.url().should('eq', relative(`/utilisation-reports/${REPORT_ID}/download`));
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/view-utilisation.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/view-utilisation.spec.js
@@ -17,8 +17,18 @@ context('Users can view utilisation', () => {
   const REPORT_ID = 1;
   const FEE_RECORD_ID_ONE = '11';
   const FEE_RECORD_ID_TWO = '22';
+  const FEE_RECORD_ID_THREE = '33';
   const FACILITY_ID_ONE = '11111111';
   const FACILITY_ID_TWO = '22222222';
+  const FACILITY_ID_THREE = '33333333';
+
+  const firstExporter = 'Exporter 1';
+  const secondExporter = 'Exporter 2';
+  const thirdExporter = 'Exporter 3';
+
+  const firstUtilisationString = '500,000.00';
+  const secondUtilisationString = '199,999.99';
+  const thirdUtilisationString = '90,000.00';
 
   const reportPeriod = { start: { month: 12, year: 2023 }, end: { month: 2, year: 2024 } };
   const dateWithinReportPeriod = new Date('2024-01-01');
@@ -66,7 +76,15 @@ context('Users can view utilisation', () => {
       ],
     };
 
-    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacilityOne, tfmFacilityTwo]);
+    const tfmFacilityThree = {
+      facilitySnapshot: {
+        ukefFacilityId: FACILITY_ID_THREE,
+        coverPercentage: 80,
+        value: 1000000,
+      },
+    };
+
+    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacilityOne, tfmFacilityTwo, tfmFacilityThree]);
 
     cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
 
@@ -80,7 +98,7 @@ context('Users can view utilisation', () => {
     const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report)
       .withId(FEE_RECORD_ID_ONE)
       .withFacilityId(FACILITY_ID_ONE)
-      .withExporter('Exporter 1')
+      .withExporter(firstExporter)
       .withBaseCurrency(CURRENCY.GBP)
       .withFacilityUtilisation(500000)
       .withTotalFeesAccruedForThePeriod(300)
@@ -95,7 +113,7 @@ context('Users can view utilisation', () => {
     const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report)
       .withId(FEE_RECORD_ID_TWO)
       .withFacilityId(FACILITY_ID_TWO)
-      .withExporter('Exporter 2')
+      .withExporter(secondExporter)
       .withBaseCurrency(CURRENCY.GBP)
       .withFacilityUtilisation(199999.99)
       .withTotalFeesAccruedForThePeriod(200)
@@ -107,7 +125,22 @@ context('Users can view utilisation', () => {
       .withStatus(FEE_RECORD_STATUS.TO_DO)
       .build();
 
-    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecordOne, feeRecordTwo]);
+    const feeRecordThree = FeeRecordEntityMockBuilder.forReport(report)
+      .withId(FEE_RECORD_ID_THREE)
+      .withFacilityId(FACILITY_ID_THREE)
+      .withExporter(thirdExporter)
+      .withBaseCurrency(CURRENCY.GBP)
+      .withFacilityUtilisation(90000)
+      .withTotalFeesAccruedForThePeriod(200)
+      .withTotalFeesAccruedForThePeriodCurrency(CURRENCY.EUR)
+      .withFeesPaidToUkefForThePeriod(100)
+      .withFeesPaidToUkefForThePeriodCurrency(CURRENCY.GBP)
+      .withPaymentExchangeRate(2)
+      .withPaymentCurrency(CURRENCY.USD)
+      .withStatus(FEE_RECORD_STATUS.TO_DO)
+      .build();
+
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecordOne, feeRecordTwo, feeRecordThree]);
 
     pages.landingPage.visit();
     cy.login(USERS.PDC_RECONCILE);
@@ -120,10 +153,10 @@ context('Users can view utilisation', () => {
   it('should render the utilisation for each fee record', () => {
     pages.utilisationReportPage.utilisationTab.table.row(FEE_RECORD_ID_ONE).within(() => {
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.facilityId(), FACILITY_ID_ONE);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), 'Exporter 1');
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), firstExporter);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.baseCurrency(), CURRENCY.GBP);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.value(), '1,000,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), '500,000.00');
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), firstUtilisationString);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.coverPercentage(), '80%');
       // 80% of 500,000 is 400,000
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.exposure(), '400,000.00');
@@ -133,15 +166,50 @@ context('Users can view utilisation', () => {
 
     pages.utilisationReportPage.utilisationTab.table.row(FEE_RECORD_ID_TWO).within(() => {
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.facilityId(), FACILITY_ID_TWO);
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), 'Exporter 2');
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), secondExporter);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.baseCurrency(), CURRENCY.GBP);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.value(), '300,000.00');
-      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), '199,999.99');
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), secondUtilisationString);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.coverPercentage(), '85%');
       // 85% of 199,999.99 is 169,999.9915
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.exposure(), '169,999.99');
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 200.00`);
       cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesPayable(), `${CURRENCY.GBP} 100.00`);
+    });
+
+    pages.utilisationReportPage.utilisationTab.table.row(FEE_RECORD_ID_THREE).within(() => {
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.facilityId(), FACILITY_ID_THREE);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exporter(), thirdExporter);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.baseCurrency(), CURRENCY.GBP);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.value(), '1,000,000.00');
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation(), thirdUtilisationString);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.coverPercentage(), '80%');
+      // 85% of 90,000 is 72,000
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.exposure(), '72,000.00');
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesAccrued(), `${CURRENCY.EUR} 200.00`);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.feesPayable(), `${CURRENCY.GBP} 100.00`);
+    });
+  });
+
+  describe('when sorting by ascending utilisation', () => {
+    it('should sort the reports correctly by utilisation', () => {
+      pages.utilisationReportPage.utilisationTab.table.utilisationHeader().click();
+
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(0), thirdUtilisationString);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(1), secondUtilisationString);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(2), firstUtilisationString);
+    });
+  });
+
+  describe('when sorting by descending utilisation', () => {
+    it('should sort the reports correctly by utilisation', () => {
+      // click twice for descending sort
+      pages.utilisationReportPage.utilisationTab.table.utilisationHeader().click();
+      pages.utilisationReportPage.utilisationTab.table.utilisationHeader().click();
+
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(0), firstUtilisationString);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(1), secondUtilisationString);
+      cy.assertText(pages.utilisationReportPage.utilisationTab.table.utilisation().eq(2), thirdUtilisationString);
     });
   });
 

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisation-reports/utilisationReportPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisation-reports/utilisationReportPage.js
@@ -70,6 +70,8 @@ const utilisationReportPage = {
     table: {
       row: (feeRecordId) => cy.get(`tr[data-cy="utilisation-table-row-${feeRecordId}"]`),
       utilisationHeader: () => cy.get('[data-cy="utilisation-header"]'),
+      valueHeader: () => cy.get('[data-cy="value-header"]'),
+      exposureHeader: () => cy.get('[data-cy="exposure-header"]'),
       facilityId: () => cy.get('[data-cy="facility-id"]'),
       exporter: () => cy.get('[data-cy="exporter"]'),
       baseCurrency: () => cy.get('[data-cy="base-currency"]'),

--- a/e2e-tests/tfm/cypress/e2e/pages/utilisation-reports/utilisationReportPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/utilisation-reports/utilisationReportPage.js
@@ -69,6 +69,7 @@ const utilisationReportPage = {
     downloadReportLink: () => cy.get('[data-cy="download-report-link"]'),
     table: {
       row: (feeRecordId) => cy.get(`tr[data-cy="utilisation-table-row-${feeRecordId}"]`),
+      utilisationHeader: () => cy.get('[data-cy="utilisation-header"]'),
       facilityId: () => cy.get('[data-cy="facility-id"]'),
       exporter: () => cy.get('[data-cy="exporter"]'),
       baseCurrency: () => cy.get('[data-cy="base-currency"]'),

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/utilisation-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/utilisation-table.component-test.ts
@@ -82,14 +82,14 @@ describe(component, () => {
     const tableRowSelector = `tbody tr[data-cy="utilisation-table-row-${feeRecordId}"]`;
 
     // Assert
-    wrapper.expectText(`${tableRowSelector} th`).toRead(row.facilityId);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(1)`).toRead(row.exporter);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(2)`).toRead(row.baseCurrency);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(3)`).toRead(row.formattedValue);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(4)`).toRead(row.formattedUtilisation);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(5)`).toRead(`${row.coverPercentage}%`);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(6)`).toRead(row.formattedExposure);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(7)`).toRead(row.feesAccrued.formattedCurrencyAndAmount);
-    wrapper.expectText(`${tableRowSelector} td:nth-of-type(8)`).toRead(row.feesPayable.formattedCurrencyAndAmount);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(1)`).toRead(row.facilityId);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(2)`).toRead(row.exporter);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(3)`).toRead(row.baseCurrency);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(4)`).toRead(row.formattedValue);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(5)`).toRead(row.formattedUtilisation);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(6)`).toRead(`${row.coverPercentage}%`);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(7)`).toRead(row.formattedExposure);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(8)`).toRead(row.feesAccrued.formattedCurrencyAndAmount);
+    wrapper.expectText(`${tableRowSelector} td:nth-of-type(9)`).toRead(row.feesPayable.formattedCurrencyAndAmount);
   });
 });

--- a/trade-finance-manager-ui/server/nunjucks-configuration/index.js
+++ b/trade-finance-manager-ui/server/nunjucks-configuration/index.js
@@ -54,6 +54,7 @@ const configureNunjucks = (opts) => {
   nunjucksEnvironment.addFilter('sentence', sentenceCase);
   nunjucksEnvironment.addFilter('userIsInTeam', (user, teamIdList) => userIsInTeam(user, teamIdList));
   nunjucksEnvironment.addFilter('userIsOnlyInTeams', (user, teamIdList) => userIsOnlyInTeams(user, teamIdList));
+  nunjucksEnvironment.addFilter('removeCommasAndFloat', (value) => parseFloat(value.replace(/,/g, '')));
 
   mojFilters = Object.assign(mojFilters);
   Object.keys(mojFilters).forEach((filterName) => {

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/utilisation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/utilisation-table.njk
@@ -18,13 +18,13 @@
     <tbody class="govuk-table__body">
       {% for utilisationTableRow in utilisationTableRows %}
         <tr class="govuk-table__row" data-cy="utilisation-table-row-{{ utilisationTableRow.feeRecordId }}">
-          <th class="govuk-table__cell" data-cy="facility-id">{{ utilisationTableRow.facilityId }}</th>
+          <td class="govuk-table__cell" data-cy="facility-id">{{ utilisationTableRow.facilityId }}</td>
           <td class="govuk-table__cell" data-cy="exporter">{{ utilisationTableRow.exporter }}</td>
           <td class="govuk-table__cell" data-cy="base-currency">{{ utilisationTableRow.baseCurrency }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="value">
             {{ utilisationTableRow.formattedValue }}
           </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="utilisation">
+          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="utilisation" data-sort-value="{{ utilisationTableRow.formattedUtilisation | float }}">
             {{ utilisationTableRow.formattedUtilisation }}
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="cover-percentage" data-sort-value="{{ utilisationTableRow.coverPercentage }}">

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/utilisation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/utilisation-table.njk
@@ -21,16 +21,16 @@
           <td class="govuk-table__cell" data-cy="facility-id">{{ utilisationTableRow.facilityId }}</td>
           <td class="govuk-table__cell" data-cy="exporter">{{ utilisationTableRow.exporter }}</td>
           <td class="govuk-table__cell" data-cy="base-currency">{{ utilisationTableRow.baseCurrency }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="value">
+          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="value" data-sort-value="{{ utilisationTableRow.formattedValue | removeCommasAndFloat }}">
             {{ utilisationTableRow.formattedValue }}
           </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="utilisation" data-sort-value="{{ utilisationTableRow.formattedUtilisation | float }}">
+          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="utilisation" data-sort-value="{{ utilisationTableRow.formattedUtilisation | removeCommasAndFloat }}">
             {{ utilisationTableRow.formattedUtilisation }}
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="cover-percentage" data-sort-value="{{ utilisationTableRow.coverPercentage }}">
             {{ utilisationTableRow.coverPercentage }}%
           </td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="exposure">
+          <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="exposure" data-sort-value="{{ utilisationTableRow.formattedExposure | removeCommasAndFloat }}">
             {{ utilisationTableRow.formattedExposure }}
           </td>
           <td class="govuk-table__cell govuk-table__cell--numeric" data-cy="fees-accrued" data-sort-value="{{ utilisationTableRow.feesAccrued.dataSortValue }}">


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an issue where the facility ids were bold on the utilisation tab and where utilisation, value and exposure were incorrectly sorted

## Resolution :heavy_check_mark:
* Changed from th to td for facilityId
* Added data-sort-value for utilisation and casted as float
* Added e2e tests
* Added removeCommasAndFloat to nunjucks config


