### PR TITLE
feat(FN-3550): use constant for fee record status everywhere

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/delete-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/delete-payment.api-test.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from 'axios';
-import { Currency, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { withSqlIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
 import { testApi } from '../../test-api';
 import { SqlDbHelper } from '../../sql-db-helper';
@@ -31,7 +31,12 @@ describe(`DELETE ${BASE_URL}`, () => {
 
   const feeRecordIds = [1, 2];
   const feeRecords = feeRecordIds.map((id) =>
-    FeeRecordEntityMockBuilder.forReport(report).withId(id).withStatus('MATCH').withPaymentCurrency(paymentCurrency).withPayments([payment]).build(),
+    FeeRecordEntityMockBuilder.forReport(report)
+      .withId(id)
+      .withStatus(FEE_RECORD_STATUS.MATCH)
+      .withPaymentCurrency(paymentCurrency)
+      .withPayments([payment])
+      .build(),
   );
   report.feeRecords = feeRecords;
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
@@ -1,6 +1,14 @@
 import { Response } from 'supertest';
 import { HttpStatusCode } from 'axios';
-import { Bank, Currency, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, ReportPeriod, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  Bank,
+  Currency,
+  FEE_RECORD_STATUS,
+  FeeRecordEntityMockBuilder,
+  PaymentEntityMockBuilder,
+  ReportPeriod,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { withSqlIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
 import { testApi } from '../../test-api';
 import { SqlDbHelper } from '../../sql-db-helper';
@@ -54,7 +62,7 @@ describe(`GET ${BASE_URL}`, () => {
       .withId(1)
       .withFacilityId('12345678')
       .withExporter('Test exporter 1')
-      .withStatus('MATCH')
+      .withStatus(FEE_RECORD_STATUS.MATCH)
       .withFeesPaidToUkefForThePeriod(75)
       .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
       .withPaymentCurrency(paymentCurrency)
@@ -64,7 +72,7 @@ describe(`GET ${BASE_URL}`, () => {
       .withId(2)
       .withFacilityId('87654321')
       .withExporter('Test exporter 2')
-      .withStatus('MATCH')
+      .withStatus(FEE_RECORD_STATUS.MATCH)
       .withFeesPaidToUkefForThePeriod(75)
       .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
       .withPaymentCurrency(paymentCurrency)
@@ -168,7 +176,7 @@ describe(`GET ${BASE_URL}`, () => {
         reportedFees: { currency: paymentCurrency, amount: 75 },
         reportedPayments: { currency: paymentCurrency, amount: 75 },
         paymentsReceived: [{ currency: paymentCurrency, amount: 75 }],
-        status: 'MATCH',
+        status: FEE_RECORD_STATUS.MATCH,
       },
       {
         id: 2,
@@ -177,7 +185,7 @@ describe(`GET ${BASE_URL}`, () => {
         reportedFees: { currency: paymentCurrency, amount: 75 },
         reportedPayments: { currency: paymentCurrency, amount: 75 },
         paymentsReceived: [{ currency: paymentCurrency, amount: 75 }],
-        status: 'MATCH',
+        status: FEE_RECORD_STATUS.MATCH,
       },
     ]);
   });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-fee-records-to-key.api-test.ts
@@ -197,8 +197,8 @@ describe(`GET ${BASE_URL}`, () => {
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
 
     const toDoFeeRecords = [
-      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('TO_DO').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('TO_DO').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.TO_DO).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.TO_DO).build(),
     ];
     report.feeRecords = toDoFeeRecords;
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-selected-fee-record-details.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-selected-fee-record-details.api-test.ts
@@ -119,7 +119,7 @@ describe(`GET ${BASE_URL}`, () => {
       .withFeesPaidToUkefForThePeriodCurrency('GBP')
       .withPaymentCurrency('USD')
       .withPayments([aPaymentInUSD])
-      .withStatus('MATCH')
+      .withStatus(FEE_RECORD_STATUS.MATCH)
       .build();
 
     report.feeRecords = [aFeeRecordInUSD, aFeeRecordInUSDWithAPaymentAttached];

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-selected-fee-record-details.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-selected-fee-record-details.api-test.ts
@@ -167,7 +167,7 @@ describe(`GET ${BASE_URL}`, () => {
       .withFeesPaidToUkefForThePeriod(100)
       .withFeesPaidToUkefForThePeriodCurrency('GBP')
       .withPaymentCurrency(paymentCurrency)
-      .withStatus('TO_DO')
+      .withStatus(FEE_RECORD_STATUS.TO_DO)
       .build();
   }
 });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-selected-fee-record-details.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-selected-fee-record-details.api-test.ts
@@ -2,6 +2,7 @@ import { Response } from 'supertest';
 import {
   Bank,
   Currency,
+  FEE_RECORD_STATUS,
   FeeRecordEntityMockBuilder,
   PaymentEntityMockBuilder,
   SelectedFeeRecordDetails,
@@ -72,7 +73,7 @@ describe(`GET ${BASE_URL}`, () => {
       .withFeesPaidToUkefForThePeriodCurrency('GBP')
       .withPaymentCurrency('GBP')
       .withPayments([aPaymentInGBP])
-      .withStatus('DOES_NOT_MATCH')
+      .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
       .build();
 
     report.feeRecords = [aFeeRecordInGBP, aFeeRecordInGBPWithAPaymentAttached];
@@ -104,7 +105,7 @@ describe(`GET ${BASE_URL}`, () => {
     });
   });
 
-  it("gets selected fee record details with canAddToExistingPayment set to false when a payment exists in the same currency but has no fee records with the 'DOES_NOT_MATCH' status", async () => {
+  it(`gets selected fee record details with canAddToExistingPayment set to false when a payment exists in the same currency but has no fee records with the ${FEE_RECORD_STATUS.DOES_NOT_MATCH} status`, async () => {
     // Arrange
     const report = aReconciliationInProgressReport();
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/patch-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/patch-payment.api-test.ts
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import { In } from 'typeorm';
 import { difference } from 'lodash';
 import {
+  FEE_RECORD_STATUS,
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
   FeeRecordStatus,
@@ -43,13 +44,13 @@ describe(`PATCH ${BASE_URL}`, () => {
   const feeRecordsForReportWithPayments = (report: UtilisationReportEntity, payments: PaymentEntity[]) => [
     FeeRecordEntityMockBuilder.forReport(report)
       .withId(1)
-      .withStatus('DOES_NOT_MATCH')
+      .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
       .withFeesPaidToUkefForThePeriodCurrency('GBP')
       .withPayments(payments)
       .build(),
     FeeRecordEntityMockBuilder.forReport(report)
       .withId(2)
-      .withStatus('DOES_NOT_MATCH')
+      .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
       .withFeesPaidToUkefForThePeriodCurrency('GBP')
       .withPayments(payments)
       .build(),
@@ -177,7 +178,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const feeRecords = [
       FeeRecordEntityMockBuilder.forReport(report)
         .withId(1)
-        .withStatus('DOES_NOT_MATCH')
+        .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
         .withFeesPaidToUkefForThePeriod(100)
         .withFeesPaidToUkefForThePeriodCurrency('GBP')
         .withPaymentCurrency('GBP')
@@ -185,7 +186,7 @@ describe(`PATCH ${BASE_URL}`, () => {
         .build(),
       FeeRecordEntityMockBuilder.forReport(report)
         .withId(2)
-        .withStatus('DOES_NOT_MATCH')
+        .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
         .withFeesPaidToUkefForThePeriod(200)
         .withFeesPaidToUkefForThePeriodCurrency('GBP')
         .withPaymentCurrency('GBP')
@@ -211,7 +212,7 @@ describe(`PATCH ${BASE_URL}`, () => {
 
     expect(oldFeeRecords).toHaveLength(feeRecords.length);
     oldFeeRecords.forEach((feeRecord) => {
-      expect(feeRecord.status).toBe<FeeRecordStatus>('DOES_NOT_MATCH');
+      expect(feeRecord.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.DOES_NOT_MATCH);
     });
 
     expect(newFeeRecords).toHaveLength(feeRecords.length);
@@ -267,7 +268,7 @@ describe(`PATCH ${BASE_URL}`, () => {
 
     expect(newFeeRecords).toHaveLength(feeRecords.length);
     newFeeRecords.forEach((feeRecord) => {
-      expect(feeRecord.status).toBe<FeeRecordStatus>('DOES_NOT_MATCH');
+      expect(feeRecord.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.DOES_NOT_MATCH);
     });
   });
 });

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/patch-payment.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/patch-payment.api-test.ts
@@ -217,7 +217,7 @@ describe(`PATCH ${BASE_URL}`, () => {
 
     expect(newFeeRecords).toHaveLength(feeRecords.length);
     newFeeRecords.forEach((feeRecord) => {
-      expect(feeRecord.status).toBe<FeeRecordStatus>('MATCH');
+      expect(feeRecord.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.MATCH);
     });
   });
 
@@ -229,7 +229,7 @@ describe(`PATCH ${BASE_URL}`, () => {
     const feeRecords = [
       FeeRecordEntityMockBuilder.forReport(report)
         .withId(1)
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(100)
         .withFeesPaidToUkefForThePeriodCurrency('GBP')
         .withPaymentCurrency('GBP')
@@ -237,7 +237,7 @@ describe(`PATCH ${BASE_URL}`, () => {
         .build(),
       FeeRecordEntityMockBuilder.forReport(report)
         .withId(2)
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(200)
         .withFeesPaidToUkefForThePeriodCurrency('GBP')
         .withPaymentCurrency('GBP')
@@ -263,7 +263,7 @@ describe(`PATCH ${BASE_URL}`, () => {
 
     expect(oldFeeRecords).toHaveLength(feeRecords.length);
     oldFeeRecords.forEach((feeRecord) => {
-      expect(feeRecord.status).toBe<FeeRecordStatus>('MATCH');
+      expect(feeRecord.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.MATCH);
     });
 
     expect(newFeeRecords).toHaveLength(feeRecords.length);

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-add-fees-to-an-existing-payment-group.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-add-fees-to-an-existing-payment-group.api-test.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from 'axios';
-import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { withSqlIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
 import { testApi } from '../../test-api';
 import { SqlDbHelper } from '../../sql-db-helper';
@@ -24,7 +24,11 @@ describe(`POST ${BASE_URL}`, () => {
   const payments = paymentIds.map((id) => PaymentEntityMockBuilder.forCurrency('GBP').withId(id).withFeeRecords([]).build());
 
   const aFeeRecordToAdd = FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).build();
-  const aFeeRecordWithPayments = FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withStatus('DOES_NOT_MATCH').withPayments(payments).build();
+  const aFeeRecordWithPayments = FeeRecordEntityMockBuilder.forReport(utilisationReport)
+    .withId(2)
+    .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
+    .withPayments(payments)
+    .build();
 
   utilisationReport.feeRecords = [aFeeRecordToAdd, aFeeRecordWithPayments];
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -109,8 +109,8 @@ describe(`POST ${BASE_URL}`, () => {
     // Arrange
     const report = anUploadedReconciliationInProgressUtilisationReport();
     const toDoFeeRecords = [
-      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('TO_DO').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('TO_DO').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.TO_DO).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.TO_DO).build(),
     ];
     report.feeRecords = toDoFeeRecords;
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -223,7 +223,7 @@ describe(`POST ${BASE_URL}`, () => {
       FeeRecordEntityMockBuilder.forReport(report)
         .withId(1)
         .withFacilityId(facilityId)
-        .withStatus('TO_DO')
+        .withStatus(FEE_RECORD_STATUS.TO_DO)
         .withLastUpdatedByPortalUserId(portalUserId)
         .withLastUpdatedByTfmUserId(null)
         .withLastUpdatedByIsSystemUser(false)
@@ -269,7 +269,7 @@ describe(`POST ${BASE_URL}`, () => {
     const secondFacilityId = '22222222';
     const feeRecords = [
       // Fee records for same facility where only one has MATCH status
-      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(firstFacilityId).withStatus('TO_DO').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(firstFacilityId).withStatus(FEE_RECORD_STATUS.TO_DO).build(),
       FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(firstFacilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
       // Fee records for same facility where both have MATCH status
       FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(secondFacilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
@@ -291,7 +291,7 @@ describe(`POST ${BASE_URL}`, () => {
 
     const allFeeRecords = await SqlDbHelper.manager.find(FeeRecordEntity, {});
     expect(allFeeRecords).toHaveLength(feeRecords.length);
-    expect(allFeeRecords.find(({ id }) => id === 1)!.status).toBe<FeeRecordStatus>('TO_DO');
+    expect(allFeeRecords.find(({ id }) => id === 1)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.TO_DO);
     expect(allFeeRecords.find(({ id }) => id === 2)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.READY_TO_KEY);
     expect(allFeeRecords.find(({ id }) => id === 3)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.READY_TO_KEY);
     expect(allFeeRecords.find(({ id }) => id === 4)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.READY_TO_KEY);
@@ -539,7 +539,7 @@ describe(`POST ${BASE_URL}`, () => {
         report.reportPeriod = currentReportPeriod;
 
         const toDoFeeRecord = FeeRecordEntityMockBuilder.forReport(report)
-          .withStatus('TO_DO')
+          .withStatus(FEE_RECORD_STATUS.TO_DO)
           .withId(toDoFeeRecordId)
           .withFacilityUtilisation(currentUtilisation)
           .withFacilityId(facilityId)
@@ -576,7 +576,7 @@ describe(`POST ${BASE_URL}`, () => {
 
       it('generates keying data for the last facility fee record which has been moved to READY_TO_KEY', async () => {
         // Arrange
-        const existingToDoFeeRecord = await SqlDbHelper.manager.findOneByOrFail(FeeRecordEntity, { id: toDoFeeRecordId, status: 'TO_DO' });
+        const existingToDoFeeRecord = await SqlDbHelper.manager.findOneByOrFail(FeeRecordEntity, { id: toDoFeeRecordId, status: FEE_RECORD_STATUS.TO_DO });
         existingToDoFeeRecord.status = FEE_RECORD_STATUS.MATCH;
         await SqlDbHelper.saveNewEntry('FeeRecord', existingToDoFeeRecord);
         await insertMatchingPaymentsForFeeRecords([existingToDoFeeRecord]);
@@ -594,7 +594,7 @@ describe(`POST ${BASE_URL}`, () => {
 
       it('updates the facility utilisation data table once all fee records for the facility have been moved to READY_TO_KEY', async () => {
         // Arrange
-        const existingToDoFeeRecord = await SqlDbHelper.manager.findOneByOrFail(FeeRecordEntity, { id: toDoFeeRecordId, status: 'TO_DO' });
+        const existingToDoFeeRecord = await SqlDbHelper.manager.findOneByOrFail(FeeRecordEntity, { id: toDoFeeRecordId, status: FEE_RECORD_STATUS.TO_DO });
         existingToDoFeeRecord.status = FEE_RECORD_STATUS.MATCH;
         await SqlDbHelper.saveNewEntry('FeeRecord', existingToDoFeeRecord);
         await insertMatchingPaymentsForFeeRecords([existingToDoFeeRecord]);

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -126,8 +126,8 @@ describe(`POST ${BASE_URL}`, () => {
     // Arrange
     const report = anUploadedReconciliationInProgressUtilisationReport();
     const feeRecords = [
-      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId('11111111').withStatus('MATCH').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId('22222222').withStatus('MATCH').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId('11111111').withStatus(FEE_RECORD_STATUS.MATCH).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId('22222222').withStatus(FEE_RECORD_STATUS.MATCH).build(),
     ];
     report.feeRecords = feeRecords;
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -148,7 +148,9 @@ describe(`POST ${BASE_URL}`, () => {
     // Arrange
     const report = anUploadedPendingReconciliationUtilisationReport();
     const facilityId = '11111111';
-    report.feeRecords = [FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withPayments([]).withStatus('MATCH').build()];
+    report.feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withPayments([]).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+    ];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
     await insertMatchingPaymentsForFeeRecords(report.feeRecords);
 
@@ -167,7 +169,9 @@ describe(`POST ${BASE_URL}`, () => {
     // Arrange
     const report = anUploadedPendingReconciliationUtilisationReport();
     const facilityId = '11111111';
-    report.feeRecords = [FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withPayments([]).withStatus('MATCH').build()];
+    report.feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withPayments([]).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+    ];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
     await insertMatchingPaymentsForFeeRecords(report.feeRecords);
 
@@ -188,8 +192,8 @@ describe(`POST ${BASE_URL}`, () => {
     const report = anUploadedReconciliationInProgressUtilisationReport();
     const facilityId = '11111111';
     const feeRecords = [
-      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withStatus('MATCH').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(facilityId).withStatus('MATCH').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
     ];
     report.feeRecords = feeRecords;
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -224,8 +228,8 @@ describe(`POST ${BASE_URL}`, () => {
         .withLastUpdatedByTfmUserId(null)
         .withLastUpdatedByIsSystemUser(false)
         .build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(facilityId).withStatus('MATCH').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(facilityId).withStatus('MATCH').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
     ];
     report.feeRecords = feeRecords;
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -266,10 +270,10 @@ describe(`POST ${BASE_URL}`, () => {
     const feeRecords = [
       // Fee records for same facility where only one has MATCH status
       FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(firstFacilityId).withStatus('TO_DO').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(firstFacilityId).withStatus('MATCH').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(firstFacilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
       // Fee records for same facility where both have MATCH status
-      FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(secondFacilityId).withStatus('MATCH').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(4).withFacilityId(secondFacilityId).withStatus('MATCH').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(secondFacilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(4).withFacilityId(secondFacilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
     ];
     report.feeRecords = feeRecords;
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -297,7 +301,7 @@ describe(`POST ${BASE_URL}`, () => {
     // Arrange
     const report = anUploadedReconciliationInProgressUtilisationReport();
     const firstFacilityId = '11111111';
-    const feeRecords = [FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(firstFacilityId).withStatus('MATCH').build()];
+    const feeRecords = [FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(firstFacilityId).withStatus(FEE_RECORD_STATUS.MATCH).build()];
     report.feeRecords = feeRecords;
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
     await insertMatchingPaymentsForFeeRecords(feeRecords);
@@ -371,7 +375,7 @@ describe(`POST ${BASE_URL}`, () => {
         .withId(1)
         .withFacilityId(facilityId)
         .withFacilityUtilisationData(utilisationData)
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFacilityUtilisation(1)
         .build(),
     ];
@@ -425,7 +429,7 @@ describe(`POST ${BASE_URL}`, () => {
         .withId(1)
         .withFacilityId(facilityId)
         .withFacilityUtilisationData(utilisationData)
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFacilityUtilisation(10000)
         .build(),
     ];
@@ -484,9 +488,9 @@ describe(`POST ${BASE_URL}`, () => {
       const report = anUploadedReconciliationInProgressUtilisationReport();
 
       const feeRecordsAtMatchStatus = [
-        FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withStatus('MATCH').build(),
-        FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(facilityId).withStatus('MATCH').build(),
-        FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(facilityId).withStatus('MATCH').build(),
+        FeeRecordEntityMockBuilder.forReport(report).withId(1).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+        FeeRecordEntityMockBuilder.forReport(report).withId(2).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+        FeeRecordEntityMockBuilder.forReport(report).withId(3).withFacilityId(facilityId).withStatus(FEE_RECORD_STATUS.MATCH).build(),
       ];
       report.feeRecords = feeRecordsAtMatchStatus;
       await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -546,13 +550,13 @@ describe(`POST ${BASE_URL}`, () => {
             .withId(2)
             .withFacilityId(facilityId)
             .withFacilityUtilisation(currentUtilisation)
-            .withStatus('MATCH')
+            .withStatus(FEE_RECORD_STATUS.MATCH)
             .build(),
           FeeRecordEntityMockBuilder.forReport(report)
             .withId(3)
             .withFacilityId(facilityId)
             .withFacilityUtilisation(currentUtilisation)
-            .withStatus('MATCH')
+            .withStatus(FEE_RECORD_STATUS.MATCH)
             .build(),
         ];
 
@@ -573,7 +577,7 @@ describe(`POST ${BASE_URL}`, () => {
       it('generates keying data for the last facility fee record which has been moved to READY_TO_KEY', async () => {
         // Arrange
         const existingToDoFeeRecord = await SqlDbHelper.manager.findOneByOrFail(FeeRecordEntity, { id: toDoFeeRecordId, status: 'TO_DO' });
-        existingToDoFeeRecord.status = 'MATCH';
+        existingToDoFeeRecord.status = FEE_RECORD_STATUS.MATCH;
         await SqlDbHelper.saveNewEntry('FeeRecord', existingToDoFeeRecord);
         await insertMatchingPaymentsForFeeRecords([existingToDoFeeRecord]);
 
@@ -591,7 +595,7 @@ describe(`POST ${BASE_URL}`, () => {
       it('updates the facility utilisation data table once all fee records for the facility have been moved to READY_TO_KEY', async () => {
         // Arrange
         const existingToDoFeeRecord = await SqlDbHelper.manager.findOneByOrFail(FeeRecordEntity, { id: toDoFeeRecordId, status: 'TO_DO' });
-        existingToDoFeeRecord.status = 'MATCH';
+        existingToDoFeeRecord.status = FEE_RECORD_STATUS.MATCH;
         await SqlDbHelper.saveNewEntry('FeeRecord', existingToDoFeeRecord);
         await insertMatchingPaymentsForFeeRecords([existingToDoFeeRecord]);
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -288,9 +288,9 @@ describe(`POST ${BASE_URL}`, () => {
     const allFeeRecords = await SqlDbHelper.manager.find(FeeRecordEntity, {});
     expect(allFeeRecords).toHaveLength(feeRecords.length);
     expect(allFeeRecords.find(({ id }) => id === 1)!.status).toBe<FeeRecordStatus>('TO_DO');
-    expect(allFeeRecords.find(({ id }) => id === 2)!.status).toBe<FeeRecordStatus>('READY_TO_KEY');
-    expect(allFeeRecords.find(({ id }) => id === 3)!.status).toBe<FeeRecordStatus>('READY_TO_KEY');
-    expect(allFeeRecords.find(({ id }) => id === 4)!.status).toBe<FeeRecordStatus>('READY_TO_KEY');
+    expect(allFeeRecords.find(({ id }) => id === 2)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.READY_TO_KEY);
+    expect(allFeeRecords.find(({ id }) => id === 3)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.READY_TO_KEY);
+    expect(allFeeRecords.find(({ id }) => id === 4)!.status).toBe<FeeRecordStatus>(FEE_RECORD_STATUS.READY_TO_KEY);
   });
 
   it('populates the fee record payment join table paymentAmountUsedForFeeRecord column', async () => {
@@ -464,7 +464,7 @@ describe(`POST ${BASE_URL}`, () => {
     const getReadyToKeyFeeRecordsWithNonNullKeyingData = async (): Promise<FeeRecordEntity[]> =>
       await SqlDbHelper.manager.find(FeeRecordEntity, {
         where: {
-          status: 'READY_TO_KEY',
+          status: FEE_RECORD_STATUS.READY_TO_KEY,
           fixedFeeAdjustment: Not(IsNull()),
           principalBalanceAdjustment: Not(IsNull()),
         },
@@ -473,7 +473,7 @@ describe(`POST ${BASE_URL}`, () => {
     const getReadyToKeyFeeRecordsWithNullKeyingData = async (): Promise<FeeRecordEntity[]> =>
       await SqlDbHelper.manager.find(FeeRecordEntity, {
         where: {
-          status: 'READY_TO_KEY',
+          status: FEE_RECORD_STATUS.READY_TO_KEY,
           fixedFeeAdjustment: IsNull(),
           principalBalanceAdjustment: IsNull(),
         },

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-remove-fees-from-payment-group.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-remove-fees-from-payment-group.api-test.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode } from 'axios';
-import { Currency, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { withSqlIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
 import { testApi } from '../../test-api';
 import { SqlDbHelper } from '../../sql-db-helper';
@@ -28,7 +28,12 @@ describe(`POST ${BASE_URL}`, () => {
 
   const feeRecordIds = [1, 2];
   const feeRecords = feeRecordIds.map((id) =>
-    FeeRecordEntityMockBuilder.forReport(report).withId(id).withStatus('MATCH').withPaymentCurrency(paymentCurrency).withPayments([payment]).build(),
+    FeeRecordEntityMockBuilder.forReport(report)
+      .withId(id)
+      .withStatus(FEE_RECORD_STATUS.MATCH)
+      .withPaymentCurrency(paymentCurrency)
+      .withPayments([payment])
+      .build(),
   );
   report.feeRecords = feeRecords;
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-done.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-done.api-test.ts
@@ -96,7 +96,7 @@ describe(`PUT ${BASE_URL}`, () => {
     // Arrange
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
     report.feeRecords = [feeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
 
@@ -144,7 +144,7 @@ describe(`PUT ${BASE_URL}`, () => {
     // Arrange
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
     const anotherFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [feeRecord, anotherFeeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
@@ -166,7 +166,7 @@ describe(`PUT ${BASE_URL}`, () => {
     // Arrange
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
     const anotherFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('MATCH').build();
     report.feeRecords = [feeRecord, anotherFeeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-done.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-done.api-test.ts
@@ -145,7 +145,7 @@ describe(`PUT ${BASE_URL}`, () => {
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
     const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
-    const anotherFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('RECONCILED').build();
+    const anotherFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [feeRecord, anotherFeeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-done.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-done.api-test.ts
@@ -167,7 +167,7 @@ describe(`PUT ${BASE_URL}`, () => {
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
     const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
-    const anotherFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('MATCH').build();
+    const anotherFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.MATCH).build();
     report.feeRecords = [feeRecord, anotherFeeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-to-do.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/put-keying-data-mark-as-to-do.api-test.ts
@@ -96,7 +96,7 @@ describe(`PUT ${BASE_URL}`, () => {
     // Arrange
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').withId(reportId).build();
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [feeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
 
@@ -144,7 +144,7 @@ describe(`PUT ${BASE_URL}`, () => {
     // Arrange
     const reportId = 1;
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withId(reportId).build();
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [feeRecord];
     await SqlDbHelper.saveNewEntry('UtilisationReport', report);
 

--- a/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.test.ts
+++ b/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_PLATFORM_TYPE, DbRequestSource, FeeRecordEntity, FeeRecordStatus, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { REQUEST_PLATFORM_TYPE, DbRequestSource, FeeRecordEntity, FeeRecordStatus, UtilisationReportEntity, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
 import { feeRecordCsvRowToSqlEntity } from './fee-record-csv-row-mapper';
 import { UtilisationReportRawCsvData } from '../types/utilisation-reports';
 import { aUtilisationReportRawCsvData } from '../../test-helpers';
@@ -68,7 +68,7 @@ describe('fee-record-helpers', () => {
       expect(feeRecordEntity.status).toEqual<FeeRecordStatus>('TO_DO');
     });
 
-    it('sets the entity status to MATCH when fees paid to ukef for the period is zero', () => {
+    it(`sets the entity status to ${FEE_RECORD_STATUS.MATCH} when fees paid to ukef for the period is zero`, () => {
       // Act
       const feeRecordEntity = feeRecordCsvRowToSqlEntity({
         dataEntry: { ...aUtilisationReportRawCsvData(), 'fees paid to ukef for the period': '0.00' },
@@ -78,7 +78,7 @@ describe('fee-record-helpers', () => {
 
       // Assert
       expect(feeRecordEntity instanceof FeeRecordEntity).toEqual(true);
-      expect(feeRecordEntity.status).toEqual<FeeRecordStatus>('MATCH');
+      expect(feeRecordEntity.status).toEqual<FeeRecordStatus>(FEE_RECORD_STATUS.MATCH);
     });
 
     it('converts the numeric string columns to numbers', () => {

--- a/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.test.ts
+++ b/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.test.ts
@@ -65,7 +65,7 @@ describe('fee-record-helpers', () => {
 
       // Assert
       expect(feeRecordEntity instanceof FeeRecordEntity).toEqual(true);
-      expect(feeRecordEntity.status).toEqual<FeeRecordStatus>('TO_DO');
+      expect(feeRecordEntity.status).toEqual<FeeRecordStatus>(FEE_RECORD_STATUS.TO_DO);
     });
 
     it(`sets the entity status to ${FEE_RECORD_STATUS.MATCH} when fees paid to ukef for the period is zero`, () => {

--- a/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.ts
+++ b/dtfs-central-api/src/helpers/fee-record-csv-row-mapper.ts
@@ -1,4 +1,4 @@
-import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, UTILISATION_REPORT_HEADERS, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, UTILISATION_REPORT_HEADERS, FeeRecordStatus, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
 import { UtilisationReportRawCsvData } from '../types/utilisation-reports';
 
 type FeeRecordCsvRowToSqlEntityParams = {
@@ -22,7 +22,7 @@ const asNumberOrDefault = (maybeString: string | undefined, defaultNumber: numbe
  */
 export const feeRecordCsvRowToSqlEntity = ({ dataEntry, requestSource, report }: FeeRecordCsvRowToSqlEntityParams): FeeRecordEntity => {
   const feesPaidToUkefForThePeriod = Number(dataEntry[UTILISATION_REPORT_HEADERS.FEES_PAID_IN_PERIOD]);
-  const status: FeeRecordStatus = feesPaidToUkefForThePeriod === 0 ? 'MATCH' : 'TO_DO';
+  const status: FeeRecordStatus = feesPaidToUkefForThePeriod === 0 ? FEE_RECORD_STATUS.MATCH : FEE_RECORD_STATUS.TO_DO;
 
   return FeeRecordEntity.create({
     facilityId: dataEntry[UTILISATION_REPORT_HEADERS.UKEF_FACILITY_ID],

--- a/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
+++ b/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
@@ -28,7 +28,7 @@ describe('keying sheet mapping', () => {
 
     it('maps the fee record RECONCILED status to the keying sheet DONE status', () => {
       // Arrange
-      const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('RECONCILED').build();
+      const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
 
       // Act
       const keyingSheetRow = mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments(feeRecordEntity);

--- a/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
+++ b/dtfs-central-api/src/mapping/keying-sheet-mapping.test.ts
@@ -17,7 +17,7 @@ describe('keying sheet mapping', () => {
 
     it('maps the fee record READY_TO_KEY status to the keying sheet TO_DO status', () => {
       // Arrange
-      const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').build();
+      const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
       // Act
       const keyingSheetRow = mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments(feeRecordEntity);
@@ -40,7 +40,7 @@ describe('keying sheet mapping', () => {
     it('maps the fee record entity id, facility id, exporter and base currency', () => {
       // Arrange
       const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('READY_TO_KEY')
+        .withStatus(FEE_RECORD_STATUS.READY_TO_KEY)
         .withId(123)
         .withFacilityId('12345678')
         .withExporter('Test exporter')
@@ -66,7 +66,10 @@ describe('keying sheet mapping', () => {
       'sets the keying sheet row fixedFeeAdjustment to $expectedMappedValue when the fee record entity fixedFeeAdjustment $condition',
       ({ value, expectedMappedValue }) => {
         // Arrange
-        const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withFixedFeeAdjustment(value).build();
+        const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
+          .withStatus(FEE_RECORD_STATUS.READY_TO_KEY)
+          .withFixedFeeAdjustment(value)
+          .build();
 
         // Act
         const keyingSheetRow = mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments(feeRecordEntity);
@@ -86,7 +89,7 @@ describe('keying sheet mapping', () => {
       ({ value, expectedMappedValue }) => {
         // Arrange
         const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-          .withStatus('READY_TO_KEY')
+          .withStatus(FEE_RECORD_STATUS.READY_TO_KEY)
           .withPrincipalBalanceAdjustment(value)
           .build();
 
@@ -100,7 +103,7 @@ describe('keying sheet mapping', () => {
 
     it('does not set the keying sheet row feePayments field', () => {
       // Arrange
-      const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').build();
+      const feeRecordEntity = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
       // Act
       const keyingSheetRow = mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments(feeRecordEntity);

--- a/dtfs-central-api/src/mapping/keying-sheet-mapping.ts
+++ b/dtfs-central-api/src/mapping/keying-sheet-mapping.ts
@@ -1,13 +1,13 @@
-import { FeeRecordEntity, KeyingSheetAdjustment, KeyingSheetRowStatus, PaymentEntity } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntity, KEYING_SHEET_ROW_STATUS, KeyingSheetAdjustment, KeyingSheetRowStatus, PaymentEntity } from '@ukef/dtfs2-common';
 import Big from 'big.js';
 import { KeyingSheetFeePayment, KeyingSheetRow } from '../types/fee-records';
 
 const mapFeeRecordEntityToKeyingSheetRowStatus = (feeRecord: FeeRecordEntity): KeyingSheetRowStatus => {
   switch (feeRecord.status) {
-    case 'READY_TO_KEY':
-      return 'TO_DO';
-    case 'RECONCILED':
-      return 'DONE';
+    case FEE_RECORD_STATUS.READY_TO_KEY:
+      return KEYING_SHEET_ROW_STATUS.TO_DO;
+    case FEE_RECORD_STATUS.RECONCILED:
+      return KEYING_SHEET_ROW_STATUS.DONE;
     default:
       throw new Error(`Cannot get keying sheet status for fee record with status '${feeRecord.status}'`);
   }

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -35,7 +35,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
     userId,
   };
 
-  const aMatchingFeeRecord = () => FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').build();
+  const aMatchingFeeRecord = () => FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
   const facility = aFacility();
 
@@ -127,7 +127,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fees paid to ukef is non zero`, async () => {
       // Arrange
       const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(0.01)
         .build();
       jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(0);
@@ -147,7 +147,10 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fixed fee adjustment is greater than zero`, async () => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').withFeesPaidToUkefForThePeriod(0).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .withFeesPaidToUkefForThePeriod(0)
+        .build();
       jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(0);
       jest.mocked(calculateFixedFeeAdjustment).mockResolvedValue(0.01);
 
@@ -165,7 +168,10 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fixed fee adjustment is less than zero`, async () => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').withFeesPaidToUkefForThePeriod(0).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .withFeesPaidToUkefForThePeriod(0)
+        .build();
       jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(0);
       jest.mocked(calculateFixedFeeAdjustment).mockResolvedValue(-0.01);
 
@@ -183,7 +189,10 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the principal balance adjustment is greater than zero`, async () => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').withFeesPaidToUkefForThePeriod(0).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .withFeesPaidToUkefForThePeriod(0)
+        .build();
       jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(0.01);
       jest.mocked(calculateFixedFeeAdjustment).mockResolvedValue(0);
 
@@ -201,7 +210,10 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the principal balance adjustment is less than zero`, async () => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').withFeesPaidToUkefForThePeriod(0).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .withFeesPaidToUkefForThePeriod(0)
+        .build();
       jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(-0.01);
       jest.mocked(calculateFixedFeeAdjustment).mockResolvedValue(0);
 
@@ -219,7 +231,10 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.RECONCILED}' if the principal balance adjustment, fixed fee adjustment and fees paid to ukef for the period are all zero`, async () => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').withFeesPaidToUkefForThePeriod(0).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .withFeesPaidToUkefForThePeriod(0)
+        .build();
       jest.mocked(calculatePrincipalBalanceAdjustment).mockReturnValue(0);
       jest.mocked(calculateFixedFeeAdjustment).mockResolvedValue(0);
 
@@ -371,7 +386,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
     it(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if fees paid to ukef is greater than zero`, async () => {
       // Arrange
       const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(0.01)
         .build();
 
@@ -389,7 +404,10 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
     it(`updates the fee record status to '${FEE_RECORD_STATUS.RECONCILED}' if fees paid to ukef is equal to zero`, async () => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport()).withStatus('MATCH').withFeesPaidToUkefForThePeriod(0).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aReconciliationInProgressReport())
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .withFeesPaidToUkefForThePeriod(0)
+        .build();
 
       // Act
       await handleFeeRecordGenerateKeyingDataEvent(feeRecord, {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordStatus, ReportPeriod } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus, ReportPeriod } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 import { calculatePrincipalBalanceAdjustment, calculateFixedFeeAdjustment, updateFacilityUtilisationData } from '../helpers';
 import { calculateUkefShareOfUtilisation, getLatestTfmFacilityValues } from '../../../../../helpers';
@@ -68,7 +68,9 @@ function getStatusToUpdateTo(
   fixedFeeAdjustment: number = 0,
   principalBalanceAdjustment: number = 0,
 ): Extract<FeeRecordStatus, 'READY_TO_KEY' | 'RECONCILED'> {
-  return feeRecordCanBeAutoReconciled(feesPaidToUkefForThePeriod, fixedFeeAdjustment, principalBalanceAdjustment) ? 'RECONCILED' : 'READY_TO_KEY';
+  return feeRecordCanBeAutoReconciled(feesPaidToUkefForThePeriod, fixedFeeAdjustment, principalBalanceAdjustment)
+    ? FEE_RECORD_STATUS.RECONCILED
+    : FEE_RECORD_STATUS.READY_TO_KEY;
 }
 
 function feeRecordCanBeAutoReconciled(feesPaidToUkefForThePeriod: number, fixedFeeAdjustment: number, principalBalanceAdjustment: number): boolean {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.test.ts
@@ -61,7 +61,7 @@ describe('handleFeeRecordMarkAsReconciledEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toEqual<FeeRecordStatus>('RECONCILED');
+    expect(feeRecord.status).toEqual<FeeRecordStatus>(FEE_RECORD_STATUS.RECONCILED);
   });
 
   it('sets the dateReconciled to the current date and reconciledByUserId field to the supplied value', async () => {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.test.ts
@@ -36,7 +36,7 @@ describe('handleFeeRecordMarkAsReconciledEvent', () => {
 
   it('saves the updated fee record with the supplied entity manager', async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus('READY_TO_KEY').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
     // Act
     await handleFeeRecordMarkAsReconciledEvent(feeRecord, {
@@ -51,7 +51,7 @@ describe('handleFeeRecordMarkAsReconciledEvent', () => {
 
   it('sets the fee record status to RECONCILED', async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus('READY_TO_KEY').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
     // Act
     await handleFeeRecordMarkAsReconciledEvent(feeRecord, {
@@ -87,7 +87,7 @@ describe('handleFeeRecordMarkAsReconciledEvent', () => {
   it('updates the last updated by user fields using the db request source', async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT)
-      .withStatus('READY_TO_KEY')
+      .withStatus(FEE_RECORD_STATUS.READY_TO_KEY)
       .withLastUpdatedByIsSystemUser(true)
       .withLastUpdatedByPortalUserId('123')
       .withLastUpdatedByTfmUserId(null)

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.test.ts
@@ -35,7 +35,7 @@ describe('handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent', () => {
   it('updates the last updated by fields to the request source', async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT)
-      .withStatus('MATCH')
+      .withStatus(FEE_RECORD_STATUS.MATCH)
       .withLastUpdatedByIsSystemUser(true)
       .withLastUpdatedByPortalUserId(null)
       .withLastUpdatedByTfmUserId(null)

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 
 type OtherFeeRecordAddedToPaymentGroupEventPayload = {
@@ -23,7 +23,7 @@ export const handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: OtherFeeRecordAddedToPaymentGroupEventPayload,
 ): Promise<FeeRecordEntity> => {
-  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? 'MATCH' : 'DOES_NOT_MATCH';
+  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? FEE_RECORD_STATUS.MATCH : FEE_RECORD_STATUS.DOES_NOT_MATCH;
   feeRecord.updateWithStatus({ status, requestSource });
   return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.test.ts
@@ -35,7 +35,7 @@ describe('handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent', () => {
   it('updates the last updated by fields to the request source', async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT)
-      .withStatus('MATCH')
+      .withStatus(FEE_RECORD_STATUS.MATCH)
       .withLastUpdatedByIsSystemUser(true)
       .withLastUpdatedByPortalUserId(null)
       .withLastUpdatedByTfmUserId(null)

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 
 type OtherFeeRemovedFromPaymentGroupEventPayload = {
@@ -26,7 +26,7 @@ export const handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: OtherFeeRemovedFromPaymentGroupEventPayload,
 ): Promise<FeeRecordEntity> => {
-  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? 'MATCH' : 'DOES_NOT_MATCH';
+  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? FEE_RECORD_STATUS.MATCH : FEE_RECORD_STATUS.DOES_NOT_MATCH;
   feeRecord.updateWithStatus({ status, requestSource });
   return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.test.ts
@@ -18,7 +18,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
 
   it('saves the updated fee record with the supplied entity manager', async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentAddedEvent(feeRecord, {
@@ -38,7 +38,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
     "sets the fee record status to '$expectedStatus' when the event payload 'feeRecordsAndPaymentsMatch' is '$feeRecordsAndPaymentsMatch'",
     async ({ feeRecordsAndPaymentsMatch, expectedStatus }) => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
       // Act
       await handleFeeRecordPaymentAddedEvent(feeRecord, {
@@ -54,7 +54,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
 
   it("sets the fee record 'lastUpdatedByIsSystemUser' field to false", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentAddedEvent(feeRecord, {
@@ -69,7 +69,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
 
   it("sets the fee record 'lastUpdatedByPortalUserId' to null", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentAddedEvent(feeRecord, {
@@ -84,7 +84,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
 
   it("sets the fee record 'lastUpdatedByTfmUserId' to the request source user id", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentAddedEvent(feeRecord, {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 
 type PaymentAddedEventPayload = {
@@ -23,7 +23,7 @@ export const handleFeeRecordPaymentAddedEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: PaymentAddedEventPayload,
 ): Promise<FeeRecordEntity> => {
-  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? 'MATCH' : 'DOES_NOT_MATCH';
+  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? FEE_RECORD_STATUS.MATCH : FEE_RECORD_STATUS.DOES_NOT_MATCH;
   feeRecord.updateWithStatus({ status, requestSource });
   return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { handleFeeRecordPaymentDeletedEvent } from './payment-deleted.event-handler';
 import { aDbRequestSource } from '../../../../../../test-helpers';
 
@@ -13,7 +13,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
 
   it("sets the fee record status to 'MATCH' when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is true", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('DOES_NOT_MATCH').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH).build();
 
     // Act
     await handleFeeRecordPaymentDeletedEvent(feeRecord, {
@@ -27,7 +27,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     expect(feeRecord.status).toEqual('MATCH');
   });
 
-  it("sets the fee record status to 'DOES_NOT_MATCH' when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is true", async () => {
+  it(`sets the fee record status to ${FEE_RECORD_STATUS.DOES_NOT_MATCH} when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is true`, async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('MATCH').build();
 
@@ -40,7 +40,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toEqual('DOES_NOT_MATCH');
+    expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.DOES_NOT_MATCH);
   });
 
   it("sets the fee record status to 'TO_DO' when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is false", async () => {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
@@ -43,7 +43,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.DOES_NOT_MATCH);
   });
 
-  it("sets the fee record status to 'TO_DO' when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is false", async () => {
+  it(`sets the fee record status to ${FEE_RECORD_STATUS.TO_DO} when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is false`, async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
@@ -56,7 +56,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toEqual('TO_DO');
+    expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.TO_DO);
   });
 
   it("throws an error when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is false", async () => {
@@ -77,7 +77,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
   it('updates the last updated by fields to the request source', async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT)
-      .withStatus('TO_DO')
+      .withStatus(FEE_RECORD_STATUS.TO_DO)
       .withLastUpdatedByIsSystemUser(true)
       .withLastUpdatedByPortalUserId(null)
       .withLastUpdatedByTfmUserId(null)

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
@@ -11,7 +11,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     save: mockSave,
   } as unknown as EntityManager;
 
-  it("sets the fee record status to 'MATCH' when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is true", async () => {
+  it(`sets the fee record status to ${FEE_RECORD_STATUS.MATCH} when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is true`, async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH).build();
 
@@ -24,12 +24,12 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toEqual('MATCH');
+    expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.MATCH);
   });
 
   it(`sets the fee record status to ${FEE_RECORD_STATUS.DOES_NOT_MATCH} when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is true`, async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('MATCH').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
     // Act
     await handleFeeRecordPaymentDeletedEvent(feeRecord, {
@@ -45,7 +45,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
 
   it("sets the fee record status to 'TO_DO' when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is false", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('MATCH').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
     // Act
     await handleFeeRecordPaymentDeletedEvent(feeRecord, {
@@ -61,7 +61,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
 
   it("throws an error when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is false", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('MATCH').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
     // Act / Assert
     await expect(

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 
 type PaymentDeletedEventPayload = {
@@ -26,7 +26,7 @@ export const handleFeeRecordPaymentDeletedEvent = async (
   { transactionEntityManager, feeRecordsAndPaymentsMatch, hasAttachedPayments, requestSource }: PaymentDeletedEventPayload,
 ): Promise<FeeRecordEntity> => {
   if (hasAttachedPayments) {
-    const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? 'MATCH' : 'DOES_NOT_MATCH';
+    const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? FEE_RECORD_STATUS.MATCH : FEE_RECORD_STATUS.DOES_NOT_MATCH;
     feeRecord.updateWithStatus({ status, requestSource });
     return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
   }

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
@@ -35,6 +35,6 @@ export const handleFeeRecordPaymentDeletedEvent = async (
     throw new Error('Fee records and payments cannot match when there are no attached payments');
   }
 
-  feeRecord.updateWithStatus({ status: 'TO_DO', requestSource });
+  feeRecord.updateWithStatus({ status: FEE_RECORD_STATUS.TO_DO, requestSource });
   return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.test.ts
@@ -18,7 +18,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
 
   it('saves the updated fee record with the supplied entity manager', async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentEditedEvent(feeRecord, {
@@ -38,7 +38,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
     "sets the fee record status to '$expectedStatus' when the event payload 'feeRecordsAndPaymentsMatch' is '$feeRecordsAndPaymentsMatch'",
     async ({ feeRecordsAndPaymentsMatch, expectedStatus }) => {
       // Arrange
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
       // Act
       await handleFeeRecordPaymentEditedEvent(feeRecord, {
@@ -54,7 +54,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
 
   it("sets the fee record 'lastUpdatedByIsSystemUser' field to false", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentEditedEvent(feeRecord, {
@@ -69,7 +69,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
 
   it("sets the fee record 'lastUpdatedByPortalUserId' to null", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentEditedEvent(feeRecord, {
@@ -84,7 +84,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
 
   it("sets the fee record 'lastUpdatedByTfmUserId' to the request source user id", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus('TO_DO').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     // Act
     await handleFeeRecordPaymentEditedEvent(feeRecord, {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
 
 type PaymentEditedEventPayload = {
@@ -23,7 +23,7 @@ export const handleFeeRecordPaymentEditedEvent = async (
   feeRecord: FeeRecordEntity,
   { transactionEntityManager, feeRecordsAndPaymentsMatch, requestSource }: PaymentEditedEventPayload,
 ): Promise<FeeRecordEntity> => {
-  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? 'MATCH' : 'DOES_NOT_MATCH';
+  const status: FeeRecordStatus = feeRecordsAndPaymentsMatch ? FEE_RECORD_STATUS.MATCH : FEE_RECORD_STATUS.DOES_NOT_MATCH;
   feeRecord.updateWithStatus({ status, requestSource });
   return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
@@ -36,7 +36,7 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
     expect(feeRecord.payments).toHaveLength(0);
   });
 
-  it("sets the fee record status to 'TO_DO'", async () => {
+  it(`sets the fee record status to ${FEE_RECORD_STATUS.TO_DO}`, async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
@@ -47,7 +47,7 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
     });
 
     // Assert
-    expect(feeRecord.status).toEqual('TO_DO');
+    expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.TO_DO);
   });
 
   it('updates the last updated by fields to the request source', async () => {

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
@@ -1,5 +1,11 @@
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntity, FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  FEE_RECORD_STATUS,
+  FeeRecordEntity,
+  FeeRecordEntityMockBuilder,
+  PaymentEntityMockBuilder,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { handleFeeRecordRemoveFromPaymentGroupEvent } from './remove-from-payment-group.event-handler';
 import { aDbRequestSource } from '../../../../../../test-helpers';
 
@@ -32,7 +38,7 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
 
   it("sets the fee record status to 'TO_DO'", async () => {
     // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus('MATCH').build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
     // Act
     await handleFeeRecordRemoveFromPaymentGroupEvent(feeRecord, {
@@ -47,7 +53,7 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
   it('updates the last updated by fields to the request source', async () => {
     // Arrange
     const feeRecord = FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT)
-      .withStatus('MATCH')
+      .withStatus(FEE_RECORD_STATUS.MATCH)
       .withLastUpdatedByIsSystemUser(true)
       .withLastUpdatedByPortalUserId(null)
       .withLastUpdatedByTfmUserId(null)

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
@@ -327,7 +327,7 @@ describe('FeeRecordStateMachine', () => {
 
   describe(`when the fee record has the '${FEE_RECORD_STATUS.READY_TO_KEY}' status`, () => {
     // Arrange
-    const READY_TO_KEY_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus('READY_TO_KEY').build();
+    const READY_TO_KEY_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
     it(`handles the '${FEE_RECORD_EVENT_TYPE.MARK_AS_RECONCILED}' event`, async () => {
       // Arrange

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
@@ -33,7 +33,7 @@ describe('FeeRecordStateMachine', () => {
 
   describe(`when the fee record has the '${FEE_RECORD_STATUS.TO_DO}' status`, () => {
     // Arrange
-    const TO_DO_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus('TO_DO').build();
+    const TO_DO_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus(FEE_RECORD_STATUS.TO_DO).build();
 
     const VALID_TO_DO_FEE_RECORD_EVENT_TYPES: FeeRecordEventType[] = ['PAYMENT_ADDED'];
     const INVALID_TO_DO_FEE_RECORD_EVENT_TYPES = difference(FEE_RECORD_EVENT_TYPES, VALID_TO_DO_FEE_RECORD_EVENT_TYPES);

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
@@ -366,7 +366,7 @@ describe('FeeRecordStateMachine', () => {
 
   describe(`when the fee record has the '${FEE_RECORD_STATUS.RECONCILED}' status`, () => {
     // Arrange
-    const RECONCILED_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus('RECONCILED').build();
+    const RECONCILED_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
 
     it(`handles the '${FEE_RECORD_EVENT_TYPE.MARK_AS_READY_TO_KEY}' event`, async () => {
       // Arrange

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
@@ -190,7 +190,7 @@ describe('FeeRecordStateMachine', () => {
 
   describe(`when the fee record has the '${FEE_RECORD_STATUS.DOES_NOT_MATCH}' status`, () => {
     // Arrange
-    const DOES_NOT_MATCH_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus('DOES_NOT_MATCH').build();
+    const DOES_NOT_MATCH_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH).build();
 
     it(`handles the '${FEE_RECORD_EVENT_TYPE.PAYMENT_EDITED}' event`, async () => {
       // Arrange

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
@@ -72,7 +72,7 @@ describe('FeeRecordStateMachine', () => {
 
   describe(`when the fee record has the '${FEE_RECORD_STATUS.MATCH}' status`, () => {
     // Arrange
-    const MATCH_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus('MATCH').build();
+    const MATCH_FEE_RECORD = FeeRecordEntityMockBuilder.forReport(UPLOADED_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
     it(`handles the '${FEE_RECORD_EVENT_TYPE.PAYMENT_EDITED}' event`, async () => {
       // Arrange

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.ts
@@ -1,4 +1,4 @@
-import { FeeRecordEntity } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntity } from '@ukef/dtfs2-common';
 import { InvalidStateMachineTransitionError, NotFoundError } from '../../../errors';
 import { FeeRecordRepo } from '../../../repositories/fee-record-repo';
 import { FeeRecordEvent } from './event/fee-record.event';
@@ -70,14 +70,14 @@ export class FeeRecordStateMachine {
    */
   public async handleEvent(event: FeeRecordEvent): Promise<FeeRecordEntity> {
     switch (this.feeRecord.status) {
-      case 'TO_DO':
+      case FEE_RECORD_STATUS.TO_DO:
         switch (event.type) {
           case 'PAYMENT_ADDED':
             return handleFeeRecordPaymentAddedEvent(this.feeRecord, event.payload);
           default:
             return this.handleInvalidTransition(event);
         }
-      case 'MATCH':
+      case FEE_RECORD_STATUS.MATCH:
         switch (event.type) {
           case 'PAYMENT_DELETED':
             return handleFeeRecordPaymentDeletedEvent(this.feeRecord, event.payload);
@@ -92,7 +92,7 @@ export class FeeRecordStateMachine {
           default:
             return this.handleInvalidTransition(event);
         }
-      case 'DOES_NOT_MATCH':
+      case FEE_RECORD_STATUS.DOES_NOT_MATCH:
         switch (event.type) {
           case 'PAYMENT_ADDED':
             return handleFeeRecordPaymentAddedEvent(this.feeRecord, event.payload);
@@ -109,14 +109,14 @@ export class FeeRecordStateMachine {
           default:
             return this.handleInvalidTransition(event);
         }
-      case 'READY_TO_KEY':
+      case FEE_RECORD_STATUS.READY_TO_KEY:
         switch (event.type) {
           case 'MARK_AS_RECONCILED':
             return handleFeeRecordMarkAsReconciledEvent(this.feeRecord, event.payload);
           default:
             return this.handleInvalidTransition(event);
         }
-      case 'RECONCILED':
+      case FEE_RECORD_STATUS.RECONCILED:
         switch (event.type) {
           case 'MARK_AS_READY_TO_KEY':
             return handleFeeRecordMarkAsReadyToKeyEvent(this.feeRecord, event.payload);

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -82,7 +82,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
     expect(mockFind).toHaveBeenCalledWith(FeeRecordEntity, {
       where: {
         report: { id: utilisationReport.id },
-        status: In(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
+        status: In([FEE_RECORD_STATUS.TO_DO, FEE_RECORD_STATUS.DOES_NOT_MATCH]),
       },
     });
 
@@ -133,7 +133,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
       expect(mockFind).toHaveBeenCalledWith(FeeRecordEntity, {
         where: {
           report: { id: utilisationReport.id },
-          status: In(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
+          status: In([FEE_RECORD_STATUS.TO_DO, FEE_RECORD_STATUS.DOES_NOT_MATCH]),
         },
       });
 
@@ -179,7 +179,10 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
 
       jest.spyOn(FeeRecordStateMachine, 'forFeeRecord').mockImplementation((feeRecord) => feeRecordStateMachines[feeRecord.id]);
 
-      const toDoFeeRecordWithSameFacilityId = FeeRecordEntityMockBuilder.forReport(utilisationReport).withStatus('TO_DO').withFacilityId(facilityId).build();
+      const toDoFeeRecordWithSameFacilityId = FeeRecordEntityMockBuilder.forReport(utilisationReport)
+        .withStatus(FEE_RECORD_STATUS.TO_DO)
+        .withFacilityId(facilityId)
+        .build();
       mockFind.mockResolvedValue([toDoFeeRecordWithSameFacilityId]);
 
       // Act
@@ -193,7 +196,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
       expect(mockFind).toHaveBeenCalledWith(FeeRecordEntity, {
         where: {
           report: { id: utilisationReport.id },
-          status: In(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
+          status: In([FEE_RECORD_STATUS.TO_DO, FEE_RECORD_STATUS.DOES_NOT_MATCH]),
         },
       });
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -7,6 +7,7 @@ import {
   FeeRecordEntity,
   UtilisationReportReconciliationStatus,
   FeeRecordPaymentJoinTableEntity,
+  FEE_RECORD_STATUS,
 } from '@ukef/dtfs2-common';
 import { handleUtilisationReportGenerateKeyingDataEvent } from './generate-keying-data.event-handler';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
@@ -81,7 +82,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
     expect(mockFind).toHaveBeenCalledWith(FeeRecordEntity, {
       where: {
         report: { id: utilisationReport.id },
-        status: In(['TO_DO', 'DOES_NOT_MATCH']),
+        status: In(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
       },
     });
 
@@ -132,7 +133,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
       expect(mockFind).toHaveBeenCalledWith(FeeRecordEntity, {
         where: {
           report: { id: utilisationReport.id },
-          status: In(['TO_DO', 'DOES_NOT_MATCH']),
+          status: In(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
         },
       });
 
@@ -192,7 +193,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
       expect(mockFind).toHaveBeenCalledWith(FeeRecordEntity, {
         where: {
           report: { id: utilisationReport.id },
-          status: In(['TO_DO', 'DOES_NOT_MATCH']),
+          status: In(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
         },
       });
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -34,7 +34,7 @@ describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
   const aReconciliationInProgressReport = () => UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
 
   const aMatchedFeeRecordForReportWithFacilityId = (report: UtilisationReportEntity, facilityId: string) =>
-    FeeRecordEntityMockBuilder.forReport(report).withStatus('MATCH').withFacilityId(facilityId).build();
+    FeeRecordEntityMockBuilder.forReport(report).withStatus(FEE_RECORD_STATUS.MATCH).withFacilityId(facilityId).build();
 
   const aMockEventHandler = () => jest.fn();
   const aMockFeeRecordStateMachine = (eventHandler: jest.Mock): FeeRecordStateMachine =>

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -1,5 +1,12 @@
 import { EntityManager, In } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, FeeRecordPaymentJoinTableEntity, FeeRecordStatus, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  FEE_RECORD_STATUS,
+  FeeRecordEntity,
+  FeeRecordPaymentJoinTableEntity,
+  FeeRecordStatus,
+  UtilisationReportEntity,
+} from '@ukef/dtfs2-common';
 import { BaseUtilisationReportEvent } from '../../event/base-utilisation-report.event';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
 import { KeyingSheetFeePaymentShare, getKeyingSheetFeePaymentSharesForFeeRecords } from '../helpers';
@@ -14,7 +21,7 @@ const getFacilityIdsAtToDoOrDoesNotMatchStatus = async (entityManager: EntityMan
   const feeRecordsAtToDoOrDoesNotMatchStatus = await entityManager.find(FeeRecordEntity, {
     where: {
       report: { id: reportId },
-      status: In<FeeRecordStatus>(['TO_DO', 'DOES_NOT_MATCH']),
+      status: In<FeeRecordStatus>(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
     },
   });
   return feeRecordsAtToDoOrDoesNotMatchStatus.reduce((facilityIds, { facilityId }) => facilityIds.add(facilityId), new Set<string>());

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -21,7 +21,7 @@ const getFacilityIdsAtToDoOrDoesNotMatchStatus = async (entityManager: EntityMan
   const feeRecordsAtToDoOrDoesNotMatchStatus = await entityManager.find(FeeRecordEntity, {
     where: {
       report: { id: reportId },
-      status: In<FeeRecordStatus>(['TO_DO', FEE_RECORD_STATUS.DOES_NOT_MATCH]),
+      status: In<FeeRecordStatus>([FEE_RECORD_STATUS.TO_DO, FEE_RECORD_STATUS.DOES_NOT_MATCH]),
     },
   });
   return feeRecordsAtToDoOrDoesNotMatchStatus.reduce((facilityIds, { facilityId }) => facilityIds.add(facilityId), new Set<string>());

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/get-keying-sheet-fee-payment-shares-for-fee-records.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/get-keying-sheet-fee-payment-shares-for-fee-records.test.ts
@@ -1,4 +1,4 @@
-import { Currency, FeeRecordEntity, FeeRecordEntityMockBuilder, PaymentEntity, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, PaymentEntity, PaymentEntityMockBuilder } from '@ukef/dtfs2-common';
 import { KeyingSheetFeePaymentShare, getKeyingSheetFeePaymentSharesForFeeRecords } from './get-keying-sheet-fee-payment-shares-for-fee-records';
 import { aUtilisationReport } from '../../../../../../test-helpers';
 
@@ -13,7 +13,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
       const feeRecordId = 456;
       const matchFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withId(feeRecordId)
         .withPaymentCurrency(paymentCurrency)
         .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -41,7 +41,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
       const feeRecordId = 456;
       const matchFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withId(feeRecordId)
         .withPaymentCurrency(paymentCurrency)
         .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -67,7 +67,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
     const aMatchFeeRecordWithIdAmountAndPayment = (id: number, amount: number, payment: PaymentEntity) =>
       FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withId(id)
         .withPaymentCurrency(paymentCurrency)
         .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -146,7 +146,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
       const feeRecordId = 123;
       const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withId(feeRecordId)
         .withPaymentCurrency(paymentCurrency)
         .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -180,7 +180,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
         const feeRecordId = 123;
         const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withId(feeRecordId)
           .withPaymentCurrency(paymentCurrency)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -210,7 +210,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
         const feeRecordId = 123;
         const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withId(feeRecordId)
           .withPaymentCurrency(paymentCurrency)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
@@ -241,7 +241,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
 
     const aFeeRecordWithIdAmountAndPayments = (id: number, amount: number, payments: PaymentEntity[]) =>
       FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withId(id)
         .withFeesPaidToUkefForThePeriod(amount)
         .withPaymentCurrency(paymentCurrency)
@@ -387,7 +387,7 @@ describe('getKeyingSheetFeePaymentSharesForFeeRecords', () => {
   describe('when the fee records have no attached payments and have been automatically moved to the MATCH status', () => {
     it('does not return any fee payments', () => {
       // Arrange
-      const matchFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('MATCH').withPayments([]).build();
+      const matchFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.MATCH).withPayments([]).build();
 
       // Act
       const result = getKeyingSheetFeePaymentSharesForFeeRecords([matchFeeRecord]);

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.test.ts
@@ -1,5 +1,11 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntityMockBuilder, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  FEE_RECORD_STATUS,
+  FeeRecordEntityMockBuilder,
+  UtilisationReportEntity,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent } from './mark-fee-records-as-ready-to-key.event-handler';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
 
@@ -34,9 +40,9 @@ describe('handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent', () => {
   it('calls the fee record state machine with the MARK_AS_READY_TO_KEY event for every fee record to reconcile', async () => {
     // Arrange
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
-    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('RECONCILED').build();
-    const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus('RECONCILED').build();
+    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [firstFeeRecord, secondFeeRecord, thirdFeeRecord];
 
     const firstEventHandler = aMockEventHandler();
@@ -84,9 +90,9 @@ describe('handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent', () => {
   it('updates the report status to RECONCILIATION_IN_PROGRESS if report status is RECONCILIATION_COMPLETED', async () => {
     // Arrange
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').build();
-    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
-    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('RECONCILED').build();
-    const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus('RECONCILED').build();
+    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [firstFeeRecord, secondFeeRecord, thirdFeeRecord];
 
     // Act
@@ -111,9 +117,9 @@ describe('handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent', () => {
   it('does not update the report status if the status is already RECONCILIATION_IN_PROGRESS', async () => {
     // Arrange
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
-    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('RECONCILED').build();
-    const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus('RECONCILED').build();
+    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     report.feeRecords = [firstFeeRecord, secondFeeRecord, thirdFeeRecord];
 
     // Act

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.test.ts
@@ -53,8 +53,8 @@ describe('handleUtilisationReportMarkFeeRecordsAsReconciledEvent', () => {
   describe('when every fee record has to be reconciled', () => {
     // Arrange
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
-    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('READY_TO_KEY').build();
+    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
+    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
     const eventHandlerOne = aMockEventHandler();
     const eventHandlerTwo = aMockEventHandler();
@@ -115,8 +115,8 @@ describe('handleUtilisationReportMarkFeeRecordsAsReconciledEvent', () => {
   describe('when all fee records are reconciled', () => {
     // Arrange
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
-    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('READY_TO_KEY').build();
+    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
+    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
     const reportWithUpdatedFeeRecords = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
     const feeRecordOneUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
@@ -159,13 +159,13 @@ describe('handleUtilisationReportMarkFeeRecordsAsReconciledEvent', () => {
   describe('when only some fee records are reconciled', () => {
     // Arrange
     const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('READY_TO_KEY').build();
-    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('READY_TO_KEY').build();
+    const feeRecordOne = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
+    const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
     const reportWithUpdatedFeeRecords = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
     const feeRecordOneUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     const feeRecordTwoUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
-    const feeRecordThreeUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus('READY_TO_KEY').build();
+    const feeRecordThreeUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
     reportWithUpdatedFeeRecords.feeRecords = [feeRecordOneUpdated, feeRecordTwoUpdated, feeRecordThreeUpdated];
 
     beforeEach(async () => {

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.test.ts
@@ -1,5 +1,11 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntityMockBuilder, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  FEE_RECORD_STATUS,
+  FeeRecordEntityMockBuilder,
+  UtilisationReportEntity,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { handleUtilisationReportMarkFeeRecordsAsReconciledEvent } from './mark-fee-records-as-reconciled.event-handler';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
 import externalApi from '../../../../../external-api/api';
@@ -113,9 +119,9 @@ describe('handleUtilisationReportMarkFeeRecordsAsReconciledEvent', () => {
     const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('READY_TO_KEY').build();
 
     const reportWithUpdatedFeeRecords = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const feeRecordOneUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
-    const feeRecordTwoUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('RECONCILED').build();
-    const feeRecordThreeUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus('RECONCILED').build();
+    const feeRecordOneUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const feeRecordTwoUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const feeRecordThreeUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     reportWithUpdatedFeeRecords.feeRecords = [feeRecordOneUpdated, feeRecordTwoUpdated, feeRecordThreeUpdated];
 
     beforeEach(async () => {
@@ -157,8 +163,8 @@ describe('handleUtilisationReportMarkFeeRecordsAsReconciledEvent', () => {
     const feeRecordTwo = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('READY_TO_KEY').build();
 
     const reportWithUpdatedFeeRecords = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    const feeRecordOneUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('RECONCILED').build();
-    const feeRecordTwoUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('RECONCILED').build();
+    const feeRecordOneUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+    const feeRecordTwoUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
     const feeRecordThreeUpdated = FeeRecordEntityMockBuilder.forReport(report).withId(3).withStatus('READY_TO_KEY').build();
     reportWithUpdatedFeeRecords.feeRecords = [feeRecordOneUpdated, feeRecordTwoUpdated, feeRecordThreeUpdated];
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, UtilisationReportEntity } from '@ukef/dtfs2-common';
 import { BaseUtilisationReportEvent } from '../../event/base-utilisation-report.event';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
 import { SendReportReconciledEmail } from '../helpers/send-report-reconciled-email';
@@ -51,7 +51,7 @@ export const handleUtilisationReportMarkFeeRecordsAsReconciledEvent = async (
       relations: { feeRecords: true },
     });
 
-    if (allFeeRecords.every((record) => record.status === 'RECONCILED')) {
+    if (allFeeRecords.every((record) => record.status === FEE_RECORD_STATUS.RECONCILED)) {
       report.updateWithStatus({ status: 'RECONCILIATION_COMPLETED', requestSource });
       await transactionEntityManager.save(UtilisationReportEntity, report);
       await SendReportReconciledEmail(report);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.test.ts
@@ -19,7 +19,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
     it('maps the fee record id to the fee record to key id', () => {
       // Arrange
       const id = 1;
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('MATCH').withId(id).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.MATCH).withId(id).build();
 
       // Act
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
@@ -31,7 +31,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
     it('maps the fee record facilityId to the fee record to key facilityId', () => {
       // Arrange
       const facilityId = '12345678';
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('MATCH').withFacilityId(facilityId).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.MATCH).withFacilityId(facilityId).build();
 
       // Act
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
@@ -43,7 +43,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
     it('maps the fee record exporter to the fee record to key exporter', () => {
       // Arrange
       const exporter = 'Test exporter';
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('MATCH').withExporter(exporter).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.MATCH).withExporter(exporter).build();
 
       // Act
       const feeRecordsToKey = mapToFeeRecordsToKey([feeRecord]);
@@ -69,7 +69,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const amount = 123;
       const currency = CURRENCY.GBP;
       const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(amount)
         .withFeesPaidToUkefForThePeriodCurrency(currency)
         .build();
@@ -89,7 +89,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const amount = 123;
       const currency = CURRENCY.GBP;
       const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(amount)
         .withFeesPaidToUkefForThePeriodCurrency(currency)
         .withPaymentCurrency(currency)
@@ -111,7 +111,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const paymentCurrency = CURRENCY.GBP;
       const exchangeRate = 1.1;
       const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withFeesPaidToUkefForThePeriod(amount)
         .withFeesPaidToUkefForThePeriodCurrency('EUR')
         .withPaymentCurrency(paymentCurrency)
@@ -146,14 +146,14 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const secondFeesPaid = 200;
       const feeRecords = [
         FeeRecordEntityMockBuilder.forReport(utilisationReport)
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withFeesPaidToUkefForThePeriod(firstFeesPaid)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
           .withPaymentCurrency(paymentCurrency)
           .withPayments(payments)
           .build(),
         FeeRecordEntityMockBuilder.forReport(utilisationReport)
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withFeesPaidToUkefForThePeriod(secondFeesPaid)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
           .withPaymentCurrency(paymentCurrency)
@@ -192,14 +192,14 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const secondFeesPaid = 200;
       const feeRecords = [
         FeeRecordEntityMockBuilder.forReport(utilisationReport)
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withFeesPaidToUkefForThePeriod(firstFeesPaid)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
           .withPaymentCurrency(paymentCurrency)
           .withPayments(payments)
           .build(),
         FeeRecordEntityMockBuilder.forReport(utilisationReport)
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withFeesPaidToUkefForThePeriod(secondFeesPaid)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
           .withPaymentCurrency(paymentCurrency)
@@ -235,7 +235,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const amount = 100;
       const feeRecords = [
         FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withFeesPaidToUkefForThePeriod(amount)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
           .withPaymentCurrency(paymentCurrency)
@@ -272,7 +272,7 @@ describe('get-fee-records-to-key.controller helpers', () => {
       const amount = 100;
       const feeRecords = [
         FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withFeesPaidToUkefForThePeriod(amount)
           .withFeesPaidToUkefForThePeriodCurrency(paymentCurrency)
           .withPaymentCurrency(paymentCurrency)

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/helpers.ts
@@ -1,4 +1,4 @@
-import { CurrencyAndAmount, FeeRecordEntity } from '@ukef/dtfs2-common';
+import { CurrencyAndAmount, FEE_RECORD_STATUS, FeeRecordEntity } from '@ukef/dtfs2-common';
 import { FeeRecordToKey } from '../../../../types/fee-records';
 import { getFeeRecordPaymentEntityGroups } from '../../../../helpers';
 import { mapFeeRecordEntityToReportedFees, mapFeeRecordEntityToReportedPayments } from '../../../../mapping/fee-record-mapper';
@@ -25,8 +25,8 @@ const mapToFeeRecordToKey = (feeRecordEntity: FeeRecordEntity, paymentsReceived:
  * @throws {Error} If the supplied fee records are not all at the 'MATCH' status
  */
 export const mapToFeeRecordsToKey = (feeRecordEntities: FeeRecordEntity[]): FeeRecordToKey[] => {
-  if (feeRecordEntities.some(({ status }) => status !== 'MATCH')) {
-    throw new Error("All fee records must have 'MATCH' status to get fee records to key");
+  if (feeRecordEntities.some(({ status }) => status !== FEE_RECORD_STATUS.MATCH)) {
+    throw new Error(`All fee records must have ${FEE_RECORD_STATUS.MATCH} status to get fee records to key`);
   }
 
   const feeRecordPaymentEntityGroups = getFeeRecordPaymentEntityGroups(feeRecordEntities);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/index.test.ts
@@ -16,7 +16,7 @@ describe('get-fee-records-to-key.controller', () => {
     const aUtilisationReportWithFeeRecordsAndPayments = () => {
       const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
       const payments = [PaymentEntityMockBuilder.forCurrency('GBP').build()];
-      const feeRecords = [FeeRecordEntityMockBuilder.forReport(report).withStatus('MATCH').withPayments(payments).build()];
+      const feeRecords = [FeeRecordEntityMockBuilder.forReport(report).withStatus(FEE_RECORD_STATUS.MATCH).withPayments(payments).build()];
       report.feeRecords = feeRecords;
       return report;
     };

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-fee-records-to-key.controller/index.ts
@@ -1,6 +1,6 @@
 import { HttpStatusCode } from 'axios';
 import { Request, Response } from 'express';
-import { ReportPeriod, SessionBank } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, ReportPeriod, SessionBank } from '@ukef/dtfs2-common';
 import { UtilisationReportRepo } from '../../../../repositories/utilisation-reports-repo';
 import { getBankNameById } from '../../../../repositories/banks-repo';
 import { ApiError, NotFoundError } from '../../../../errors';
@@ -20,7 +20,7 @@ export const getFeeRecordsToKey = async (req: Request, res: GetFeeRecordsToKeyRe
   const { reportId } = req.params;
 
   try {
-    const utilisationReport = await UtilisationReportRepo.findOneByIdWithFeeRecordsFilteredByStatusWithPayments(Number(reportId), ['MATCH']);
+    const utilisationReport = await UtilisationReportRepo.findOneByIdWithFeeRecordsFilteredByStatusWithPayments(Number(reportId), [FEE_RECORD_STATUS.MATCH]);
     if (!utilisationReport) {
       throw new NotFoundError(`Failed to find a report with id ${reportId}`);
     }

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.test.ts
@@ -1,5 +1,6 @@
 import {
   CurrencyAndAmount,
+  FEE_RECORD_STATUS,
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
   PaymentEntityMockBuilder,
@@ -309,7 +310,7 @@ describe('get selected fee record details controller helpers', () => {
       // Arrange
       const existsUnmatchedPaymentSpy = jest.spyOn(PaymentRepo, 'existsUnmatchedPaymentOfCurrencyForReportWithId').mockResolvedValue(true);
       const aUtilisationReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport).withPaymentCurrency('USD').withStatus('READY_TO_KEY').build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport).withPaymentCurrency('USD').withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
 
       // Act
       const result = await canFeeRecordsBeAddedToExistingPayment('123', [feeRecord]);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.test.ts
@@ -335,6 +335,6 @@ describe('get selected fee record details controller helpers', () => {
 
   function aFeeRecordWithStatusToDo(): FeeRecordEntity {
     const aUtilisationReport = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-    return FeeRecordEntityMockBuilder.forReport(aUtilisationReport).withPaymentCurrency('GBP').withStatus('TO_DO').build();
+    return FeeRecordEntityMockBuilder.forReport(aUtilisationReport).withPaymentCurrency('GBP').withStatus(FEE_RECORD_STATUS.TO_DO).build();
   }
 });

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.test.ts
@@ -237,12 +237,12 @@ describe('get selected fee record details controller helpers', () => {
       const firstFeeRecordEntity = FeeRecordEntityMockBuilder.forReport(UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build())
         .withId(1)
         .withPayments([firstPaymentEntity, secondPaymentEntity])
-        .withStatus('DOES_NOT_MATCH')
+        .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
         .build();
       const secondFeeRecordEntity = FeeRecordEntityMockBuilder.forReport(UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build())
         .withId(2)
         .withPayments([thirdPaymentEntity])
-        .withStatus('DOES_NOT_MATCH')
+        .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
         .build();
 
       const mockFeeRecordEntities: FeeRecordEntity[] = [firstFeeRecordEntity, secondFeeRecordEntity];

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-selected-fee-records-details.controller/helpers.ts
@@ -8,6 +8,7 @@ import {
   SelectedFeeRecordsDetails,
   SelectedFeeRecordsPaymentDetails,
   SelectedFeeRecordsAvailablePaymentGroups,
+  FEE_RECORD_STATUS,
 } from '@ukef/dtfs2-common';
 import { getBankNameById } from '../../../../repositories/banks-repo';
 import { NotFoundError } from '../../../../errors';
@@ -73,7 +74,7 @@ export const canFeeRecordsBeAddedToExistingPayment = async (reportId: string, fe
     return false;
   }
 
-  const anyFeeRecordDoesNotHaveStatusToDo = feeRecords.some((record) => record.status !== 'TO_DO');
+  const anyFeeRecordDoesNotHaveStatusToDo = feeRecords.some((record) => record.status !== FEE_RECORD_STATUS.TO_DO);
   if (anyFeeRecordDoesNotHaveStatusToDo) {
     return false;
   }

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
@@ -53,7 +53,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -92,7 +92,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -146,7 +146,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -185,7 +185,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -226,7 +226,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -268,7 +268,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -290,7 +290,7 @@ describe('getKeyingSheetForReportId', () => {
   });
 
   describe('when there are fee records with no payments', () => {
-    const FEE_RECORD_STATUSES_TO_INCLUDE_IN_KEYING_SHEET: FeeRecordStatus[] = ['READY_TO_KEY', 'RECONCILED'];
+    const FEE_RECORD_STATUSES_TO_INCLUDE_IN_KEYING_SHEET: FeeRecordStatus[] = ['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED];
 
     it.each(FEE_RECORD_STATUSES_TO_INCLUDE_IN_KEYING_SHEET)(
       'sets the fee record fee payment to a zero amount fee payment when a %s fee record has no payments',
@@ -308,7 +308,7 @@ describe('getKeyingSheetForReportId', () => {
             where: {
               feeRecord: {
                 report: { id: reportId },
-                status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+                status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
               },
             },
             relations: {
@@ -355,7 +355,7 @@ describe('getKeyingSheetForReportId', () => {
             where: {
               feeRecord: {
                 report: { id: reportId },
-                status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+                status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
               },
             },
             relations: {
@@ -393,7 +393,7 @@ describe('getKeyingSheetForReportId', () => {
           where: {
             feeRecord: {
               report: { id: reportId },
-              status: In<FeeRecordStatus>(['READY_TO_KEY', 'RECONCILED']),
+              status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
             },
           },
           relations: {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.test.ts
@@ -38,8 +38,8 @@ describe('getKeyingSheetForReportId', () => {
     const secondPayment = PaymentEntityMockBuilder.forCurrency('GBP').withId(22).build();
     const thirdPayment = PaymentEntityMockBuilder.forCurrency('GBP').withId(33).build();
 
-    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(12).build();
-    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(24).build();
+    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(12).build();
+    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(24).build();
 
     const joinTableEntities = [
       aFeeRecordPaymentJoinTableEntityWith({ feeRecord: firstFeeRecord, payment: firstPayment, paymentAmountUsedForFeeRecord: 1 }),
@@ -53,7 +53,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+            status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -76,7 +76,7 @@ describe('getKeyingSheetForReportId', () => {
 
     const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
       .withId(12)
-      .withStatus('READY_TO_KEY')
+      .withStatus(FEE_RECORD_STATUS.READY_TO_KEY)
       .withFacilityId('11111111')
       .withExporter('Test exporter 1')
       .withBaseCurrency('GBP')
@@ -92,7 +92,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+            status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -118,14 +118,14 @@ describe('getKeyingSheetForReportId', () => {
 
   it('creates a keying sheet row fee payments item for each payment attached to the same unique fee record in the join table', async () => {
     // Arrange
-    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(12).build();
+    const firstFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(12).build();
     const firstFeeRecordPayments = [
       PaymentEntityMockBuilder.forCurrency('GBP').withId(11).build(),
       PaymentEntityMockBuilder.forCurrency('GBP').withId(12).build(),
       PaymentEntityMockBuilder.forCurrency('GBP').withId(13).build(),
     ];
 
-    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(13).build();
+    const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(13).build();
     const secondFeeRecordPayments = [
       PaymentEntityMockBuilder.forCurrency('GBP').withId(21).build(),
       PaymentEntityMockBuilder.forCurrency('GBP').withId(22).build(),
@@ -146,7 +146,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+            status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -171,7 +171,7 @@ describe('getKeyingSheetForReportId', () => {
     const secondPayment = PaymentEntityMockBuilder.forCurrency('GBP').withId(22).build();
     const thirdPayment = PaymentEntityMockBuilder.forCurrency('GBP').withId(33).build();
 
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(12).build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(12).build();
 
     const joinTableEntities = [
       aFeeRecordPaymentJoinTableEntityWith({ feeRecord, payment: firstPayment, paymentAmountUsedForFeeRecord: 1000 }),
@@ -185,7 +185,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+            status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -212,7 +212,7 @@ describe('getKeyingSheetForReportId', () => {
     const secondPayment = PaymentEntityMockBuilder.forCurrency('USD').withDateReceived(new Date('2022')).withId(22).build();
     const thirdPayment = PaymentEntityMockBuilder.forCurrency('EUR').withDateReceived(new Date('2023')).withId(33).build();
 
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(12).build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(12).build();
 
     const joinTableEntities = [
       aFeeRecordPaymentJoinTableEntityWith({ feeRecord, payment: firstPayment, paymentAmountUsedForFeeRecord: 1000 }),
@@ -226,7 +226,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+            status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -255,7 +255,7 @@ describe('getKeyingSheetForReportId', () => {
     const firstPayment = PaymentEntityMockBuilder.forCurrency('GBP').withId(11).withDateReceived(new Date('2021')).build();
     const secondPayment = PaymentEntityMockBuilder.forCurrency('USD').withId(22).withDateReceived(new Date('2022')).build();
 
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(12).build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(12).build();
 
     const joinTableEntities = [
       aFeeRecordPaymentJoinTableEntityWith({ feeRecord, payment: firstPayment, paymentAmountUsedForFeeRecord: 1000 }),
@@ -268,7 +268,7 @@ describe('getKeyingSheetForReportId', () => {
         where: {
           feeRecord: {
             report: { id: reportId },
-            status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+            status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
           },
         },
         relations: {
@@ -290,7 +290,7 @@ describe('getKeyingSheetForReportId', () => {
   });
 
   describe('when there are fee records with no payments', () => {
-    const FEE_RECORD_STATUSES_TO_INCLUDE_IN_KEYING_SHEET: FeeRecordStatus[] = ['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED];
+    const FEE_RECORD_STATUSES_TO_INCLUDE_IN_KEYING_SHEET: FeeRecordStatus[] = [FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED];
 
     it.each(FEE_RECORD_STATUSES_TO_INCLUDE_IN_KEYING_SHEET)(
       'sets the fee record fee payment to a zero amount fee payment when a %s fee record has no payments',
@@ -308,7 +308,7 @@ describe('getKeyingSheetForReportId', () => {
             where: {
               feeRecord: {
                 report: { id: reportId },
-                status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+                status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
               },
             },
             relations: {
@@ -336,7 +336,7 @@ describe('getKeyingSheetForReportId', () => {
         // Arrange
         const firstPayment = PaymentEntityMockBuilder.forCurrency('GBP').withId(11).withDateReceived(new Date('2021')).build();
 
-        const feeRecordWithPayment = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withId(12).build();
+        const feeRecordWithPayment = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withId(12).build();
         const feeRecordWithoutPayment = FeeRecordEntityMockBuilder.forReport(aUtilisationReport())
           .withStatus(status)
           .withPaymentCurrency('EUR')
@@ -355,7 +355,7 @@ describe('getKeyingSheetForReportId', () => {
             where: {
               feeRecord: {
                 report: { id: reportId },
-                status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+                status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
               },
             },
             relations: {
@@ -385,7 +385,7 @@ describe('getKeyingSheetForReportId', () => {
         PaymentEntityMockBuilder.forCurrency('GBP').withAmount(1000).build(),
         PaymentEntityMockBuilder.forCurrency('GBP').withAmount(1000).build(),
       ];
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus('READY_TO_KEY').withPayments(payments).build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(aUtilisationReport()).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).withPayments(payments).build();
 
       const reportId = 123;
       when(mockFind)
@@ -393,7 +393,7 @@ describe('getKeyingSheetForReportId', () => {
           where: {
             feeRecord: {
               report: { id: reportId },
-              status: In<FeeRecordStatus>(['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED]),
+              status: In<FeeRecordStatus>([FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED]),
             },
           },
           relations: {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.ts
@@ -5,7 +5,7 @@ import { SqlDbDataSource } from '@ukef/dtfs2-common/sql-db-connection';
 import { mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments } from '../../../../../mapping/keying-sheet-mapping';
 import { KeyingSheet, KeyingSheetFeePayment, KeyingSheetRow } from '../../../../../types/fee-records';
 
-const STATUSES_OF_FEE_RECORDS_TO_DISPLAY_ON_KEYING_SHEET: FeeRecordStatus[] = ['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED];
+const STATUSES_OF_FEE_RECORDS_TO_DISPLAY_ON_KEYING_SHEET: FeeRecordStatus[] = [FEE_RECORD_STATUS.READY_TO_KEY, FEE_RECORD_STATUS.RECONCILED];
 
 /**
  * Gets all the keying sheet fee record payment join table entries

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-keying-sheet-for-report-id.ts
@@ -1,11 +1,11 @@
 import { In } from 'typeorm';
 import { remove } from 'lodash';
-import { FeeRecordEntity, FeeRecordPaymentJoinTableEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordPaymentJoinTableEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { SqlDbDataSource } from '@ukef/dtfs2-common/sql-db-connection';
 import { mapFeeRecordEntityToKeyingSheetRowWithoutFeePayments } from '../../../../../mapping/keying-sheet-mapping';
 import { KeyingSheet, KeyingSheetFeePayment, KeyingSheetRow } from '../../../../../types/fee-records';
 
-const STATUSES_OF_FEE_RECORDS_TO_DISPLAY_ON_KEYING_SHEET: FeeRecordStatus[] = ['READY_TO_KEY', 'RECONCILED'];
+const STATUSES_OF_FEE_RECORDS_TO_DISPLAY_ON_KEYING_SHEET: FeeRecordStatus[] = ['READY_TO_KEY', FEE_RECORD_STATUS.RECONCILED];
 
 /**
  * Gets all the keying sheet fee record payment join table entries

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.test.ts
@@ -45,8 +45,11 @@ describe('reconciliation-summary-item-mapper', () => {
     it('does not count reconciled fee records in the reported fees left to reconcile', () => {
       // Arrange
       const report = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
-      const aNotYetReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus('READY_TO_KEY').build();
-      const anotherNotYetReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('5555').withStatus('READY_TO_KEY').build();
+      const aNotYetReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
+      const anotherNotYetReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report)
+        .withFacilityId('5555')
+        .withStatus(FEE_RECORD_STATUS.READY_TO_KEY)
+        .build();
       const aReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus(FEE_RECORD_STATUS.RECONCILED).build();
       const anotherReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('2222').withStatus(FEE_RECORD_STATUS.RECONCILED).build();
       report.feeRecords = [aNotYetReconciledFeeRecord, anotherNotYetReconciledFeeRecord, aReconciledFeeRecord, anotherReconciledFeeRecord];

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.test.ts
@@ -80,7 +80,7 @@ describe('reconciliation-summary-item-mapper', () => {
     it('sets the reported fees left to reconcile to zero if the report is reconciled but not all fee records are', () => {
       // Arrange
       const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_COMPLETED').withFeeRecords([]).build();
-      const aNotReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus('TO_DO').build();
+      const aNotReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus(FEE_RECORD_STATUS.TO_DO).build();
       report.feeRecords = [aNotReconciledFeeRecord];
 
       // Act

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.test.ts
@@ -47,8 +47,8 @@ describe('reconciliation-summary-item-mapper', () => {
       const report = UtilisationReportEntityMockBuilder.forStatus('PENDING_RECONCILIATION').build();
       const aNotYetReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus('READY_TO_KEY').build();
       const anotherNotYetReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('5555').withStatus('READY_TO_KEY').build();
-      const aReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus('RECONCILED').build();
-      const anotherReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('2222').withStatus('RECONCILED').build();
+      const aReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('1111').withStatus(FEE_RECORD_STATUS.RECONCILED).build();
+      const anotherReconciledFeeRecord = FeeRecordEntityMockBuilder.forReport(report).withFacilityId('2222').withStatus(FEE_RECORD_STATUS.RECONCILED).build();
       report.feeRecords = [aNotYetReconciledFeeRecord, anotherNotYetReconciledFeeRecord, aReconciledFeeRecord, anotherReconciledFeeRecord];
 
       // Act

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-reports-reconciliation-summary.controller/helpers/reconciliation-summary-item-mapper.ts
@@ -1,8 +1,8 @@
-import { Bank, FeeRecordEntity, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { Bank, FEE_RECORD_STATUS, FeeRecordEntity, UtilisationReportEntity } from '@ukef/dtfs2-common';
 import { UtilisationReportReconciliationSummaryItem } from '../../../../../types/utilisation-reports';
 
 const getCountOfReconciledFeeRecords = (feeRecords: FeeRecordEntity[]): number => {
-  return feeRecords.filter((feeRecord) => feeRecord.status === 'RECONCILED').length;
+  return feeRecords.filter((feeRecord) => feeRecord.status === FEE_RECORD_STATUS.RECONCILED).length;
 };
 
 const getCountOfDistinctFacilities = (feeRecords: FeeRecordEntity[]): number => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/index.test.ts
@@ -1,6 +1,6 @@
 import httpMocks from 'node-mocks-http';
 import { ObjectId } from 'mongodb';
-import { PaymentEntityMockBuilder, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder, TestApiError } from '@ukef/dtfs2-common';
+import { PaymentEntityMockBuilder, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder, TestApiError, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { PostAddFeesToAnExistingPaymentGroupRequest, postAddFeesToAnExistingPaymentGroup } from '.';
 import { TfmSessionUser } from '../../../../types/tfm/tfm-session-user';
@@ -28,7 +28,11 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
     const paymentIds = [3, 4];
     const payments = paymentIds.map((id) => PaymentEntityMockBuilder.forCurrency('GBP').withId(id).withFeeRecords([]).build());
 
-    const aFeeRecordToAdd = FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withPaymentCurrency('GBP').withStatus('TO_DO').build();
+    const aFeeRecordToAdd = FeeRecordEntityMockBuilder.forReport(utilisationReport)
+      .withId(1)
+      .withPaymentCurrency('GBP')
+      .withStatus(FEE_RECORD_STATUS.TO_DO)
+      .build();
     const aFeeRecordWithPayments = FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withPaymentCurrency('GBP').withPayments(payments).build();
 
     const paymentsWithFeeRecords = paymentIds.map((id) =>
@@ -161,7 +165,7 @@ describe('post-fees-to-an-existing-payment-group.controller', () => {
       const feeRecordInDifferentCurrencyToExistingPayment = FeeRecordEntityMockBuilder.forReport(utilisationReport)
         .withId(1)
         .withPaymentCurrency('GBP')
-        .withStatus('TO_DO')
+        .withStatus(FEE_RECORD_STATUS.TO_DO)
         .build();
 
       const req = httpMocks.createRequest<PostAddFeesToAnExistingPaymentGroupRequest>({

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
@@ -2,7 +2,7 @@ import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
 import { when } from 'jest-when';
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { postKeyingData, PostKeyingDataRequest } from '.';
 import { FeeRecordRepo } from '../../../../repositories/fee-record-repo';
 import { executeWithSqlTransaction } from '../../../../helpers';
@@ -26,8 +26,8 @@ describe('post-keying-data.controller', () => {
       });
 
     const someFeeRecordsForReport = (report: UtilisationReportEntity) => [
-      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus('MATCH').build(),
-      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus('MATCH').build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(1).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+      FeeRecordEntityMockBuilder.forReport(report).withId(2).withStatus(FEE_RECORD_STATUS.MATCH).build(),
     ];
 
     const feeRecordRepoFindSpy = jest.spyOn(FeeRecordRepo, 'findByReportIdAndStatusesWithReportAndPayments');
@@ -58,7 +58,7 @@ describe('post-keying-data.controller', () => {
       // Arrange
       const { req, res } = getHttpMocks();
 
-      when(feeRecordRepoFindSpy).calledWith(reportId, ['MATCH']).mockResolvedValue([]);
+      when(feeRecordRepoFindSpy).calledWith(reportId, [FEE_RECORD_STATUS.MATCH]).mockResolvedValue([]);
 
       // Act
       await postKeyingData(req, res);
@@ -78,7 +78,7 @@ describe('post-keying-data.controller', () => {
         // eslint-disable-next-line no-param-reassign
         delete feeRecord.report;
       });
-      when(feeRecordRepoFindSpy).calledWith(reportId, ['MATCH']).mockResolvedValue(feeRecords);
+      when(feeRecordRepoFindSpy).calledWith(reportId, [FEE_RECORD_STATUS.MATCH]).mockResolvedValue(feeRecords);
 
       // Act
       await postKeyingData(req, res);
@@ -96,11 +96,11 @@ describe('post-keying-data.controller', () => {
       req.body.user._id = userId;
 
       const feeRecords = [
-        FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus('MATCH').build(),
-        FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus('MATCH').build(),
+        FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build(),
+        FeeRecordEntityMockBuilder.forReport(RECONCILIATION_IN_PROGRESS_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build(),
       ];
 
-      when(feeRecordRepoFindSpy).calledWith(reportId, ['MATCH']).mockResolvedValue(feeRecords);
+      when(feeRecordRepoFindSpy).calledWith(reportId, [FEE_RECORD_STATUS.MATCH]).mockResolvedValue(feeRecords);
 
       // Act
       await postKeyingData(req, res);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
-import { ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { ApiError, CustomExpressRequest, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
 import { FeeRecordRepo } from '../../../../repositories/fee-record-repo';
 import { NotFoundError } from '../../../../errors';
 import { executeWithSqlTransaction } from '../../../../helpers';
@@ -16,7 +16,7 @@ export const postKeyingData = async (req: PostKeyingDataRequest, res: Response) 
   const { user } = req.body;
 
   try {
-    const feeRecordsAtMatchStatusWithPayments = await FeeRecordRepo.findByReportIdAndStatusesWithReportAndPayments(Number(reportId), ['MATCH']);
+    const feeRecordsAtMatchStatusWithPayments = await FeeRecordRepo.findByReportIdAndStatusesWithReportAndPayments(Number(reportId), [FEE_RECORD_STATUS.MATCH]);
 
     if (feeRecordsAtMatchStatusWithPayments.length === 0) {
       throw new NotFoundError(`Failed to find any fee records which can be keyed attached to report with id '${reportId}'`);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-done.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-done.controller/index.test.ts
@@ -1,6 +1,6 @@
 import httpMocks from 'node-mocks-http';
 import { ObjectId } from 'mongodb';
-import { FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { EntityManager } from 'typeorm';
 import { aTfmSessionUser } from '../../../../../test-helpers';
@@ -44,7 +44,7 @@ describe('put-keying-data-mark-as-done.controller', () => {
       });
       UtilisationReportStateMachine.forReport = mockForReport;
       const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(feeRecordId).withStatus('READY_TO_KEY').build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(feeRecordId).withStatus(FEE_RECORD_STATUS.READY_TO_KEY).build();
       feeRecordRepoFindByIdAndReportIdSpy.mockResolvedValue([feeRecord]);
     });
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-to-do.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-to-do.controller/index.test.ts
@@ -1,6 +1,6 @@
 import httpMocks from 'node-mocks-http';
 import { ObjectId } from 'mongodb';
-import { FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { EntityManager } from 'typeorm';
 import { aTfmSessionUser } from '../../../../../test-helpers';
@@ -44,7 +44,7 @@ describe('put-keying-data-mark-as-to-do.controller', () => {
       });
       UtilisationReportStateMachine.forReport = mockForReport;
       const report = UtilisationReportEntityMockBuilder.forStatus('RECONCILIATION_IN_PROGRESS').build();
-      const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(feeRecordId).withStatus('RECONCILED').build();
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withId(feeRecordId).withStatus(FEE_RECORD_STATUS.RECONCILED).build();
       feeRecordRepoFindByIdAndReportIdSpy.mockResolvedValue([feeRecord]);
     });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
@@ -148,8 +148,8 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
     ];
 
     const toDoFeeRecords = [
-      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(4).withStatus('TO_DO').withFacilityId('44444444').build(),
-      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(5).withStatus('TO_DO').withFacilityId('55555555').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(4).withStatus(FEE_RECORD_STATUS.TO_DO).withFacilityId('44444444').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(5).withStatus(FEE_RECORD_STATUS.TO_DO).withFacilityId('55555555').build(),
     ];
 
     const allFeeRecords = [...groupedFeeRecords, ...toDoFeeRecords];

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/filter-fee-records-by-facility-id.spec.js
@@ -3,6 +3,7 @@ import {
   PaymentEntityMockBuilder,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntityMockBuilder,
+  FEE_RECORD_STATUS,
 } from '@ukef/dtfs2-common';
 import pages from '../../pages';
 import { PDC_TEAMS } from '../../../fixtures/teams';
@@ -141,9 +142,9 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can filter fee records by facility id`
 
   it('should display the entire fee record payment group when only one of the fee records in the group has a matching facility id', () => {
     const groupedFeeRecords = [
-      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withStatus('DOES_NOT_MATCH').withFacilityId('11111111').build(),
-      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withStatus('DOES_NOT_MATCH').withFacilityId('22222222').build(),
-      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(3).withStatus('DOES_NOT_MATCH').withFacilityId('33333333').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(1).withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH).withFacilityId('11111111').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(2).withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH).withFacilityId('22222222').build(),
+      FeeRecordEntityMockBuilder.forReport(utilisationReport).withId(3).withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH).withFacilityId('33333333').build(),
     ];
 
     const toDoFeeRecords = [

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/reconcile-fee-records.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/reconcile-fee-records.spec.js
@@ -5,6 +5,7 @@ import {
   UtilisationReportEntityMockBuilder,
   toIsoMonthStamp,
   getPreviousReportPeriodForBankScheduleByMonth,
+  FEE_RECORD_STATUS,
 } from '@ukef/dtfs2-common';
 import pages from '../../pages';
 import USERS from '../../../fixtures/users';
@@ -77,7 +78,7 @@ context('PDC_RECONCILE users can reconcile fee records', () => {
           .withFeesPaidToUkefForThePeriod(100)
           .withFeesPaidToUkefForThePeriodCurrency('JPY')
           .withPaymentExchangeRate(2)
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withPayments([paymentMatchingFeeRecordOneAndTwo])
           .build();
 
@@ -89,7 +90,7 @@ context('PDC_RECONCILE users can reconcile fee records', () => {
           .withFeesPaidToUkefForThePeriodCurrency('EUR')
           .withPaymentCurrency('GBP')
           .withPaymentExchangeRate(0.5)
-          .withStatus('MATCH')
+          .withStatus(FEE_RECORD_STATUS.MATCH)
           .withPayments([paymentMatchingFeeRecordOneAndTwo])
           .build();
         cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecordOne, feeRecordTwo]);

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/sort-premium-payments.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/sort-premium-payments.spec.js
@@ -3,6 +3,7 @@ import {
   PaymentEntityMockBuilder,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntityMockBuilder,
+  FEE_RECORD_STATUS,
 } from '@ukef/dtfs2-common';
 import pages from '../../pages';
 import { NODE_TASKS } from '../../../../../e2e-fixtures';
@@ -23,14 +24,14 @@ context(`users can sort premium payments table by total reported payments and to
     .withId(1)
     .withFeesPaidToUkefForThePeriod(30)
     .withFeesPaidToUkefForThePeriodCurrency('EUR')
-    .withStatus('DOES_NOT_MATCH')
+    .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
     .withFacilityId('11111111')
     .build();
   const secondFeeRecord = FeeRecordEntityMockBuilder.forReport(utilisationReport)
     .withId(2)
     .withFeesPaidToUkefForThePeriod(20)
     .withFeesPaidToUkefForThePeriodCurrency('GBP')
-    .withStatus('DOES_NOT_MATCH')
+    .withStatus(FEE_RECORD_STATUS.DOES_NOT_MATCH)
     .withFacilityId('22222222')
     .build();
   const thirdFeeRecord = FeeRecordEntityMockBuilder.forReport(utilisationReport)

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.test.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.test.ts
@@ -112,7 +112,7 @@ describe('FeeRecordEntity', () => {
       const payment = PaymentEntityMockBuilder.forCurrency(paymentCurrency).withId(paymentId).build();
 
       const feeRecord = FeeRecordEntityMockBuilder.forReport(utilisationReport)
-        .withStatus('MATCH')
+        .withStatus(FEE_RECORD_STATUS.MATCH)
         .withPaymentCurrency(paymentCurrency)
         .withPayments([payment])
         .withLastUpdatedByIsSystemUser(true)

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.test.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.test.ts
@@ -105,7 +105,7 @@ describe('FeeRecordEntity', () => {
   });
 
   describe('removeAllPayments', () => {
-    it("removes all payments, sets the report status to 'TO_DO' and updates the 'lastUpdatedBy...' fields", () => {
+    it(`removes all payments, sets the record status to ${FEE_RECORD_STATUS.TO_DO} and updates the 'lastUpdatedBy...' fields`, () => {
       // Arrange
       const paymentCurrency: Currency = 'GBP';
       const paymentId = 123;
@@ -129,7 +129,7 @@ describe('FeeRecordEntity', () => {
 
       // Assert
       expect(feeRecord.payments).toHaveLength(0);
-      expect(feeRecord.status).toEqual('TO_DO');
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.TO_DO);
       expect(feeRecord.lastUpdatedByIsSystemUser).toEqual(false);
       expect(feeRecord.lastUpdatedByPortalUserId).toBeNull();
       expect(feeRecord.lastUpdatedByTfmUserId).toEqual(userId);

--- a/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record/fee-record.entity.ts
@@ -254,7 +254,7 @@ export class FeeRecordEntity extends AuditableBaseEntity {
    */
   public removeAllPayments({ requestSource }: RemoveAllPaymentsParams): void {
     this.payments = [];
-    this.status = 'TO_DO';
+    this.status = FEE_RECORD_STATUS.TO_DO;
     this.updateLastUpdatedBy(requestSource);
   }
 

--- a/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record.entity.mock-builder.ts
@@ -1,7 +1,7 @@
 import { DbRequestSource, FeeRecordEntity, UtilisationReportEntity, FacilityUtilisationDataEntity, PaymentEntity } from '../../sql-db-entities';
 import { Currency, FeeRecordStatus, ReportPeriod } from '../../types';
 import { FacilityUtilisationDataEntityMockBuilder } from './facility-utilisation-data.entity.mock-builder';
-import { REQUEST_PLATFORM_TYPE } from '../../constants';
+import { FEE_RECORD_STATUS, REQUEST_PLATFORM_TYPE } from '../../constants';
 
 /**
  * Gets the previous report period based on a monthly reporting
@@ -53,7 +53,7 @@ export class FeeRecordEntityMockBuilder {
     data.feesPaidToUkefForThePeriodCurrency = 'GBP';
     data.paymentCurrency = 'GBP';
     data.paymentExchangeRate = 1;
-    data.status = 'TO_DO';
+    data.status = FEE_RECORD_STATUS.TO_DO;
     data.payments = [];
     data.fixedFeeAdjustment = null;
     data.principalBalanceAdjustment = null;

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/check-keying-data/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/check-keying-data/index.test.ts
@@ -1,5 +1,5 @@
 import httpMocks from 'node-mocks-http';
-import { SessionBank } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, SessionBank } from '@ukef/dtfs2-common';
 import { postCheckKeyingData } from '.';
 import { aTfmSessionUser } from '../../../../test-helpers/test-data/tfm-session-user';
 import api from '../../../api';
@@ -87,7 +87,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
         reportedFees: { currency: 'EUR', amount: 100 },
         reportedPayments: { currency: 'GBP', amount: 90.91 },
         paymentsReceived: [{ currency: 'GBP', amount: 90.91 }],
-        status: 'MATCH',
+        status: FEE_RECORD_STATUS.MATCH,
       });
 
       beforeEach(() => {
@@ -179,7 +179,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
               reportedFees: { currency: 'EUR', amount: 100 },
               reportedPayments: { currency: 'GBP', amount: 90.91 },
               paymentsReceived: [{ currency: 'GBP', amount: 90.91 }],
-              status: 'MATCH',
+              status: FEE_RECORD_STATUS.MATCH,
             },
           ],
         };
@@ -204,7 +204,7 @@ describe('controllers/utilisation-reports/check-keying-data', () => {
             dataSortValue: 0,
           },
           paymentsReceived: ['GBP 90.91'],
-          status: 'MATCH',
+          status: FEE_RECORD_STATUS.MATCH,
           displayStatus: 'MATCH',
         });
       });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -333,7 +333,7 @@ describe('reconciliation-for-report-helper', () => {
 
     it('should map the group status to the view model status', () => {
       // Arrange
-      const status: FeeRecordStatus = 'TO_DO';
+      const status: FeeRecordStatus = FEE_RECORD_STATUS.TO_DO;
       const premiumPaymentGroups: PremiumPaymentsGroup[] = [{ ...aPremiumPaymentsGroup(), status }];
 
       // Act
@@ -345,7 +345,7 @@ describe('reconciliation-for-report-helper', () => {
     });
 
     it.each([
-      { feeRecordStatus: 'TO_DO', feeRecordDisplayStatus: 'TO DO' },
+      { feeRecordStatus: FEE_RECORD_STATUS.TO_DO, feeRecordDisplayStatus: 'TO DO' },
       { feeRecordStatus: FEE_RECORD_STATUS.MATCH, feeRecordDisplayStatus: 'MATCH' },
       { feeRecordStatus: FEE_RECORD_STATUS.DOES_NOT_MATCH, feeRecordDisplayStatus: 'DOES NOT MATCH' },
       { feeRecordStatus: FEE_RECORD_STATUS.READY_TO_KEY, feeRecordDisplayStatus: 'READY TO KEY' },
@@ -389,7 +389,7 @@ describe('reconciliation-for-report-helper', () => {
 
       const feeRecords = [firstFeeRecord, secondFeeRecord];
 
-      const groupStatus: FeeRecordStatus = 'TO_DO';
+      const groupStatus: FeeRecordStatus = FEE_RECORD_STATUS.TO_DO;
 
       const premiumPaymentGroups: PremiumPaymentsGroup[] = [{ ...aPremiumPaymentsGroup(), feeRecords, status: groupStatus }];
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -348,7 +348,7 @@ describe('reconciliation-for-report-helper', () => {
       { feeRecordStatus: 'TO_DO', feeRecordDisplayStatus: 'TO DO' },
       { feeRecordStatus: 'MATCH', feeRecordDisplayStatus: 'MATCH' },
       { feeRecordStatus: 'DOES_NOT_MATCH', feeRecordDisplayStatus: 'DOES NOT MATCH' },
-      { feeRecordStatus: 'READY_TO_KEY', feeRecordDisplayStatus: 'READY TO KEY' },
+      { feeRecordStatus: FEE_RECORD_STATUS.READY_TO_KEY, feeRecordDisplayStatus: 'READY TO KEY' },
       { feeRecordStatus: FEE_RECORD_STATUS.RECONCILED, feeRecordDisplayStatus: 'RECONCILED' },
     ] as const)(
       "maps the fee record status '$feeRecordStatus' to the view model display status '$feeRecordDisplayStatus'",

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -347,7 +347,7 @@ describe('reconciliation-for-report-helper', () => {
     it.each([
       { feeRecordStatus: 'TO_DO', feeRecordDisplayStatus: 'TO DO' },
       { feeRecordStatus: 'MATCH', feeRecordDisplayStatus: 'MATCH' },
-      { feeRecordStatus: 'DOES_NOT_MATCH', feeRecordDisplayStatus: 'DOES NOT MATCH' },
+      { feeRecordStatus: FEE_RECORD_STATUS.DOES_NOT_MATCH, feeRecordDisplayStatus: 'DOES NOT MATCH' },
       { feeRecordStatus: FEE_RECORD_STATUS.READY_TO_KEY, feeRecordDisplayStatus: 'READY TO KEY' },
       { feeRecordStatus: FEE_RECORD_STATUS.RECONCILED, feeRecordDisplayStatus: 'RECONCILED' },
     ] as const)(
@@ -415,7 +415,7 @@ describe('reconciliation-for-report-helper', () => {
         },
       };
 
-      const status: FeeRecordStatus = 'DOES_NOT_MATCH';
+      const status = FEE_RECORD_STATUS.DOES_NOT_MATCH;
 
       const premiumPaymentGroups: PremiumPaymentsGroup[] = [{ ...aPremiumPaymentsGroup(), feeRecords: [feeRecord], status }];
 
@@ -443,7 +443,7 @@ describe('reconciliation-for-report-helper', () => {
         },
       };
 
-      const status: FeeRecordStatus = 'DOES_NOT_MATCH';
+      const status = FEE_RECORD_STATUS.DOES_NOT_MATCH;
 
       const premiumPaymentGroups: PremiumPaymentsGroup[] = [{ ...aPremiumPaymentsGroup(), feeRecords: [feeRecord], status }];
 

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -346,7 +346,7 @@ describe('reconciliation-for-report-helper', () => {
 
     it.each([
       { feeRecordStatus: 'TO_DO', feeRecordDisplayStatus: 'TO DO' },
-      { feeRecordStatus: 'MATCH', feeRecordDisplayStatus: 'MATCH' },
+      { feeRecordStatus: FEE_RECORD_STATUS.MATCH, feeRecordDisplayStatus: 'MATCH' },
       { feeRecordStatus: FEE_RECORD_STATUS.DOES_NOT_MATCH, feeRecordDisplayStatus: 'DOES NOT MATCH' },
       { feeRecordStatus: FEE_RECORD_STATUS.READY_TO_KEY, feeRecordDisplayStatus: 'READY TO KEY' },
       { feeRecordStatus: FEE_RECORD_STATUS.RECONCILED, feeRecordDisplayStatus: 'RECONCILED' },

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -1,5 +1,5 @@
 import { when } from 'jest-when';
-import { CURRENCY, Currency, CurrencyAndAmount, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { CURRENCY, Currency, CurrencyAndAmount, FEE_RECORD_STATUS, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { mapCurrenciesToRadioItems } from '../../../helpers/map-currencies-to-radio-items';
 import {
   getFormattedDateReconciled,
@@ -349,7 +349,7 @@ describe('reconciliation-for-report-helper', () => {
       { feeRecordStatus: 'MATCH', feeRecordDisplayStatus: 'MATCH' },
       { feeRecordStatus: 'DOES_NOT_MATCH', feeRecordDisplayStatus: 'DOES NOT MATCH' },
       { feeRecordStatus: 'READY_TO_KEY', feeRecordDisplayStatus: 'READY TO KEY' },
-      { feeRecordStatus: 'RECONCILED', feeRecordDisplayStatus: 'RECONCILED' },
+      { feeRecordStatus: FEE_RECORD_STATUS.RECONCILED, feeRecordDisplayStatus: 'RECONCILED' },
     ] as const)(
       "maps the fee record status '$feeRecordStatus' to the view model display status '$feeRecordDisplayStatus'",
       ({ feeRecordStatus, feeRecordDisplayStatus }) => {

--- a/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.test.ts
@@ -95,7 +95,7 @@ describe('validatePostAddPaymentRequestBody', () => {
   });
 
   describe('when the body contains checkbox ids with different payment currencies', () => {
-    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', 'TO_DO'), getCheckboxId(2, 'EUR', 'TO_DO')];
+    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', FEE_RECORD_STATUS.TO_DO), getCheckboxId(2, 'EUR', FEE_RECORD_STATUS.TO_DO)];
     const next = jest.fn();
 
     it(`redirects to '${REDIRECT_URL}'`, () => {
@@ -236,11 +236,11 @@ describe('validatePostAddPaymentRequestBody', () => {
     });
   });
 
-  it("calls the 'next' function when the body contains multiple checkbox ids with the 'TO_DO' fee record status", () => {
+  it(`calls the 'next' function when the body contains multiple checkbox ids with the ${FEE_RECORD_STATUS.TO_DO} fee record status`, () => {
     // Arrange
     const { req, res } = getHttpMocks();
 
-    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', 'TO_DO'), getCheckboxId(2, 'GBP', 'TO_DO')];
+    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', FEE_RECORD_STATUS.TO_DO), getCheckboxId(2, 'GBP', FEE_RECORD_STATUS.TO_DO)];
     req.body = getRequestBodyFromCheckboxIds(checkedCheckboxIds);
 
     const next = jest.fn();
@@ -252,11 +252,11 @@ describe('validatePostAddPaymentRequestBody', () => {
     expect(next).toHaveBeenCalled();
   });
 
-  it("calls the 'next' function when the body contains one checkbox id with the 'TO_DO' fee record status", () => {
+  it(`calls the 'next' function when the body contains one checkbox id with the ${FEE_RECORD_STATUS.TO_DO} fee record status`, () => {
     // Arrange
     const { req, res } = getHttpMocks();
 
-    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', 'TO_DO')];
+    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', FEE_RECORD_STATUS.TO_DO)];
     req.body = getRequestBodyFromCheckboxIds(checkedCheckboxIds);
 
     const next = jest.fn();

--- a/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.test.ts
+++ b/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.test.ts
@@ -1,5 +1,5 @@
 import httpMocks from 'node-mocks-http';
-import { Currency, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { validatePostAddPaymentRequestBody } from '.';
 import { MOCK_TFM_SESSION_USER } from '../../test-mocks/mock-tfm-session-user';
 import { AddPaymentErrorKey } from '../../controllers/utilisation-reports/helpers';
@@ -149,7 +149,7 @@ describe('validatePostAddPaymentRequestBody', () => {
   });
 
   describe('when the body contains checkbox ids with different statuses', () => {
-    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', 'TO_DO'), getCheckboxId(2, 'GBP', 'DOES_NOT_MATCH')];
+    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', FEE_RECORD_STATUS.TO_DO), getCheckboxId(2, 'GBP', FEE_RECORD_STATUS.DOES_NOT_MATCH)];
     const next = jest.fn();
 
     it(`redirects to '${REDIRECT_URL}'`, () => {
@@ -202,11 +202,11 @@ describe('validatePostAddPaymentRequestBody', () => {
     });
   });
 
-  describe("when the body contains more than one checkbox id with the 'DOES_NOT_MATCH' status", () => {
+  describe(`when the body contains more than one checkbox id with the ${FEE_RECORD_STATUS.DOES_NOT_MATCH} status`, () => {
     // Arrange
     const { req, res } = getHttpMocks();
 
-    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', 'DOES_NOT_MATCH'), getCheckboxId(2, 'GBP', 'DOES_NOT_MATCH')];
+    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', FEE_RECORD_STATUS.DOES_NOT_MATCH), getCheckboxId(2, 'GBP', FEE_RECORD_STATUS.DOES_NOT_MATCH)];
     req.body = getRequestBodyFromCheckboxIds(checkedCheckboxIds);
 
     const next = jest.fn();
@@ -268,11 +268,11 @@ describe('validatePostAddPaymentRequestBody', () => {
     expect(next).toHaveBeenCalled();
   });
 
-  it("calls the 'next' function when the body contains one checkbox id with the 'DOES_NOT_MATCH' fee record status", () => {
+  it(`calls the 'next' function when the body contains one checkbox id with the ${FEE_RECORD_STATUS.DOES_NOT_MATCH} fee record status`, () => {
     // Arrange
     const { req, res } = getHttpMocks();
 
-    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', 'DOES_NOT_MATCH')];
+    const checkedCheckboxIds = [getCheckboxId(1, 'GBP', FEE_RECORD_STATUS.DOES_NOT_MATCH)];
     req.body = getRequestBodyFromCheckboxIds(checkedCheckboxIds);
 
     const next = jest.fn();

--- a/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.ts
+++ b/trade-finance-manager-ui/server/middleware/validatePostAddPaymentRequestBody/index.ts
@@ -1,4 +1,4 @@
-import { Currency, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordStatus } from '@ukef/dtfs2-common';
 import { NextFunction, Request, Response } from 'express';
 import axios from 'axios';
 import { asUserSession } from '../../helpers/express-session';
@@ -138,7 +138,7 @@ export const validatePostAddPaymentRequestBody = (req: Request, res: Response, n
     return redirectWithError(req, res, reportId, 'different-fee-record-statuses', mapCheckedCheckboxesToRecord(checkedCheckboxIds));
   }
 
-  if (selectedFeeRecordStatuses.has('DOES_NOT_MATCH') && checkedCheckboxIds.length > 1) {
+  if (selectedFeeRecordStatuses.has(FEE_RECORD_STATUS.DOES_NOT_MATCH) && checkedCheckboxIds.length > 1) {
     return redirectWithError(req, res, reportId, 'multiple-does-not-match-selected', mapCheckedCheckboxesToRecord(checkedCheckboxIds));
   }
 

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { FeeRecordEntity, FeeRecordStatus, UtilisationReportEntity, Currency } from '@ukef/dtfs2-common';
+import { FeeRecordEntity, FeeRecordStatus, UtilisationReportEntity, Currency, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
 import { getRandomCurrency, getRandomFinancialAmount, getExchangeRate } from '../helpers';
 
 type CreateRandomFeeRecordForReportOverrides = {
@@ -57,7 +57,7 @@ export const createAutoMatchedZeroPaymentFeeRecordForReport = (report: Utilisati
 
   feeRecord.report = report;
 
-  feeRecord.status = 'MATCH';
+  feeRecord.status = FEE_RECORD_STATUS.MATCH;
   feeRecord.facilityId = faker.string.numeric({ length: { min: 8, max: 10 } });
   feeRecord.exporter = faker.company.name();
 

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
@@ -14,7 +14,7 @@ export const createRandomFeeRecordForReport = (report: UtilisationReportEntity, 
 
   feeRecord.report = report;
 
-  feeRecord.status = overrides.status ?? 'TO_DO';
+  feeRecord.status = overrides.status ?? FEE_RECORD_STATUS.TO_DO;
   feeRecord.facilityId = overrides.facilityId ?? faker.string.numeric({ length: { min: 8, max: 10 } });
   feeRecord.exporter = overrides.exporter ?? faker.company.name();
 

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
@@ -25,7 +25,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
@@ -39,7 +39,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
@@ -53,7 +53,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
@@ -67,7 +67,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
@@ -22,7 +22,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.MATCH, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
@@ -36,7 +36,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.MATCH, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
@@ -50,7 +50,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.MATCH, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')
@@ -64,7 +64,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.MATCH, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.READY_TO_KEY, 'GBP')

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
@@ -19,7 +19,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReport(reconciliationInProgressReport).addManyRandomFeeRecords(3, { facilityId: '11111111' }).save(dataSource);
 
   // Groups of one fee record to one payment
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'DOES_NOT_MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
@@ -33,7 +33,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
     .addPaymentsAndSave(1, dataSource);
 
   // Groups of many fee records with a single bulk payment
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'DOES_NOT_MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
@@ -47,7 +47,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
     .addPaymentsAndSave(1, dataSource);
 
   // Groups of single fee record with many payments
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'DOES_NOT_MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')
@@ -61,7 +61,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
     .addPaymentsAndSave(4, dataSource);
 
   // Groups of many fee records to many payments
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'DOES_NOT_MATCH', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.DOES_NOT_MATCH, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'MATCH', 'GBP')

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seed.ts
@@ -1,5 +1,5 @@
 import { DataSource } from 'typeorm';
-import { UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, UtilisationReportEntity } from '@ukef/dtfs2-common';
 import { FeeRecordPaymentGroupSeeder } from './fee-record-payment-group.seeder';
 
 export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
@@ -28,7 +28,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'RECONCILED', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(1, dataSource);
 
@@ -42,7 +42,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'RECONCILED', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(1, dataSource);
 
@@ -56,7 +56,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'RECONCILED', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
     .addOneRandomFeeRecord()
     .addPaymentsAndSave(4, dataSource);
 
@@ -70,7 +70,7 @@ export const seedFeeRecordPaymentGroups = async (dataSource: DataSource) => {
   await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'READY_TO_KEY', 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
-  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, 'RECONCILED', 'GBP')
+  await FeeRecordPaymentGroupSeeder.forReportStatusAndPaymentCurrency(reconciliationInProgressReport, FEE_RECORD_STATUS.RECONCILED, 'GBP')
     .addManyRandomFeeRecords(4)
     .addPaymentsAndSave(4, dataSource);
 };

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seeder.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seeder.ts
@@ -53,7 +53,7 @@ export class FeeRecordPaymentGroupSeeder {
   }
 
   public static forManuallyCompletedReport(report: UtilisationReportEntity): FeeRecordPaymentGroupSeeder {
-    return new FeeRecordPaymentGroupSeeder(report, 'RECONCILED', null, true);
+    return new FeeRecordPaymentGroupSeeder(report, FEE_RECORD_STATUS.RECONCILED, null, true);
   }
 
   public addOneRandomFeeRecord(overrides: AddRandomFeeRecordOverrides = {}): FeeRecordPaymentGroupSeeder {
@@ -113,7 +113,7 @@ export class FeeRecordPaymentGroupSeeder {
     if (!this.reportIsManuallyReconciled && this.status !== 'TO_DO') {
       throw new Error(`Cannot save fee records with status '${this.status}' when there are no payments`);
     }
-    if (this.reportIsManuallyReconciled && this.status !== 'RECONCILED') {
+    if (this.reportIsManuallyReconciled && this.status !== FEE_RECORD_STATUS.RECONCILED) {
       throw new Error(`Cannot save fee records with status '${this.status}' when report is manually reconciled`);
     }
     if (this.feeRecords.length === 0) {

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seeder.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seeder.ts
@@ -49,7 +49,7 @@ export class FeeRecordPaymentGroupSeeder {
   }
 
   public static forReport(report: UtilisationReportEntity): FeeRecordPaymentGroupSeeder {
-    return new FeeRecordPaymentGroupSeeder(report, 'TO_DO', null, null);
+    return new FeeRecordPaymentGroupSeeder(report, FEE_RECORD_STATUS.TO_DO, null, null);
   }
 
   public static forManuallyCompletedReport(report: UtilisationReportEntity): FeeRecordPaymentGroupSeeder {
@@ -110,7 +110,7 @@ export class FeeRecordPaymentGroupSeeder {
   public async save(dataSource: DataSource): Promise<void> {
     await this.saveFacilityUtilisationData(dataSource);
 
-    if (!this.reportIsManuallyReconciled && this.status !== 'TO_DO') {
+    if (!this.reportIsManuallyReconciled && this.status !== FEE_RECORD_STATUS.TO_DO) {
       throw new Error(`Cannot save fee records with status '${this.status}' when there are no payments`);
     }
     if (this.reportIsManuallyReconciled && this.status !== FEE_RECORD_STATUS.RECONCILED) {
@@ -126,7 +126,7 @@ export class FeeRecordPaymentGroupSeeder {
     await this.saveFacilityUtilisationData(dataSource);
 
     if (this.status === FEE_RECORD_STATUS.TO_DO) {
-      throw new Error("Cannot add payments to fee records with 'TO_DO' status");
+      throw new Error(`Cannot add payments to fee records with ${FEE_RECORD_STATUS.TO_DO} status`);
     }
     if (!this.paymentCurrency) {
       throw new Error(`Cannot create payments without a payment currency`);


### PR DESCRIPTION
## Introduction :pencil2:
Historically we had been using string literals to set variables of type FeeRecordStatus, but this is not the preferred pattern.

## Resolution :heavy_check_mark:
- Replace instances of setting variables of type FeeRecordStatus with string literals, with the constant that underlies the FeeRecordStatus type.

