### PR TITLE
feat(DTFS2-7573): call submit cancellation in tfm-api

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/as-non-pim-user.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/as-non-pim-user.spec.js
@@ -1,0 +1,90 @@
+import relative from '../../relativeURL';
+import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import caseDealPage from '../../pages/caseDealPage';
+import { yesterday } from '../../../../../e2e-fixtures/dateConstants';
+
+context('Deal cancellation - logged in as non-PIM user', () => {
+  let dealId;
+  const dealFacilities = [];
+
+  before(() => {
+    cy.insertOneDeal(MOCK_DEAL_AIN, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      const { dealType, mockFacilities } = MOCK_DEAL_AIN;
+
+      cy.createFacilities(dealId, [mockFacilities[0]], BANK1_MAKER1).then((createdFacilities) => {
+        dealFacilities.push(...createdFacilities);
+      });
+
+      cy.submitDeal(dealId, dealType, PIM_USER_1);
+    });
+  });
+
+  after(() => {
+    cy.deleteDeals(dealId, ADMIN);
+    dealFacilities.forEach((facility) => {
+      cy.deleteFacility(facility._id, BANK1_MAKER1);
+    });
+  });
+
+  beforeEach(() => {
+    cy.login(T1_USER_1);
+  });
+
+  describe('when logged in as a non-PIM user', () => {
+    before(() => {
+      cy.login(PIM_USER_1);
+
+      cy.visit(relative(`/case/${dealId}/deal`));
+
+      caseDealPage.cancelDealButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+
+      cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
+
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+
+      cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
+
+      cy.clickContinueButton();
+    });
+
+    it('should redirect when visiting the reason for cancelling page', () => {
+      cy.visit(`/case/${dealId}/cancellation/reason`);
+
+      cy.url().should('eq', relative('/deals/0'));
+    });
+
+    it('should redirect when visiting the bank request date page', () => {
+      cy.visit(`/case/${dealId}/cancellation/bank-request-date`);
+
+      cy.url().should('eq', relative('/deals/0'));
+    });
+
+    it('should redirect when visiting the effective from date page', () => {
+      cy.visit(`/case/${dealId}/cancellation/effective-from-date`);
+
+      cy.url().should('eq', relative('/deals/0'));
+    });
+
+    it('should redirect when visiting the check details page', () => {
+      cy.visit(`/case/${dealId}/cancellation/check-details`);
+
+      cy.url().should('eq', relative('/deals/0'));
+    });
+
+    it('should redirect when visiting the cancel cancellation page', () => {
+      cy.visit(`/case/${dealId}/cancellation/cancel`);
+
+      cy.url().should('eq', relative('/deals/0'));
+    });
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/as-non-pim-user.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/as-non-pim-user.spec.js
@@ -29,10 +29,6 @@ context('Deal cancellation - logged in as non-PIM user', () => {
     });
   });
 
-  beforeEach(() => {
-    cy.login(T1_USER_1);
-  });
-
   describe('when logged in as a non-PIM user', () => {
     before(() => {
       cy.login(PIM_USER_1);
@@ -55,6 +51,10 @@ context('Deal cancellation - logged in as non-PIM user', () => {
       cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
 
       cy.clickContinueButton();
+    });
+
+    beforeEach(() => {
+      cy.login(T1_USER_1);
     });
 
     it('should redirect when visiting the reason for cancelling page', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/bank-request-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/bank-request-date.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../relativeURL';
 import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
-import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import { backLink, cancelLink, continueButton, errorSummary } from '../../partials';
 import bankRequestDatePage from '../../pages/deal-cancellation/bank-request-date';
@@ -96,18 +96,6 @@ context('Deal cancellation - bank request date', () => {
       bankRequestDatePage.bankRequestDateDay().should('have.value', today.day);
       bankRequestDatePage.bankRequestDateMonth().should('have.value', today.month);
       bankRequestDatePage.bankRequestDateYear().should('have.value', today.year);
-    });
-  });
-
-  describe('when logged in as a non-PIM user', () => {
-    beforeEach(() => {
-      cy.login(T1_USER_1);
-
-      cy.visit(relative(`/case/${dealId}/cancellation/bank-request-date`));
-    });
-
-    it('should redirect when visiting bank request date page ', () => {
-      cy.url().should('eq', relative('/deals/0'));
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/cancel-cancellation.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/cancel-cancellation.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../relativeURL';
 import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
-import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import reasonForCancellingPage from '../../pages/deal-cancellation/reason-for-cancelling';
 import { backLink } from '../../partials';
@@ -164,18 +164,6 @@ context('Deal cancellation - cancel cancellation', () => {
           });
         });
       });
-    });
-  });
-
-  describe('when logged in as a non-PIM user', () => {
-    beforeEach(() => {
-      cy.login(T1_USER_1);
-
-      cy.visit(relative(`/case/${dealId}/cancellation/cancel`));
-    });
-
-    it('should redirect when visiting reason for cancelling page ', () => {
-      cy.url().should('eq', relative('/deals/0'));
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../relativeURL';
 import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
-import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import { backLink, errorSummary } from '../../partials';
 import { today, threeMonthsOneDay, yesterday } from '../../../../../e2e-fixtures/dateConstants';
@@ -29,38 +29,6 @@ context('Deal cancellation - check details', () => {
     cy.deleteDeals(dealId, ADMIN);
     dealFacilities.forEach((facility) => {
       cy.deleteFacility(facility._id, BANK1_MAKER1);
-    });
-  });
-
-  describe('when logged in as a non-PIM user', () => {
-    beforeEach(() => {
-      cy.login(PIM_USER_1);
-      cy.visit(relative(`/case/${dealId}/deal`));
-
-      caseDealPage.cancelDealButton().click();
-
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
-      cy.clickContinueButton();
-
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
-
-      cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
-
-      cy.clickContinueButton();
-
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
-
-      cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
-
-      cy.clickContinueButton();
-
-      cy.login(T1_USER_1);
-
-      cy.visit(`/case/${dealId}/cancellation/check-details`);
-    });
-
-    it('should redirect when visiting the check details page', () => {
-      cy.url().should('eq', relative('/deals/0'));
     });
   });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -32,31 +32,31 @@ context('Deal cancellation - check details', () => {
     });
   });
 
-  beforeEach(() => {
-    cy.login(PIM_USER_1);
-    cy.visit(relative(`/case/${dealId}/deal`));
-
-    caseDealPage.cancelDealButton().click();
-
-    cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
-    cy.clickContinueButton();
-
-    cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
-
-    cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
-
-    cy.clickContinueButton();
-
-    cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
-
-    cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
-
-    cy.clickContinueButton();
-  });
-
   describe('when logged in as a non-PIM user', () => {
     beforeEach(() => {
+      cy.login(PIM_USER_1);
+      cy.visit(relative(`/case/${dealId}/deal`));
+
+      caseDealPage.cancelDealButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+
+      cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
+
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+
+      cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
+
+      cy.clickContinueButton();
+
       cy.login(T1_USER_1);
+
+      cy.visit(`/case/${dealId}/cancellation/check-details`);
     });
 
     it('should redirect when visiting the check details page', () => {
@@ -65,6 +65,28 @@ context('Deal cancellation - check details', () => {
   });
 
   describe('when logged in as a PIM user', () => {
+    beforeEach(() => {
+      cy.login(PIM_USER_1);
+      cy.visit(relative(`/case/${dealId}/deal`));
+
+      caseDealPage.cancelDealButton().click();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+
+      cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
+
+      cy.clickContinueButton();
+
+      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+
+      cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
+
+      cy.clickContinueButton();
+    });
+
     it('should render the page correctly', () => {
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
 
@@ -250,8 +272,8 @@ context('Deal cancellation - check details', () => {
       });
     });
 
-    describe('"delete deals" button', () => {
-      it('delete deal button takes you to the deal summary page', () => {
+    describe('when clicking the "delete deals" button', () => {
+      it('redirects you to the deal summary page', () => {
         checkDetailsPage.dealDeletionButton().click();
 
         cy.url().should('eq', relative(`/case/${dealId}/deal`));

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/check-details.spec.js
@@ -3,7 +3,7 @@ import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
 import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import { backLink, errorSummary } from '../../partials';
-import { today, tomorrow, threeMonthsOneDay } from '../../../../../e2e-fixtures/dateConstants';
+import { today, threeMonthsOneDay, yesterday } from '../../../../../e2e-fixtures/dateConstants';
 import checkDetailsPage from '../../pages/deal-cancellation/check-details';
 import reasonForCancellingPage from '../../pages/deal-cancellation/reason-for-cancelling';
 
@@ -32,29 +32,39 @@ context('Deal cancellation - check details', () => {
     });
   });
 
-  describe('when logged in as a PIM user', () => {
+  beforeEach(() => {
+    cy.login(PIM_USER_1);
+    cy.visit(relative(`/case/${dealId}/deal`));
+
+    caseDealPage.cancelDealButton().click();
+
+    cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
+    cy.clickContinueButton();
+
+    cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
+
+    cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
+
+    cy.clickContinueButton();
+
+    cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
+
+    cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: yesterday.date });
+
+    cy.clickContinueButton();
+  });
+
+  describe('when logged in as a non-PIM user', () => {
     beforeEach(() => {
-      cy.login(PIM_USER_1);
-      cy.visit(relative(`/case/${dealId}/deal`));
-
-      caseDealPage.cancelDealButton().click();
-
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
-      cy.clickContinueButton();
-
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/bank-request-date`));
-
-      cy.completeDateFormFields({ idPrefix: 'bank-request-date' });
-
-      cy.clickContinueButton();
-
-      cy.url().should('eq', relative(`/case/${dealId}/cancellation/effective-from-date`));
-
-      cy.completeDateFormFields({ idPrefix: 'effective-from-date', date: tomorrow.date });
-
-      cy.clickContinueButton();
+      cy.login(T1_USER_1);
     });
 
+    it('should redirect when visiting the check details page', () => {
+      cy.url().should('eq', relative('/deals/0'));
+    });
+  });
+
+  describe('when logged in as a PIM user', () => {
     it('should render the page correctly', () => {
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
 
@@ -69,7 +79,7 @@ context('Deal cancellation - check details', () => {
       checkDetailsPage.bankRequestDateLink();
 
       checkDetailsPage.effectiveFromResponse();
-      cy.assertText(checkDetailsPage.effectiveFromResponse(), tomorrow.d_MMMM_yyyy);
+      cy.assertText(checkDetailsPage.effectiveFromResponse(), yesterday.d_MMMM_yyyy);
       checkDetailsPage.effectiveFromLink();
 
       checkDetailsPage.dealDeletionButton();
@@ -87,12 +97,6 @@ context('Deal cancellation - check details', () => {
       cy.url().should('eq', relative(`/case/${dealId}/cancellation/reason`));
 
       cy.clickBackLink();
-      cy.url().should('eq', relative(`/case/${dealId}/deal`));
-    });
-
-    it('delete deal button takes you to the deal summary page', () => {
-      checkDetailsPage.dealDeletionButton().click();
-
       cy.url().should('eq', relative(`/case/${dealId}/deal`));
     });
 
@@ -123,7 +127,7 @@ context('Deal cancellation - check details', () => {
         cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
         cy.assertText(checkDetailsPage.reasonResponse(), testReason);
         cy.assertText(checkDetailsPage.bankRequestDateResponse(), today.d_MMMM_yyyy);
-        cy.assertText(checkDetailsPage.effectiveFromResponse(), tomorrow.d_MMMM_yyyy);
+        cy.assertText(checkDetailsPage.effectiveFromResponse(), yesterday.d_MMMM_yyyy);
       });
 
       describe('clicking the back link', () => {
@@ -171,7 +175,7 @@ context('Deal cancellation - check details', () => {
         cy.url().should('eq', relative(`/case/${dealId}/cancellation/check-details`));
         cy.assertText(checkDetailsPage.reasonResponse(), testReason);
         cy.assertText(checkDetailsPage.bankRequestDateResponse(), threeMonthsOneDay.d_MMMM_yyyy);
-        cy.assertText(checkDetailsPage.effectiveFromResponse(), tomorrow.d_MMMM_yyyy);
+        cy.assertText(checkDetailsPage.effectiveFromResponse(), yesterday.d_MMMM_yyyy);
       });
 
       describe('clicking the back link', () => {
@@ -245,15 +249,13 @@ context('Deal cancellation - check details', () => {
         });
       });
     });
-  });
 
-  describe('when logged in as a non-PIM user', () => {
-    beforeEach(() => {
-      cy.login(T1_USER_1);
-    });
+    describe('"delete deals" button', () => {
+      it('delete deal button takes you to the deal summary page', () => {
+        checkDetailsPage.dealDeletionButton().click();
 
-    it('should redirect when visiting the check details page', () => {
-      cy.url().should('eq', relative('/deals/0'));
+        cy.url().should('eq', relative(`/case/${dealId}/deal`));
+      });
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/effective-from-date.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../relativeURL';
 import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
-import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import { backLink, cancelLink, continueButton, errorSummary } from '../../partials';
 import effectiveFromDatePage from '../../pages/deal-cancellation/effective-from-date';
@@ -102,18 +102,6 @@ context('Deal cancellation - effective from date', () => {
       effectiveFromDatePage.effectiveFromDateDay().should('have.value', today.day);
       effectiveFromDatePage.effectiveFromDateMonth().should('have.value', today.month);
       effectiveFromDatePage.effectiveFromDateYear().should('have.value', today.year);
-    });
-  });
-
-  describe('when logged in as a non-PIM user', () => {
-    beforeEach(() => {
-      cy.login(T1_USER_1);
-
-      cy.visit(relative(`/case/${dealId}/cancellation/effective-from-date`));
-    });
-
-    it('should redirect when visiting effective from date page ', () => {
-      cy.url().should('eq', relative('/deals/0'));
     });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/reason-for-cancelling.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/reason-for-cancelling.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../relativeURL';
 import MOCK_DEAL_AIN from '../../../fixtures/deal-AIN';
-import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../e2e-fixtures';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import reasonForCancellingPage from '../../pages/deal-cancellation/reason-for-cancelling';
 import { backLink, cancelLink, continueButton, errorSummary } from '../../partials';
@@ -82,18 +82,6 @@ context('Deal cancellation - reason for cancelling', () => {
       cy.clickBackLink();
 
       reasonForCancellingPage.reasonForCancellingTextBox().should('have.value', reason);
-    });
-  });
-
-  describe('when logged in as a non-PIM user', () => {
-    beforeEach(() => {
-      cy.login(T1_USER_1);
-
-      cy.visit(relative(`/case/${dealId}/cancellation/reason`));
-    });
-
-    it('should redirect when visiting reason for cancelling page ', () => {
-      cy.url().should('eq', relative('/deals/0'));
     });
   });
 });

--- a/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
@@ -1,5 +1,5 @@
 import { add, format } from 'date-fns';
-import { AnyObject, MAX_CHARACTER_COUNT, TEAM_IDS, TestApiError, TfmDeal, TfmFacility } from '@ukef/dtfs2-common';
+import { AnyObject, MAX_CHARACTER_COUNT, TEAM_IDS, TestApiError, TfmDealCancellationResponse, TfmFacility } from '@ukef/dtfs2-common';
 import { ObjectId, UpdateResult } from 'mongodb';
 import { HttpStatusCode } from 'axios';
 import { createApi } from '../../api';
@@ -12,7 +12,7 @@ import { CANCEL_DEAL_FUTURE_DATE, CANCEL_DEAL_PAST_DATE } from '../../../src/con
 
 const updateDealCancellationMock = jest.fn() as jest.Mock<Promise<UpdateResult>>;
 const sendEmailMock = jest.fn() as jest.Mock<Promise<void>>;
-const findOneDealMock = jest.fn() as jest.Mock<Promise<TfmDeal>>;
+const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<TfmDealCancellationResponse>>;
 const findFacilitiesByDealIdMock = jest.fn() as jest.Mock<Promise<TfmFacility[]>>;
 
 const mockPimEmailAddress = 'pim@example.com';
@@ -22,7 +22,7 @@ jest.mock('../../../src/v1/api', () => ({
   updateDealCancellation: () => updateDealCancellationMock(),
   sendEmail: (templateId: string, sendToEmailAddress: string, emailVariables: object) => sendEmailMock(templateId, sendToEmailAddress, emailVariables),
   findOneTeam: () => ({ email: mockPimEmailAddress }),
-  findOneDeal: () => findOneDealMock(),
+  submitDealCancellation: (params: AnyObject) => submitDealCancellationMock(params),
   findFacilitiesByDealId: () => findFacilitiesByDealIdMock(),
 }));
 
@@ -79,7 +79,7 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
     });
 
     beforeEach(() => {
-      findOneDealMock.mockResolvedValue({ dealSnapshot: { ukefDealId } } as TfmDeal);
+      submitDealCancellationMock.mockResolvedValue({ cancelledDealUkefId: ukefDealId } as TfmDealCancellationResponse);
       findFacilitiesByDealIdMock.mockResolvedValue(
         ukefFacilityIds.map(
           (ukefFacilityId) =>
@@ -139,9 +139,26 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
       expect(response.status).toEqual(HttpStatusCode.BadRequest);
     });
 
+    it('calls api.submitDealCancellation with the correct parameters', async () => {
+      // Arrange
+      const url = getSubmitTfmDealCancellationUrl({ id: validId });
+      const cancellation = aValidPayload();
+
+      // Act
+      await as(aPimUser).post(cancellation).to(url);
+
+      // Assert
+      expect(submitDealCancellationMock).toHaveBeenCalledTimes(1);
+      expect(submitDealCancellationMock).toHaveBeenCalledWith({
+        dealId: validId,
+        cancellation,
+        auditDetails: expect.any(Object) as object,
+      });
+    });
+
     it('returns 500 if an unknown error is thrown', async () => {
       // Arrange
-      findOneDealMock.mockRejectedValueOnce(new Error('An error occurred'));
+      submitDealCancellationMock.mockRejectedValueOnce(new Error('An error occurred'));
 
       const url = getSubmitTfmDealCancellationUrl({ id: validId });
 
@@ -157,7 +174,7 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
       // Arrange
       const errorStatus = HttpStatusCode.BadRequest;
       const errorMessage = 'An error occurred';
-      findOneDealMock.mockRejectedValueOnce(new TestApiError(errorStatus, errorMessage));
+      submitDealCancellationMock.mockRejectedValueOnce(new TestApiError(errorStatus, errorMessage));
 
       const url = getSubmitTfmDealCancellationUrl({ id: validId });
 

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -361,6 +361,39 @@ const deleteDealCancellation = async ({ dealId, auditDetails }) => {
   }
 };
 
+/**
+ * Submits the deal cancellation
+ * @param {Object} params
+ * @param {string} params.dealId - id of deal to cancel
+ * @param {import('@ukef/dtfs2-common').TfmDealCancellation} params.cancellation - the cancellation details to submit
+ * @param {import('@ukef/dtfs2-common').AuditDetails} params.auditDetails - user making the request
+ * @returns {Promise<import('@ukef/dtfs2-common').TfmDealCancellationResponse>} update result object
+ */
+const submitDealCancellation = async ({ dealId, cancellation, auditDetails }) => {
+  try {
+    const isValidDealId = isValidMongoId(dealId);
+
+    if (!isValidDealId) {
+      throw new InvalidDealIdError(dealId);
+    }
+
+    const response = await axios({
+      method: 'post',
+      url: `${DTFS_CENTRAL_API_URL}/v1/tfm/deals/${dealId}/cancellation/submit`,
+      headers: headers.central,
+      data: {
+        cancellation,
+        auditDetails,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
 const findOneFacility = async (facilityId) => {
   try {
     const isValidFacilityId = isValidMongoId(facilityId);
@@ -1679,6 +1712,7 @@ module.exports = {
   updateDealCancellation,
   getDealCancellation,
   deleteDealCancellation,
+  submitDealCancellation,
   findPortalUserById,
   updateUserTasks,
   findOneTeam,

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb';
 import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
-import { AnyObject, TestApiError } from '@ukef/dtfs2-common';
+import { AuditDetails, TestApiError, TfmDealCancellation } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { submitDealCancellation, SubmitDealCancellationRequest } from './submit-deal-cancellation.controller';
 
@@ -9,11 +9,11 @@ const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<void>>;
 
 jest.mock('../../services/deal-cancellation/deal-cancellation.service', () => ({
   DealCancellationService: {
-    submitDealCancellation: (params: AnyObject) => submitDealCancellationMock(params),
+    submitDealCancellation: (params: { dealId: string; cancellation: TfmDealCancellation; auditDetails: AuditDetails }) => submitDealCancellationMock(params),
   },
 }));
 
-const cancellation = {
+const dealCancellation = {
   reason: 'test reason',
   bankRequestDate: 1794418807,
   effectiveFrom: 1794418808,
@@ -34,7 +34,7 @@ describe('controllers - deal cancellation', () => {
 
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: cancellation,
+        body: dealCancellation,
         user: { _id: mockUserId },
       });
 
@@ -54,7 +54,7 @@ describe('controllers - deal cancellation', () => {
 
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: cancellation,
+        body: dealCancellation,
         user: { _id: mockUserId },
       });
 
@@ -70,7 +70,7 @@ describe('controllers - deal cancellation', () => {
       // Arrange
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: cancellation,
+        body: dealCancellation,
         user: { _id: mockUserId },
       });
 
@@ -79,14 +79,18 @@ describe('controllers - deal cancellation', () => {
 
       // Assert
       expect(submitDealCancellationMock).toHaveBeenCalledTimes(1);
-      expect(submitDealCancellationMock).toHaveBeenCalledWith({ dealId: mockDealId, cancellation, auditDetails: generateTfmAuditDetails(mockUserId) });
+      expect(submitDealCancellationMock).toHaveBeenCalledWith({
+        dealId: mockDealId,
+        cancellation: dealCancellation,
+        auditDetails: generateTfmAuditDetails(mockUserId),
+      });
     });
 
     it('should return 200', async () => {
       // Arrange
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: cancellation,
+        body: dealCancellation,
         user: { _id: mockUserId },
       });
 

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.test.ts
@@ -1,18 +1,19 @@
 import { ObjectId } from 'mongodb';
 import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
-import { TestApiError, TfmDealCancellation } from '@ukef/dtfs2-common';
+import { AnyObject, TestApiError } from '@ukef/dtfs2-common';
+import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { submitDealCancellation, SubmitDealCancellationRequest } from './submit-deal-cancellation.controller';
 
 const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<void>>;
 
 jest.mock('../../services/deal-cancellation/deal-cancellation.service', () => ({
   DealCancellationService: {
-    submitDealCancellation: (dealId: string, dealCancellation: TfmDealCancellation) => submitDealCancellationMock(dealId, dealCancellation),
+    submitDealCancellation: (params: AnyObject) => submitDealCancellationMock(params),
   },
 }));
 
-const dealCancellation = {
+const cancellation = {
   reason: 'test reason',
   bankRequestDate: 1794418807,
   effectiveFrom: 1794418808,
@@ -33,7 +34,7 @@ describe('controllers - deal cancellation', () => {
 
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: dealCancellation,
+        body: cancellation,
         user: { _id: mockUserId },
       });
 
@@ -53,7 +54,7 @@ describe('controllers - deal cancellation', () => {
 
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: dealCancellation,
+        body: cancellation,
         user: { _id: mockUserId },
       });
 
@@ -69,7 +70,7 @@ describe('controllers - deal cancellation', () => {
       // Arrange
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: dealCancellation,
+        body: cancellation,
         user: { _id: mockUserId },
       });
 
@@ -78,14 +79,14 @@ describe('controllers - deal cancellation', () => {
 
       // Assert
       expect(submitDealCancellationMock).toHaveBeenCalledTimes(1);
-      expect(submitDealCancellationMock).toHaveBeenCalledWith(mockDealId, dealCancellation);
+      expect(submitDealCancellationMock).toHaveBeenCalledWith({ dealId: mockDealId, cancellation, auditDetails: generateTfmAuditDetails(mockUserId) });
     });
 
     it('should return 200', async () => {
       // Arrange
       const { req, res } = httpMocks.createMocks<SubmitDealCancellationRequest>({
         params: { dealId: mockDealId },
-        body: dealCancellation,
+        body: cancellation,
         user: { _id: mockUserId },
       });
 

--- a/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/deal-cancellation/submit-deal-cancellation.controller.ts
@@ -1,6 +1,7 @@
 import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
 import { ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { PostSubmitDealCancellationPayload } from '../../middleware/validate-post-submit-deal-cancellation-payload';
 import { DealCancellationService } from '../../services/deal-cancellation/deal-cancellation.service';
 
@@ -20,7 +21,9 @@ export const submitDealCancellation = async (req: SubmitDealCancellationRequest,
   const cancellation = req.body;
   const { dealId } = req.params;
   try {
-    await DealCancellationService.submitDealCancellation(dealId, cancellation);
+    const auditDetails = generateTfmAuditDetails(req.user._id);
+
+    await DealCancellationService.submitDealCancellation({ dealId, cancellation, auditDetails });
 
     return res.status(HttpStatusCode.Ok).send();
   } catch (error) {

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
@@ -1,18 +1,21 @@
-import { TfmDealCancellation } from '@ukef/dtfs2-common';
+import { AnyObject, TfmDealCancellation, TfmDealCancellationResponse } from '@ukef/dtfs2-common';
+import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { add, format } from 'date-fns';
 import { CANCEL_DEAL_FUTURE_DATE, CANCEL_DEAL_PAST_DATE } from '../../../constants/email-template-ids';
 import sendTfmEmail from '../send-tfm-email';
 import { DealCancellationService } from './deal-cancellation.service';
 import { formatFacilityIds } from './helpers/format-facility-ids';
+import { MOCK_TFM_SESSION_USER } from '../../__mocks__/mock-tfm-session-user';
 
 const mockPimEmailAddress = 'pim@example.com';
 const ukefDealId = 'ukefDealId';
 const ukefFacilityIds = ['aFacilityId'];
 
+const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<TfmDealCancellationResponse>>;
+
 jest.mock('../send-tfm-email');
 jest.mock('../../api', () => ({
   findOneTeam: jest.fn(() => ({ email: mockPimEmailAddress })),
-  findOneDeal: jest.fn(() => ({ dealSnapshot: { ukefDealId } })),
   findFacilitiesByDealId: jest.fn(() =>
     ukefFacilityIds.map((ukefFacilityId) => ({
       facilitySnapshot: {
@@ -20,6 +23,7 @@ jest.mock('../../api', () => ({
       },
     })),
   ),
+  submitDealCancellation: jest.fn((params: AnyObject) => submitDealCancellationMock(params)),
 }));
 
 const dealId = 'dealId';
@@ -33,6 +37,12 @@ describe('deal cancellation service', () => {
   });
 
   describe('submitDealCancellation', () => {
+    beforeEach(() => {
+      submitDealCancellationMock.mockResolvedValueOnce({
+        cancelledDealUkefId: ukefDealId,
+      } as TfmDealCancellationResponse);
+    });
+
     describe('when effective date is in the future', () => {
       const aDealCancellation = (): TfmDealCancellation => ({
         reason: 'a reason',
@@ -40,17 +50,31 @@ describe('deal cancellation service', () => {
         effectiveFrom: tomorrow.valueOf(),
       });
 
-      it('calls sendTfmEmail with the correct parameters', async () => {
+      it('calls submitDealCancellation', async () => {
         // Arrange
-        const dealCancellation = aDealCancellation();
+        const cancellation = aDealCancellation();
+        const auditDetails = generateTfmAuditDetails(MOCK_TFM_SESSION_USER._id);
 
         // Act
-        await DealCancellationService.submitDealCancellation(dealId, dealCancellation);
+        await DealCancellationService.submitDealCancellation({ dealId, cancellation, auditDetails });
+
+        // Assert
+        expect(submitDealCancellationMock).toHaveBeenCalledTimes(1);
+        expect(submitDealCancellationMock).toHaveBeenCalledWith({ dealId, cancellation, auditDetails });
+      });
+
+      it('calls sendTfmEmail with the correct parameters', async () => {
+        // Arrange
+        const cancellation = aDealCancellation();
+        const auditDetails = generateTfmAuditDetails(MOCK_TFM_SESSION_USER._id);
+
+        // Act
+        await DealCancellationService.submitDealCancellation({ dealId, cancellation, auditDetails });
 
         // Assert
         expect(sendTfmEmail).toHaveBeenCalledTimes(1);
         expect(sendTfmEmail).toHaveBeenCalledWith(CANCEL_DEAL_FUTURE_DATE, mockPimEmailAddress, {
-          cancelReason: dealCancellation.reason,
+          cancelReason: cancellation.reason,
           bankRequestDate: format(today, 'dd MMMM yyyy'),
           effectiveFromDate: format(tomorrow, 'dd MMMM yyyy'),
           formattedFacilitiesList: formatFacilityIds(ukefFacilityIds),
@@ -64,14 +88,15 @@ describe('deal cancellation service', () => {
 
       it('calls sendTfmEmail with the correct parameters', async () => {
         // Arrange
-        const dealCancellation = aDealCancellation();
+        const cancellation = aDealCancellation();
+        const auditDetails = generateTfmAuditDetails(MOCK_TFM_SESSION_USER._id);
 
         // Act
-        await DealCancellationService.submitDealCancellation(dealId, dealCancellation);
+        await DealCancellationService.submitDealCancellation({ dealId, cancellation, auditDetails });
         // Assert
         expect(sendTfmEmail).toHaveBeenCalledTimes(1);
         expect(sendTfmEmail).toHaveBeenCalledWith(CANCEL_DEAL_PAST_DATE, mockPimEmailAddress, {
-          cancelReason: dealCancellation.reason,
+          cancelReason: cancellation.reason,
           bankRequestDate: format(today, 'dd MMMM yyyy'),
           effectiveFromDate: format(today, 'dd MMMM yyyy'),
           formattedFacilitiesList: formatFacilityIds(ukefFacilityIds),

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.ts
@@ -53,8 +53,11 @@ export class DealCancellationService {
 
   /**
    * Submit the deal cancellation
-   * @param dealId the Deal ID
-   * @param dealCancellation the deal cancellation object
+   *
+   * @param params
+   * @param params.dealId the Deal ID
+   * @param params.dealCancellation the deal cancellation object
+   * @param params.auditDetails the users audit details
    */
   public static async submitDealCancellation({ dealId, cancellation, auditDetails }: SubmitDealCancellationParams) {
     console.info(`Submitting deal cancellation for ${dealId}`);

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.ts
@@ -1,13 +1,19 @@
 import { endOfDay, format, isAfter, toDate } from 'date-fns';
-import { DATE_FORMATS, DEAL_TYPE, TEAMS, TfmDealCancellation } from '@ukef/dtfs2-common';
+import { AuditDetails, DATE_FORMATS, TEAMS, TfmDealCancellation } from '@ukef/dtfs2-common';
 import sendTfmEmail from '../send-tfm-email';
 import { CANCEL_DEAL_PAST_DATE, CANCEL_DEAL_FUTURE_DATE } from '../../../constants/email-template-ids';
 import * as api from '../../api';
 import { formatFacilityIds } from './helpers/format-facility-ids';
-import { getUkefFacilityIds } from './helpers/get-ukef-facility-ids';
 import { UKEF_ID } from '../../../constants/deals';
+import { getUkefFacilityIds } from './helpers/get-ukef-facility-ids';
 
 const { D_MMMM_YYYY } = DATE_FORMATS;
+
+type SubmitDealCancellationParams = {
+  dealId: string;
+  cancellation: TfmDealCancellation;
+  auditDetails: AuditDetails;
+};
 
 export class DealCancellationService {
   /**
@@ -50,15 +56,11 @@ export class DealCancellationService {
    * @param dealId the Deal ID
    * @param dealCancellation the deal cancellation object
    */
-  public static async submitDealCancellation(dealId: string, dealCancellation: TfmDealCancellation) {
+  public static async submitDealCancellation({ dealId, cancellation, auditDetails }: SubmitDealCancellationParams) {
     console.info(`Submitting deal cancellation for ${dealId}`);
 
-    // TODO: DTFS2-7298 - update cancellation in database & return cancelled deal/facility ids
-
-    const { dealSnapshot } = await api.findOneDeal(dealId);
+    const { cancelledDealUkefId } = await api.submitDealCancellation({ dealId, cancellation, auditDetails });
     const facilities = await api.findFacilitiesByDealId(dealId);
-
-    const ukefDealId = dealSnapshot.dealType === DEAL_TYPE.BSS_EWCS ? dealSnapshot.details.ukefDealId : dealSnapshot.ukefDealId;
 
     const ukefFacilityIds = getUkefFacilityIds(facilities);
 
@@ -70,6 +72,6 @@ export class DealCancellationService {
       throw new Error(`Some UKEF facility ids were invalid when submitting deal ${dealId} for cancellation. No email has been sent`);
     }
 
-    await this.sendDealCancellationEmail(ukefDealId, dealCancellation, ukefFacilityIds);
+    await this.sendDealCancellationEmail(cancelledDealUkefId.toString(), cancellation, ukefFacilityIds);
   }
 }


### PR DESCRIPTION
## Introduction :pencil2:
The tfm-api submit cancellation endpoint needs to call the dtfs-central-api endpoint.

## Resolution :heavy_check_mark:
- Add new api method `submitDealCancellation`
- Call `api.submitDealCancellation` in `DealCancellationService.submitDealCancellation`.
- Update unit test coverage


