### PR TITLE
feat(FN-3328): screenreader ux improvements to payment details

### DIFF
--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
@@ -8,7 +8,7 @@ const component = '../templates/utilisation-reports/_macros/payment-details-tabl
 const render = componentRenderer(component, true);
 
 describe(component, () => {
-  const screenreaderAlternativeCellSelector = '[data-cy="screenreader-alternative-facility-id-and-expoter"]';
+  const hiddenCellSelector = '[data-cy="hidden-facility-id-and-expoter"]';
 
   const aPaymentDetailsPayment = (): PaymentDetailsPaymentViewModel => ({
     id: 1,
@@ -80,7 +80,7 @@ describe(component, () => {
     wrapper.expectElement(`tr td:contains("Some exporter")`).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('renders screenreader alternative combined facility ID and exporter cell', () => {
+  it('renders visually hidden alternative combined facility ID and exporter cell', () => {
     const paymentDetailsRow: PaymentDetailsRowViewModel = {
       ...aPaymentDetailsTableRow(),
       feeRecords: [
@@ -93,9 +93,9 @@ describe(component, () => {
     };
     const wrapper = getWrapper({ paymentDetailsRow });
 
-    wrapper.expectElement(`tr ${screenreaderAlternativeCellSelector}`).toExist();
-    wrapper.expectElement(`tr ${screenreaderAlternativeCellSelector}`).hasClass('govuk-visually-hidden');
-    wrapper.expectText(`tr ${screenreaderAlternativeCellSelector}`).toRead('Some facility id Some exporter');
+    wrapper.expectElement(`tr ${hiddenCellSelector}`).toExist();
+    wrapper.expectElement(`tr ${hiddenCellSelector}`).hasClass('govuk-visually-hidden');
+    wrapper.expectText(`tr ${hiddenCellSelector}`).toRead('Some facility id Some exporter');
   });
 
   it('renders the date reconciled', () => {
@@ -197,7 +197,7 @@ describe(component, () => {
       wrapper.expectElement('tr').toHaveCount(3);
     });
 
-    it('should hide all rows other than first row from screenreaders', () => {
+    it('should visually hide all rows other than first row', () => {
       const paymentDetailsRow: PaymentDetailsRowViewModel = {
         ...aPaymentDetailsTableRow(),
         feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
@@ -339,7 +339,7 @@ describe(component, () => {
       wrapper.expectElement('tr:eq(2) td:contains("Test exporter 3")').toExist();
     });
 
-    it('renders all facility ids and exporters in screenreader only cell in the first row of group', () => {
+    it('renders all facility ids and exporters in visually hidden cell in the first row of group', () => {
       const feeRecords: { id: number; facilityId: string; exporter: string }[] = [
         { id: 1, facilityId: '11111111', exporter: 'Test exporter 1' },
         { id: 1, facilityId: '22222222', exporter: 'Test exporter 2' },
@@ -351,10 +351,10 @@ describe(component, () => {
       };
       const wrapper = getWrapper({ paymentDetailsRow });
 
-      wrapper.expectElement(`tr:eq(0) ${screenreaderAlternativeCellSelector}`).toExist();
-      wrapper.expectText(`tr:eq(0) ${screenreaderAlternativeCellSelector} li:eq(0)`).toRead('11111111 Test exporter 1');
-      wrapper.expectText(`tr:eq(0) ${screenreaderAlternativeCellSelector} li:eq(1)`).toRead('22222222 Test exporter 2');
-      wrapper.expectText(`tr:eq(0) ${screenreaderAlternativeCellSelector} li:eq(2)`).toRead('33333333 Test exporter 3');
+      wrapper.expectElement(`tr:eq(0) ${hiddenCellSelector}`).toExist();
+      wrapper.expectText(`tr:eq(0) ${hiddenCellSelector} li:eq(0)`).toRead('11111111 Test exporter 1');
+      wrapper.expectText(`tr:eq(0) ${hiddenCellSelector} li:eq(1)`).toRead('22222222 Test exporter 2');
+      wrapper.expectText(`tr:eq(0) ${hiddenCellSelector} li:eq(2)`).toRead('33333333 Test exporter 3');
     });
   });
 });

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table-row.component-test.ts
@@ -8,6 +8,8 @@ const component = '../templates/utilisation-reports/_macros/payment-details-tabl
 const render = componentRenderer(component, true);
 
 describe(component, () => {
+  const screenreaderAlternativeCellSelector = '[data-cy="screenreader-alternative-facility-id-and-expoter"]';
+
   const aPaymentDetailsPayment = (): PaymentDetailsPaymentViewModel => ({
     id: 1,
     amount: {
@@ -74,6 +76,26 @@ describe(component, () => {
 
     wrapper.expectElement(`tr td:contains("Some facility id")`).toExist();
     wrapper.expectElement(`tr td:contains("Some exporter")`).toExist();
+    wrapper.expectElement(`tr td:contains("Some facility id")`).toHaveAttribute('aria-hidden', 'true');
+    wrapper.expectElement(`tr td:contains("Some exporter")`).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders screenreader alternative combined facility ID and exporter cell', () => {
+    const paymentDetailsRow: PaymentDetailsRowViewModel = {
+      ...aPaymentDetailsTableRow(),
+      feeRecords: [
+        {
+          id: 1,
+          facilityId: 'Some facility id',
+          exporter: 'Some exporter',
+        },
+      ],
+    };
+    const wrapper = getWrapper({ paymentDetailsRow });
+
+    wrapper.expectElement(`tr ${screenreaderAlternativeCellSelector}`).toExist();
+    wrapper.expectElement(`tr ${screenreaderAlternativeCellSelector}`).hasClass('govuk-visually-hidden');
+    wrapper.expectText(`tr ${screenreaderAlternativeCellSelector}`).toRead('Some facility id Some exporter');
   });
 
   it('renders the date reconciled', () => {
@@ -173,6 +195,18 @@ describe(component, () => {
       const wrapper = getWrapper({ paymentDetailsRow });
 
       wrapper.expectElement('tr').toHaveCount(3);
+    });
+
+    it('should hide all rows other than first row from screenreaders', () => {
+      const paymentDetailsRow: PaymentDetailsRowViewModel = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords: [aFeeRecord(), aFeeRecord(), aFeeRecord()],
+      };
+      const wrapper = getWrapper({ paymentDetailsRow });
+
+      wrapper.expectElement('tr:eq(0)').toHaveAttribute('aria-hidden', 'false');
+      wrapper.expectElement('tr:eq(1)').toHaveAttribute('aria-hidden', 'true');
+      wrapper.expectElement('tr:eq(2)').toHaveAttribute('aria-hidden', 'true');
     });
 
     it('renders the non-fee record payment details data only in the first row', () => {
@@ -303,6 +337,24 @@ describe(component, () => {
 
       wrapper.expectElement('tr:eq(2) td:contains("33333333")').toExist();
       wrapper.expectElement('tr:eq(2) td:contains("Test exporter 3")').toExist();
+    });
+
+    it('renders all facility ids and exporters in screenreader only cell in the first row of group', () => {
+      const feeRecords: { id: number; facilityId: string; exporter: string }[] = [
+        { id: 1, facilityId: '11111111', exporter: 'Test exporter 1' },
+        { id: 1, facilityId: '22222222', exporter: 'Test exporter 2' },
+        { id: 1, facilityId: '33333333', exporter: 'Test exporter 3' },
+      ];
+      const paymentDetailsRow: PaymentDetailsRowViewModel = {
+        ...aPaymentDetailsTableRow(),
+        feeRecords,
+      };
+      const wrapper = getWrapper({ paymentDetailsRow });
+
+      wrapper.expectElement(`tr:eq(0) ${screenreaderAlternativeCellSelector}`).toExist();
+      wrapper.expectText(`tr:eq(0) ${screenreaderAlternativeCellSelector} li:eq(0)`).toRead('11111111 Test exporter 1');
+      wrapper.expectText(`tr:eq(0) ${screenreaderAlternativeCellSelector} li:eq(1)`).toRead('22222222 Test exporter 2');
+      wrapper.expectText(`tr:eq(0) ${screenreaderAlternativeCellSelector} li:eq(2)`).toRead('33333333 Test exporter 3');
     });
   });
 });

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table.component-test.ts
@@ -59,7 +59,7 @@ describe(component, () => {
     wrapper.expectElement(tableHeaderSelector('Exporter')).notToHaveAttribute('aria-sort');
   });
 
-  it('should hide the facility ID and exporter headings from screenreaders', () => {
+  it('should render the facility ID and exporter headings as aria hidden', () => {
     const wrapper = getWrapper();
 
     wrapper.expectElement(tableHeaderSelector('Facility ID')).toExist();
@@ -69,7 +69,7 @@ describe(component, () => {
     wrapper.expectElement(tableHeaderSelector('Exporter')).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('should render the combined facility ID and export heading to screenreaders only', () => {
+  it('should render the combined facility ID and export heading as visually hidden', () => {
     const wrapper = getWrapper();
 
     wrapper.expectElement(tableHeaderSelector('Facility ID and Exporter')).toExist();

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/payment-details-table.component-test.ts
@@ -19,11 +19,11 @@ describe(component, () => {
 
   const tableHeaderSelector = (text: string) => `thead th:contains("${text}")`;
 
-  it('renders 7 table headings', () => {
+  it('renders 8 table headings', () => {
     const wrapper = getWrapper();
 
     wrapper.expectElement('table thead tr').toHaveCount(1);
-    wrapper.expectElement('table thead th').toHaveCount(7);
+    wrapper.expectElement('table thead th').toHaveCount(8);
   });
 
   it('renders the amount heading with the aria-sort attribute set to ascending', () => {
@@ -57,5 +57,22 @@ describe(component, () => {
 
     wrapper.expectElement(tableHeaderSelector('Exporter')).toExist();
     wrapper.expectElement(tableHeaderSelector('Exporter')).notToHaveAttribute('aria-sort');
+  });
+
+  it('should hide the facility ID and exporter headings from screenreaders', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement(tableHeaderSelector('Facility ID')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Facility ID')).toHaveAttribute('aria-hidden', 'true');
+
+    wrapper.expectElement(tableHeaderSelector('Exporter')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Exporter')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should render the combined facility ID and export heading to screenreaders only', () => {
+    const wrapper = getWrapper();
+
+    wrapper.expectElement(tableHeaderSelector('Facility ID and Exporter')).toExist();
+    wrapper.expectElement(tableHeaderSelector('Facility ID')).hasClass('govuk-visually-hidden');
   });
 });

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table-row.njk
@@ -7,21 +7,33 @@
   {% set feeRecords = paymentDetails.feeRecords %}
   {% set reconciledBy = paymentDetails.reconciledBy %}
   {% set dateReconciled = paymentDetails.dateReconciled %}
+
   {% set paymentAmountHtml %}
-  {% if userCanEdit and groupStatus !== 'READY_TO_KEY' and groupStatus !== 'RECONCILED' %}
-    <a
-      href="/utilisation-reports/{{ reportId }}/edit-payment/{{ payment.id }}?redirectTab=payment-details"
-      data-cy="payment-details-tab-edit-payment-link--paymentId-{{ payment.id }}">
+    {% if userCanEdit and groupStatus !== 'READY_TO_KEY' and groupStatus !== 'RECONCILED' %}
+      <a
+        href="/utilisation-reports/{{ reportId }}/edit-payment/{{ payment.id }}?redirectTab=payment-details"
+        data-cy="payment-details-tab-edit-payment-link--paymentId-{{ payment.id }}">
+        {{ payment.amount.formattedCurrencyAndAmount }}
+      </a>
+    {% else %}
       {{ payment.amount.formattedCurrencyAndAmount }}
-    </a>
-  {% else %}
-    {{ payment.amount.formattedCurrencyAndAmount }}
-  {% endif %}
+    {% endif %}
   {% endset %}
+
+  {% set screenReaderAlternativeFacilityIdAndExporterHtml %}
+    <span>
+      <ul>
+        {% for feeRecord in feeRecords %}
+         <li>{{ feeRecord.facilityId }} {{ feeRecord.exporter }}</li>
+        {% endfor %}
+      </ul>
+    </span>
+  {% endset %}
+
   {% for feeRecord in feeRecords %}
     {% set isFirstLineOfRow = loop.index === 1 %}
     {% set isLastLineOfRow = loop.index === feeRecords.length %}
-    <tr class="govuk-table__row" data-cy="payment-details-row--paymentId-{{ payment.id }}-feeRecordId-{{ feeRecord.id }}">
+    <tr class="govuk-table__row" aria-hidden="{{ false if isFirstLineOfRow else true }}"data-cy="payment-details-row--paymentId-{{ payment.id }}-feeRecordId-{{ feeRecord.id }}">
       <td
         class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}"
         data-sort-value="{{ payment.amount.dataSortValue }}"
@@ -30,8 +42,11 @@
         {{ (paymentAmountHtml | safe) if isFirstLineOfRow }}
       </td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-cy="payment-reference" data-sort-value="{{ payment.reference }}">{{ payment.reference if isFirstLineOfRow }}</td>
-      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-cy="facility-id">{{ feeRecord.facilityId }}</td>
-      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}">{{ feeRecord.exporter }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" aria-hidden="true" data-cy="facility-id">{{ feeRecord.facilityId }}</td>
+      <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" aria-hidden="true">{{ feeRecord.exporter }}</td>
+      <td class="govuk-visually-hidden" data-cy="screenreader-alternative-facility-id-and-expoter">
+        {{ (screenReaderAlternativeFacilityIdAndExporterHtml | safe) if isFirstLineOfRow }}
+        </td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ payment.dateReceived.dataSortValue }}">{{ payment.dateReceived.formattedDateReceived if isFirstLineOfRow }}</td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ reconciledBy }}" data-cy="reconciled-by">{{ reconciledBy if isFirstLineOfRow }}</td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ dateReconciled.dataSortValue }}" data-cy="date-reconciled">{{ dateReconciled.formattedDateReconciled if isFirstLineOfRow }}</td>

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table-row.njk
@@ -20,7 +20,7 @@
     {% endif %}
   {% endset %}
 
-  {% set screenReaderAlternativeFacilityIdAndExporterHtml %}
+  {% set hiddenFacilityIdAndExporterHtml %}
     <span>
       <ul>
         {% for feeRecord in feeRecords %}
@@ -33,7 +33,7 @@
   {% for feeRecord in feeRecords %}
     {% set isFirstLineOfRow = loop.index === 1 %}
     {% set isLastLineOfRow = loop.index === feeRecords.length %}
-    <tr class="govuk-table__row" aria-hidden="{{ false if isFirstLineOfRow else true }}"data-cy="payment-details-row--paymentId-{{ payment.id }}-feeRecordId-{{ feeRecord.id }}">
+    <tr class="govuk-table__row" aria-hidden="{{ not isFirstLineOfRow }}"data-cy="payment-details-row--paymentId-{{ payment.id }}-feeRecordId-{{ feeRecord.id }}">
       <td
         class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}"
         data-sort-value="{{ payment.amount.dataSortValue }}"
@@ -44,8 +44,8 @@
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-cy="payment-reference" data-sort-value="{{ payment.reference }}">{{ payment.reference if isFirstLineOfRow }}</td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" aria-hidden="true" data-cy="facility-id">{{ feeRecord.facilityId }}</td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" aria-hidden="true">{{ feeRecord.exporter }}</td>
-      <td class="govuk-visually-hidden" data-cy="screenreader-alternative-facility-id-and-expoter">
-        {{ (screenReaderAlternativeFacilityIdAndExporterHtml | safe) if isFirstLineOfRow }}
+      <td class="govuk-visually-hidden" data-cy="hidden-facility-id-and-expoter">
+        {{ (hiddenFacilityIdAndExporterHtml | safe) if isFirstLineOfRow }}
         </td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ payment.dateReceived.dataSortValue }}">{{ payment.dateReceived.formattedDateReceived if isFirstLineOfRow }}</td>
       <td class="govuk-table__cell{{ " no-border" if not isLastLineOfRow }}" data-sort-value="{{ reconciledBy }}" data-cy="reconciled-by">{{ reconciledBy if isFirstLineOfRow }}</td>

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/payment-details-table.njk
@@ -8,8 +8,9 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header" aria-sort="ascending">Amount</th>
         <th scope="col" class="govuk-table__header" aria-sort="none">Payment reference</th>
-        <th scope="col" class="govuk-table__header">Facility ID</th>
-        <th scope="col" class="govuk-table__header">Exporter</th>
+        <th scope="col" class="govuk-table__header" aria-hidden="true">Facility ID</th>
+        <th scope="col" class="govuk-table__header" aria-hidden="true">Exporter</th>
+        <th scope="col" class="govuk-table__header govuk-visually-hidden">Facility ID and Exporter</th>
         <th scope="col" class="govuk-table__header" aria-sort="none">Date received</th>
         <th scope="col" class="govuk-table__header" aria-sort="none">Reconciled by</th>
         <th scope="col" class="govuk-table__header" aria-sort="none">Date reconciled</th>


### PR DESCRIPTION
## Introduction :pencil2:
The payment details tab has a complciated table with grouped rows. These grouped rows mean that standard navigation with a screenreader does not convey the same meaning as the visual display. This PR improves that by making the screenreader experience line up with the order of reading of the table with the intended visual flow.

## Resolution :heavy_check_mark:
- Hide sub rows of grouped rows from screenreaders
- Hide facility id and exporter columns from screenreaders
- Add hidden column containing the facility id and exporter in a screenreader friendly format

