### PR TITLE
fix(DTFS2-7567): acbs container initilisation

### DIFF
--- a/azure-functions/acbs-function/Dockerfile
+++ b/azure-functions/acbs-function/Dockerfile
@@ -10,9 +10,7 @@ ENV AzureWebJobsFeatureFlags=EnableWorkerIndexing
 # Directories setup
 WORKDIR /app
 
-COPY libs libs
 COPY azure-functions/acbs-function .
 
-COPY package*.json .
-RUN npm ci
+RUN npm i
 RUN npm cache clean --force

--- a/azure-functions/acbs-function/package.json
+++ b/azure-functions/acbs-function/package.json
@@ -32,17 +32,16 @@
     "axios": "^1.7.7",
     "date-fns": "^2.30.0",
     "dotenv": "^16.4.5",
-    "durable-functions": "^3.1.0",
-    "lodash": "^4.17.21"
+    "durable-functions": "^3.1.0"
   },
   "devDependencies": {
-    "@ukef/dtfs2-common": "1.0.0",
     "babel-jest": "29.5.0",
     "babel-loader": "9.1.2",
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.30.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "lodash": "^4.17.21"
   },
   "engines": {
     "node": ">=22.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,17 +55,16 @@
         "axios": "^1.7.7",
         "date-fns": "^2.30.0",
         "dotenv": "^16.4.5",
-        "durable-functions": "^3.1.0",
-        "lodash": "^4.17.21"
+        "durable-functions": "^3.1.0"
       },
       "devDependencies": {
-        "@ukef/dtfs2-common": "1.0.0",
         "babel-jest": "29.5.0",
         "babel-loader": "9.1.2",
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.30.0",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=22.8.0",


### PR DESCRIPTION
## Introduction :pencil2:
ACBS microservice container did not initialise properly despite no errors on the logs, it was unable to accept any request and returned `404` status code. 

## Resolution :heavy_check_mark:
* Removed `libs` library due to lack of Typescript support in current Azure functions base image.
* Removed root `package-lock.json` to ensure only `acbs-function` `package.json` is included in the container and replaced `ci` with `i` (since no package-lock.json exists due to workspaces)

## Miscellaneous :heavy_plus_sign:
* Moved few test pertinent dependencies to `devDependencies`.
