### PR TITLE
fix(DTFS2-7440): acbs microservice docker communication

### DIFF
--- a/azure-functions/acbs-function/src/functions/acbs-amend-facility.js
+++ b/azure-functions/acbs-function/src/functions/acbs-amend-facility.js
@@ -139,9 +139,9 @@ df.app.orchestration('acbs-amend-facility', function* amendFacility(context) {
     });
 
     /**
-     * Below have disabled due to BR.
-     * Enable below two alongside with investor and fixed fee records.
      * TODO: DTFS2-7581
+     * Below have been disabled for release 2.4.0.
+     * Enable below two alongside with investor and fixed fee records.
      */
     // 3. SOF: Facility Covenant Record (FCR)
     // const facilityCovenantRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-covenant-record', {

--- a/azure-functions/acbs-function/src/functions/acbs-amend-facility.js
+++ b/azure-functions/acbs-function/src/functions/acbs-amend-facility.js
@@ -138,23 +138,28 @@ df.app.orchestration('acbs-amend-facility', function* amendFacility(context) {
       amendments,
     });
 
+    /**
+     * Below have disabled due to BR.
+     * Enable below two alongside with investor and fixed fee records.
+     * TODO: DTFS2-7581
+     */
     // 3. SOF: Facility Covenant Record (FCR)
-    const facilityCovenantRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-covenant-record', {
-      facilityId,
-      amendments,
-    });
+    // const facilityCovenantRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-covenant-record', {
+    //   facilityId,
+    //   amendments,
+    // });
 
     // 4. SOF: Facility Guarantee Record (FGR)
-    const facilityGuaranteeRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-guarantee-record', {
-      facilityId,
-      amendments,
-    });
+    // const facilityGuaranteeRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-guarantee-record', {
+    //   facilityId,
+    //   amendments,
+    // });
 
     return {
       facilityId,
       facilityMasterRecord: facilityMasterRecord.result,
-      facilityCovenantRecord: facilityCovenantRecord.result,
-      facilityGuaranteeRecord: facilityGuaranteeRecord.result,
+      // facilityCovenantRecord: facilityCovenantRecord.result,
+      // facilityGuaranteeRecord: facilityGuaranteeRecord.result,
       facilityLoanRecord: facilityLoanRecord.result,
     };
   } catch (error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
       - UKEF_TFM_API_SYSTEM_KEY=${UKEF_TFM_API_SYSTEM_KEY}
       - UKEF_TFM_API_REPORTS_KEY
       - TFM_UI_URL=http://localhost:5003
-      - AZURE_ACBS_FUNCTION_URL=http://host.docker.internal:7071
+      - AZURE_ACBS_FUNCTION_URL=http://acbs
       - JWT_SIGNING_KEY
       - JWT_VALIDATING_KEY
       - UKEF_INTERNAL_NOTIFICATION=test
@@ -296,7 +296,7 @@ services:
       - APIM_ESTORE_URL
       - APIM_ESTORE_KEY
       - APIM_ESTORE_VALUE
-      - AZURE_ACBS_FUNCTION_URL=http://host.docker.internal:7071
+      - AZURE_ACBS_FUNCTION_URL=http://acbs
       - GOV_NOTIFY_API_KEY
       - MONGO_INITDB_DATABASE
       - MONGODB_URI
@@ -381,7 +381,7 @@ services:
       - TZ
       - AzureWebJobsStorage=DefaultEndpointsProtocol=https;AccountName=${AZURE_PORTAL_STORAGE_ACCOUNT};AccountKey=${AZURE_PORTAL_STORAGE_ACCESS_KEY};EndpointSuffix=core.windows.net
       - FUNCTIONS_WORKER_RUNTIME=node
-      - WEBSITE_HOSTNAME=localhost:7071
+      - WEBSITE_HOSTNAME=acbs:7071
       - APIM_MDM_URL
       - APIM_MDM_KEY
       - APIM_MDM_VALUE


### PR DESCRIPTION
## Introduction :pencil2:
Locally `external-api` is unable to communicate with `acbs` microservice, the issue is due to recent `acbs` docker service update inline with other microservices however the ACBS URL has not been updated.

## Resolution :heavy_check_mark:
* Set `AZURE_ACBS_FUNCTION_URL` to `http://acbs` when executing `acbs` microservice locally using `docker compose` command. This does not have any impact of Azure RG.

## Miscellaneous :heavy_plus_sign:
* Disabled SOF `acbs-amend-facility-covenant-record` and `acbs-amend-facility-guarantee-record`.

