### PR TITLE
feat(FN-3548): update utilisation tab headers

### DIFF
--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/utilisation-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/utilisation-table.component-test.ts
@@ -27,12 +27,12 @@ describe(component, () => {
     wrapper.expectText('th[data-cy="facility-id-header"]').toRead('Facility ID');
     wrapper.expectText('th[data-cy="exporter-header"]').toRead('Exporter');
     wrapper.expectText('th[data-cy="base-currency-header"]').toRead('Base currency');
-    wrapper.expectText('th[data-cy="value-header"]').toRead('Value');
-    wrapper.expectText('th[data-cy="utilisation-header"]').toRead('Utilisation');
+    wrapper.expectText('th[data-cy="value-header"]').toRead('Facility value');
+    wrapper.expectText('th[data-cy="utilisation-header"]').toRead('Bank utilisation');
     wrapper.expectText('th[data-cy="cover-percentage-header"]').toRead('UKEF cover');
     wrapper.expectText('th[data-cy="exposure-header"]').toRead('UKEF exposure');
-    wrapper.expectText('th[data-cy="fees-accrued-header"]').toRead('Fees accrued');
-    wrapper.expectText('th[data-cy="fees-payable-header"]').toRead('Fees payable to UKEF (reported currency)');
+    wrapper.expectText('th[data-cy="fees-accrued-header"]').toRead('Fees accrued for the period');
+    wrapper.expectText('th[data-cy="fees-payable-header"]').toRead('Fees payable to UKEF for the period (reported currency)');
   });
 
   it('should set all columns as sortable with the default sort order as the facility id column ascending', () => {

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/utilisation-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/utilisation-table.njk
@@ -7,12 +7,12 @@
         <th scope="col" class="govuk-table__header" aria-sort="ascending" data-cy="facility-id-header">Facility ID</th>
         <th scope="col" class="govuk-table__header" aria-sort="none" data-cy="exporter-header">Exporter</th>
         <th scope="col" class="govuk-table__header" aria-sort="none" data-cy="base-currency-header">Base currency</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="value-header">Value</th>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="utilisation-header">Utilisation</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="value-header">Facility value</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="utilisation-header">Bank utilisation</th>
         <th scope="colgroup" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="cover-percentage-header">UKEF cover</th>
         <th scope="colgroup" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="exposure-header">UKEF exposure</th>
-        <th scope="colgroup" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="fees-accrued-header">Fees accrued</th>
-        <th scope="colgroup" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="fees-payable-header">Fees payable to UKEF (reported currency)</th>
+        <th scope="colgroup" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="fees-accrued-header">Fees accrued for the period</th>
+        <th scope="colgroup" class="govuk-table__header govuk-table__header--numeric" aria-sort="none" data-cy="fees-payable-header">Fees payable to UKEF for the period (reported currency)</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">


### PR DESCRIPTION
## Introduction :pencil2:
Update utilisation tab headers to new wording.

## Resolution :heavy_check_mark:
Renamed headers should be: 

- Facility ID
- Exporter
- Base currency
- Facility value
- Bank utilisation
- UKEF cover
- UKEF exposure
- Fees accrued for the period
- Fees payable to UKEF for the period (reported currency) 

## Screenshot of changes
<img width="1602" alt="Screenshot 2024-10-28 at 11 49 12" src="https://github.com/user-attachments/assets/54b65b05-b684-4be0-b06f-44d463af69a7">


