### PR TITLE
feat(FN-3518): hide select all when there is nothing to select

### DIFF
--- a/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/premium-payments-table.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/_macros/premium-payments-table.component-test.ts
@@ -496,53 +496,45 @@ describe(component, () => {
     });
   });
 
-  const FEE_RECORD_STATUSES_WHERE_CHECKBOX_SHOULD_EXIST = [FEE_RECORD_STATUS.TO_DO, FEE_RECORD_STATUS.DOES_NOT_MATCH];
+  it('should render the checkbox when userCanEdit and displaySelectAllCheckbox are true, and the fee record status is selectable', () => {
+    const checkboxId: PremiumPaymentsTableCheckboxId = `feeRecordIds-1-reportedPaymentsCurrency-GBP-status-TO_DO`;
+    const feeRecordPaymentGroups: PremiumPaymentsViewModelItem[] = [
+      {
+        ...aPremiumPaymentsViewModelItem(),
+        isSelectable: true,
+        checkboxId,
+      },
+    ];
 
-  it.each(FEE_RECORD_STATUSES_WHERE_CHECKBOX_SHOULD_EXIST)(
-    'should render the checkbox when userCanEdit and displaySelectAllCheckbox are true, and the fee record status is %s',
-    (feeRecordStatus) => {
-      const checkboxId: PremiumPaymentsTableCheckboxId = `feeRecordIds-1-reportedPaymentsCurrency-GBP-status-${feeRecordStatus}`;
-      const feeRecordPaymentGroups: PremiumPaymentsViewModelItem[] = [
-        {
-          ...aPremiumPaymentsViewModelItem(),
-          status: feeRecordStatus,
-          checkboxId,
-        },
-      ];
+    const wrapper = render({
+      ...defaultRendererParams(),
+      userCanEdit: true,
+      displaySelectAllCheckbox: true,
+      feeRecordPaymentGroups,
+    });
 
-      const wrapper = render({
-        ...defaultRendererParams(),
-        userCanEdit: true,
-        displaySelectAllCheckbox: true,
-        feeRecordPaymentGroups,
-      });
+    wrapper.expectElement(`input#${checkboxId}[type="checkbox"]`).toExist();
+  });
 
-      wrapper.expectElement(`input#${checkboxId}[type="checkbox"]`).toExist();
-    },
-  );
+  it('should not render the checkbox when userCanEdit and displaySelectAllCheckbox are true, and the fee record is not selectable', () => {
+    const checkboxId = 'feeRecordIds-1,2,3-reportedPaymentsCurrency-GBP-status-TO_DO';
+    const feeRecordPaymentGroups: PremiumPaymentsViewModelItem[] = [
+      {
+        ...aPremiumPaymentsViewModelItem(),
+        isSelectable: false,
+        checkboxId,
+      },
+    ];
 
-  it.each(difference(Object.values(FEE_RECORD_STATUS), FEE_RECORD_STATUSES_WHERE_CHECKBOX_SHOULD_EXIST))(
-    'should not render the checkbox when userCanEdit and displaySelectAllCheckbox are true, and the fee record status is %s',
-    (feeRecordStatus) => {
-      const checkboxId = 'feeRecordIds-1,2,3-reportedPaymentsCurrency-GBP-status-TO_DO';
-      const feeRecordPaymentGroups: PremiumPaymentsViewModelItem[] = [
-        {
-          ...aPremiumPaymentsViewModelItem(),
-          status: feeRecordStatus,
-          checkboxId,
-        },
-      ];
+    const wrapper = render({
+      ...defaultRendererParams(),
+      userCanEdit: true,
+      displaySelectAllCheckbox: true,
+      feeRecordPaymentGroups,
+    });
 
-      const wrapper = render({
-        ...defaultRendererParams(),
-        userCanEdit: true,
-        displaySelectAllCheckbox: true,
-        feeRecordPaymentGroups,
-      });
-
-      wrapper.expectElement(`input#${checkboxId}[type="checkbox"]`).notToExist();
-    },
-  );
+    wrapper.expectElement(`input#${checkboxId}[type="checkbox"]`).notToExist();
+  });
 
   it('should not render any checkboxes when userCanEdit is false', () => {
     const feeRecordPaymentGroups: PremiumPaymentsViewModelItem[] = Object.values(FEE_RECORD_STATUS).map((status) => ({

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/utilisation-report-reconciliation-for-report.component-test.ts
@@ -32,16 +32,19 @@ describe(page, () => {
     bank,
     formattedReportPeriod,
     reportId: reportId.toString(),
-    premiumPaymentsFilters,
-    enablePaymentsReceivedSorting: false,
-    premiumPayments: [],
+    premiumPayments: {
+      payments: [],
+      filters: premiumPaymentsFilters,
+      displayMatchSuccessNotification: false,
+      displaySelectAllCheckbox: true,
+      enablePaymentsReceivedSorting: false,
+    },
     keyingSheet: [],
     paymentDetails: {
       rows: [],
       selectedFilters: null,
     },
     utilisationDetails: { utilisationTableRows: [], downloadUrl },
-    displayMatchSuccessNotification: false,
   };
 
   const getWrapper = (viewModel: UtilisationReportReconciliationForReportViewModel = params) => render(viewModel);
@@ -147,8 +150,14 @@ describe(page, () => {
       wrapper.expectText('[data-cy="premium-payments-facility-filter-clear-button"]').toRead('Clear filter');
     });
 
-    it('renders error when premiumPaymentsFilterError is provided', () => {
-      const wrapper = getWrapper({ ...params, premiumPaymentsFilterError: { text: 'Oh no that is not correct', href: '#filter-component' } });
+    it('renders error when filterError is provided', () => {
+      const wrapper = getWrapper({
+        ...params,
+        premiumPayments: {
+          ...params.premiumPayments,
+          filterError: { text: 'Oh no that is not correct', href: '#filter-component' },
+        },
+      });
       wrapper.expectText('[data-cy="facility-filter-form"]').toContain('Oh no that is not correct');
       wrapper.expectLink('[data-cy="error-summary"] a').toLinkTo('#filter-component', 'Oh no that is not correct');
     });
@@ -189,13 +198,25 @@ describe(page, () => {
     });
 
     it('should not display "match success notification" when param is false', () => {
-      const wrapper = getWrapper({ ...params, displayMatchSuccessNotification: false });
+      const wrapper = getWrapper({
+        ...params,
+        premiumPayments: {
+          ...params.premiumPayments,
+          displayMatchSuccessNotification: false,
+        },
+      });
 
       wrapper.expectElement('[data-cy="match-success-notification"]').notToExist();
     });
 
     it('should display "match success notification" when param is true', () => {
-      const wrapper = getWrapper({ ...params, displayMatchSuccessNotification: true });
+      const wrapper = getWrapper({
+        ...params,
+        premiumPayments: {
+          ...params.premiumPayments,
+          displayMatchSuccessNotification: true,
+        },
+      });
 
       wrapper.expectElement('[data-cy="match-success-notification"]').toExist();
       wrapper.expectText('[data-cy="match-success-notification-heading"]').toRead('Match payment recorded');

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.test.ts
@@ -1,5 +1,6 @@
 import { when } from 'jest-when';
 import { CURRENCY, Currency, CurrencyAndAmount, FEE_RECORD_STATUS, FeeRecordStatus } from '@ukef/dtfs2-common';
+import difference from 'lodash.difference';
 import { mapCurrenciesToRadioItems } from '../../../helpers/map-currencies-to-radio-items';
 import {
   getFormattedDateReconciled,
@@ -8,9 +9,11 @@ import {
   mapPaymentDetailsGroupsToPaymentDetailsViewModel,
   mapKeyingSheetToKeyingSheetViewModel,
   mapPaymentDetailsFiltersToViewModel,
+  shouldDisplayPremiumPaymentsSelectAllCheckbox,
 } from './reconciliation-for-report-helper';
 import { FeeRecord, KeyingSheet, KeyingSheetRow, Payment, PaymentDetails, PremiumPaymentsGroup } from '../../../api-response-types';
-import { aPremiumPaymentsGroup, aFeeRecord, aPayment, aPaymentDetails } from '../../../../test-helpers';
+import { aPremiumPaymentsGroup, aFeeRecord, aPayment, aPaymentDetails, aPremiumPaymentsViewModelItem } from '../../../../test-helpers';
+import { PremiumPaymentsViewModelItem } from '../../../types/view-models';
 
 describe('reconciliation-for-report-helper', () => {
   describe('mapPremiumPaymentsToViewModelItems', () => {
@@ -343,6 +346,35 @@ describe('reconciliation-for-report-helper', () => {
       expect(viewModel).toHaveLength(1);
       expect(viewModel[0].status).toEqual(status);
     });
+
+    const selectableFeeRecordStatuses = [FEE_RECORD_STATUS.TO_DO, FEE_RECORD_STATUS.DOES_NOT_MATCH];
+
+    it.each(selectableFeeRecordStatuses)('should set isSelectable to true if the group status is %s', (status: FeeRecordStatus) => {
+      // Arrange
+      const premiumPaymentGroups: PremiumPaymentsGroup[] = [{ ...aPremiumPaymentsGroup(), status }];
+
+      // Act
+      const viewModel = mapPremiumPaymentsToViewModelItems(premiumPaymentGroups, DEFAULT_IS_CHECKBOX_SELECTED);
+
+      // Assert
+      expect(viewModel).toHaveLength(1);
+      expect(viewModel[0].isSelectable).toEqual(true);
+    });
+
+    it.each(difference(Object.values(FEE_RECORD_STATUS), selectableFeeRecordStatuses))(
+      'should set isSelectable to false if the group status is %s',
+      (status: FeeRecordStatus) => {
+        // Arrange
+        const premiumPaymentGroups: PremiumPaymentsGroup[] = [{ ...aPremiumPaymentsGroup(), status }];
+
+        // Act
+        const viewModel = mapPremiumPaymentsToViewModelItems(premiumPaymentGroups, DEFAULT_IS_CHECKBOX_SELECTED);
+
+        // Assert
+        expect(viewModel).toHaveLength(1);
+        expect(viewModel[0].isSelectable).toEqual(false);
+      },
+    );
 
     it.each([
       { feeRecordStatus: FEE_RECORD_STATUS.TO_DO, feeRecordDisplayStatus: 'TO DO' },
@@ -1043,6 +1075,61 @@ describe('reconciliation-for-report-helper', () => {
           paymentCurrency: mapCurrenciesToRadioItems(),
         });
       });
+    });
+  });
+
+  describe('shouldDisplayPremiumPaymentsSelectAllCheckbox', () => {
+    it('should return false if there are no items to display', () => {
+      // Arrange
+      const items: PremiumPaymentsViewModelItem[] = [];
+
+      // Act
+      const result = shouldDisplayPremiumPaymentsSelectAllCheckbox(items);
+
+      // Assert
+      expect(result).toEqual(false);
+    });
+
+    it('should return false if all items in the table are not selectable', () => {
+      // Arrange
+      const items = [
+        { ...aPremiumPaymentsViewModelItem(), isSelectable: false },
+        { ...aPremiumPaymentsViewModelItem(), isSelectable: false },
+      ];
+
+      // Act
+      const result = shouldDisplayPremiumPaymentsSelectAllCheckbox(items);
+
+      // Assert
+      expect(result).toEqual(false);
+    });
+
+    it('should return true if any item in the table is selectable', () => {
+      // Arrange
+      const items = [
+        { ...aPremiumPaymentsViewModelItem(), isSelectable: false },
+        { ...aPremiumPaymentsViewModelItem(), isSelectable: true },
+      ];
+
+      // Act
+      const result = shouldDisplayPremiumPaymentsSelectAllCheckbox(items);
+
+      // Assert
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if all items in the table are selectable', () => {
+      // Arrange
+      const items = [
+        { ...aPremiumPaymentsViewModelItem(), isSelectable: true },
+        { ...aPremiumPaymentsViewModelItem(), isSelectable: true },
+      ];
+
+      // Act
+      const result = shouldDisplayPremiumPaymentsSelectAllCheckbox(items);
+
+      // Assert
+      expect(result).toEqual(true);
     });
   });
 });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/helpers/reconciliation-for-report-helper.ts
@@ -1,5 +1,6 @@
 import orderBy from 'lodash.orderby';
 import {
+  FEE_RECORD_STATUS,
   FeeRecordStatus,
   getFormattedCurrencyAndAmount,
   getFormattedMonetaryValue,
@@ -129,6 +130,8 @@ export const mapPremiumPaymentsToViewModelItems = (
     const feeRecordViewModelItems = mapFeeRecordsToFeeRecordViewModelItems(feeRecordsSortedByReportedPayments);
     const paymentViewModelItems = mapPaymentsToPaymentViewModelItems(paymentsReceived);
 
+    const isSelectable = status === FEE_RECORD_STATUS.TO_DO || status === FEE_RECORD_STATUS.DOES_NOT_MATCH;
+
     return {
       feeRecords: feeRecordViewModelItems,
       totalReportedPayments: {
@@ -142,6 +145,7 @@ export const mapPremiumPaymentsToViewModelItems = (
       },
       status,
       displayStatus,
+      isSelectable,
       checkboxId,
       isChecked,
       checkboxAriaLabel,
@@ -323,3 +327,10 @@ export const mapPaymentDetailsFiltersToViewModel = (paymentDetailsFilters: Payme
     paymentCurrency: mapCurrenciesToRadioItems(paymentDetailsFilters.paymentCurrency),
   };
 };
+
+/**
+ * Determines whether the premium payments select all checkbox should be displayed
+ * @param items - the items that will be displayed in the table
+ * @returns - whether premium payments select all checkbox should be displayed
+ */
+export const shouldDisplayPremiumPaymentsSelectAllCheckbox = (items: PremiumPaymentsViewModelItem[]): boolean => items.some((item) => item.isSelectable);

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
@@ -12,6 +12,7 @@ import {
   PaymentDetailsViewModel,
   UtilisationReportReconciliationForReportViewModel,
   UtilisationDetailsViewModel,
+  PremiumPaymentsViewModel,
 } from '../../../types/view-models';
 import { mapPaymentDetailsFiltersToViewModel } from '../helpers';
 import { mapToSelectedPaymentDetailsFiltersViewModel } from './map-to-selected-payment-details-filters-view-model';
@@ -149,7 +150,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       };
       const formattedReportPeriod = 'January 2024';
 
-      const expectedPremiumPayments: PremiumPaymentsViewModelItem[] = [
+      const expectedPremiumPaymentsPayments: PremiumPaymentsViewModelItem[] = [
         {
           feeRecords: [
             {
@@ -177,6 +178,18 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
         },
       ];
 
+      const premiumPaymentsFilters = {
+        facilityId: premiumPaymentsFacilityId,
+      };
+
+      const expectedPremiumPayments: PremiumPaymentsViewModel = {
+        payments: expectedPremiumPaymentsPayments,
+        enablePaymentsReceivedSorting: true,
+        displayMatchSuccessNotification: false,
+        filters: premiumPaymentsFilters,
+        displaySelectAllCheckbox: true,
+      };
+
       const expectedUtilisationDetails: UtilisationDetailsViewModel = {
         utilisationTableRows: [
           {
@@ -193,10 +206,6 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
           },
         ],
         downloadUrl: `/utilisation-reports/${reportId}/download`,
-      };
-
-      const premiumPaymentsFilters = {
-        facilityId: premiumPaymentsFacilityId,
       };
 
       const paymentDetailsFilters = {
@@ -240,14 +249,11 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
         activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
         bank,
         formattedReportPeriod,
-        enablePaymentsReceivedSorting: true,
         reportId: '1',
         premiumPayments: expectedPremiumPayments,
-        premiumPaymentsFilters,
         paymentDetails: expectedPaymentDetailsViewModel,
         keyingSheet: [],
         utilisationDetails: expectedUtilisationDetails,
-        displayMatchSuccessNotification: false,
       });
     });
 
@@ -278,10 +284,10 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.premiumPaymentsTableDataError).toBeDefined();
-      expect(viewModel.premiumPaymentsTableDataError?.href).toEqual('#premium-payments-table');
-      expect(viewModel.premiumPaymentsTableDataError?.text).toEqual('Select a fee or fees with the same status');
-      expect(viewModel.premiumPayments[0].isChecked).toEqual(true);
+      expect(viewModel.premiumPayments.tableDataError).toBeDefined();
+      expect(viewModel.premiumPayments.tableDataError?.href).toEqual('#premium-payments-table');
+      expect(viewModel.premiumPayments.tableDataError?.text).toEqual('Select a fee or fees with the same status');
+      expect(viewModel.premiumPayments.payments[0].isChecked).toEqual(true);
     });
 
     it("renders the page with 'displayMatchSuccessNotification' set to true if matchSuccess query param is set to 'true'", async () => {
@@ -304,7 +310,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.displayMatchSuccessNotification).toEqual(true);
+      expect(viewModel.premiumPayments.displayMatchSuccessNotification).toEqual(true);
     });
 
     it("renders the page with 'displayMatchSuccessNotification' set to false if matchSuccess query param is not set", async () => {
@@ -325,7 +331,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.displayMatchSuccessNotification).toEqual(false);
+      expect(viewModel.premiumPayments.displayMatchSuccessNotification).toEqual(false);
     });
 
     it("renders the page with 'displayMatchSuccessNotification' set to false if matchSuccess query param is set to a value other than 'true'", async () => {
@@ -348,7 +354,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.displayMatchSuccessNotification).toEqual(false);
+      expect(viewModel.premiumPayments.displayMatchSuccessNotification).toEqual(false);
     });
 
     it("renders the page with 'enablePaymentsReceivedSorting' set to true if at least one fee record has a non-null 'paymentsReceived'", async () => {
@@ -379,7 +385,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.enablePaymentsReceivedSorting).toEqual(true);
+      expect(viewModel.premiumPayments.enablePaymentsReceivedSorting).toEqual(true);
     });
 
     it("renders the page with 'enablePaymentsReceivedSorting' set to false if all fee records have null 'paymentsReceived'", async () => {
@@ -401,7 +407,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.enablePaymentsReceivedSorting).toEqual(false);
+      expect(viewModel.premiumPayments.enablePaymentsReceivedSorting).toEqual(false);
     });
 
     it('should set the premium payments filter error when invalid premium payments facility ID query value used', async () => {
@@ -433,9 +439,9 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
       // Assert
       expect(res._getRenderView()).toEqual('utilisation-reports/utilisation-report-reconciliation-for-report.njk');
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.premiumPaymentsFilterError).toBeDefined();
-      expect(viewModel.premiumPaymentsFilterError?.href).toEqual('#premium-payments-facility-id-filter');
-      expect(viewModel.premiumPaymentsFilterError?.text).toEqual('Facility ID must be a number');
+      expect(viewModel.premiumPayments.filterError).toBeDefined();
+      expect(viewModel.premiumPayments.filterError?.href).toEqual('#premium-payments-facility-id-filter');
+      expect(viewModel.premiumPayments.filterError?.text).toEqual('Facility ID must be a number');
     });
 
     it('should set the payment details filter error when invalid payment details facility ID query value used', async () => {
@@ -519,9 +525,9 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
 
       // Assert
       const viewModel = res._getRenderData() as UtilisationReportReconciliationForReportViewModel;
-      expect(viewModel.premiumPayments[0].isChecked).toEqual(true);
-      expect(viewModel.premiumPayments[1].isChecked).toEqual(true);
-      expect(viewModel.premiumPayments[2].isChecked).toEqual(false);
+      expect(viewModel.premiumPayments.payments[0].isChecked).toEqual(true);
+      expect(viewModel.premiumPayments.payments[1].isChecked).toEqual(true);
+      expect(viewModel.premiumPayments.payments[2].isChecked).toEqual(false);
     });
 
     it('should clear the redirect session data', async () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.test.ts
@@ -172,6 +172,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
           },
           status: FEE_RECORD_STATUS.MATCH,
           displayStatus: 'MATCH',
+          isSelectable: false,
           checkboxId: 'feeRecordIds-1-reportedPaymentsCurrency-GBP-status-MATCH',
           isChecked: false,
           checkboxAriaLabel: 'Select 12345678',
@@ -187,7 +188,7 @@ describe('controllers/utilisation-reports/utilisation-report-reconciliation-for-
         enablePaymentsReceivedSorting: true,
         displayMatchSuccessNotification: false,
         filters: premiumPaymentsFilters,
-        displaySelectAllCheckbox: true,
+        displaySelectAllCheckbox: false,
       };
 
       const expectedUtilisationDetails: UtilisationDetailsViewModel = {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
@@ -114,15 +114,18 @@ export const getUtilisationReportReconciliationByReportId = async (req: GetUtili
       bank,
       formattedReportPeriod,
       reportId,
-      premiumPaymentsFilters,
-      premiumPaymentsFilterError,
-      premiumPaymentsTableDataError,
-      enablePaymentsReceivedSorting,
-      premiumPayments: premiumPaymentsViewModel,
+      premiumPayments: {
+        payments: premiumPaymentsViewModel,
+        filters: premiumPaymentsFilters,
+        filterError: premiumPaymentsFilterError,
+        tableDataError: premiumPaymentsTableDataError,
+        enablePaymentsReceivedSorting,
+        displayMatchSuccessNotification: matchSuccess === 'true',
+        displaySelectAllCheckbox: true,
+      },
       paymentDetails: paymentDetailsViewModel,
       utilisationDetails: utilisationDetailsViewModel,
       keyingSheet: keyingSheetViewModel,
-      displayMatchSuccessNotification: matchSuccess === 'true',
     });
   } catch (error) {
     console.error(`Failed to render utilisation report with id ${reportId}`, error);

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/utilisation-report-reconciliation-for-report/index.ts
@@ -8,6 +8,7 @@ import {
   mapPaymentDetailsGroupsToPaymentDetailsViewModel,
   mapKeyingSheetToKeyingSheetViewModel,
   mapPaymentDetailsFiltersToViewModel,
+  shouldDisplayPremiumPaymentsSelectAllCheckbox,
 } from '../helpers';
 import { PaymentDetailsViewModel, UtilisationReportReconciliationForReportViewModel } from '../../../types/view-models';
 import { PremiumPaymentsGroup } from '../../../api-response-types';
@@ -92,7 +93,17 @@ export const getUtilisationReportReconciliationByReportId = async (req: GetUtili
 
     const enablePaymentsReceivedSorting = premiumPaymentsGroupsHaveAtLeastOnePaymentReceived(premiumPayments);
 
-    const premiumPaymentsViewModel = mapPremiumPaymentsToViewModelItems(premiumPayments, isCheckboxChecked);
+    const premiumPaymentsItems = mapPremiumPaymentsToViewModelItems(premiumPayments, isCheckboxChecked);
+
+    const premiumPaymentsViewModel = {
+      payments: premiumPaymentsItems,
+      filters: premiumPaymentsFilters,
+      filterError: premiumPaymentsFilterError,
+      tableDataError: premiumPaymentsTableDataError,
+      enablePaymentsReceivedSorting,
+      displayMatchSuccessNotification: matchSuccess === 'true',
+      displaySelectAllCheckbox: shouldDisplayPremiumPaymentsSelectAllCheckbox(premiumPaymentsItems),
+    };
 
     const keyingSheetViewModel = mapKeyingSheetToKeyingSheetViewModel(keyingSheet);
 
@@ -114,15 +125,7 @@ export const getUtilisationReportReconciliationByReportId = async (req: GetUtili
       bank,
       formattedReportPeriod,
       reportId,
-      premiumPayments: {
-        payments: premiumPaymentsViewModel,
-        filters: premiumPaymentsFilters,
-        filterError: premiumPaymentsFilterError,
-        tableDataError: premiumPaymentsTableDataError,
-        enablePaymentsReceivedSorting,
-        displayMatchSuccessNotification: matchSuccess === 'true',
-        displaySelectAllCheckbox: true,
-      },
+      premiumPayments: premiumPaymentsViewModel,
       paymentDetails: paymentDetailsViewModel,
       utilisationDetails: utilisationDetailsViewModel,
       keyingSheet: keyingSheetViewModel,

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -149,17 +149,22 @@ export type UtilisationDetailsViewModel = {
   downloadUrl: string;
 };
 
+export type PremiumPaymentsViewModel = {
+  payments: PremiumPaymentsViewModelItem[];
+  filters?: PremiumPaymentsFilters;
+  filterError?: ErrorSummaryViewModel;
+  tableDataError?: ErrorSummaryViewModel;
+  enablePaymentsReceivedSorting: boolean;
+  displayMatchSuccessNotification: boolean;
+  displaySelectAllCheckbox: boolean;
+};
+
 export type UtilisationReportReconciliationForReportViewModel = BaseViewModel & {
   bank: SessionBank;
   formattedReportPeriod: string;
   reportId: string;
-  premiumPayments: PremiumPaymentsViewModelItem[];
-  premiumPaymentsFilters?: PremiumPaymentsFilters;
-  premiumPaymentsFilterError?: ErrorSummaryViewModel;
-  premiumPaymentsTableDataError?: ErrorSummaryViewModel;
-  enablePaymentsReceivedSorting: boolean;
+  premiumPayments: PremiumPaymentsViewModel;
   keyingSheet: KeyingSheetViewModel;
   paymentDetails: PaymentDetailsViewModel;
   utilisationDetails: UtilisationDetailsViewModel;
-  displayMatchSuccessNotification: boolean;
 };

--- a/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/utilisation-report-reconciliation-for-report-view-model.ts
@@ -78,6 +78,7 @@ export type PremiumPaymentsViewModelItem = {
   totalPaymentsReceived: SortedAndFormattedCurrencyAndAmount;
   status: FeeRecordStatus;
   displayStatus: FeeRecordDisplayStatus;
+  isSelectable: boolean;
   checkboxId: PremiumPaymentsTableCheckboxId;
   isChecked: boolean;
   checkboxAriaLabel: string;

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
@@ -4,6 +4,7 @@
   {% set reportId = params.reportId %}
   {% set feeRecordPaymentGroup = params.feeRecordPaymentGroup %}
   {% set userCanEdit = params.userCanEdit %}
+  {% set displayCheckboxColumn = params.displayCheckboxColumn %}
   {% set feeRecords = feeRecordPaymentGroup.feeRecords %}
   {% set totalReportedPayments = feeRecordPaymentGroup.totalReportedPayments %}
   {% set paymentsReceived = feeRecordPaymentGroup.paymentsReceived %}
@@ -13,6 +14,7 @@
   {% set checkboxId = feeRecordPaymentGroup.checkboxId %}
   {% set isChecked = feeRecordPaymentGroup.isChecked %}
   {% set checkboxAriaLabel = feeRecordPaymentGroup.checkboxAriaLabel %}
+
   {% for feeRecord in feeRecords %}
     {% set isFirstFeeRecordInGroup = loop.index === 1 %}
     {% set isLastFeeRecordInGroup = loop.index === feeRecords.length %}
@@ -60,7 +62,7 @@
           displayStatus: displayStatus
         }) if isFirstFeeRecordInGroup else "" }}
       </td>
-      {% if userCanEdit %}
+      {% if userCanEdit and displayCheckboxColumn %}
         <td class="govuk-table__cell{{ " no-border" if not isLastFeeRecordInGroup }}">
           {% if status === 'TO_DO' or status === 'DOES_NOT_MATCH' %}
             {{ tableCellCheckbox.render({

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
@@ -10,6 +10,7 @@
   {% set paymentsReceived = feeRecordPaymentGroup.paymentsReceived %}
   {% set totalPaymentsReceived = feeRecordPaymentGroup.totalPaymentsReceived %}
   {% set status = feeRecordPaymentGroup.status %}
+  {% set isSelectable = feeRecordPaymentGroup.isSelectable %}
   {% set displayStatus = feeRecordPaymentGroup.displayStatus %}
   {% set checkboxId = feeRecordPaymentGroup.checkboxId %}
   {% set isChecked = feeRecordPaymentGroup.isChecked %}
@@ -64,7 +65,7 @@
       </td>
       {% if userCanEdit and displayCheckboxColumn %}
         <td class="govuk-table__cell{{ " no-border" if not isLastFeeRecordInGroup }}">
-          {% if status === 'TO_DO' or status === 'DOES_NOT_MATCH' %}
+          {% if isSelectable %}
             {{ tableCellCheckbox.render({
               checkboxId: checkboxId,
               checked: isChecked,

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table.njk
@@ -6,6 +6,7 @@
   {% set feeRecordPaymentGroups = params.feeRecordPaymentGroups %}
   {% set enablePaymentsReceivedSorting = params.enablePaymentsReceivedSorting %}
   {% set userCanEdit = params.userCanEdit %}
+  {% set displaySelectAllCheckbox = params.displaySelectAllCheckbox %}
 
   {% macro tableHeader(params) %}
     {% set headerText = params.headerText %}
@@ -50,7 +51,7 @@
         {{ tableHeader({ headerText: 'Payments received', isNumericColumn: true, enableSorting: false }) }}
         {{ tableHeader({ headerText: 'Total payments received', isNumericColumn: true, enableSorting: enablePaymentsReceivedSorting, ariaSort: 'none', dataCy: 'premium-payments-table--total-payments-received' }) }}
         {{ tableHeader({ headerText: 'Status', isNumericColumn: false, enableSorting: true, ariaSort: 'none', dataCy: 'premium-payments-table--status' }) }}
-        {% if userCanEdit %}
+        {% if userCanEdit and displaySelectAllCheckbox %}
           <td class="govuk-table__header">
             {{ selectAllTableCellCheckbox.render() }}
           </td>
@@ -60,7 +61,7 @@
 
     <tbody class="govuk-table__body">
     {% for feeRecordPaymentGroup in feeRecordPaymentGroups %}
-      {{ premiumPaymentsTableRow.render({ reportId: reportId, feeRecordPaymentGroup: feeRecordPaymentGroup, userCanEdit: userCanEdit }) }}
+      {{ premiumPaymentsTableRow.render({ reportId: reportId, feeRecordPaymentGroup: feeRecordPaymentGroup, userCanEdit: userCanEdit, displayCheckboxColumn: displaySelectAllCheckbox }) }}
     {% endfor %}
     </tbody>
   </table>

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -19,7 +19,7 @@
 {% endblock %}
 
 {% set premiumPaymentsHtml %}
-  {% if displayMatchSuccessNotification %}
+  {% if premiumPayments.displayMatchSuccessNotification %}
     {% set notificationHtml %}
       <h3 class="govuk-notification-banner__heading" data-cy="match-success-notification-heading">
         Match payment recorded
@@ -36,10 +36,11 @@
       </div>
     </div>
   {% endif %}
-  {% if premiumPaymentsTableDataError or premiumPaymentsFilterError %}
+
+  {% if premiumPayments.tableDataError or premiumPayments.filterError %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
-      errorList: [premiumPaymentsTableDataError, premiumPaymentsFilterError],
+      errorList: [premiumPayments.tableDataError, premiumPayments.filterError],
       attributes: {
         'data-cy': 'error-summary'
       }
@@ -74,9 +75,9 @@
               },
               id: "premium-payments-facility-id-filter",
               name: "premiumPaymentsFacilityId",
-              value: premiumPaymentsFilters.facilityId,
-              errorMessage: premiumPaymentsFilterError and {
-                text: premiumPaymentsFilterError.text
+              value: premiumPayments.filters.facilityId,
+              errorMessage: premiumPayments.filterError and {
+                text: premiumPayments.filterError.text
               },
               attributes: {'data-cy': 'premium-payments-facility-filter-input'}
             }) }}
@@ -104,7 +105,7 @@
       </div>
     </div>
 
-  {% if premiumPaymentsTableDataError %}
+  {% if premiumPayments.tableDataError %}
     <div class="govuk-form-group--error">
   {% endif %}
   {% if userCanEdit %}
@@ -129,14 +130,15 @@
   {% endif %}
   {{ premiumPaymentsTable.render({
     reportId: reportId,
-    feeRecordPaymentGroups: premiumPayments,
-    enablePaymentsReceivedSorting: enablePaymentsReceivedSorting,
-    userCanEdit: userCanEdit
+    feeRecordPaymentGroups: premiumPayments.payments,
+    enablePaymentsReceivedSorting: premiumPayments.enablePaymentsReceivedSorting,
+    userCanEdit: userCanEdit,
+    displaySelectAllCheckbox: premiumPayments.displaySelectAllCheckbox
   }) }}
   {% if userCanEdit %}
     </form>
   {% endif %}
-  {% if premiumPaymentsTableDataError %}
+  {% if premiumPayments.tableDataError %}
     </div>
   {% endif %}
 {% endset %}

--- a/trade-finance-manager-ui/test-helpers/fee-record-payment-group-view-model-item.ts
+++ b/trade-finance-manager-ui/test-helpers/fee-record-payment-group-view-model-item.ts
@@ -22,6 +22,7 @@ export const aPremiumPaymentsViewModelItem = (): PremiumPaymentsViewModelItem =>
   },
   status: FEE_RECORD_STATUS.TO_DO,
   displayStatus: 'TO DO',
+  isSelectable: true,
   checkboxId: `feeRecordIds-1-reportedPaymentsCurrency-${CURRENCY.GBP}-status-${FEE_RECORD_STATUS.TO_DO}`,
   isChecked: false,
   checkboxAriaLabel: '',


### PR DESCRIPTION
## Introduction :pencil2:
Currently we always display the select all checkbox on the premium payments tab, even if there is nothing to select.

## Resolution :heavy_check_mark:
- Hide select all checkbox and it's corresponding column when there are no selectable premium payments

## Miscellaneous :heavy_plus_sign:
- Nest premium payments tab only fields of view model to match pattern for other tabs

