### PR TITLE
fix(DTFS2-7576): facility amendment empty tasks graceful handle

### DIFF
--- a/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.api-test.js
@@ -209,21 +209,21 @@ describe('filterTasks', () => {
 
   describe('filterTasks function', () => {
     describe('when there are no tasks', () => {
-      it('should return an empty array back when there are no tasks', () => {
+      it('should return an empty array, when there are no tasks', () => {
         const mockFiltersObj = {};
 
         const result = filterTasks(mockEmptyTasks, mockFiltersObj);
         expect(result).toEqual([]);
       });
 
-      it('should return an empty array back when the task is null', () => {
+      it('should return an empty array, when the task is null', () => {
         const mockFiltersObj = {};
 
         const result = filterTasks(null, mockFiltersObj);
         expect(result).toEqual([]);
       });
 
-      it('should return an empty array back when tasks are undefined', () => {
+      it('should return an empty array, when tasks are undefined', () => {
         const mockFiltersObj = {};
 
         const result = filterTasks(undefined, mockFiltersObj);

--- a/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.api-test.js
@@ -38,19 +38,27 @@ describe('filterTasks', () => {
     },
   ];
 
+  const mockEmptyTasks = [];
+
   describe('mapAndFilter function', () => {
+    const mockArgsFunc = (task, group) => {
+      if (task.id === '2') {
+        return {
+          ...group,
+          groupTasks: [task],
+        };
+      }
+
+      return group;
+    };
+
+    it.each([null, undefined, {}, []])('should return empty array when tasks are empty', (invalidTasks) => {
+      const result = mapAndFilter(invalidTasks, mockArgsFunc, MOCK_TEAM_ID);
+
+      expect(result).toEqual([]);
+    });
+
     it('should return tasks filtered by the given function via params', () => {
-      const mockArgsFunc = (task, group) => {
-        if (task.id === '2') {
-          return {
-            ...group,
-            groupTasks: [task],
-          };
-        }
-
-        return group;
-      };
-
       const result = mapAndFilter(mockTasks, mockArgsFunc, MOCK_TEAM_ID);
 
       const mockTasksThatDoNotHaveTaskId1 = [
@@ -200,6 +208,29 @@ describe('filterTasks', () => {
   });
 
   describe('filterTasks function', () => {
+    describe('when there are no tasks', () => {
+      it('should return empty array back when there are no tasks', () => {
+        const mockFiltersObj = {};
+
+        const result = filterTasks(mockEmptyTasks, mockFiltersObj);
+        expect(result).toEqual([]);
+      });
+
+      it('should return empty array back when tasks are null', () => {
+        const mockFiltersObj = {};
+
+        const result = filterTasks(null, mockFiltersObj);
+        expect(result).toEqual([]);
+      });
+
+      it('should return empty array back when tasks is undefined', () => {
+        const mockFiltersObj = {};
+
+        const result = filterTasks(undefined, mockFiltersObj);
+        expect(result).toEqual([]);
+      });
+    });
+
     describe('when there is no filterType', () => {
       it('should return all tasks', () => {
         const mockFiltersObj = {};

--- a/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.api-test.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.api-test.js
@@ -52,7 +52,7 @@ describe('filterTasks', () => {
       return group;
     };
 
-    it.each([null, undefined, {}, []])('should return empty array when tasks are empty', (invalidTasks) => {
+    it.each([null, undefined, {}, []])('should return an empty array when tasks are empty', (invalidTasks) => {
       const result = mapAndFilter(invalidTasks, mockArgsFunc, MOCK_TEAM_ID);
 
       expect(result).toEqual([]);
@@ -209,21 +209,21 @@ describe('filterTasks', () => {
 
   describe('filterTasks function', () => {
     describe('when there are no tasks', () => {
-      it('should return empty array back when there are no tasks', () => {
+      it('should return an empty array back when there are no tasks', () => {
         const mockFiltersObj = {};
 
         const result = filterTasks(mockEmptyTasks, mockFiltersObj);
         expect(result).toEqual([]);
       });
 
-      it('should return empty array back when tasks are null', () => {
+      it('should return an empty array back when the task is null', () => {
         const mockFiltersObj = {};
 
         const result = filterTasks(null, mockFiltersObj);
         expect(result).toEqual([]);
       });
 
-      it('should return empty array back when tasks is undefined', () => {
+      it('should return an empty array back when tasks are undefined', () => {
         const mockFiltersObj = {};
 
         const result = filterTasks(undefined, mockFiltersObj);

--- a/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.js
+++ b/trade-finance-manager-api/src/v1/rest-mappings/filters/filterTasks.js
@@ -7,6 +7,10 @@ const FILTER_TYPE = {
 const mapAndFilter = (tasks, argsFunc, FILTER_VALUE) => {
   const filteredTasks = [];
 
+  if (!tasks?.length) {
+    return filteredTasks;
+  }
+
   tasks.map((group) => {
     const { groupTasks } = group;
 
@@ -61,6 +65,11 @@ const filterUserTasksInGroup = (task, group, FILTER_VALUE) => {
 const filterUserTasks = (tasks, FILTER_USER_ID) => mapAndFilter(tasks, filterUserTasksInGroup, FILTER_USER_ID);
 
 const filterTasks = (tasks, filtersObj) => {
+  // Return an empty array if the tasks are null or void.
+  if (!tasks?.length) {
+    return [];
+  }
+
   if (!filtersObj?.filterType || filtersObj?.filterType === FILTER_TYPE.ALL) {
     return tasks;
   }

--- a/trade-finance-manager-ui/server/controllers/helpers/tasks.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/tasks.helper.js
@@ -25,6 +25,10 @@ const FILTER_TYPE = {
 const mapAndFilter = (tasks, argsFunc, FILTER_VALUE) => {
   const filteredTasks = [];
 
+  if (!tasks?.length) {
+    return filteredTasks;
+  }
+
   tasks.map((group) => {
     const { groupTasks } = group;
 
@@ -79,6 +83,11 @@ const filterUserTasksInGroup = (task, group, FILTER_VALUE) => {
 const filterUserTasks = (tasks, FILTER_USER_ID) => mapAndFilter(tasks, filterUserTasksInGroup, FILTER_USER_ID);
 
 const filterTasks = (tasks, filtersObj) => {
+  // Return an empty array if the tasks are null or void.
+  if (!tasks?.length) {
+    return [];
+  }
+
   if (!filtersObj || !filtersObj.filterType || filtersObj.filterType === FILTER_TYPE.ALL) {
     return tasks;
   }


### PR DESCRIPTION
## Introduction :pencil2:
A facility amendment generates various tasks for `PIM`, when no such tasks are available using `Filter results` on TFM can throw `502` due to the lack of exceptional handling and validation.

![image](https://github.com/user-attachments/assets/f3d46421-9081-4622-80d1-c36adab173ad)


## Resolution :heavy_check_mark:
* Added validation across both the TFM microservices `ui` and `api` to ensure empty tasks are validated.

## Miscellaneous :heavy_plus_sign:
* Improved test coverage.

