### PR TITLE
feat(FN-3398): replace source platform string literals

### DIFF
--- a/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.test.ts
+++ b/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.test.ts
@@ -1,4 +1,11 @@
-import { getCurrentReportPeriodForBankSchedule, Bank, ReportPeriod, UtilisationReportEntityMockBuilder, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import {
+  getCurrentReportPeriodForBankSchedule,
+  Bank,
+  ReportPeriod,
+  UtilisationReportEntityMockBuilder,
+  UtilisationReportEntity,
+  REQUEST_PLATFORM_TYPE,
+} from '@ukef/dtfs2-common';
 import { createUtilisationReportForBanksJob } from '.';
 import { getAllBanks } from '../../repositories/banks-repo';
 import { UtilisationReportRepo } from '../../repositories/utilisation-reports-repo';
@@ -134,7 +141,7 @@ describe('scheduler/jobs/create-utilisation-reports', () => {
           bankId: bank.id,
           reportPeriod: mockReportPeriod,
           requestSource: {
-            platform: 'SYSTEM',
+            platform: REQUEST_PLATFORM_TYPE.SYSTEM,
           },
         });
         expect(saveUtilisationReportSpy).toHaveBeenCalledWith(newReport);
@@ -169,7 +176,7 @@ describe('scheduler/jobs/create-utilisation-reports', () => {
         bankId: bankWithoutReport.id,
         reportPeriod: mockReportPeriod,
         requestSource: {
-          platform: 'SYSTEM',
+          platform: REQUEST_PLATFORM_TYPE.SYSTEM,
         },
       });
       expect(saveUtilisationReportSpy).toHaveBeenCalledWith(newReportForBankWithoutReport);

--- a/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.ts
+++ b/dtfs-central-api/src/cron-scheduler-jobs/create-utilisation-reports/index.ts
@@ -1,4 +1,4 @@
-import { asString, CronSchedulerJob, getCurrentReportPeriodForBankSchedule, Bank, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { asString, CronSchedulerJob, getCurrentReportPeriodForBankSchedule, Bank, UtilisationReportEntity, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { validateUtilisationReportPeriodSchedule } from './utilisation-report-period-schedule-validator';
 import { UtilisationReportRepo } from '../../repositories/utilisation-reports-repo';
 import { getAllBanks } from '../../repositories/banks-repo';
@@ -63,7 +63,7 @@ const createUtilisationReportForBanks = async (): Promise<void> => {
         bankId: id,
         reportPeriod,
         requestSource: {
-          platform: 'SYSTEM',
+          platform: REQUEST_PLATFORM_TYPE.SYSTEM,
         },
       });
       await UtilisationReportRepo.save(newUtilisationReport);

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -6,6 +6,7 @@ import {
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
   ReportPeriod,
+  REQUEST_PLATFORM_TYPE,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
 import { handleFeeRecordGenerateKeyingDataEvent } from './generate-keying-data.event-handler';
@@ -31,7 +32,7 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
 
   const userId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/update-facility-utilisation-data.test.ts
@@ -1,6 +1,12 @@
 import { EntityManager } from 'typeorm';
 import { when } from 'jest-when';
-import { DbRequestSource, FacilityUtilisationDataEntity, FacilityUtilisationDataEntityMockBuilder, ReportPeriod } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  FacilityUtilisationDataEntity,
+  FacilityUtilisationDataEntityMockBuilder,
+  ReportPeriod,
+  REQUEST_PLATFORM_TYPE,
+} from '@ukef/dtfs2-common';
 import { updateFacilityUtilisationData } from './update-facility-utilisation-data';
 import { getFixedFeeForFacility } from './get-fixed-fee-for-facility';
 import { aDbRequestSource } from '../../../../../../test-helpers';
@@ -39,7 +45,7 @@ describe('updateFacilityUtilisationData', () => {
     const utilisation = 9876543.21;
     const ukefShareOfUtilisation = 1234567.77;
     const requestSource: DbRequestSource = {
-      platform: 'TFM',
+      platform: REQUEST_PLATFORM_TYPE.TFM,
       userId: 'abc123',
     };
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-ready-to-key/mark-as-ready-to-key.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-ready-to-key/mark-as-ready-to-key.event-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FEE_RECORD_STATUS,
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
@@ -27,7 +28,7 @@ describe('handleFeeRecordMarkAsReadyToKeyEvent', () => {
 
   const userId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/mark-as-reconciled/mark-as-reconciled.event-handler.test.ts
@@ -5,6 +5,7 @@ import {
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
   FeeRecordStatus,
+  REQUEST_PLATFORM_TYPE,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
 import { handleFeeRecordMarkAsReconciledEvent } from './mark-as-reconciled.event-handler';
@@ -19,7 +20,7 @@ describe('handleFeeRecordMarkAsReconciledEvent', () => {
 
   const userId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-added-to-payment-group/other-fee-added-to-payment-group.event-handler.test.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent } from './other-fee-added-to-payment-group.event-handler';
 import { aDbRequestSource } from '../../../../../../test-helpers/test-data/db-request-source';
 
@@ -47,7 +47,7 @@ describe('handleFeeRecordOtherFeeRecordAddedToPaymentGroupEvent', () => {
       transactionEntityManager: mockEntityManager,
       feeRecordsAndPaymentsMatch: true,
       requestSource: {
-        platform: 'TFM',
+        platform: REQUEST_PLATFORM_TYPE.TFM,
         userId,
       },
     });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/other-fee-removed-from-payment-group/other-fee-removed-from-payment-group.event-handler.test.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent } from './other-fee-removed-from-payment-group.event-handler';
 import { aDbRequestSource } from '../../../../../../test-helpers';
 
@@ -47,7 +47,7 @@ describe('handleFeeRecordOtherFeeRemovedFromPaymentGroupEvent', () => {
       transactionEntityManager: mockEntityManager,
       feeRecordsAndPaymentsMatch: true,
       requestSource: {
-        platform: 'TFM',
+        platform: REQUEST_PLATFORM_TYPE.TFM,
         userId,
       },
     });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-added/payment-added.event-handler.test.ts
@@ -1,5 +1,12 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  FEE_RECORD_STATUS,
+  FeeRecordEntity,
+  FeeRecordEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { handleFeeRecordPaymentAddedEvent } from './payment-added.event-handler';
 
 describe('handleFeeRecordPaymentAddedEvent', () => {
@@ -12,7 +19,7 @@ describe('handleFeeRecordPaymentAddedEvent', () => {
 
   const userId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
@@ -1,5 +1,5 @@
 import { EntityManager } from 'typeorm';
-import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { handleFeeRecordPaymentDeletedEvent } from './payment-deleted.event-handler';
 import { aDbRequestSource } from '../../../../../../test-helpers';
 
@@ -89,7 +89,7 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
       feeRecordsAndPaymentsMatch: false,
       hasAttachedPayments: false,
       requestSource: {
-        platform: 'TFM',
+        platform: REQUEST_PLATFORM_TYPE.TFM,
         userId: '123',
       },
     });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-edited/payment-edited.event-handler.test.ts
@@ -1,5 +1,12 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  FEE_RECORD_STATUS,
+  FeeRecordEntity,
+  FeeRecordEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { handleFeeRecordPaymentEditedEvent } from './payment-edited.event-handler';
 
 describe('handleFeeRecordPaymentEditedEvent', () => {
@@ -12,7 +19,7 @@ describe('handleFeeRecordPaymentEditedEvent', () => {
 
   const userId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/remove-from-payment-group/remove-from-payment-group.event-handler.test.ts
@@ -4,6 +4,7 @@ import {
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
   PaymentEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
 import { handleFeeRecordRemoveFromPaymentGroupEvent } from './remove-from-payment-group.event-handler';
@@ -64,7 +65,7 @@ describe('handleFeeRecordRemoveFromPaymentGroupEvent', () => {
     await handleFeeRecordRemoveFromPaymentGroupEvent(feeRecord, {
       transactionEntityManager: mockEntityManager,
       requestSource: {
-        platform: 'TFM',
+        platform: REQUEST_PLATFORM_TYPE.TFM,
         userId,
       },
     });

--- a/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/fee-record.state-machine.test.ts
@@ -1,6 +1,6 @@
 import difference from 'lodash/difference';
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder, FEE_RECORD_STATUS, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder, FEE_RECORD_STATUS, FeeRecordStatus, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { InvalidStateMachineTransitionError } from '../../../errors';
 import { FEE_RECORD_EVENT_TYPE, FEE_RECORD_EVENT_TYPES, FeeRecordEventType } from './event/fee-record.event-type';
 import { FeeRecordStateMachine } from './fee-record.state-machine';
@@ -61,7 +61,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as unknown as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -84,7 +84,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -103,7 +103,7 @@ describe('FeeRecordStateMachine', () => {
           transactionEntityManager: {} as unknown as EntityManager,
           feeRecordsAndPaymentsMatch: true,
           hasAttachedPayments: false,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -122,7 +122,7 @@ describe('FeeRecordStateMachine', () => {
           transactionEntityManager: {} as unknown as EntityManager,
           isFinalFeeRecordForFacility: false,
           reportPeriod: aReportPeriod(),
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -139,7 +139,7 @@ describe('FeeRecordStateMachine', () => {
         type: 'REMOVE_FROM_PAYMENT_GROUP',
         payload: {
           transactionEntityManager: {} as EntityManager,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -157,7 +157,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -202,7 +202,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -221,7 +221,7 @@ describe('FeeRecordStateMachine', () => {
           transactionEntityManager: {} as unknown as EntityManager,
           feeRecordsAndPaymentsMatch: true,
           hasAttachedPayments: false,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -239,7 +239,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as unknown as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -256,7 +256,7 @@ describe('FeeRecordStateMachine', () => {
         type: 'REMOVE_FROM_PAYMENT_GROUP',
         payload: {
           transactionEntityManager: {} as EntityManager,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -274,7 +274,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -292,7 +292,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAndPaymentsMatch: true,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -339,7 +339,7 @@ describe('FeeRecordStateMachine', () => {
         payload: {
           transactionEntityManager: {} as unknown as EntityManager,
           reconciledByUserId: 'abc123',
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -377,7 +377,7 @@ describe('FeeRecordStateMachine', () => {
         type: 'MARK_AS_READY_TO_KEY',
         payload: {
           transactionEntityManager: {} as unknown as EntityManager,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-a-payment/add-a-payment.event-handler.test.ts
@@ -5,6 +5,7 @@ import {
   FeeRecordEntity,
   FeeRecordEntityMockBuilder,
   PaymentEntity,
+  REQUEST_PLATFORM_TYPE,
   UTILISATION_REPORT_RECONCILIATION_STATUS,
   UtilisationReportEntity,
   UtilisationReportEntityMockBuilder,
@@ -19,7 +20,7 @@ jest.mock('../helpers');
 describe('handleUtilisationReportAddAPaymentEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-fees-to-an-existing-payment-group/add-fees-to-an-existing-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/add-fees-to-an-existing-payment-group/add-fees-to-an-existing-payment-group.event-handler.test.ts
@@ -6,6 +6,7 @@ import {
   UtilisationReportEntity,
   PaymentEntityMockBuilder,
   PaymentEntity,
+  REQUEST_PLATFORM_TYPE,
 } from '@ukef/dtfs2-common';
 import { handleUtilisationReportAddFeesToAnExistingPaymentGroupEvent } from './add-fees-to-an-existing-payment-group.event-handler';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
@@ -16,7 +17,7 @@ jest.mock('../helpers');
 describe('handleUtilisationReportAddFeesToAnExistingPaymentGroupEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/edit-payment/edit-payment.event-handler.test.ts
@@ -5,6 +5,7 @@ import {
   FeeRecordEntityMockBuilder,
   PaymentEntity,
   PaymentEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
   UtilisationReportEntity,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
@@ -17,7 +18,7 @@ jest.mock('../helpers');
 describe('handleUtilisationReportAddAPaymentEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -8,6 +8,7 @@ import {
   UtilisationReportReconciliationStatus,
   FeeRecordPaymentJoinTableEntity,
   FEE_RECORD_STATUS,
+  REQUEST_PLATFORM_TYPE,
 } from '@ukef/dtfs2-common';
 import { handleUtilisationReportGenerateKeyingDataEvent } from './generate-keying-data.event-handler';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
@@ -18,7 +19,7 @@ jest.mock('../helpers');
 describe('handleUtilisationReportGenerateKeyingDataEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-completed/manually-set-completed.event-handler.test.ts
@@ -1,10 +1,16 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, UTILISATION_REPORT_RECONCILIATION_STATUS, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  DbRequestSource,
+  REQUEST_PLATFORM_TYPE,
+  UTILISATION_REPORT_RECONCILIATION_STATUS,
+  UtilisationReportEntity,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { handleUtilisationReportManuallySetCompletedEvent } from './manually-set-completed.event-handler';
 
 describe('handleUtilisationReportManuallySetCompletedEvent', () => {
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: 'abc123',
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/manually-set-incomplete/manually-set-incomplete.event-handler.test.ts
@@ -1,10 +1,10 @@
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { DbRequestSource, REQUEST_PLATFORM_TYPE, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { handleUtilisationReportManuallySetIncompleteEvent } from '.';
 
 describe('handleUtilisationReportManuallySetIncompleteEvent', () => {
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: 'abc123',
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-ready-to-key/mark-fee-records-as-ready-to-key.event-handler.test.ts
@@ -3,6 +3,7 @@ import {
   DbRequestSource,
   FEE_RECORD_STATUS,
   FeeRecordEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
   UtilisationReportEntity,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
@@ -12,7 +13,7 @@ import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-mach
 describe('handleUtilisationReportMarkFeeRecordsAsReadyToKeyEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/mark-fee-records-as-reconciled/mark-fee-records-as-reconciled.event-handler.test.ts
@@ -3,6 +3,7 @@ import {
   DbRequestSource,
   FEE_RECORD_STATUS,
   FeeRecordEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
   UtilisationReportEntity,
   UtilisationReportEntityMockBuilder,
 } from '@ukef/dtfs2-common';
@@ -18,7 +19,7 @@ jest.mock('../../../../../external-api/api');
 describe('handleUtilisationReportMarkFeeRecordsAsReconciledEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/remove-fees-from-payment-group/remove-fees-from-payment-group.event-handler.test.ts
@@ -1,5 +1,11 @@
 import { EntityManager } from 'typeorm';
-import { UtilisationReportEntityMockBuilder, DbRequestSource, FeeRecordEntityMockBuilder, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import {
+  UtilisationReportEntityMockBuilder,
+  DbRequestSource,
+  FeeRecordEntityMockBuilder,
+  UtilisationReportEntity,
+  REQUEST_PLATFORM_TYPE,
+} from '@ukef/dtfs2-common';
 import { handleUtilisationReportRemoveFeesFromPaymentGroupEvent } from './remove-fees-from-payment-group.event-handler';
 import { FeeRecordStateMachine } from '../../../fee-record/fee-record.state-machine';
 import { feeRecordsMatchAttachedPayments } from '../helpers';
@@ -9,7 +15,7 @@ jest.mock('../helpers');
 describe('handleUtilisationReportRemoveFeesFromPaymentGroupEvent', () => {
   const tfmUserId = 'abc123';
   const requestSource: DbRequestSource = {
-    platform: 'TFM',
+    platform: REQUEST_PLATFORM_TYPE.TFM,
     userId: tfmUserId,
   };
 

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/utilisation-report.state-machine.test.ts
@@ -138,7 +138,7 @@ describe('UtilisationReportStateMachine', () => {
             reference: 'A payment reference',
           },
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: 'abc123',
           },
         },
@@ -158,7 +158,7 @@ describe('UtilisationReportStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAtMatchStatusWithPayments: [],
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -169,7 +169,7 @@ describe('UtilisationReportStateMachine', () => {
     it(`handles the '${UTILISATION_REPORT_EVENT_TYPE.MANUALLY_SET_COMPLETED}' event`, async () => {
       // Arrange
       const requestSource: DbRequestSource = {
-        platform: 'TFM',
+        platform: REQUEST_PLATFORM_TYPE.TFM,
         userId: 'abc123',
       };
       const transactionEntityManager = {} as unknown as EntityManager;
@@ -226,7 +226,7 @@ describe('UtilisationReportStateMachine', () => {
             reference: 'A payment reference',
           },
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: 'abc123',
           },
         },
@@ -246,7 +246,7 @@ describe('UtilisationReportStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           paymentId: 1,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -264,7 +264,7 @@ describe('UtilisationReportStateMachine', () => {
         payload: {
           transactionEntityManager: {} as EntityManager,
           feeRecordsAtMatchStatusWithPayments: [],
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -286,7 +286,7 @@ describe('UtilisationReportStateMachine', () => {
           paymentAmount: 100,
           datePaymentReceived: new Date(),
           paymentReference: undefined,
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
 
@@ -305,7 +305,7 @@ describe('UtilisationReportStateMachine', () => {
           transactionEntityManager: {} as EntityManager,
           feeRecordsToRemove: [],
           otherFeeRecordsInGroup: [],
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
       expect(handleUtilisationReportRemoveFeesFromPaymentGroupEvent).toHaveBeenCalledTimes(1);
@@ -322,7 +322,7 @@ describe('UtilisationReportStateMachine', () => {
           transactionEntityManager: {} as unknown as EntityManager,
           feeRecordsToMarkAsReadyToKey: [],
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: 'abc123',
           },
         },
@@ -344,7 +344,7 @@ describe('UtilisationReportStateMachine', () => {
           feeRecordsToReconcile: [],
           reconciledByUserId: 'abc123',
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: 'abc123',
           },
         },
@@ -366,7 +366,7 @@ describe('UtilisationReportStateMachine', () => {
           feeRecordsToAdd: [],
           existingFeeRecordsInPaymentGroup: [],
           payments: [],
-          requestSource: { platform: 'TFM', userId: 'abc123' },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId: 'abc123' },
         },
       });
       expect(handleUtilisationReportAddFeesToAnExistingPaymentGroupEvent).toHaveBeenCalledTimes(1);
@@ -401,7 +401,7 @@ describe('UtilisationReportStateMachine', () => {
     it(`handles the '${UTILISATION_REPORT_EVENT_TYPE.MANUALLY_SET_INCOMPLETE}' event`, async () => {
       // Arrange
       const requestSource: DbRequestSource = {
-        platform: 'TFM',
+        platform: REQUEST_PLATFORM_TYPE.TFM,
         userId: 'abc123',
       };
       const transactionEntityManager = {} as unknown as EntityManager;
@@ -431,7 +431,7 @@ describe('UtilisationReportStateMachine', () => {
           transactionEntityManager: {} as unknown as EntityManager,
           feeRecordsToMarkAsReadyToKey: [],
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: 'abc123',
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.test.ts
@@ -1,6 +1,6 @@
 import httpMocks from 'node-mocks-http';
 import { ObjectId } from 'mongodb';
-import { TestApiError } from '@ukef/dtfs2-common';
+import { REQUEST_PLATFORM_TYPE, TestApiError } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { EntityManager } from 'typeorm';
 import { DeletePaymentRequest, deletePayment } from '.';
@@ -83,7 +83,7 @@ describe('delete-payment.controller', () => {
           transactionEntityManager: mockEntityManager,
           paymentId: Number(paymentId),
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: tfmUserId,
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/delete-payment.controller/index.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@ukef/dtfs2-common';
+import { ApiError, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
 import { CustomExpressRequest } from '../../../../types/custom-express-request';
@@ -50,7 +50,7 @@ export const deletePayment = async (req: DeletePaymentRequest, res: Response) =>
           transactionEntityManager,
           paymentId: Number(paymentId),
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: user._id.toString(),
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/patch-payment.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/patch-payment.controller/index.test.ts
@@ -1,7 +1,7 @@
 import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { patchPayment } from '.';
 import { PatchPaymentPayload } from '../../../routes/middleware/payload-validation';
 import { aTfmSessionUser } from '../../../../../test-helpers';
@@ -116,7 +116,7 @@ describe('patch-payment.controller', () => {
           datePaymentReceived,
           paymentReference,
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId,
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/patch-payment.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/patch-payment.controller/index.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
-import { ApiError } from '@ukef/dtfs2-common';
+import { ApiError, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { CustomExpressRequest } from '../../../../types/custom-express-request';
 import { PatchPaymentPayload } from '../../../routes/middleware/payload-validation/validate-patch-payment-payload';
 import { executeWithSqlTransaction } from '../../../../helpers';
@@ -40,7 +40,7 @@ export const patchPayment = async (req: PatchPaymentRequest, res: Response) => {
             datePaymentReceived,
             paymentReference,
             requestSource: {
-              platform: 'TFM',
+              platform: REQUEST_PLATFORM_TYPE.TFM,
               userId: user._id.toString(),
             },
           },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/helpers.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb';
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { addFeesToAnExistingPaymentGroup } from './helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
 import { TfmSessionUser } from '../../../../types/tfm/tfm-session-user';
@@ -74,7 +74,7 @@ describe('post-fees-to-an-existing-payment-group.controller helpers', () => {
           existingFeeRecordsInPaymentGroup,
           payments,
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: tfmUserId,
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-add-fees-to-an-existing-payment-group.controller/helpers.ts
@@ -1,4 +1,4 @@
-import { FeeRecordEntity, PaymentEntity, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { FeeRecordEntity, PaymentEntity, REQUEST_PLATFORM_TYPE, UtilisationReportEntity } from '@ukef/dtfs2-common';
 import { TfmSessionUser } from '../../../../types/tfm/tfm-session-user';
 import { executeWithSqlTransaction } from '../../../../helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
@@ -21,7 +21,7 @@ export const addFeesToAnExistingPaymentGroup = async (
         existingFeeRecordsInPaymentGroup,
         payments,
         requestSource: {
-          platform: 'TFM',
+          platform: REQUEST_PLATFORM_TYPE.TFM,
           userId: user._id.toString(),
         },
       },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.test.ts
@@ -2,7 +2,14 @@ import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
 import { when } from 'jest-when';
 import { EntityManager } from 'typeorm';
-import { FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, TestApiError, UtilisationReportEntity, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import {
+  FEE_RECORD_STATUS,
+  FeeRecordEntityMockBuilder,
+  REQUEST_PLATFORM_TYPE,
+  TestApiError,
+  UtilisationReportEntity,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
 import { postKeyingData, PostKeyingDataRequest } from '.';
 import { FeeRecordRepo } from '../../../../repositories/fee-record-repo';
 import { executeWithSqlTransaction } from '../../../../helpers';
@@ -114,7 +121,7 @@ describe('post-keying-data.controller', () => {
           transactionEntityManager: mockEntityManager,
           feeRecordsAtMatchStatusWithPayments: feeRecords,
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId,
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-keying-data.controller/index.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
-import { ApiError, CustomExpressRequest, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
+import { ApiError, CustomExpressRequest, FEE_RECORD_STATUS, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { FeeRecordRepo } from '../../../../repositories/fee-record-repo';
 import { NotFoundError } from '../../../../errors';
 import { executeWithSqlTransaction } from '../../../../helpers';
@@ -35,7 +35,7 @@ export const postKeyingData = async (req: PostKeyingDataRequest, res: Response) 
           transactionEntityManager,
           feeRecordsAtMatchStatusWithPayments,
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: user._id.toString(),
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/helpers.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb';
 import { In, EntityManager } from 'typeorm';
-import { Currency, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { Currency, FEE_RECORD_STATUS, FeeRecordEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { addPaymentToUtilisationReport } from './helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
 import { InvalidPayloadError, NotFoundError } from '../../../../errors';
@@ -136,7 +136,7 @@ describe('post-add-payment.controller helpers', () => {
           feeRecords: feeRecordsInPaymentCurrency,
           paymentDetails: newPaymentDetails,
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: tfmUserId,
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-payment.controller/helpers.ts
@@ -1,5 +1,5 @@
 import { In } from 'typeorm';
-import { FeeRecordEntity, FeeRecordStatus } from '@ukef/dtfs2-common';
+import { FeeRecordEntity, FeeRecordStatus, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
 import { InvalidPayloadError, NotFoundError } from '../../../../errors';
 import { FeeRecordRepo } from '../../../../repositories/fee-record-repo';
@@ -42,7 +42,7 @@ export const addPaymentToUtilisationReport = async (
         feeRecords,
         paymentDetails: payment,
         requestSource: {
-          platform: 'TFM',
+          platform: REQUEST_PLATFORM_TYPE.TFM,
           userId: user._id.toString(),
         },
       },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-remove-fees-from-payment-group.controller/helpers.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-remove-fees-from-payment-group.controller/helpers.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb';
 import { EntityManager } from 'typeorm';
-import { FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import { FeeRecordEntityMockBuilder, REQUEST_PLATFORM_TYPE, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
 import { removeFeesFromPaymentGroup } from './helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
 import { TfmSessionUser } from '../../../../types/tfm/tfm-session-user';
@@ -70,7 +70,7 @@ describe('post-remove-fees-from-payment.controller helpers', () => {
           feeRecordsToRemove,
           otherFeeRecordsInGroup,
           requestSource: {
-            platform: 'TFM',
+            platform: REQUEST_PLATFORM_TYPE.TFM,
             userId: tfmUserId,
           },
         },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-remove-fees-from-payment-group.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/post-remove-fees-from-payment-group.controller/helpers.ts
@@ -1,4 +1,4 @@
-import { FeeRecordEntity, UtilisationReportEntity } from '@ukef/dtfs2-common';
+import { FeeRecordEntity, REQUEST_PLATFORM_TYPE, UtilisationReportEntity } from '@ukef/dtfs2-common';
 import { TfmSessionUser } from '../../../../types/tfm/tfm-session-user';
 import { executeWithSqlTransaction } from '../../../../helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
@@ -19,7 +19,7 @@ export const removeFeesFromPaymentGroup = async (
         feeRecordsToRemove,
         otherFeeRecordsInGroup,
         requestSource: {
-          platform: 'TFM',
+          platform: REQUEST_PLATFORM_TYPE.TFM,
           userId: user._id.toString(),
         },
       },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-done.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-done.controller/index.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
-import { ApiError } from '@ukef/dtfs2-common';
+import { ApiError, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { CustomExpressRequest } from '../../../../types/custom-express-request';
 import { executeWithSqlTransaction } from '../../../../helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
@@ -31,7 +31,7 @@ export const putKeyingDataMarkAsDone = async (req: PutKeyingDataMarkDoneRequest,
             feeRecordsToReconcile: selectedFeeRecords,
             reconciledByUserId: user._id.toString(),
             requestSource: {
-              platform: 'TFM',
+              platform: REQUEST_PLATFORM_TYPE.TFM,
               userId: user._id.toString(),
             },
           },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-to-do.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-keying-data-mark-as-to-do.controller/index.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
-import { ApiError } from '@ukef/dtfs2-common';
+import { ApiError, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { CustomExpressRequest } from '../../../../types/custom-express-request';
 import { executeWithSqlTransaction } from '../../../../helpers';
 import { UtilisationReportStateMachine } from '../../../../services/state-machines/utilisation-report/utilisation-report.state-machine';
@@ -30,7 +30,7 @@ export const putKeyingDataMarkAsToDo = async (req: PutKeyingDataMarkToDoRequest,
             transactionEntityManager,
             feeRecordsToMarkAsReadyToKey: selectedFeeRecords,
             requestSource: {
-              platform: 'TFM',
+              platform: REQUEST_PLATFORM_TYPE.TFM,
               userId: user._id.toString(),
             },
           },

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-utilisation-report-status.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/put-utilisation-report-status.controller/index.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
 import { EntityManager } from 'typeorm';
-import { DbRequestSource, ReportWithStatus } from '@ukef/dtfs2-common';
+import { DbRequestSource, ReportWithStatus, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { TfmSessionUser } from '../../../../types/tfm/tfm-session-user';
 import { CustomExpressRequest } from '../../../../types/custom-express-request';
 import { ApiError, InvalidPayloadError } from '../../../../errors';
@@ -88,7 +88,7 @@ export const putUtilisationReportStatus = async (req: PutUtilisationReportStatus
     }
 
     const requestSource: DbRequestSource = {
-      platform: 'TFM',
+      platform: REQUEST_PLATFORM_TYPE.TFM,
       userId: user._id.toString(),
     };
 

--- a/dtfs-central-api/test-helpers/test-data/db-request-source.ts
+++ b/dtfs-central-api/test-helpers/test-data/db-request-source.ts
@@ -1,6 +1,6 @@
-import { DbRequestSource } from '@ukef/dtfs2-common';
+import { DbRequestSource, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 
 export const aDbRequestSource = (): DbRequestSource => ({
-  platform: 'TFM',
+  platform: REQUEST_PLATFORM_TYPE.TFM,
   userId: '123',
 });

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -1,10 +1,10 @@
 const { eachMonthOfInterval, getYear, getMonth, subMonths, addMonths } = require('date-fns');
-const { UtilisationReportEntityMockBuilder, AzureFileInfoEntity, MOCK_AZURE_FILE_INFO } = require('@ukef/dtfs2-common');
+const { UtilisationReportEntityMockBuilder, AzureFileInfoEntity, MOCK_AZURE_FILE_INFO, REQUEST_PLATFORM_TYPE } = require('@ukef/dtfs2-common');
 const { BANK1_PAYMENT_REPORT_OFFICER1, BANK2_PAYMENT_REPORT_OFFICER1 } = require('../../../e2e-fixtures');
 
 const bankId = BANK1_PAYMENT_REPORT_OFFICER1.bank.id;
 
-const createAzureFileInfo = () => AzureFileInfoEntity.create({ ...MOCK_AZURE_FILE_INFO, requestSource: { platform: 'SYSTEM' } });
+const createAzureFileInfo = () => AzureFileInfoEntity.create({ ...MOCK_AZURE_FILE_INFO, requestSource: { platform: REQUEST_PLATFORM_TYPE.SYSTEM } });
 
 function* idGenerator() {
   let id = 0;

--- a/libs/common/src/sql-db-entities/base-entities/auditable.base-entity.test.ts
+++ b/libs/common/src/sql-db-entities/base-entities/auditable.base-entity.test.ts
@@ -7,7 +7,7 @@ class TestAuditableBaseEntity extends AuditableBaseEntity {}
 
 describe('AuditableBaseEntity', () => {
   describe('updateLastUpdatedBy', () => {
-    it("updates the portal audit details and resets the rest when the request source platform is 'PORTAL'", () => {
+    it(`updates the portal audit details and resets the rest when the request source platform is '${REQUEST_PLATFORM_TYPE.PORTAL}'`, () => {
       // Arrange
       const testAuditableBaseEntity = new TestAuditableBaseEntity();
       const userId = 'abc123';
@@ -25,13 +25,13 @@ describe('AuditableBaseEntity', () => {
       );
     });
 
-    it("updates the tfm audit details and resets the rest when the request source platform is 'TFM'", () => {
+    it(`updates the tfm audit details and resets the rest when the request source platform is '${REQUEST_PLATFORM_TYPE.TFM}'`, () => {
       // Arrange
       const testAuditableBaseEntity = new TestAuditableBaseEntity();
       const userId = 'def456';
 
       // Act
-      testAuditableBaseEntity.updateLastUpdatedBy({ platform: 'TFM', userId });
+      testAuditableBaseEntity.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.TFM, userId });
 
       // Assert
       expect(testAuditableBaseEntity).toEqual(
@@ -43,12 +43,12 @@ describe('AuditableBaseEntity', () => {
       );
     });
 
-    it("updates the system audit details and resets the rest when the request source platform is 'SYSTEM'", () => {
+    it(`updates the system audit details and resets the rest when the request source platform is '${REQUEST_PLATFORM_TYPE.SYSTEM}'`, () => {
       // Arrange
       const testAuditableBaseEntity = new TestAuditableBaseEntity();
 
       // Act
-      testAuditableBaseEntity.updateLastUpdatedBy({ platform: 'SYSTEM' });
+      testAuditableBaseEntity.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.SYSTEM });
 
       // Assert
       expect(testAuditableBaseEntity).toEqual(

--- a/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
+++ b/libs/common/src/sql-db-entities/facility-utilisation-data/facility-utilisation-data.entity.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_PLATFORM_TYPE } from '../../constants';
 import { FacilityUtilisationDataEntityMockBuilder } from '../../test-helpers';
 
 describe('FacilityUtilisationDataEntity', () => {
@@ -23,7 +24,7 @@ describe('FacilityUtilisationDataEntity', () => {
           start: { month: 3, year: 2023 },
           end: { month: 4, year: 2024 },
         },
-        requestSource: { platform: 'TFM', userId },
+        requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId },
       });
 
       // Assert

--- a/libs/common/src/sql-db-entities/payment/payment.entity.test.ts
+++ b/libs/common/src/sql-db-entities/payment/payment.entity.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_PLATFORM_TYPE } from '../../constants';
 import { FeeRecordEntityMockBuilder, PaymentEntityMockBuilder, UtilisationReportEntityMockBuilder } from '../../test-helpers';
 
 describe('PaymentEntity', () => {
@@ -19,7 +20,7 @@ describe('PaymentEntity', () => {
       // Act
       payment.updateWithAdditionalFeeRecords({
         additionalFeeRecords: [firstNewFeeRecord, secondNewFeeRecord],
-        requestSource: { platform: 'TFM', userId },
+        requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId },
       });
 
       // Assert
@@ -44,7 +45,7 @@ describe('PaymentEntity', () => {
       expect(() => {
         payment.updateWithAdditionalFeeRecords({
           additionalFeeRecords: [feeRecordWithDuplicateId],
-          requestSource: { platform: 'TFM', userId },
+          requestSource: { platform: REQUEST_PLATFORM_TYPE.TFM, userId },
         });
       }).toThrow(Error);
 

--- a/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.test.ts
+++ b/libs/common/src/sql-db-entities/utilisation-report/utilisation-report.entity.test.ts
@@ -49,7 +49,7 @@ describe('UtilisationReportEntity', () => {
 
   describe('updateWithStatus', () => {
     const requestSource: DbRequestSource = {
-      platform: 'TFM',
+      platform: REQUEST_PLATFORM_TYPE.TFM,
       userId: 'abc123',
     };
 

--- a/libs/common/src/test-helpers/mock-data/facility-utilisation-data.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/facility-utilisation-data.entity.mock-builder.ts
@@ -1,3 +1,4 @@
+import { REQUEST_PLATFORM_TYPE } from '../../constants';
 import { FeeRecordEntity, FacilityUtilisationDataEntity } from '../../sql-db-entities';
 import { ReportPeriod } from '../../types';
 
@@ -17,7 +18,7 @@ export class FacilityUtilisationDataEntityMockBuilder {
       end: { month: 1, year: 2024 },
     };
     facility.fixedFee = 0;
-    facility.updateLastUpdatedBy({ platform: 'SYSTEM' });
+    facility.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.SYSTEM });
     return new FacilityUtilisationDataEntityMockBuilder(facility);
   }
 

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.helpers.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { FeeRecordEntity, FeeRecordStatus, UtilisationReportEntity, Currency, FEE_RECORD_STATUS } from '@ukef/dtfs2-common';
+import { FeeRecordEntity, FeeRecordStatus, UtilisationReportEntity, Currency, FEE_RECORD_STATUS, REQUEST_PLATFORM_TYPE } from '@ukef/dtfs2-common';
 import { getRandomCurrency, getRandomFinancialAmount, getExchangeRate } from '../helpers';
 
 type CreateRandomFeeRecordForReportOverrides = {
@@ -47,7 +47,7 @@ export const createRandomFeeRecordForReport = (report: UtilisationReportEntity, 
   feeRecord.reconciledByUserId = null;
   feeRecord.dateReconciled = null;
 
-  feeRecord.updateLastUpdatedBy({ platform: 'SYSTEM' });
+  feeRecord.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.SYSTEM });
 
   return feeRecord;
 };
@@ -84,7 +84,7 @@ export const createAutoMatchedZeroPaymentFeeRecordForReport = (report: Utilisati
   feeRecord.fixedFeeAdjustment = null;
   feeRecord.principalBalanceAdjustment = null;
 
-  feeRecord.updateLastUpdatedBy({ platform: 'SYSTEM' });
+  feeRecord.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.SYSTEM });
 
   return feeRecord;
 };

--- a/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seeder.ts
+++ b/utils/sql-db-seeder/src/fee-record-payment-group/fee-record-payment-group.seeder.ts
@@ -7,6 +7,7 @@ import {
   FacilityUtilisationDataEntity,
   FEE_RECORD_STATUS,
   ReportPeriod,
+  REQUEST_PLATFORM_TYPE,
 } from '@ukef/dtfs2-common';
 import { DataSource } from 'typeorm';
 import Big from 'big.js';
@@ -113,7 +114,7 @@ export class FeeRecordPaymentGroupSeeder {
       facilityUtilisationData.id = facilityId;
       facilityUtilisationData.reportPeriod = this.utilisationDataReportPeriod;
       facilityUtilisationData.utilisation = facilityUtilisation * faker.number.float({ min: 0.8, max: 1.2 });
-      facilityUtilisationData.updateLastUpdatedBy({ platform: 'SYSTEM' });
+      facilityUtilisationData.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.SYSTEM });
       await dataSource.manager.save(FacilityUtilisationDataEntity, facilityUtilisationData);
     }
   }
@@ -155,7 +156,7 @@ export class FeeRecordPaymentGroupSeeder {
         dateReceived: faker.date.past({ years: 3 }),
         reference: faker.lorem.words({ min: 0, max: 3 }),
         feeRecords: this.feeRecords,
-        requestSource: { platform: 'SYSTEM' },
+        requestSource: { platform: REQUEST_PLATFORM_TYPE.SYSTEM },
       });
 
     if (this.status === FEE_RECORD_STATUS.DOES_NOT_MATCH) {
@@ -167,7 +168,7 @@ export class FeeRecordPaymentGroupSeeder {
     if (this.status === FEE_RECORD_STATUS.RECONCILED && !this.reportIsManuallyReconciled) {
       const pdcReconcileUser = await MongoDbDataLoader.getPdcReconcileUserOrFail();
       for (const feeRecord of this.feeRecords) {
-        feeRecord.updateLastUpdatedBy({ platform: 'TFM', userId: pdcReconcileUser._id.toString() });
+        feeRecord.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.TFM, userId: pdcReconcileUser._id.toString() });
         feeRecord.dateReconciled = faker.date.recent({ days: 15 });
         feeRecord.reconciledByUserId = pdcReconcileUser._id.toString();
       }

--- a/utils/sql-db-seeder/src/utilisation-report/utilisation-report.seeder.ts
+++ b/utils/sql-db-seeder/src/utilisation-report/utilisation-report.seeder.ts
@@ -1,5 +1,12 @@
 import { faker } from '@faker-js/faker';
-import { AzureFileInfoEntity, MOCK_AZURE_FILE_INFO, ReportPeriod, UtilisationReportEntity, UtilisationReportReconciliationStatus } from '@ukef/dtfs2-common';
+import {
+  AzureFileInfoEntity,
+  MOCK_AZURE_FILE_INFO,
+  ReportPeriod,
+  REQUEST_PLATFORM_TYPE,
+  UtilisationReportEntity,
+  UtilisationReportReconciliationStatus,
+} from '@ukef/dtfs2-common';
 import { DataSource } from 'typeorm';
 
 export class UtilisationReportSeeder {
@@ -9,7 +16,7 @@ export class UtilisationReportSeeder {
 
   private readonly azureFileInfo = AzureFileInfoEntity.create({
     ...MOCK_AZURE_FILE_INFO,
-    requestSource: { platform: 'SYSTEM' },
+    requestSource: { platform: REQUEST_PLATFORM_TYPE.SYSTEM },
   });
 
   private uploadedByUserId: string | null = null;
@@ -34,7 +41,7 @@ export class UtilisationReportSeeder {
     report.status = status;
     report.bankId = this.bankId;
     report.reportPeriod = this.reportPeriod;
-    report.updateLastUpdatedBy({ platform: 'SYSTEM' });
+    report.updateLastUpdatedBy({ platform: REQUEST_PLATFORM_TYPE.SYSTEM });
 
     if (status === 'REPORT_NOT_RECEIVED') {
       await dataSource.manager.save(UtilisationReportEntity, report);


### PR DESCRIPTION
## Introduction :pencil2:
At present, our request source objects look similar to the following objects: `{ platform: 'SYSTEM' }`  `{ platform: 'TFM', userId: 'abc123' }`. The values of the platform attribute within these objects are string literals (`SYSTEM`, `TFM`, or `PORTAL`) - we want to replace these with a reference to the `REQUEST_PLATFORM_TYPE` constant/enum (i.e. change `'SYSTEM'` references to `REQUEST_PLATFORM_TYPE.SYSTEM` etc).

## Resolution :heavy_check_mark:
Updated all string literals to reference `REQUEST_PLATFORM_TYPE`

## Miscellaneous :heavy_plus_sign:
N/A

