### PR TITLE
feat(DTFS2-7469): display 'Risk Expired' on All Facilities page

### DIFF
--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/all-facilities-and-facility-count.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/all-facilities-and-facility-count.ts
@@ -43,6 +43,8 @@ export const allFacilitiesAndFacilityCount = ({
         dealType: '$tfmDeals.dealSnapshot.dealType',
         // create the `type` property
         type: '$facilitySnapshot.type',
+        // create the `tfmFacilityStage` property
+        tfmFacilityStage: '$tfm.facilityStage',
         // create the `value` property - this is the facility value
         value: '$facilitySnapshot.value',
         // create the `currency` property

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/submit-deal-cancellation-in-past.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/submit-deal-cancellation-in-past.spec.js
@@ -5,6 +5,7 @@ import { ADMIN, BANK1_MAKER1, PIM_USER_1 } from '../../../../../e2e-fixtures';
 import caseDealPage from '../../pages/caseDealPage';
 import { yesterday } from '../../../../../e2e-fixtures/dateConstants';
 import checkDetailsPage from '../../pages/deal-cancellation/check-details';
+import facilitiesPage from '../../pages/facilitiesPage';
 
 context('Deal cancellation - effective from date in past', () => {
   let dealId;
@@ -75,6 +76,14 @@ context('Deal cancellation - effective from date in past', () => {
       const facilityId = dealFacilities[0]._id;
 
       cy.assertText(caseDealPage.dealFacilitiesTable.row(facilityId).facilityStage(), TFM_FACILITY_STAGE.RISK_EXPIRED);
+    });
+
+    it(`should show the facility stage on the "All facilities" page as ${TFM_FACILITY_STAGE.RISK_EXPIRED}`, () => {
+      cy.visit(relative(`/facilities/0`));
+      const facilityId = dealFacilities[0]._id;
+
+      const row = facilitiesPage.facilitiesTable.row(facilityId);
+      cy.assertText(row.facilityStage(), TFM_FACILITY_STAGE.RISK_EXPIRED);
     });
   });
 });

--- a/trade-finance-manager-ui/component-tests/facilities/_macros/facilities-table.component-test.js
+++ b/trade-finance-manager-ui/component-tests/facilities/_macros/facilities-table.component-test.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-underscore-dangle */
+const { TFM_FACILITY_STAGE } = require('@ukef/dtfs2-common');
 const { componentRenderer } = require('../../componentRenderer');
 
 const component = '../templates/facilities/_macros/facilities-table.njk';
@@ -140,6 +141,27 @@ describe(component, () => {
     });
 
     describe('`facility stage` table cell', () => {
+      describe('when the facility has a tfm facility stage', () => {
+        it('should render the tfm facility stage', () => {
+          const facilityWithTfmStage = {
+            ...params.facilities[0],
+            tfmFacilityStage: TFM_FACILITY_STAGE.RISK_EXPIRED,
+          };
+
+          const paramsWithTfmFacilityStage = {
+            facilities: [facilityWithTfmStage],
+            user: params.user,
+          };
+
+          wrapper = render(paramsWithTfmFacilityStage);
+
+          paramsWithTfmFacilityStage.facilities.forEach((facility) => {
+            const cellSelector = `[data-cy="facility-${facility.facilityId}-facilityStage"]`;
+            wrapper.expectText(cellSelector).toRead(TFM_FACILITY_STAGE.RISK_EXPIRED);
+          });
+        });
+      });
+
       describe('when the facility has been issued', () => {
         describe('when the facility has an amendment in progress', () => {
           const issuedFacilityWithAmendmentInProgress = {

--- a/trade-finance-manager-ui/templates/facilities/_macros/facilities-table.njk
+++ b/trade-finance-manager-ui/templates/facilities/_macros/facilities-table.njk
@@ -102,7 +102,9 @@
             {% endset %}
 
             {% set facilityStage %}
-                {% if facility.hasAmendmentInProgress === true %}
+                {% if facility.tfmFacilityStage %}
+                    {{ facility.tfmFacilityStage }}
+                {% elif facility.hasAmendmentInProgress === true %}
                     {{stage}} (amendment in progress)
                 {% else %}
                     {{stage}}


### PR DESCRIPTION
## Introduction :pencil2:
When a deal is cancelled, it should display the updated facility stage on the 'All facilities' page. 

## Resolution :heavy_check_mark:
- Return the TfmFacilityStage in the `allFacilities` api call 
- Display this in the front end if it exists

## Miscellaneous :heavy_plus_sign:
![image](https://github.com/user-attachments/assets/3359f973-e302-47d6-a3b8-079d25a80112)


