### PR TITLE
fix(DTFS2-7567): working directory for azure functions

### DIFF
--- a/azure-functions/acbs-function/Dockerfile
+++ b/azure-functions/acbs-function/Dockerfile
@@ -2,13 +2,13 @@
 FROM mcr.microsoft.com/azure-functions/node:4-node22
 
 # Variables
-ENV AzureWebJobsScriptRoot=/app
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot
 ENV AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 ENV FUNCTIONS_WORKER_RUNTIME=node
 ENV AzureWebJobsFeatureFlags=EnableWorkerIndexing
 
 # Directories setup
-WORKDIR /app
+WORKDIR /home/site/wwwroot
 
 COPY azure-functions/acbs-function .
 

--- a/azure-functions/acbs-function/README.md
+++ b/azure-functions/acbs-function/README.md
@@ -1,6 +1,7 @@
 # ACBS - Azure Function App ⚡️
 
-Azure Functions are not platform-agnostic and work exclusively within the Azure cloud ecosystem.
+Azure Functions are not platform-agnostic and work exclusively
+within the Azure cloud ecosystem.
 They are accessed through Azure's serverless compute service.
 
 ## Jargons ✏️
@@ -23,13 +24,17 @@ They are accessed through Azure's serverless compute service.
 
 ## Local Development :computer:
 
-Azure Functions can be run locally on port 7071 using the Azure Functions Core Tools. This local environment enables testing and debugging before deploying to Azure.
+Azure Functions can be run locally on port 7071 using the Azure Functions Core Tools.
+This local environment enables testing and debugging before deploying to Azure.
 
 ### Running Durable Functions locally using Azure Functions Core Tools
 
-This guide provides detailed steps to run Durable Functions locally using Azure Functions Core Tools with Node.js.
-Durable Functions is an extension of Azure Functions that lets you write stateful functions in a serverless environment.
-By running it locally, you can develop and test your functions before deploying them to Azure.
+This guide provides detailed steps to run Durable Functions locally using Azure
+Functions Core Tools with Node.js.
+Durable Functions is an extension of Azure Functions that lets you write stateful
+functions in a serverless environment.
+By running it locally, you can develop and test your functions
+before deploying them to Azure.
 
 #### Prerequisites
 
@@ -74,25 +79,47 @@ curl -X POST http://localhost:7071/api/orchestrators/acbs
 
 ## Orchestrating with HTTP trigger Function :electric_plug:
 
-Durable Functions are initiated by an HTTP trigger function, often referred to as `acbs-http`. This starter function triggers the execution of durable orchestrator functions.
+Durable Functions are initiated by an HTTP trigger function,
+often referred to as `acbs-http`. This starter function triggers
+the execution of durable orchestrator functions.
 
 ## Durable Functions 🔄
 
-Durable Functions are an extension of Azure Functions, allowing for stateful orchestrator functions within a serverless environment.
-These orchestrator functions enable the orchestration of various functions over extended time periods.
+Durable Functions are an extension of Azure Functions, allowing for stateful
+orchestrator functions within a serverless environment.
+These orchestrator functions enable the orchestration of various functions
+over extended time periods.
 Orchestrations can persist their state, even in the event of disruptions.
 
 ## Application Pattern :rocket:
 
-As of October 7, 2021, two application patterns are primarily used for durable functions execution:
+As of October 7, 2021, two application patterns are primarily
+used for durable functions execution:
 
-- **Function Chaining (Linear)** 🔄 - This pattern involves executing functions sequentially, one after the other, in a linear fashion.
-- **Fan Out - Fan In (Parallel)** ⚙️ - In this pattern, functions are executed in parallel (fan out) and their results are then aggregated (fan in) for further processing.
+- **Function Chaining (Linear)** 🔄 - This pattern involves executing functions sequentially,
+  one after the other, in a linear fashion.
+- **Fan Out - Fan In (Parallel)** ⚙️ - In this pattern,
+  functions are executed in parallel (fan out)and their results are
+  then aggregated (fan in) for further processing.
 
 ## Queue Storage :file_folder:
 
-Orchestrator functions utilize Azure Storage Queues to store and manage their state. Cleaning up queues when necessary is important to prevent unnecessary executions.
+Orchestrator functions utilize Azure Storage Queues to store and manage their state.
+Cleaning up queues when necessary is important to prevent unnecessary executions.
 
-Azure Functions and Durable Functions play a critical role in orchestrating tasks, interfacing with external services (such as Mulesoft), and automating workflows within the Azure cloud ecosystem.
+Azure Functions and Durable Functions play a critical role in orchestrating tasks,
+interfacing with external services (such as Mulesoft), and automating workflows
+within the Azure cloud ecosystem.
 
-If you have any specific questions or need further assistance with your development process, please don't hesitate to ask! :memo:
+If you have any specific questions or need further assistance with your development
+process, please don't hesitate to ask! :memo:
+
+## Azure
+
+### Dockerfile
+
+Ensure `WORKDIR` is always set to `/home/site/wwwroot` alongside
+with environment variable `AzureWebJobsScriptRoot`.
+
+Setting to `/app` or anything else will cause failure in instantiation of
+durable functions inside `src/functions`.


### PR DESCRIPTION
## Introduction :pencil2:
Durable functions were not being instantiated and thus receiving `404` on `external-api` upon calling any ACBS orchestrated function endpoint.

## Resolution :heavy_check_mark:
* Set `WORKDIR` and environment variable `AzureWebJobsScriptRoot` to `/home/site/wwwroot`.

## Miscellaneous :heavy_plus_sign:
* Added documentation regarding working directory to `README.md`.

