### PR TITLE
fix(DTFS2-7594): fix failing dates tests

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/maker-loan/loan-form-values.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker-loan/loan-form-values.js
@@ -9,8 +9,8 @@ const GUARANTEE_DETAILS = {
   requestedCoverStartDateDay: today.dayLong,
   requestedCoverStartDateMonth: today.monthLong,
   requestedCoverStartDateYear: today.year,
-  coverEndDateDay: oneMonth.day,
-  coverEndDateMonth: oneMonth.month,
+  coverEndDateDay: oneMonth.dayLong,
+  coverEndDateMonth: oneMonth.monthLong,
   coverEndDateYear: oneMonth.year,
 };
 

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
@@ -141,8 +141,8 @@ describe('deal cancellation service', () => {
         expect(sendTfmEmail).toHaveBeenCalledTimes(1);
         expect(sendTfmEmail).toHaveBeenCalledWith(CANCEL_DEAL_PAST_DATE, mockPimEmailAddress, {
           cancelReason: dealCancellation.reason,
-          bankRequestDate: format(today, 'dd MMMM yyyy'),
-          effectiveFromDate: format(today, 'dd MMMM yyyy'),
+          bankRequestDate: format(today, DATE_FORMATS.D_MMMM_YYYY),
+          effectiveFromDate: format(today, DATE_FORMATS.D_MMMM_YYYY),
           formattedFacilitiesList: formatFacilityIds(ukefFacilityIds),
           ukefDealId,
         });


### PR DESCRIPTION
## Introduction :pencil2:
We have a unit test that is failing today at the start of the month, due to checking for `dd` date instead of a `d` date. 
Separately, we have an E2E test failing for the opposite reason.
I've fixed both in this PR

## Resolution :heavy_check_mark:
Replace `dd` with `d` in the unit test, and replace 'd' with 'dd' in the e2e test

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

