### PR TITLE
fix(DTFS2-7604): access _id deal property

### DIFF
--- a/trade-finance-manager-api/src/v1/__mocks__/amendmentVariables.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/amendmentVariables.js
@@ -11,6 +11,7 @@ const conditions = 'ABCD';
 const declined = 'EFGH';
 
 const approvedWithoutConditionsBothAmendments = {
+  _id: 'test',
   user: {
     firstname: 'Bob',
     surname: 'Smith',
@@ -217,6 +218,20 @@ const noTaskVariables = {
   },
 };
 
+const noCompanyNameDeal = {
+  ...firstTaskVariables,
+  dealSnapshot: {
+    ukefDealId,
+    exporter: {},
+    bankInternalRefName: 'UKEF',
+  },
+};
+
+const noDealId = {
+  ...firstTaskVariables,
+  _id: null,
+};
+
 module.exports = {
   approvedWithoutConditionsBothAmendments,
   approvedWithoutConditionsBothAmendmentsBSS,
@@ -234,4 +249,6 @@ module.exports = {
   wrongAmendments,
   firstTaskVariables,
   noTaskVariables,
+  noDealId,
+  noCompanyNameDeal,
 };

--- a/trade-finance-manager-api/src/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/src/v1/helpers/amendment.helpers.js
@@ -20,6 +20,8 @@ const dealTypeCoverStartDate = require('./dealTypeCoverStartDate.helper');
 const { formattedNumber } = require('../../utils/number');
 const { decimalsCount, roundNumber } = require('./number');
 
+const { TFM_UI_URL } = process.env;
+
 // checks if amendment exists and if eligible to send email
 const amendmentEmailEligible = (amendment) =>
   amendment &&
@@ -310,24 +312,50 @@ const firstTaskEmailConfirmation = async (facilityId, amendmentId, auditDetails)
   await api.updateFacilityAmendment(facilityId, amendmentId, payload, auditDetails);
 };
 
-// sends email for first amendment task when pim submit amendment
-const sendFirstTaskEmail = async (taskVariables, auditDetails) => {
-  const { amendment, dealSnapshot, facilityId, amendmentId } = taskVariables;
+/**
+ * Sends an email notification for the first task of an amendment.
+ *
+ * This function performs the following operations:
+ * 1. Extracts necessary details from the deal and amendment.
+ * 2. Retrieves the first task from the amendment tasks.
+ * 3. Constructs the email variables and sends the email using the TFM email service.
+ * 4. Updates the flag to indicate that the email has been sent if the email is successfully sent.
+ *
+ * @param {Object} deal - The deal object containing deal and amendment details.
+ * @param {Object} deal.amendment - The amendment details.
+ * @param {Object} deal.dealSnapshot - The snapshot of the deal details.
+ * @param {string} deal.facilityId - The ID of the facility.
+ * @param {string} deal.amendmentId - The ID of the amendment.
+ * @param {Object} deal.dealSnapshot.exporter - The exporter details.
+ * @param {string} deal.dealSnapshot.exporter.companyName - The name of the exporter company.
+ * @param {string} [deal.dealSnapshot.ukefDealId] - The UKEF deal ID for GEF deals.
+ * @param {Object} [deal.dealSnapshot.details] - The details object for BSS deals.
+ * @param {string} [deal.dealSnapshot.details.ukefDealId] - The UKEF deal ID for BSS deals.
+ * @param {Object} auditDetails - The audit details for logging purposes.
+ * @returns {Promise<void>} - A promise that resolves when the email has been sent and the flag has been updated.
+ * @throws {Error} - Logs the error if any error occurs during the email sending process.
+ * */
+const sendFirstTaskEmail = async (deal, auditDetails) => {
+  const { amendment, dealSnapshot, facilityId, amendmentId } = deal;
   const { tasks } = amendment;
-  const { dealId, exporter } = dealSnapshot;
+  const { _id: dealId } = deal;
+  const { exporter } = dealSnapshot;
+  const { companyName } = exporter;
 
   // dealId in snapshot for gef and details for bss
-  const ukefDealId = dealSnapshot.ukefDealId || dealSnapshot.details.ukefDealId;
-
+  const ukefDealId = dealSnapshot.ukefDealId || dealSnapshot?.details?.ukefDealId;
   const firstTask = getFirstTask(tasks);
-  const urlOrigin = process.env.TFM_UI_URL;
   const templateId = EMAIL_TEMPLATE_IDS.TASK_READY_TO_START;
 
   try {
     const { team } = firstTask;
     const { email: sendToEmailAddress } = await api.findOneTeam(team.id);
 
-    const emailVariables = generateTaskEmailVariables(urlOrigin, firstTask, dealId, exporter.companyName, ukefDealId);
+    if (!dealId || !ukefDealId || !firstTask || !companyName) {
+      throw new Error('Invalid imperative arguments %s %s %o %s', dealId, ukefDealId, firstTask, companyName);
+    }
+
+    const emailVariables = generateTaskEmailVariables(TFM_UI_URL, firstTask, dealId, companyName, ukefDealId);
 
     const emailResponse = await sendTfmEmail(templateId, sendToEmailAddress, emailVariables);
 

--- a/trade-finance-manager-api/src/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/src/v1/helpers/amendment.helpers.test.js
@@ -16,9 +16,7 @@ const {
 const CONSTANTS = require('../../constants');
 const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../constants/deals');
 const { formattedNumber } = require('../../utils/number');
-
 const amendmentVariables = require('../__mocks__/amendmentVariables');
-
 const MOCK_NOTIFY_EMAIL_RESPONSE = require('../__mocks__/mock-notify-email-response');
 const MOCK_NOTIFY_EMAIL_BAD_RESPONSE = require('../__mocks__/mock-notify-email-bad-response');
 
@@ -507,8 +505,8 @@ describe('sendManualDecisionAmendmentEmail()', () => {
 
 describe('sendFirstTaskEmail()', () => {
   const sendEmailApiSpy = jest.fn(() => Promise.resolve(MOCK_NOTIFY_EMAIL_RESPONSE));
-
   const updateFacilityAmendmentSpy = jest.fn(() => Promise.resolve({}));
+  console.error = jest.fn();
 
   beforeEach(() => {
     sendEmailApiSpy.mockClear();
@@ -574,6 +572,32 @@ describe('sendFirstTaskEmail()', () => {
     expect(sendEmailApiSpy).not.toHaveBeenCalled();
 
     expect(updateFacilityAmendmentSpy).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error if deal id is missing', async () => {
+    await sendFirstTaskEmail(amendmentVariables.noDealId, mockAuditDetails);
+
+    const error = new Error(
+      'Invalid imperative arguments %s %s %o %s',
+      undefined,
+      amendmentVariables.firstTaskVariables.dealSnapshot.ukefDealId,
+      {},
+      amendmentVariables.firstTaskVariables.dealSnapshot.exporter.companyName,
+    );
+    expect(console.error).toHaveBeenCalledWith('Error sending first amendment task email %o', error);
+  });
+
+  it('should throw an error if company name is missing', async () => {
+    await sendFirstTaskEmail(amendmentVariables.noCompanyNameDeal, mockAuditDetails);
+
+    const error = new Error(
+      'Invalid imperative arguments %s %s %o %s',
+      undefined,
+      amendmentVariables.firstTaskVariables.dealSnapshot.ukefDealId,
+      {},
+      amendmentVariables.firstTaskVariables.dealSnapshot.exporter.companyName,
+    );
+    expect(console.error).toHaveBeenCalledWith('Error sending first amendment task email %o', error);
   });
 });
 

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -20,52 +20,57 @@ const {
 } = CONSTANTS;
 
 const getCaseDeal = async (req, res) => {
-  const dealId = req.params._id;
-  const { userToken } = req.session;
+  try {
+    const dealId = req.params._id;
+    const { userToken } = req.session;
 
-  const { user } = asUserSession(req.session);
+    const { user } = asUserSession(req.session);
 
-  const deal = await api.getDeal(dealId, userToken);
-  const { data: amendments } = await api.getAmendmentsByDealId(dealId, userToken);
+    const deal = await api.getDeal(dealId, userToken);
+    const { data: amendments } = await api.getAmendmentsByDealId(dealId, userToken);
 
-  if (!deal) {
-    return res.redirect('/not-found');
+    if (!deal) {
+      return res.redirect('/not-found');
+    }
+
+    if (!amendments || !Array.isArray(amendments)) {
+      console.error('Unable to get amendments for deal id %s', dealId);
+      return res.redirect('/not-found');
+    }
+
+    const amendmentsInProgress = amendments.filter(({ status }) => status === AMENDMENT_STATUS.IN_PROGRESS);
+    const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+    if (hasAmendmentInProgress) {
+      deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
+    }
+
+    const { submissionType } = deal.dealSnapshot;
+
+    const dealCancellationIsEnabled = isDealCancellationEnabled(submissionType, user);
+    let hasDraftCancellation = false;
+
+    if (dealCancellationIsEnabled) {
+      const cancellation = await api.getDealCancellation(dealId, userToken);
+      hasDraftCancellation = !isEmpty(cancellation);
+    }
+
+    return res.render('case/deal/deal.njk', {
+      deal: deal.dealSnapshot,
+      tfm: deal.tfm,
+      activePrimaryNavigation: 'manage work',
+      activeSubNavigation: 'deal',
+      dealId,
+      user: req.session.user,
+      amendments,
+      amendmentsInProgress,
+      hasAmendmentInProgress,
+      showDealCancelButton: dealCancellationIsEnabled,
+      hasDraftCancellation,
+    });
+  } catch (error) {
+    console.error('Unable to render deal %o', error);
+    return res.render('_partials/problem-with-service.njk');
   }
-
-  if (!amendments || !Array.isArray(amendments)) {
-    console.error('Unable to get amendments for deal id %s', dealId);
-    return res.redirect('/not-found');
-  }
-
-  const amendmentsInProgress = amendments.filter(({ status }) => status === AMENDMENT_STATUS.IN_PROGRESS);
-  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
-  if (hasAmendmentInProgress) {
-    deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
-  }
-
-  const { submissionType } = deal.dealSnapshot;
-
-  const dealCancellationIsEnabled = isDealCancellationEnabled(submissionType, user);
-  let hasDraftCancellation = false;
-
-  if (dealCancellationIsEnabled) {
-    const cancellation = await api.getDealCancellation(dealId, userToken);
-    hasDraftCancellation = !isEmpty(cancellation);
-  }
-
-  return res.render('case/deal/deal.njk', {
-    deal: deal.dealSnapshot,
-    tfm: deal.tfm,
-    activePrimaryNavigation: 'manage work',
-    activeSubNavigation: 'deal',
-    dealId,
-    user: req.session.user,
-    amendments,
-    amendmentsInProgress,
-    hasAmendmentInProgress,
-    showDealCancelButton: dealCancellationIsEnabled,
-    hasDraftCancellation,
-  });
 };
 
 const getCaseTasks = async (req, res) => {

--- a/trade-finance-manager-ui/server/controllers/case/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.test.js
@@ -180,6 +180,26 @@ describe('controllers - case', () => {
         expect(res.redirect).toHaveBeenCalledWith('/not-found');
       });
     });
+
+    describe('should catch any thrown error', () => {
+      beforeEach(() => {
+        api.getDeal = () => Promise.reject(new Error('An exception has occurred'));
+      });
+
+      it('should render problem with service page with console error', async () => {
+        const req = {
+          params: {
+            _id: '1',
+          },
+          session,
+        };
+
+        await caseController.getCaseDeal(req, res);
+
+        expect(console.error).toHaveBeenCalledWith('Unable to render deal %o', new Error('An exception has occurred'));
+        expect(res.render).toHaveBeenCalledWith('_partials/problem-with-service.njk');
+      });
+    });
   });
 
   describe('GET case tasks', () => {


### PR DESCRIPTION
## Introduction :pencil2:
When dispatching first amendment task email, deal ID in the email is `undefined`.

## Resolution :heavy_check_mark:
* Access `_id` for Mongo Object deal ID.
* Added validation for imperative mandatory arguments.
* Added exceptional handling to `TFM-UI` case render.

## Miscellaneous :heavy_plus_sign:
* Improved test coverage with additional mocks.
* Improved documentation.

