### PR TITLE
chore(dtfs2-7298): update success banner following moj package fix

### DIFF
--- a/trade-finance-manager-ui/templates/_macros/success-banner.njk
+++ b/trade-finance-manager-ui/templates/_macros/success-banner.njk
@@ -1,18 +1,13 @@
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% macro render(message) %}
-
-  <div class="govuk-!-padding-top-7">
-
-    {{ mojBanner({
-      type: 'success',
-      text: message,
-      iconFallbackText: 'Success',
-      attributes: {
-        'data-cy': 'success-banner'
-      }
+  {{ mojBanner({
+    type: 'success',
+    classes: 'govuk-!-padding-top-7',
+    text: message,
+    iconFallbackText: 'Success',
+    attributes: {
+    'data-cy': 'success-banner'
+    }
     }) }}
-
-  <div />
-
 {% endmacro %}


### PR DESCRIPTION
## Introduction :pencil2:
Due to [a now fixed bug](https://github.com/ministryofjustice/moj-frontend/issues/886) in MoJ banner, we had to do a work around to get the padding correct on our success banner.

This now reflects the updated module