### PR TITLE
feat(DTFS2-7612): refactor get facility controller to have consistent return type

### DIFF
--- a/dtfs-central-api/api-tests/v1/facilities/facility-put.api-test.js
+++ b/dtfs-central-api/api-tests/v1/facilities/facility-put.api-test.js
@@ -76,9 +76,9 @@ describe('/v1/portal/facilities', () => {
       expect(body.auditRecord).toEqual(expectedAuditRecord);
     });
 
-    it('returns 404 when adding facility to non-existent deal', async () => {
-      const aValidButIncorrectDealId = new ObjectId();
-      const { status } = await testApi.put(aValidUpdateRequest).to(`/v1/portal/facilities/${aValidButIncorrectDealId}`);
+    it('returns 404 when facility id is valid but does not exist', async () => {
+      const aValidButIncorrectFacilityId = new ObjectId();
+      const { status } = await testApi.put(aValidUpdateRequest).to(`/v1/portal/facilities/${aValidButIncorrectFacilityId}`);
 
       expect(status).toEqual(404);
     });

--- a/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.ts
@@ -44,6 +44,9 @@ export const deleteFacility = async (
         code: error.code,
       });
     }
+
+    console.error(`Error whilst deleting facility, ${JSON.stringify(error)}`);
+
     return res.status(500).send({ status: 500, message: 'An unknown error occurred' });
   }
 };

--- a/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.ts
@@ -23,14 +23,6 @@ export const deleteFacility = async (
 
     const facility = await findOneFacility(facilityId);
 
-    if (!facility) {
-      return res.status(404).send({ status: 400, message: 'Facility not found' });
-    }
-
-    if (!('dealId' in facility)) {
-      return res.status(500).send({ status: 500, message: 'Facility object missing dealId' });
-    }
-
     await deleteOne({
       documentId: new ObjectId(facilityId),
       collectionName: MONGO_DB_COLLECTIONS.FACILITIES,

--- a/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/delete-facility.controller.ts
@@ -1,4 +1,4 @@
-import { ApiError, ApiErrorResponseBody, AuditDetails, DocumentNotDeletedError, MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
+import { ApiError, ApiErrorResponseBody, AuditDetails, DocumentNotDeletedError, InvalidFacilityIdError, MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
 import { ObjectId } from 'mongodb';
 import { Response } from 'express';
 import { deleteOne, validateAuditDetailsAndUserType } from '@ukef/dtfs2-common/change-stream';
@@ -14,11 +14,11 @@ export const deleteFacility = async (
   const { id: facilityId } = req.params;
   const { auditDetails, user } = req.body;
 
-  if (!ObjectId.isValid(facilityId)) {
-    return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
-  }
-
   try {
+    if (!ObjectId.isValid(facilityId)) {
+      throw new InvalidFacilityIdError(facilityId);
+    }
+
     validateAuditDetailsAndUserType(auditDetails, 'portal');
 
     const facility = await findOneFacility(facilityId);

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
@@ -3,22 +3,22 @@ const { ObjectId } = require('mongodb');
 const { mongoDbClient: db } = require('../../../../drivers/db-client');
 
 /**
- * @param {string} _id - the facility Id
+ * @param {string} facilityId - the facility Id
  * @returns {Promise<import('@ukef/dtfs2-common').Facility>} - returns the facility if it is found
  *
  * @throws {InvalidFacilityIdError} if the id is invalid
  * @throws {FacilityNotFoundError} if the id is valid but does not correspond to a facility
  */
-const findOneFacility = async (_id) => {
-  if (!ObjectId.isValid(_id)) {
-    throw new InvalidFacilityIdError(_id);
+const findOneFacility = async (facilityId) => {
+  if (!ObjectId.isValid(facilityId)) {
+    throw new InvalidFacilityIdError(facilityId);
   }
 
   const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
-  const facility = await collection.findOne({ _id: { $eq: ObjectId(_id) } });
+  const facility = await collection.findOne({ _id: { $eq: ObjectId(facilityId) } });
 
   if (!facility) {
-    throw new FacilityNotFoundError(_id);
+    throw new FacilityNotFoundError(facilityId);
   }
 
   return facility;
@@ -27,13 +27,10 @@ exports.findOneFacility = findOneFacility;
 
 exports.findOneFacilityGet = async (req, res) => {
   const {
-    params: { id },
+    params: { id: facilityId },
   } = req;
   try {
-    if (!ObjectId.isValid(id)) {
-      throw new InvalidFacilityIdError(id);
-    }
-    const facility = await findOneFacility(req.params.id);
+    const facility = await findOneFacility(facilityId);
 
     return res.status(200).send(facility);
   } catch (error) {

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
@@ -11,14 +11,14 @@ const { mongoDbClient: db } = require('../../../../drivers/db-client');
  */
 const findOneFacility = async (_id) => {
   if (!ObjectId.isValid(_id)) {
-    throw InvalidFacilityIdError(_id);
+    throw new InvalidFacilityIdError(_id);
   }
 
   const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
   const facility = await collection.findOne({ _id: { $eq: ObjectId(_id) } });
 
   if (!facility) {
-    throw FacilityNotFoundError(_id);
+    throw new FacilityNotFoundError(_id);
   }
 
   return facility;
@@ -31,7 +31,7 @@ exports.findOneFacilityGet = async (req, res) => {
   } = req;
   try {
     if (!ObjectId.isValid(id)) {
-      throw InvalidFacilityIdError(id);
+      throw new InvalidFacilityIdError(id);
     }
     const facility = await findOneFacility(req.params.id);
 
@@ -44,6 +44,8 @@ exports.findOneFacilityGet = async (req, res) => {
         code: error.code,
       });
     }
+
+    console.error(`Error whilst getting facility, ${error}`);
 
     return res.status(500).send({ status: 500, message: 'An unknown error occurred' });
   }

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-facility.controller.js
@@ -1,32 +1,50 @@
-const { MONGO_DB_COLLECTIONS } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, InvalidFacilityIdError, ApiError, FacilityNotFoundError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const { mongoDbClient: db } = require('../../../../drivers/db-client');
 
-const findOneFacility = async (_id, callback) => {
-  if (ObjectId.isValid(_id)) {
-    const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
-    const facility = await collection.findOne({ _id: { $eq: ObjectId(_id) } });
-
-    if (callback) {
-      callback(facility);
-    }
-
-    return facility;
+/**
+ * @param {string} _id - the facility Id
+ * @returns {Promise<import('@ukef/dtfs2-common').Facility>} - returns the facility if it is found
+ *
+ * @throws {InvalidFacilityIdError} if the id is invalid
+ * @throws {FacilityNotFoundError} if the id is valid but does not correspond to a facility
+ */
+const findOneFacility = async (_id) => {
+  if (!ObjectId.isValid(_id)) {
+    throw InvalidFacilityIdError(_id);
   }
-  return { status: 400, message: 'Invalid Facility Id' };
+
+  const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
+  const facility = await collection.findOne({ _id: { $eq: ObjectId(_id) } });
+
+  if (!facility) {
+    throw FacilityNotFoundError(_id);
+  }
+
+  return facility;
 };
 exports.findOneFacility = findOneFacility;
 
 exports.findOneFacilityGet = async (req, res) => {
-  if (ObjectId.isValid(req.params.id)) {
+  const {
+    params: { id },
+  } = req;
+  try {
+    if (!ObjectId.isValid(id)) {
+      throw InvalidFacilityIdError(id);
+    }
     const facility = await findOneFacility(req.params.id);
 
-    if (facility) {
-      return res.status(200).send(facility);
+    return res.status(200).send(facility);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return res.status(error.status).send({
+        status: error.status,
+        message: error.message,
+        code: error.code,
+      });
     }
 
-    return res.status(404).send();
+    return res.status(500).send({ status: 500, message: 'An unknown error occurred' });
   }
-
-  return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
 };

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
@@ -1,5 +1,5 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { MONGO_DB_COLLECTIONS, FacilityNotFoundError, InvalidParameterError, ApiError } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, InvalidParameterError, ApiError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { findOneFacility } = require('./get-facility.controller');
@@ -12,11 +12,7 @@ const withoutId = (obj) => {
 };
 
 const updateFacilityStatus = async ({ facilityId, status, auditDetails }) => {
-  const existingFacility = findOneFacility(facilityId);
-
-  if (!existingFacility) {
-    throw FacilityNotFoundError(facilityId);
-  }
+  const existingFacility = await findOneFacility(facilityId);
 
   if (existingFacility.status === 400) {
     throw InvalidParameterError('facilityId', facilityId);

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
@@ -1,5 +1,5 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { MONGO_DB_COLLECTIONS, InvalidParameterError, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { findOneFacility } = require('./get-facility.controller');
@@ -11,12 +11,16 @@ const withoutId = (obj) => {
   return cleanedObject;
 };
 
+/**
+ * Update a facility status
+ * @param updateFacilityStatusParams
+ * @param updateFacilityStatusParams.facilityId - the facility Id
+ * @param updateFacilityStatusParams.status - the new status to set
+ * @param updateFacilityStatusParams.auditDetails - the logged in users audit details
+ * @returns {import('@ukef/dtfs2-common').Facility} - the updated Facility
+ */
 const updateFacilityStatus = async ({ facilityId, status, auditDetails }) => {
   const existingFacility = await findOneFacility(facilityId);
-
-  if (existingFacility.status === 400) {
-    throw new InvalidParameterError('facilityId', facilityId);
-  }
 
   const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
 

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
@@ -1,5 +1,5 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { MONGO_DB_COLLECTIONS, InvalidParameterError, ApiError } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, InvalidParameterError, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { findOneFacility } = require('./get-facility.controller');
@@ -15,7 +15,7 @@ const updateFacilityStatus = async ({ facilityId, status, auditDetails }) => {
   const existingFacility = await findOneFacility(facilityId);
 
   if (existingFacility.status === 400) {
-    throw InvalidParameterError('facilityId', facilityId);
+    throw new InvalidParameterError('facilityId', facilityId);
   }
 
   const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
@@ -52,7 +52,7 @@ exports.updateFacilityStatusPut = async (req, res) => {
 
   try {
     if (!ObjectId.isValid(facilityId)) {
-      throw InvalidParameterError('facilityId', facilityId);
+      throw new InvalidFacilityIdError(facilityId);
     }
 
     validateAuditDetails(auditDetails);
@@ -68,6 +68,8 @@ exports.updateFacilityStatusPut = async (req, res) => {
         code: error.code,
       });
     }
+
+    console.error(`Error whilst updating facility status, ${error}`);
 
     return res.status(500).send({ status: 500, error });
   }

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
@@ -1,5 +1,5 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { MONGO_DB_COLLECTIONS, InvalidAuditDetailsError } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, FacilityNotFoundError, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { findOneFacility } = require('./get-facility.controller');
@@ -49,30 +49,32 @@ exports.updateFacilityPut = async (req, res) => {
     routePath,
   } = req;
 
-  if (!ObjectId.isValid(facilityId)) {
-    return res.status(400).send({ status: 400, message: 'Invalid Facility Id' });
-  }
-
   try {
+    if (!ObjectId.isValid(facilityId)) {
+      throw InvalidFacilityIdError(facilityId);
+    }
+
     validateAuditDetails(auditDetails);
+
+    const facility = await findOneFacility(facilityId);
+
+    if (!facility) {
+      throw FacilityNotFoundError(facilityId);
+    }
+    const { dealId } = facility;
+
+    const updatedFacility = await updateFacility({ facilityId, facilityUpdate, dealId, user, routePath, auditDetails });
+
+    return res.status(200).json(updatedFacility);
   } catch (error) {
-    if (error instanceof InvalidAuditDetailsError) {
+    if (error instanceof ApiError) {
       return res.status(error.status).send({
         status: error.status,
         message: error.message,
         code: error.code,
       });
     }
+
+    return res.status(500).send({ status: 500, message: 'An unknown error occurred' });
   }
-  const facility = await findOneFacility(facilityId);
-
-  if (!facility) {
-    return res.status(404).send();
-  }
-
-  const { dealId } = facility;
-
-  const updatedFacility = await updateFacility({ facilityId, facilityUpdate, dealId, user, routePath, auditDetails });
-
-  return res.status(200).json(updatedFacility);
 };

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
@@ -51,7 +51,7 @@ exports.updateFacilityPut = async (req, res) => {
 
   try {
     if (!ObjectId.isValid(facilityId)) {
-      throw InvalidFacilityIdError(facilityId);
+      throw new InvalidFacilityIdError(facilityId);
     }
 
     validateAuditDetails(auditDetails);
@@ -71,6 +71,8 @@ exports.updateFacilityPut = async (req, res) => {
         code: error.code,
       });
     }
+
+    console.error(`Error whilst updating facility, ${error}`);
 
     return res.status(500).send({ status: 500, message: 'An unknown error occurred' });
   }

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
@@ -1,5 +1,5 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { MONGO_DB_COLLECTIONS, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, ApiError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { findOneFacility } = require('./get-facility.controller');
@@ -50,10 +50,6 @@ exports.updateFacilityPut = async (req, res) => {
   } = req;
 
   try {
-    if (!ObjectId.isValid(facilityId)) {
-      throw new InvalidFacilityIdError(facilityId);
-    }
-
     validateAuditDetails(auditDetails);
 
     const facility = await findOneFacility(facilityId);

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility.controller.js
@@ -1,5 +1,5 @@
 const { generateAuditDatabaseRecordFromAuditDetails, validateAuditDetails } = require('@ukef/dtfs2-common/change-stream');
-const { MONGO_DB_COLLECTIONS, FacilityNotFoundError, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
+const { MONGO_DB_COLLECTIONS, ApiError, InvalidFacilityIdError } = require('@ukef/dtfs2-common');
 const { ObjectId } = require('mongodb');
 const $ = require('mongo-dot-notation');
 const { findOneFacility } = require('./get-facility.controller');
@@ -58,9 +58,6 @@ exports.updateFacilityPut = async (req, res) => {
 
     const facility = await findOneFacility(facilityId);
 
-    if (!facility) {
-      throw FacilityNotFoundError(facilityId);
-    }
     const { dealId } = facility;
 
     const updatedFacility = await updateFacility({ facilityId, facilityUpdate, dealId, user, routePath, auditDetails });


### PR DESCRIPTION
## Introduction :pencil2:
The `findOneFacility` function was returning `Facility`, `null` or `{ status: 400, message: 'Invalid Facility Id' }`. This makes it hard to use with new functions. `updateFacilityStatus` will be needed to update the facility status after cancellation 

## Resolution :heavy_check_mark:
- Refactor the `findOneFacility` to throw `InvalidFacilityIdError` or `FacilityNotFoundError` to be handled in the controller. Remove `callback` parameter since this was unused
- Refactor the controllers that call this function to wrap in a try/catch block & handle the `ApiErrors` properly
- Refactor the `updateFacilityStatus` function to not have `existingFacility` passed in, and instead call `findOneFacility`. Throw `ApiError`s to be handled by the controlle

