### PR TITLE
feat(DTFS2-7612): commonise facility status constant

### DIFF
--- a/libs/common/src/constants/portal/facility-status.ts
+++ b/libs/common/src/constants/portal/facility-status.ts
@@ -1,0 +1,6 @@
+export const FACILITY_STATUS = {
+  COMPLETED: 'Completed',
+  INCOMPLETE: 'Incomplete',
+  NOT_STARTED: 'Not started',
+  RISK_EXPIRED: 'Risk expired',
+};

--- a/libs/common/src/constants/portal/index.ts
+++ b/libs/common/src/constants/portal/index.ts
@@ -2,3 +2,4 @@ export * from './roles';
 export * from './facility-end-date';
 export * from './login-status';
 export * from './deal-status';
+export * from './facility-status';

--- a/portal/component-tests/contract/components/bond-transactions-table.component-test.js
+++ b/portal/component-tests/contract/components/bond-transactions-table.component-test.js
@@ -1,5 +1,4 @@
-const { ROLES, timezoneConfig } = require('@ukef/dtfs2-common');
-const { DEAL, FACILITY } = require('../../../server/constants/status');
+const { ROLES, timezoneConfig, FACILITY_STATUS, DEAL_STATUS } = require('@ukef/dtfs2-common');
 const { getNowAsEpoch } = require('../../../server/helpers');
 
 const { NON_MAKER_OR_CHECKER_ROLES } = require('../../../test-helpers/common-role-lists');
@@ -14,13 +13,13 @@ const render = componentRenderer(component);
 describe(component, () => {
   const deal = {
     submissionType: 'Manual Inclusion Application',
-    status: DEAL.READY_FOR_APPROVAL,
+    status: DEAL_STATUS.READY_FOR_APPROVAL,
     bondTransactions: {
       items: [
         {
           _id: '5f3ab3f705e6630007dcfb21',
           ukefFacilityId: '5678',
-          status: FACILITY.INCOMPLETE,
+          status: FACILITY_STATUS.INCOMPLETE,
           value: '100',
           currency: { id: 'GBP' },
           facilityStage: 'Unissued',
@@ -32,7 +31,7 @@ describe(component, () => {
         {
           _id: '5f3ab3f705e6630007dcfb22',
           ukefFacilityId: '5678',
-          status: FACILITY.INCOMPLETE,
+          status: FACILITY_STATUS.INCOMPLETE,
           value: '100',
           currency: { id: 'GBP' },
           facilityStage: 'Unissued',
@@ -46,7 +45,7 @@ describe(component, () => {
   };
 
   const dealWithBondsThatCanChangeCoverDate = JSON.parse(JSON.stringify(deal));
-  dealWithBondsThatCanChangeCoverDate.status = DEAL.UKEF_ACKNOWLEDGED;
+  dealWithBondsThatCanChangeCoverDate.status = DEAL_STATUS.UKEF_ACKNOWLEDGED;
   dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].facilityStage = 'Issued';
   dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].hasBeenIssued = true;
   dealWithBondsThatCanChangeCoverDate.bondTransactions.items[0].issueFacilityDetailsSubmitted = true;

--- a/portal/server/constants/status.js
+++ b/portal/server/constants/status.js
@@ -11,12 +11,6 @@ const DEAL = {
   UKEF_REFUSED: 'Rejected by UKEF',
 };
 
-const FACILITY = {
-  COMPLETED: 'Completed',
-  INCOMPLETE: 'Incomplete',
-  NOT_STARTED: 'Not started',
-};
-
 const SECTION = {
   COMPLETED: 'Completed',
   NOT_COMPLETED: 'Not completed',
@@ -24,6 +18,5 @@ const SECTION = {
 
 module.exports = {
   DEAL,
-  FACILITY,
   SECTION,
 };

--- a/portal/server/helpers/dealFormsCompleted.js
+++ b/portal/server/helpers/dealFormsCompleted.js
@@ -1,3 +1,4 @@
+const { FACILITY_STATUS } = require('@ukef/dtfs2-common');
 const CONSTANTS = require('../constants');
 
 /**
@@ -9,9 +10,9 @@ const CONSTANTS = require('../constants');
 const isEveryFacilityComplete = (facilities = []) => {
   const facilityProcessedStatus = [CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED, CONSTANTS.STATUS.DEAL.SUBMITTED_TO_UKEF];
 
-  const completed = facilities.filter((facility) => facility.status === CONSTANTS.STATUS.FACILITY.COMPLETED).length;
-  const incomplete = facilities.filter((facility) => facility.status === CONSTANTS.STATUS.FACILITY.INCOMPLETE).length;
-  const notStarted = facilities.filter((facility) => facility.status === CONSTANTS.STATUS.FACILITY.NOT_STARTED).length;
+  const completed = facilities.filter((facility) => facility.status === FACILITY_STATUS.COMPLETED).length;
+  const incomplete = facilities.filter((facility) => facility.status === FACILITY_STATUS.INCOMPLETE).length;
+  const notStarted = facilities.filter((facility) => facility.status === FACILITY_STATUS.NOT_STARTED).length;
   const acknowledged = facilities.filter(
     (facility) => facilityProcessedStatus.includes(facility.status) && facility.requestedCoverStartDate && facility.coverDateConfirmed,
   ).length;

--- a/portal/server/helpers/dealFormsCompleted.test.js
+++ b/portal/server/helpers/dealFormsCompleted.test.js
@@ -1,18 +1,19 @@
+import { FACILITY_STATUS } from '@ukef/dtfs2-common';
 import { isEligibilityComplete, isSubmissionDetailComplete, isEveryDealFormComplete, isEveryFacilityInDealComplete } from './dealFormsCompleted';
 import CONSTANTS from '../constants';
 
 const completeFacilities = {
   items: [
-    { _id: '12345678910', status: CONSTANTS.STATUS.SECTION.COMPLETED },
-    { _id: '12345678911', status: CONSTANTS.STATUS.SECTION.COMPLETED },
-    { _id: '12345678912', status: CONSTANTS.STATUS.SECTION.COMPLETED },
+    { _id: '12345678910', status: FACILITY_STATUS.COMPLETED },
+    { _id: '12345678911', status: FACILITY_STATUS.COMPLETED },
+    { _id: '12345678912', status: FACILITY_STATUS.COMPLETED },
   ],
 };
 
 const incompleteFacilities = {
   items: [
-    { _id: '12345678911', status: CONSTANTS.STATUS.SECTION.COMPLETED },
-    { _id: '12345678910', status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
+    { _id: '12345678911', status: FACILITY_STATUS.COMPLETED },
+    { _id: '12345678910', status: FACILITY_STATUS.INCOMPLETE },
   ],
 };
 

--- a/portal/server/helpers/isFacilityComplete.test.js
+++ b/portal/server/helpers/isFacilityComplete.test.js
@@ -1,4 +1,4 @@
-const { FACILITY_TYPE } = require('@ukef/dtfs2-common');
+const { FACILITY_TYPE, FACILITY_STATUS } = require('@ukef/dtfs2-common');
 const { isEveryFacilityComplete } = require('./dealFormsCompleted');
 const CONSTANTS = require('../constants');
 
@@ -20,11 +20,7 @@ describe('isEveryFacilityComplete', () => {
   });
 
   it('should return false when all facilities are incomplete', () => {
-    const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
-    ];
+    const facilities = [{ status: FACILITY_STATUS.INCOMPLETE }, { status: FACILITY_STATUS.INCOMPLETE }, { status: FACILITY_STATUS.INCOMPLETE }];
 
     const result = isEveryFacilityComplete(facilities);
 
@@ -32,11 +28,7 @@ describe('isEveryFacilityComplete', () => {
   });
 
   it('should return false when all facilities are not started', () => {
-    const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-    ];
+    const facilities = [{ status: FACILITY_STATUS.NOT_STARTED }, { status: FACILITY_STATUS.NOT_STARTED }, { status: FACILITY_STATUS.NOT_STARTED }];
 
     const result = isEveryFacilityComplete(facilities);
 
@@ -45,12 +37,12 @@ describe('isEveryFacilityComplete', () => {
 
   it('should return false when all facilities are not started and are incomplete', () => {
     const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
+      { status: FACILITY_STATUS.NOT_STARTED },
+      { status: FACILITY_STATUS.NOT_STARTED },
+      { status: FACILITY_STATUS.NOT_STARTED },
+      { status: FACILITY_STATUS.INCOMPLETE },
+      { status: FACILITY_STATUS.INCOMPLETE },
+      { status: FACILITY_STATUS.INCOMPLETE },
     ];
 
     const result = isEveryFacilityComplete(facilities);
@@ -59,11 +51,7 @@ describe('isEveryFacilityComplete', () => {
   });
 
   it('should return true when atleast one facility is completed', () => {
-    const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-      { status: CONSTANTS.STATUS.FACILITY.NOT_STARTED },
-    ];
+    const facilities = [{ status: FACILITY_STATUS.NOT_STARTED }, { status: FACILITY_STATUS.COMPLETED }, { status: FACILITY_STATUS.NOT_STARTED }];
 
     const result = isEveryFacilityComplete(facilities);
 
@@ -71,11 +59,7 @@ describe('isEveryFacilityComplete', () => {
   });
 
   it('should return true when facilities is complete', () => {
-    const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-    ];
+    const facilities = [{ status: FACILITY_STATUS.COMPLETED }, { status: FACILITY_STATUS.COMPLETED }, { status: FACILITY_STATUS.COMPLETED }];
 
     const result = isEveryFacilityComplete(facilities);
 
@@ -83,11 +67,7 @@ describe('isEveryFacilityComplete', () => {
   });
 
   it('should return false when a single facility is incomplete', () => {
-    const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-    ];
+    const facilities = [{ status: FACILITY_STATUS.COMPLETED }, { status: FACILITY_STATUS.INCOMPLETE }, { status: FACILITY_STATUS.COMPLETED }];
 
     const result = isEveryFacilityComplete(facilities);
 
@@ -96,22 +76,22 @@ describe('isEveryFacilityComplete', () => {
 
   it('should return false when multiple facilities are in `Incomplete` status', () => {
     const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       {
         status: CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED,
         requestedCoverStartDate: '2022-01-01',
         coverDateConfirmed: true,
       },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       {
         status: CONSTANTS.STATUS.DEAL.SUBMITTED_TO_UKEF,
         requestedCoverStartDate: '2022-01-01',
         coverDateConfirmed: true,
       },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE, type: FACILITY_TYPE.BOND },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE, type: FACILITY_TYPE.LOAN },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE, type: FACILITY_TYPE.CASH },
-      { status: CONSTANTS.STATUS.FACILITY.INCOMPLETE, type: FACILITY_TYPE.CONTINGENT },
+      { status: FACILITY_STATUS.INCOMPLETE, type: FACILITY_TYPE.BOND },
+      { status: FACILITY_STATUS.INCOMPLETE, type: FACILITY_TYPE.LOAN },
+      { status: FACILITY_STATUS.INCOMPLETE, type: FACILITY_TYPE.CASH },
+      { status: FACILITY_STATUS.INCOMPLETE, type: FACILITY_TYPE.CONTINGENT },
     ];
 
     const result = isEveryFacilityComplete(facilities);
@@ -120,11 +100,7 @@ describe('isEveryFacilityComplete', () => {
   });
 
   it('should return false when facilities has acknowledged items but not all are complete', () => {
-    const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-      { status: CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
-    ];
+    const facilities = [{ status: FACILITY_STATUS.COMPLETED }, { status: CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED }, { status: FACILITY_STATUS.COMPLETED }];
 
     const result = isEveryFacilityComplete(facilities);
 
@@ -133,9 +109,9 @@ describe('isEveryFacilityComplete', () => {
 
   it('should return false when facilities has acknowledged items and all are complete with missing properties', () => {
     const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       { status: CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       { status: CONSTANTS.STATUS.DEAL.SUBMITTED_TO_UKEF },
     ];
 
@@ -146,9 +122,9 @@ describe('isEveryFacilityComplete', () => {
 
   it('should return false when facilities has acknowledged items but not all have requestedCoverStartDate and coverDateConfirmed', () => {
     const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       { status: CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED, requestedCoverStartDate: '2022-01-01' },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
     ];
 
     const result = isEveryFacilityComplete(facilities);
@@ -158,13 +134,13 @@ describe('isEveryFacilityComplete', () => {
 
   it('should return true when facilities has acknowledged items and all have requestedCoverStartDate and coverDateConfirmed', () => {
     const facilities = [
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       {
         status: CONSTANTS.STATUS.DEAL.UKEF_ACKNOWLEDGED,
         requestedCoverStartDate: '2022-01-01',
         coverDateConfirmed: true,
       },
-      { status: CONSTANTS.STATUS.FACILITY.COMPLETED },
+      { status: FACILITY_STATUS.COMPLETED },
       {
         status: CONSTANTS.STATUS.DEAL.SUBMITTED_TO_UKEF,
         requestedCoverStartDate: '2022-01-01',


### PR DESCRIPTION
## Introduction :pencil2:
Facility Status constants need to be accessible in all services in order to update when cancelling

## Resolution :heavy_check_mark:
- add `FACILITY_STATUS` constant to libs common
- refactor portal uses of this constant to fetch from libs/common

## Note ⚠️ 
- Theres a suspicious lack of this constant being used in portal, I did catch one place using the wrong constant but I expect there's lots more facility statuses being set as `DEAL_STATUS.INCOMPLETE`. I've not searched in depth for these & we should look to move these across iteratively when we find them
