### PR TITLE
feat(DTFS2-7612): update portal facility status to risk expired

### DIFF
--- a/dtfs-central-api/api-tests/v1/tfm/deal-cancellation/tfm-submit-deal-cancellation-post.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/tfm/deal-cancellation/tfm-submit-deal-cancellation-post.api-test.ts
@@ -1,6 +1,14 @@
 import { ObjectId } from 'mongodb';
 import { HttpStatusCode } from 'axios';
-import { MONGO_DB_COLLECTIONS, AnyObject, TFM_DEAL_STAGE, API_ERROR_CODE, TfmAuditDetails, TfmDeal } from '@ukef/dtfs2-common';
+import {
+  MONGO_DB_COLLECTIONS,
+  AnyObject,
+  TFM_DEAL_STAGE,
+  API_ERROR_CODE,
+  TfmAuditDetails,
+  TfmDealCancellationResponse,
+  FACILITY_TYPE,
+} from '@ukef/dtfs2-common';
 import { generatePortalAuditDetails, generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { withMongoIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
 import wipeDB from '../../../wipeDB';
@@ -17,7 +25,7 @@ const originalProcessEnv = { ...process.env };
 
 describe('/v1/tfm/deals/:dealId/cancellation/submit', () => {
   let dealId: string;
-  let ukefFacilityId: string;
+  const ukefFacilityId = 'ukefFacilityId';
   let submitDealCancellationUrl: string;
   let auditDetails: TfmAuditDetails;
   let tfmUserId: string;
@@ -28,13 +36,16 @@ describe('/v1/tfm/deals/:dealId/cancellation/submit', () => {
     effectiveFrom: new Date().valueOf(),
   };
 
+  const ukefDealId = 'ukefDealId';
+
   const newDeal = aDeal({
     dealType: DEALS.DEAL_TYPE.BSS_EWCS,
     submissionType: DEALS.SUBMISSION_TYPE.AIN,
+    details: { ukefDealId },
   }) as AnyObject;
 
   beforeAll(async () => {
-    await wipeDB.wipe([MONGO_DB_COLLECTIONS.TFM_DEALS, MONGO_DB_COLLECTIONS.DEALS]);
+    await wipeDB.wipe([MONGO_DB_COLLECTIONS.TFM_DEALS, MONGO_DB_COLLECTIONS.DEALS, MONGO_DB_COLLECTIONS.FACILITIES, MONGO_DB_COLLECTIONS.TFM_FACILITIES]);
 
     const tfmUser = await createTfmUser();
     tfmUserId = tfmUser._id;
@@ -42,16 +53,17 @@ describe('/v1/tfm/deals/:dealId/cancellation/submit', () => {
 
   beforeEach(async () => {
     const createDealResponse: { body: { _id: string } } = await createDeal({ deal: newDeal, user: aPortalUser() });
-    const createFacilityResponse: { body: { ukefFacilityId: string } } = await createFacility({
+    dealId = createDealResponse.body._id;
+
+    await createFacility({
       facility: {
         dealId,
-        ukefFacilityId: 'ukefFacilityId',
+        type: FACILITY_TYPE.BOND,
+        ukefFacilityId,
       },
       user: aPortalUser(),
     });
 
-    dealId = createDealResponse.body._id;
-    ukefFacilityId = createFacilityResponse.body.ukefFacilityId;
     auditDetails = generateTfmAuditDetails(tfmUserId);
     submitDealCancellationUrl = `/v1/tfm/deals/${dealId}/cancellation/submit`;
 
@@ -88,7 +100,7 @@ describe('/v1/tfm/deals/:dealId/cancellation/submit', () => {
 
   afterEach(async () => {
     process.env = { ...originalProcessEnv };
-    await wipeDB.wipe([MONGO_DB_COLLECTIONS.TFM_DEALS, MONGO_DB_COLLECTIONS.DEALS]);
+    await wipeDB.wipe([MONGO_DB_COLLECTIONS.TFM_DEALS, MONGO_DB_COLLECTIONS.DEALS, MONGO_DB_COLLECTIONS.FACILITIES, MONGO_DB_COLLECTIONS.TFM_FACILITIES]);
   });
 
   describe('POST /v1/tfm/deals/:dealId/cancellation/submit', () => {
@@ -126,9 +138,9 @@ describe('/v1/tfm/deals/:dealId/cancellation/submit', () => {
         const submitCancellationResponse = await testApi.post({ cancellation, auditDetails }).to(submitDealCancellationUrl);
 
         expect(submitCancellationResponse.body).toEqual({
-          cancelledDeal: expect.objectContaining({ _id: dealId }) as TfmDeal,
+          cancelledDealUkefId: ukefDealId,
           riskExpiredFacilityUkefIds: [ukefFacilityId],
-        });
+        } as TfmDealCancellationResponse);
         expect(submitCancellationResponse.status).toEqual(HttpStatusCode.Ok);
       });
 

--- a/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.scheduleDealCancellation.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.scheduleDealCancellation.test.ts
@@ -39,10 +39,7 @@ describe('tfm-deals-cancellation-repo', () => {
   const findToArrayMock = jest.fn();
   const getCollectionMock = jest.fn();
 
-  const matchingFacilityId1 = new ObjectId();
-  const matchingFacilityId2 = new ObjectId();
-
-  const mockMatchedFacilities = [{ facilitySnapshot: { ukefFacilityId: matchingFacilityId1 } }, { facilitySnapshot: { ukefFacilityId: matchingFacilityId2 } }];
+  const mockMatchedFacilities = [{ facilitySnapshot: { _id: new ObjectId() } }, { facilitySnapshot: { _id: new ObjectId() } }];
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -178,7 +175,7 @@ describe('tfm-deals-cancellation-repo', () => {
       });
 
       // Assert
-      expect(result).toEqual({ cancelledDeal: mockDeal, riskExpiredFacilityUkefIds: [matchingFacilityId1, matchingFacilityId2] });
+      expect(result).toEqual({ cancelledDeal: mockDeal, riskExpiredFacilities: mockMatchedFacilities });
     });
   });
 });

--- a/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.submitDealCancellation.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.submitDealCancellation.test.ts
@@ -41,10 +41,7 @@ describe('tfm-deals-cancellation-repo', () => {
   const findToArrayMock = jest.fn();
   const getCollectionMock = jest.fn();
 
-  const matchingFacilityId1 = new ObjectId();
-  const matchingFacilityId2 = new ObjectId();
-
-  const mockMatchedFacilities = [{ facilitySnapshot: { ukefFacilityId: matchingFacilityId1 } }, { facilitySnapshot: { ukefFacilityId: matchingFacilityId2 } }];
+  const mockMatchedFacilities = [{ facilitySnapshot: { _id: new ObjectId() } }, { facilitySnapshot: { _id: new ObjectId() } }];
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -186,7 +183,7 @@ describe('tfm-deals-cancellation-repo', () => {
       });
 
       // Assert
-      expect(result).toEqual({ cancelledDeal: mockDeal, riskExpiredFacilityUkefIds: [matchingFacilityId1, matchingFacilityId2] });
+      expect(result).toEqual({ cancelledDeal: mockDeal, riskExpiredFacilities: mockMatchedFacilities });
     });
   });
 });

--- a/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-deals-repo/tfm-deal-cancellation.repo.ts
@@ -11,7 +11,6 @@ import {
   TFM_FACILITY_STAGE,
   TfmDeal,
   TfmDealCancellation,
-  TfmDealCancellationResponse,
   TfmDealCancellationWithStatus,
   TfmDealWithCancellation,
   TfmFacility,
@@ -19,7 +18,6 @@ import {
 import { generateAuditDatabaseRecordFromAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { flatten } from 'mongo-dot-notation';
 import { mongoDbClient } from '../../drivers/db-client';
-import { getUkefFacilityIds } from '../../helpers/get-ukef-facility-ids';
 
 export class TfmDealCancellationRepo {
   private static async getDealCollection(): Promise<Collection<WithoutId<TfmDeal>>> {
@@ -156,7 +154,7 @@ export class TfmDealCancellationRepo {
     cancellation: TfmDealCancellation;
     activity?: TfmActivity;
     auditDetails: AuditDetails;
-  }): Promise<TfmDealCancellationResponse> {
+  }): Promise<{ cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }> {
     if (!ObjectId.isValid(dealId)) {
       throw new InvalidDealIdError(dealId.toString());
     }
@@ -203,11 +201,9 @@ export class TfmDealCancellationRepo {
       }),
     );
 
-    const updatedFacilities = await facilityCollection.find({ 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } }).toArray();
+    const riskExpiredFacilities = await facilityCollection.find({ 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } }).toArray();
 
-    const updatedFacilityUkefIds = getUkefFacilityIds(updatedFacilities);
-
-    return { cancelledDeal: deal, riskExpiredFacilityUkefIds: updatedFacilityUkefIds };
+    return { cancelledDeal: deal, riskExpiredFacilities };
   }
 
   /**
@@ -232,7 +228,7 @@ export class TfmDealCancellationRepo {
     cancellation: TfmDealCancellation;
     activity?: TfmActivity;
     auditDetails: AuditDetails;
-  }): Promise<TfmDealCancellationResponse> {
+  }): Promise<{ cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }> {
     if (!ObjectId.isValid(dealId)) {
       throw new InvalidDealIdError(dealId.toString());
     }
@@ -270,10 +266,8 @@ export class TfmDealCancellationRepo {
 
     const facilityCollection = await this.getFacilityCollection();
 
-    const cancelledFacilities = await facilityCollection.find({ 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } }).toArray();
+    const riskExpiredFacilities = await facilityCollection.find({ 'facilitySnapshot.dealId': { $eq: new ObjectId(dealId) } }).toArray();
 
-    const cancelledFacilityUkefIds = getUkefFacilityIds(cancelledFacilities);
-
-    return { cancelledDeal: deal, riskExpiredFacilityUkefIds: cancelledFacilityUkefIds };
+    return { cancelledDeal: deal, riskExpiredFacilities };
   }
 }

--- a/dtfs-central-api/src/services/portal/facility.service.ts
+++ b/dtfs-central-api/src/services/portal/facility.service.ts
@@ -5,11 +5,11 @@ import { updateFacility } from '../../v1/controllers/portal/gef-facility/update-
 
 export class PortalFacilityService {
   /**
-   * Updates the deal status
+   * Updates the facility status
    *
    * @param updateStatusParams
-   * @param updateStatusParams.dealId - the deal Id to update
-   * @param updateStatusParams.newStatus - the status change to make
+   * @param updateStatusParams.facilityId - the facility Id to update
+   * @param updateStatusParams.status - the status change to make
    * @param updateStatusParams.auditDetails - the users audit details
    * @param updateStatusParams.dealType - the deal type
    */

--- a/dtfs-central-api/src/services/portal/facility.service.ts
+++ b/dtfs-central-api/src/services/portal/facility.service.ts
@@ -1,6 +1,6 @@
 import { AuditDetails, DEAL_TYPE, DealType, FacilityStatus } from '@ukef/dtfs2-common';
 import { ObjectId } from 'mongodb';
-import { updateFacilityStatus } from '../../v1/controllers/portal/facility/update-facility-status.controller';
+import { updateBssEwcsFacilityStatus } from '../../v1/controllers/portal/facility/update-facility-status.controller';
 import { updateFacility } from '../../v1/controllers/portal/gef-facility/update-facility.controller';
 
 export class PortalFacilityService {
@@ -27,7 +27,7 @@ export class PortalFacilityService {
     if (dealType === DEAL_TYPE.GEF) {
       await updateFacility({ facilityId, facilityUpdate: { status }, auditDetails });
     } else if (dealType === DEAL_TYPE.BSS_EWCS) {
-      await updateFacilityStatus({
+      await updateBssEwcsFacilityStatus({
         facilityId,
         status,
         auditDetails,

--- a/dtfs-central-api/src/services/portal/facility.service.ts
+++ b/dtfs-central-api/src/services/portal/facility.service.ts
@@ -1,0 +1,39 @@
+import { AuditDetails, DEAL_TYPE, DealType, FacilityStatus } from '@ukef/dtfs2-common';
+import { ObjectId } from 'mongodb';
+import { updateFacilityStatus } from '../../v1/controllers/portal/facility/update-facility-status.controller';
+import { updateFacility } from '../../v1/controllers/portal/gef-facility/update-facility.controller';
+
+export class PortalFacilityService {
+  /**
+   * Updates the deal status
+   *
+   * @param updateStatusParams
+   * @param updateStatusParams.dealId - the deal Id to update
+   * @param updateStatusParams.newStatus - the status change to make
+   * @param updateStatusParams.auditDetails - the users audit details
+   * @param updateStatusParams.dealType - the deal type
+   */
+  public static async updateStatus({
+    facilityId,
+    status,
+    auditDetails,
+    dealType,
+  }: {
+    facilityId: ObjectId | string;
+    status: FacilityStatus;
+    auditDetails: AuditDetails;
+    dealType: DealType;
+  }): Promise<void> {
+    if (dealType === DEAL_TYPE.GEF) {
+      await updateFacility({ facilityId, facilityUpdate: { status }, auditDetails });
+    } else if (dealType === DEAL_TYPE.BSS_EWCS) {
+      await updateFacilityStatus({
+        facilityId,
+        status,
+        auditDetails,
+      });
+    } else {
+      throw new Error(`Invalid dealType ${dealType}`);
+    }
+  }
+}

--- a/dtfs-central-api/src/services/portal/facility.service.update-status.test.ts
+++ b/dtfs-central-api/src/services/portal/facility.service.update-status.test.ts
@@ -6,7 +6,7 @@ const updateBssEwcsFacilityStatusMock = jest.fn() as jest.Mock<Deal>;
 const updateGefFacilityMock = jest.fn() as jest.Mock<Deal>;
 
 jest.mock('../../v1/controllers/portal/facility/update-facility-status.controller', () => ({
-  updateFacilityStatus: (params: AnyObject) => updateBssEwcsFacilityStatusMock(params),
+  updateBssEwcsFacilityStatus: (params: AnyObject) => updateBssEwcsFacilityStatusMock(params),
 }));
 
 jest.mock('../../v1/controllers/portal/gef-facility/update-facility.controller', () => ({
@@ -40,7 +40,7 @@ describe('PortalFacilityService', () => {
       expect(updateBssEwcsFacilityStatusMock).toHaveBeenCalledTimes(0);
     });
 
-    it(`calls updateFacilityStatus when submissionType is ${DEAL_TYPE.BSS_EWCS}`, async () => {
+    it(`calls updateBssEwcsFacilityStatus when submissionType is ${DEAL_TYPE.BSS_EWCS}`, async () => {
       // Arrange
       const dealType = DEAL_TYPE.BSS_EWCS;
 

--- a/dtfs-central-api/src/services/portal/facility.service.update-status.test.ts
+++ b/dtfs-central-api/src/services/portal/facility.service.update-status.test.ts
@@ -1,0 +1,60 @@
+import { AnyObject, Deal, DEAL_STATUS, DEAL_TYPE } from '@ukef/dtfs2-common';
+import { generateSystemAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { PortalFacilityService } from './facility.service';
+
+const updateBssEwcsFacilityStatusMock = jest.fn() as jest.Mock<Deal>;
+const updateGefFacilityMock = jest.fn() as jest.Mock<Deal>;
+
+jest.mock('../../v1/controllers/portal/facility/update-facility-status.controller', () => ({
+  updateFacilityStatus: (params: AnyObject) => updateBssEwcsFacilityStatusMock(params),
+}));
+
+jest.mock('../../v1/controllers/portal/gef-facility/update-facility.controller', () => ({
+  updateFacility: (params: AnyObject) => updateGefFacilityMock(params),
+}));
+
+const facilityId = 'facilityId';
+const status = DEAL_STATUS.CANCELLED;
+const auditDetails = generateSystemAuditDetails();
+
+describe('PortalFacilityService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('updateStatus', () => {
+    it(`calls updateGefDealStatus when submissionType is ${DEAL_TYPE.GEF}`, async () => {
+      // Arrange
+      const dealType = DEAL_TYPE.GEF;
+
+      // Act
+      await PortalFacilityService.updateStatus({ facilityId, status, auditDetails, dealType });
+
+      // Assert
+      expect(updateGefFacilityMock).toHaveBeenCalledTimes(1);
+      expect(updateGefFacilityMock).toHaveBeenCalledWith({
+        facilityId,
+        facilityUpdate: { status },
+        auditDetails,
+      });
+      expect(updateBssEwcsFacilityStatusMock).toHaveBeenCalledTimes(0);
+    });
+
+    it(`calls updateBssEwcsDealStatus when submissionType is ${DEAL_TYPE.BSS_EWCS}`, async () => {
+      // Arrange
+      const dealType = DEAL_TYPE.BSS_EWCS;
+
+      // Act
+      await PortalFacilityService.updateStatus({ facilityId, status, auditDetails, dealType });
+
+      // Assert
+      expect(updateBssEwcsFacilityStatusMock).toHaveBeenCalledTimes(1);
+      expect(updateBssEwcsFacilityStatusMock).toHaveBeenCalledWith({
+        facilityId,
+        status,
+        auditDetails,
+      });
+      expect(updateGefFacilityMock).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/dtfs-central-api/src/services/portal/facility.service.update-status.test.ts
+++ b/dtfs-central-api/src/services/portal/facility.service.update-status.test.ts
@@ -23,7 +23,7 @@ describe('PortalFacilityService', () => {
   });
 
   describe('updateStatus', () => {
-    it(`calls updateGefDealStatus when submissionType is ${DEAL_TYPE.GEF}`, async () => {
+    it(`calls updateFacility when submissionType is ${DEAL_TYPE.GEF}`, async () => {
       // Arrange
       const dealType = DEAL_TYPE.GEF;
 
@@ -40,7 +40,7 @@ describe('PortalFacilityService', () => {
       expect(updateBssEwcsFacilityStatusMock).toHaveBeenCalledTimes(0);
     });
 
-    it(`calls updateBssEwcsDealStatus when submissionType is ${DEAL_TYPE.BSS_EWCS}`, async () => {
+    it(`calls updateFacilityStatus when submissionType is ${DEAL_TYPE.BSS_EWCS}`, async () => {
       // Arrange
       const dealType = DEAL_TYPE.BSS_EWCS;
 

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.getTfmDealCancellationResponse.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.getTfmDealCancellationResponse.test.ts
@@ -6,7 +6,7 @@ const dealType = DEAL_TYPE.GEF;
 const ukefDealId = 'ukefDealId';
 
 describe('DealCancellationService', () => {
-  describe('submitDealCancellation', () => {
+  describe('getTfmDealCancellationResponse', () => {
     it('returns the deal and facility ids', () => {
       // Arrange
       const cancelledDeal = { dealSnapshot: { dealType, ukefDealId } } as TfmDeal;

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.getTfmDealCancellationResponse.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.getTfmDealCancellationResponse.test.ts
@@ -27,32 +27,5 @@ describe('DealCancellationService', () => {
       const expected: TfmDealCancellationResponse = { cancelledDealUkefId: getUkefDealId(cancelledDeal.dealSnapshot) as string, riskExpiredFacilityUkefIds };
       expect(response).toEqual(expected);
     });
-
-    it('removes facility Ids that are null', () => {
-      // Arrange
-      const cancelledDeal = { dealSnapshot: { dealType, ukefDealId } } as TfmDeal;
-
-      const facilityId1 = 'facilityId1';
-      const facilityId2 = 'facilityId1';
-      const riskExpiredFacilityUkefIds = [facilityId1, null, facilityId2];
-
-      const mockRepositoryResponse = {
-        cancelledDeal,
-        riskExpiredFacilities: riskExpiredFacilityUkefIds.map((ukefFacilityId) => ({
-          ...aTfmFacility(),
-          facilitySnapshot: { ...aTfmFacility().facilitySnapshot, ukefFacilityId },
-        })),
-      };
-
-      // Act
-      const response = DealCancellationService.getTfmDealCancellationResponse(mockRepositoryResponse);
-
-      // Assert
-      const expected: TfmDealCancellationResponse = {
-        cancelledDealUkefId: getUkefDealId(cancelledDeal.dealSnapshot) as string,
-        riskExpiredFacilityUkefIds: [facilityId1, facilityId2],
-      };
-      expect(response).toEqual(expected);
-    });
   });
 });

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.getTfmDealCancellationResponse.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.getTfmDealCancellationResponse.test.ts
@@ -1,0 +1,58 @@
+import { DEAL_TYPE, getUkefDealId, TfmDeal, TfmDealCancellationResponse } from '@ukef/dtfs2-common';
+import { aTfmFacility } from '../../../test-helpers';
+import { DealCancellationService } from './deal-cancellation.service';
+
+const dealType = DEAL_TYPE.GEF;
+const ukefDealId = 'ukefDealId';
+
+describe('DealCancellationService', () => {
+  describe('submitDealCancellation', () => {
+    it('returns the deal and facility ids', () => {
+      // Arrange
+      const cancelledDeal = { dealSnapshot: { dealType, ukefDealId } } as TfmDeal;
+      const riskExpiredFacilityUkefIds = ['facilityId1', 'facilityId2'];
+
+      const mockRepositoryResponse = {
+        cancelledDeal,
+        riskExpiredFacilities: riskExpiredFacilityUkefIds.map((ukefFacilityId) => ({
+          ...aTfmFacility(),
+          facilitySnapshot: { ...aTfmFacility().facilitySnapshot, ukefFacilityId },
+        })),
+      };
+
+      // Act
+      const response = DealCancellationService.getTfmDealCancellationResponse(mockRepositoryResponse);
+
+      // Assert
+      const expected: TfmDealCancellationResponse = { cancelledDealUkefId: getUkefDealId(cancelledDeal.dealSnapshot) as string, riskExpiredFacilityUkefIds };
+      expect(response).toEqual(expected);
+    });
+
+    it('removes facility Ids that are null', () => {
+      // Arrange
+      const cancelledDeal = { dealSnapshot: { dealType, ukefDealId } } as TfmDeal;
+
+      const facilityId1 = 'facilityId1';
+      const facilityId2 = 'facilityId1';
+      const riskExpiredFacilityUkefIds = [facilityId1, null, facilityId2];
+
+      const mockRepositoryResponse = {
+        cancelledDeal,
+        riskExpiredFacilities: riskExpiredFacilityUkefIds.map((ukefFacilityId) => ({
+          ...aTfmFacility(),
+          facilitySnapshot: { ...aTfmFacility().facilitySnapshot, ukefFacilityId },
+        })),
+      };
+
+      // Act
+      const response = DealCancellationService.getTfmDealCancellationResponse(mockRepositoryResponse);
+
+      // Assert
+      const expected: TfmDealCancellationResponse = {
+        cancelledDealUkefId: getUkefDealId(cancelledDeal.dealSnapshot) as string,
+        riskExpiredFacilityUkefIds: [facilityId1, facilityId2],
+      };
+      expect(response).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.processScheduledCancellation.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.processScheduledCancellation.test.ts
@@ -1,17 +1,22 @@
-import { AnyObject, AuditDetails, DEAL_STATUS, DEAL_TYPE, TfmActivity, TfmDealCancellation, TfmDealCancellationResponse, TfmUser } from '@ukef/dtfs2-common';
+import { AnyObject, AuditDetails, DEAL_STATUS, DEAL_TYPE, TfmActivity, TfmDeal, TfmDealCancellation, TfmFacility, TfmUser } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { ObjectId } from 'mongodb';
 import { DealCancellationService } from './deal-cancellation.service';
-import { aTfmUser } from '../../../test-helpers';
+import { aTfmFacility, aTfmUser } from '../../../test-helpers';
 
 const dealType = DEAL_TYPE.GEF;
 
 const mockCancellationResponse = {
-  cancelledDeal: { dealSnapshot: { dealType } },
-  riskExpiredFacilityUkefIds: ['1', '2'],
-} as TfmDealCancellationResponse;
+  cancelledDeal: { dealSnapshot: { dealType } } as TfmDeal,
+  riskExpiredFacilities: [aTfmFacility()],
+};
 
-const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<Promise<TfmDealCancellationResponse>>;
+const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<
+  Promise<{
+    cancelledDeal: TfmDeal;
+    riskExpiredFacilities: TfmFacility[];
+  }>
+>;
 
 const findOneUserByIdMock = jest.fn() as jest.Mock<Promise<TfmUser | null>>;
 

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.processScheduledCancellation.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.processScheduledCancellation.test.ts
@@ -1,4 +1,15 @@
-import { AnyObject, AuditDetails, DEAL_STATUS, DEAL_TYPE, TfmActivity, TfmDeal, TfmDealCancellation, TfmFacility, TfmUser } from '@ukef/dtfs2-common';
+import {
+  AnyObject,
+  AuditDetails,
+  DEAL_STATUS,
+  DEAL_TYPE,
+  FACILITY_STATUS,
+  TfmActivity,
+  TfmDeal,
+  TfmDealCancellation,
+  TfmFacility,
+  TfmUser,
+} from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { ObjectId } from 'mongodb';
 import { DealCancellationService } from './deal-cancellation.service';
@@ -6,12 +17,14 @@ import { aTfmFacility, aTfmUser } from '../../../test-helpers';
 
 const dealType = DEAL_TYPE.GEF;
 
-const mockCancellationResponse = {
+const riskExpiredFacilityIds = [new ObjectId(), new ObjectId()];
+
+const mockRepositoryResponse = {
   cancelledDeal: { dealSnapshot: { dealType } } as TfmDeal,
-  riskExpiredFacilities: [aTfmFacility()],
+  riskExpiredFacilities: riskExpiredFacilityIds.map((_id) => ({ ...aTfmFacility(), _id })),
 };
 
-const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<
+const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockRepositoryResponse)) as jest.Mock<
   Promise<{
     cancelledDeal: TfmDeal;
     riskExpiredFacilities: TfmFacility[];
@@ -21,6 +34,7 @@ const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellatio
 const findOneUserByIdMock = jest.fn() as jest.Mock<Promise<TfmUser | null>>;
 
 const updatePortalDealStatusMock = jest.fn() as jest.Mock<Promise<void>>;
+const updatePortalFacilityStatusMock = jest.fn() as jest.Mock<Promise<void>>;
 
 jest.mock('../../repositories/tfm-deals-repo/tfm-deal-cancellation.repo', () => ({
   TfmDealCancellationRepo: {
@@ -38,6 +52,12 @@ jest.mock('../../repositories/tfm-users-repo', () => ({
 jest.mock('../portal/deal.service', () => ({
   PortalDealService: {
     updateStatus: (params: AnyObject) => updatePortalDealStatusMock(params),
+  },
+}));
+
+jest.mock('../portal/facility.service', () => ({
+  PortalFacilityService: {
+    updateStatus: (params: AnyObject) => updatePortalFacilityStatusMock(params),
   },
 }));
 
@@ -88,7 +108,7 @@ describe('DealCancellationService', () => {
       const dealCancellationResponse = await DealCancellationService.processScheduledCancellation(dealId, cancellation, auditDetails);
 
       // Assert
-      expect(dealCancellationResponse).toEqual(mockCancellationResponse);
+      expect(dealCancellationResponse).toEqual(DealCancellationService.getTfmDealCancellationResponse(mockRepositoryResponse));
     });
 
     it(`it calls PortalDealService.updateStatus with ${DEAL_STATUS.CANCELLED} status`, async () => {
@@ -101,6 +121,30 @@ describe('DealCancellationService', () => {
       // Assert
       expect(updatePortalDealStatusMock).toHaveBeenCalledTimes(1);
       expect(updatePortalDealStatusMock).toHaveBeenCalledWith({ dealId, dealType, auditDetails, newStatus: DEAL_STATUS.CANCELLED });
+    });
+
+    it(`it calls PortalFacilityService.updateStatus with ${DEAL_STATUS.CANCELLED} status for each facility`, async () => {
+      // Arrange
+      const cancellation = aDealCancellation();
+
+      // Act
+      await DealCancellationService.processScheduledCancellation(dealId, cancellation, auditDetails);
+
+      // Assert
+      expect(updatePortalFacilityStatusMock).toHaveBeenCalledTimes(2);
+      expect(updatePortalFacilityStatusMock).toHaveBeenCalledWith({
+        facilityId: riskExpiredFacilityIds[0],
+        dealType,
+        auditDetails,
+        status: FACILITY_STATUS.RISK_EXPIRED,
+      });
+
+      expect(updatePortalFacilityStatusMock).toHaveBeenCalledWith({
+        facilityId: riskExpiredFacilityIds[1],
+        dealType,
+        auditDetails,
+        status: FACILITY_STATUS.RISK_EXPIRED,
+      });
     });
   });
 });

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.submitDealCancellation.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.submitDealCancellation.test.ts
@@ -6,25 +6,36 @@ import {
   DEAL_TYPE,
   InvalidAuditDetailsError,
   TfmActivity,
+  TfmDeal,
   TfmDealCancellation,
-  TfmDealCancellationResponse,
+  TfmFacility,
   TfmUser,
 } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { add, endOfDay, getUnixTime, startOfDay, sub } from 'date-fns';
 import { ObjectId } from 'mongodb';
 import { DealCancellationService } from './deal-cancellation.service';
-import { aTfmUser } from '../../../test-helpers';
+import { aTfmFacility, aTfmUser } from '../../../test-helpers';
 
 const dealType = DEAL_TYPE.GEF;
 
 const mockCancellationResponse = {
-  cancelledDeal: { dealSnapshot: { dealType } },
-  riskExpiredFacilityUkefIds: ['1', '2'],
-} as TfmDealCancellationResponse;
+  cancelledDeal: { dealSnapshot: { dealType } } as TfmDeal,
+  riskExpiredFacilities: [aTfmFacility()],
+};
 
-const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<Promise<TfmDealCancellationResponse>>;
-const scheduleDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<Promise<TfmDealCancellationResponse>>;
+const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<
+  Promise<{
+    cancelledDeal: TfmDeal;
+    riskExpiredFacilities: TfmFacility[];
+  }>
+>;
+const scheduleDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<
+  Promise<{
+    cancelledDeal: TfmDeal;
+    riskExpiredFacilities: TfmFacility[];
+  }>
+>;
 
 const findOneUserByIdMock = jest.fn() as jest.Mock<Promise<TfmUser | null>>;
 

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.submitDealCancellation.test.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.submitDealCancellation.test.ts
@@ -4,6 +4,7 @@ import {
   AuditDetails,
   DEAL_STATUS,
   DEAL_TYPE,
+  FACILITY_STATUS,
   InvalidAuditDetailsError,
   TfmActivity,
   TfmDeal,
@@ -19,18 +20,20 @@ import { aTfmFacility, aTfmUser } from '../../../test-helpers';
 
 const dealType = DEAL_TYPE.GEF;
 
-const mockCancellationResponse = {
+const riskExpiredFacilityIds = [new ObjectId(), new ObjectId()];
+
+const mockRepositoryResponse = {
   cancelledDeal: { dealSnapshot: { dealType } } as TfmDeal,
-  riskExpiredFacilities: [aTfmFacility()],
+  riskExpiredFacilities: riskExpiredFacilityIds.map((_id) => ({ ...aTfmFacility(), _id })),
 };
 
-const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<
+const submitDealCancellationMock = jest.fn(() => Promise.resolve(mockRepositoryResponse)) as jest.Mock<
   Promise<{
     cancelledDeal: TfmDeal;
     riskExpiredFacilities: TfmFacility[];
   }>
 >;
-const scheduleDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellationResponse)) as jest.Mock<
+const scheduleDealCancellationMock = jest.fn(() => Promise.resolve(mockRepositoryResponse)) as jest.Mock<
   Promise<{
     cancelledDeal: TfmDeal;
     riskExpiredFacilities: TfmFacility[];
@@ -40,6 +43,7 @@ const scheduleDealCancellationMock = jest.fn(() => Promise.resolve(mockCancellat
 const findOneUserByIdMock = jest.fn() as jest.Mock<Promise<TfmUser | null>>;
 
 const updatePortalDealStatusMock = jest.fn() as jest.Mock<Promise<void>>;
+const updatePortalFacilityStatusMock = jest.fn() as jest.Mock<Promise<void>>;
 
 jest.mock('../../repositories/tfm-deals-repo/tfm-deal-cancellation.repo', () => ({
   TfmDealCancellationRepo: {
@@ -59,6 +63,12 @@ jest.mock('../../repositories/tfm-users-repo', () => ({
 jest.mock('../portal/deal.service', () => ({
   PortalDealService: {
     updateStatus: (params: AnyObject) => updatePortalDealStatusMock(params),
+  },
+}));
+
+jest.mock('../portal/facility.service', () => ({
+  PortalFacilityService: {
+    updateStatus: (params: AnyObject) => updatePortalFacilityStatusMock(params),
   },
 }));
 
@@ -176,7 +186,7 @@ describe('DealCancellationService', () => {
           const dealCancellationResponse = await DealCancellationService.submitDealCancellation(dealId, cancellation, auditDetails);
 
           // Assert
-          expect(dealCancellationResponse).toEqual(mockCancellationResponse);
+          expect(dealCancellationResponse).toEqual(DealCancellationService.getTfmDealCancellationResponse(mockRepositoryResponse));
         });
 
         it(`it calls PortalDealService.updateStatus with ${DEAL_STATUS.CANCELLED} status`, async () => {
@@ -186,6 +196,27 @@ describe('DealCancellationService', () => {
           // Assert
           expect(updatePortalDealStatusMock).toHaveBeenCalledTimes(1);
           expect(updatePortalDealStatusMock).toHaveBeenCalledWith({ dealId, dealType, auditDetails, newStatus: DEAL_STATUS.CANCELLED });
+        });
+
+        it(`it calls PortalFacilityService.updateStatus with ${DEAL_STATUS.CANCELLED} status for each facility`, async () => {
+          // Act
+          await DealCancellationService.submitDealCancellation(dealId, cancellation, auditDetails);
+
+          // Assert
+          expect(updatePortalFacilityStatusMock).toHaveBeenCalledTimes(2);
+          expect(updatePortalFacilityStatusMock).toHaveBeenCalledWith({
+            facilityId: riskExpiredFacilityIds[0],
+            dealType,
+            auditDetails,
+            status: FACILITY_STATUS.RISK_EXPIRED,
+          });
+
+          expect(updatePortalFacilityStatusMock).toHaveBeenCalledWith({
+            facilityId: riskExpiredFacilityIds[1],
+            dealType,
+            auditDetails,
+            status: FACILITY_STATUS.RISK_EXPIRED,
+          });
         });
 
         it('throws InvalidAuditDetailsError when no user is found', async () => {
@@ -240,7 +271,7 @@ describe('DealCancellationService', () => {
           const dealCancellationResponse = await DealCancellationService.submitDealCancellation(dealId, cancellation, auditDetails);
 
           // Assert
-          expect(dealCancellationResponse).toEqual(mockCancellationResponse);
+          expect(dealCancellationResponse).toEqual(DealCancellationService.getTfmDealCancellationResponse(mockRepositoryResponse));
         });
 
         it('does not call PortalDealService.updateStatus', async () => {
@@ -249,6 +280,14 @@ describe('DealCancellationService', () => {
 
           // Assert
           expect(updatePortalDealStatusMock).toHaveBeenCalledTimes(0);
+        });
+
+        it('does not call PortalFacilityService.updateStatus', async () => {
+          // Act
+          await DealCancellationService.submitDealCancellation(dealId, cancellation, auditDetails);
+
+          // Assert
+          expect(updatePortalFacilityStatusMock).toHaveBeenCalledTimes(0);
         });
 
         it('throws InvalidAuditDetailsError when no user is found', async () => {

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
@@ -14,7 +14,7 @@ import { endOfDay, getUnixTime, isAfter, toDate } from 'date-fns';
 import { TfmDealCancellationRepo } from '../../repositories/tfm-deals-repo';
 import { TfmUsersRepo } from '../../repositories/tfm-users-repo';
 import { PortalDealService } from '../portal/deal.service';
-import { updateFacilityStatus } from '../../v1/controllers/portal/facility/update-facility-status.controller';
+import { PortalFacilityService } from '../portal/facility.service';
 
 export class DealCancellationService {
   /**
@@ -83,7 +83,9 @@ export class DealCancellationService {
     });
 
     await Promise.all(
-      riskExpiredFacilities.map(({ _id: facilityId }) => updateFacilityStatus({ facilityId, status: FACILITY_STATUS.RISK_EXPIRED, auditDetails })),
+      riskExpiredFacilities.map(({ _id: facilityId }) =>
+        PortalFacilityService.updateStatus({ facilityId, status: FACILITY_STATUS.RISK_EXPIRED, dealType, auditDetails }),
+      ),
     );
 
     return {
@@ -120,7 +122,9 @@ export class DealCancellationService {
     });
 
     await Promise.all(
-      riskExpiredFacilities.map(({ _id: facilityId }) => updateFacilityStatus({ facilityId, status: FACILITY_STATUS.RISK_EXPIRED, auditDetails })),
+      riskExpiredFacilities.map(({ _id: facilityId }) =>
+        PortalFacilityService.updateStatus({ facilityId, status: FACILITY_STATUS.RISK_EXPIRED, dealType, auditDetails }),
+      ),
     );
 
     return {

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
@@ -3,11 +3,14 @@ import {
   AuditDetails,
   DEAL_STATUS,
   FACILITY_STATUS,
+  getUkefDealId,
   InvalidAuditDetailsError,
   TfmActivity,
   TfmAuditDetails,
+  TfmDeal,
   TfmDealCancellation,
   TfmDealCancellationResponse,
+  TfmFacility,
 } from '@ukef/dtfs2-common';
 import { ObjectId } from 'mongodb';
 import { endOfDay, getUnixTime, isAfter, toDate } from 'date-fns';
@@ -61,12 +64,7 @@ export class DealCancellationService {
         auditDetails,
       });
 
-      return {
-        cancelledDeal,
-        riskExpiredFacilityUkefIds: riskExpiredFacilities
-          .map(({ facilitySnapshot }) => facilitySnapshot.ukefFacilityId)
-          .filter((facilityId) => facilityId !== null),
-      };
+      return this.getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities });
     }
 
     const { cancelledDeal, riskExpiredFacilities } = await TfmDealCancellationRepo.submitDealCancellation({ dealId, cancellation, activity, auditDetails });
@@ -88,12 +86,7 @@ export class DealCancellationService {
       ),
     );
 
-    return {
-      cancelledDeal,
-      riskExpiredFacilityUkefIds: riskExpiredFacilities
-        .map(({ facilitySnapshot }) => facilitySnapshot.ukefFacilityId)
-        .filter((facilityId) => facilityId !== null),
-    };
+    return this.getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities });
   }
 
   /**
@@ -127,8 +120,14 @@ export class DealCancellationService {
       ),
     );
 
+    return this.getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities });
+  }
+
+  private static getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities }: { cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }) {
+    const cancelledDealUkefId = getUkefDealId(cancelledDeal.dealSnapshot) as string;
+
     return {
-      cancelledDeal,
+      cancelledDealUkefId,
       riskExpiredFacilityUkefIds: riskExpiredFacilities
         .map(({ facilitySnapshot }) => facilitySnapshot.ukefFacilityId)
         .filter((facilityId) => facilityId !== null),

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
@@ -134,9 +134,7 @@ export class DealCancellationService {
 
     return {
       cancelledDealUkefId,
-      riskExpiredFacilityUkefIds: riskExpiredFacilities
-        .map(({ facilitySnapshot }) => facilitySnapshot.ukefFacilityId)
-        .filter((facilityId) => facilityId !== null),
+      riskExpiredFacilityUkefIds: riskExpiredFacilities.map(({ facilitySnapshot }) => facilitySnapshot.ukefFacilityId as string),
     };
   }
 }

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
@@ -2,6 +2,7 @@ import {
   ACTIVITY_TYPES,
   AuditDetails,
   DEAL_STATUS,
+  FACILITY_STATUS,
   InvalidAuditDetailsError,
   TfmActivity,
   TfmAuditDetails,
@@ -13,6 +14,7 @@ import { endOfDay, getUnixTime, isAfter, toDate } from 'date-fns';
 import { TfmDealCancellationRepo } from '../../repositories/tfm-deals-repo';
 import { TfmUsersRepo } from '../../repositories/tfm-users-repo';
 import { PortalDealService } from '../portal/deal.service';
+import { updateFacilityStatus } from '../../v1/controllers/portal/facility/update-facility-status.controller';
 
 export class DealCancellationService {
   /**
@@ -80,6 +82,10 @@ export class DealCancellationService {
       dealType,
     });
 
+    await Promise.all(
+      riskExpiredFacilities.map(({ _id: facilityId }) => updateFacilityStatus({ facilityId, status: FACILITY_STATUS.RISK_EXPIRED, auditDetails })),
+    );
+
     return {
       cancelledDeal,
       riskExpiredFacilityUkefIds: riskExpiredFacilities
@@ -112,6 +118,10 @@ export class DealCancellationService {
       auditDetails,
       dealType,
     });
+
+    await Promise.all(
+      riskExpiredFacilities.map(({ _id: facilityId }) => updateFacilityStatus({ facilityId, status: FACILITY_STATUS.RISK_EXPIRED, auditDetails })),
+    );
 
     return {
       cancelledDeal,

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
@@ -123,6 +123,12 @@ export class DealCancellationService {
     return this.getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities });
   }
 
+  /**
+   * Maps values returned by repository to return deal cancellation DTO
+   *
+   * @param repositoryResponse - The response from the deal cancellation repository method
+   * @returns Tfm deal cancellation response DTO
+   */
   public static getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities }: { cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }) {
     const cancelledDealUkefId = getUkefDealId(cancelledDeal.dealSnapshot) as string;
 

--- a/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
+++ b/dtfs-central-api/src/services/tfm/deal-cancellation.service.ts
@@ -123,7 +123,7 @@ export class DealCancellationService {
     return this.getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities });
   }
 
-  private static getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities }: { cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }) {
+  public static getTfmDealCancellationResponse({ cancelledDeal, riskExpiredFacilities }: { cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }) {
     const cancelledDealUkefId = getUkefDealId(cancelledDeal.dealSnapshot) as string;
 
     return {

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
@@ -12,12 +12,12 @@ const withoutId = (obj) => {
 };
 
 /**
- * Update a facility status
+ * Update a BSS/EWCS facility status
  * @param updateFacilityStatusParams
- * @param updateFacilityStatusParams.facilityId - the facility Id
- * @param updateFacilityStatusParams.status - the new status to set
- * @param updateFacilityStatusParams.auditDetails - the logged in users audit details
- * @returns {import('@ukef/dtfs2-common').Facility} - the updated Facility
+ * @param {string | ObjectId} updateFacilityStatusParams.facilityId - the facility Id
+ * @param {import('@ukef/dtfs2-common').FacilityStatus} updateFacilityStatusParams.status - the new status to set
+ * @param {import('@ukef/dtfs2-common').AuditDetails} updateFacilityStatusParams.auditDetails - the logged in users audit details
+ * @returns {Promise<import('@ukef/dtfs2-common').Facility>} - the updated Facility
  */
 const updateFacilityStatus = async ({ facilityId, status, auditDetails }) => {
   const existingFacility = await findOneFacility(facilityId);

--- a/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/update-facility-status.controller.js
@@ -19,12 +19,12 @@ const withoutId = (obj) => {
  * @param {import('@ukef/dtfs2-common').AuditDetails} updateFacilityStatusParams.auditDetails - the logged in users audit details
  * @returns {Promise<import('@ukef/dtfs2-common').Facility>} - the updated Facility
  */
-const updateFacilityStatus = async ({ facilityId, status, auditDetails }) => {
+const updateBssEwcsFacilityStatus = async ({ facilityId, status, auditDetails }) => {
   const existingFacility = await findOneFacility(facilityId);
 
   const collection = await db.getCollection(MONGO_DB_COLLECTIONS.FACILITIES);
 
-  console.info('Updating Portal facility status to %s', status);
+  console.info('Updating Portal BSS/EWCS facility status to %s', status);
   const previousStatus = existingFacility.status;
 
   const auditRecord = generateAuditDatabaseRecordFromAuditDetails(auditDetails);
@@ -42,11 +42,11 @@ const updateFacilityStatus = async ({ facilityId, status, auditDetails }) => {
     returnDocument: 'after',
   });
 
-  console.info('Updated Portal facility status from %s to %s', previousStatus, status);
+  console.info('Updated Portal BSS/EWCS facility status from %s to %s', previousStatus, status);
 
   return findAndUpdateResponse.value;
 };
-exports.updateFacilityStatus = updateFacilityStatus;
+exports.updateBssEwcsFacilityStatus = updateBssEwcsFacilityStatus;
 
 exports.updateFacilityStatusPut = async (req, res) => {
   const {
@@ -61,7 +61,7 @@ exports.updateFacilityStatusPut = async (req, res) => {
 
     validateAuditDetails(auditDetails);
 
-    const updatedFacility = await updateFacilityStatus({ facilityId, status, auditDetails });
+    const updatedFacility = await updateBssEwcsFacilityStatus({ facilityId, status, auditDetails });
 
     return res.status(200).json(updatedFacility);
   } catch (error) {

--- a/dtfs-central-api/src/v1/controllers/portal/gef-facility/update-facility.controller.js
+++ b/dtfs-central-api/src/v1/controllers/portal/gef-facility/update-facility.controller.js
@@ -10,6 +10,14 @@ const {
 const { ObjectId } = require('mongodb');
 const { mongoDbClient: db } = require('../../../../drivers/db-client');
 
+/**
+ *
+ * @param updateFacilityParams
+ * @param {ObjectId | string} updateFacilityParams.facilityId
+ * @param {Partial<import('@ukef/dtfs2-common').Facility} updateFacilityParams.facilityUpdate
+ * @param {import('@ukef/dtfs2-common').AuditDetails} updateFacilityParams.auditDetails
+ * @returns
+ */
 const updateFacility = async ({ facilityId, facilityUpdate, auditDetails }) => {
   if (!ObjectId.isValid(facilityId)) {
     throw new InvalidFacilityIdError(facilityId);

--- a/dtfs-central-api/test-helpers/test-data/tfm-facility.ts
+++ b/dtfs-central-api/test-helpers/test-data/tfm-facility.ts
@@ -4,16 +4,13 @@ import { generateMockPortalUserAuditDatabaseRecord } from '@ukef/dtfs2-common/ch
 import { aFacility } from './facility';
 import { KeyingSheetCalculationFacilityValues } from '../../src/types/tfm/tfm-facility';
 
-const facility = aFacility();
-const { dayCountBasis, interestPercentage, coverPercentage, value } = facility;
-
 export const aTfmFacility = (): TfmFacility => {
   const tfmFacilityId = new ObjectId();
 
   return {
     _id: tfmFacilityId,
     facilitySnapshot: {
-      ...facility,
+      ...aFacility(),
       _id: tfmFacilityId,
     },
     amendments: [],
@@ -21,6 +18,8 @@ export const aTfmFacility = (): TfmFacility => {
     auditRecord: generateMockPortalUserAuditDatabaseRecord(new ObjectId()),
   };
 };
+
+const { dayCountBasis, interestPercentage, coverPercentage, value } = aFacility();
 
 export const keyingSheetCalculationFacilityValues: KeyingSheetCalculationFacilityValues = {
   coverEndDate: new Date(),

--- a/libs/common/src/types/portal/facility-status.ts
+++ b/libs/common/src/types/portal/facility-status.ts
@@ -1,0 +1,4 @@
+import { ValuesOf } from '..';
+import { FACILITY_STATUS } from '../../constants';
+
+export type FacilityStatus = ValuesOf<typeof FACILITY_STATUS>;

--- a/libs/common/src/types/portal/index.ts
+++ b/libs/common/src/types/portal/index.ts
@@ -1,2 +1,3 @@
 export * from './roles';
 export * from './deal-status';
+export * from './facility-status';

--- a/libs/common/src/types/tfm-deal-cancellation.ts
+++ b/libs/common/src/types/tfm-deal-cancellation.ts
@@ -1,10 +1,10 @@
 import z from 'zod';
+import { ObjectId } from 'mongodb';
 import { DEAL_CANCELLATION } from '../schemas/deal-cancellation';
-import { TfmDeal } from './mongo-db-models';
 
 export type TfmDealCancellation = z.infer<typeof DEAL_CANCELLATION>;
 
 export type TfmDealCancellationResponse = {
-  cancelledDeal: TfmDeal;
+  cancelledDealUkefId: string | ObjectId;
   riskExpiredFacilityUkefIds: string[];
 };

--- a/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
+++ b/trade-finance-manager-api/api-tests/v1/deal-cancellation/submit-deal-cancellation.post.api-test.ts
@@ -1,5 +1,5 @@
 import { add, format } from 'date-fns';
-import { AnyObject, DEAL_TYPE, MAX_CHARACTER_COUNT, TEAM_IDS, TestApiError, TfmDealCancellationResponse, TfmFacility } from '@ukef/dtfs2-common';
+import { AnyObject, MAX_CHARACTER_COUNT, TEAM_IDS, TestApiError, TfmDealCancellationResponse, TfmFacility } from '@ukef/dtfs2-common';
 import { ObjectId, UpdateResult } from 'mongodb';
 import { HttpStatusCode } from 'axios';
 import { createApi } from '../../api';
@@ -80,7 +80,7 @@ describe('POST /v1/deals/:id/cancellation/submit', () => {
 
     beforeEach(() => {
       submitDealCancellationMock.mockResolvedValue({
-        cancelledDeal: { dealSnapshot: { dealType: DEAL_TYPE.GEF, ukefDealId } },
+        cancelledDealUkefId: ukefDealId,
         riskExpiredFacilityUkefIds: ukefFacilityIds,
       } as TfmDealCancellationResponse);
     });

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
@@ -1,4 +1,4 @@
-import { AnyObject, DATE_FORMATS, DEAL_TYPE, TfmDealCancellation, TfmDealCancellationResponse } from '@ukef/dtfs2-common';
+import { AnyObject, DATE_FORMATS, TfmDealCancellation, TfmDealCancellationResponse } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { add, format } from 'date-fns';
 import { CANCEL_DEAL_FUTURE_DATE, CANCEL_DEAL_PAST_DATE } from '../../../constants/email-template-ids';
@@ -32,7 +32,7 @@ describe('deal cancellation service', () => {
   describe('submitDealCancellation', () => {
     beforeEach(() => {
       submitDealCancellationMock.mockResolvedValueOnce({
-        cancelledDeal: { dealSnapshot: { dealType: DEAL_TYPE.GEF, ukefDealId } },
+        cancelledDealUkefId: ukefDealId,
         riskExpiredFacilityUkefIds: ukefFacilityIds,
       } as TfmDealCancellationResponse);
     });

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
@@ -1,4 +1,4 @@
-import { AnyObject, DATE_FORMATS, DEAL_TYPE, TfmDeal, TfmDealCancellation, TfmFacility } from '@ukef/dtfs2-common';
+import { AnyObject, DATE_FORMATS, DEAL_TYPE, TfmDealCancellation, TfmDealCancellationResponse } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { add, format } from 'date-fns';
 import { CANCEL_DEAL_FUTURE_DATE, CANCEL_DEAL_PAST_DATE } from '../../../constants/email-template-ids';
@@ -11,7 +11,7 @@ const mockPimEmailAddress = 'pim@example.com';
 const ukefDealId = 'ukefDealId';
 const ukefFacilityIds = ['aFacilityId'];
 
-const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<{ cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }>>;
+const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<TfmDealCancellationResponse>>;
 
 jest.mock('../send-tfm-email');
 jest.mock('../../api', () => ({
@@ -32,9 +32,9 @@ describe('deal cancellation service', () => {
   describe('submitDealCancellation', () => {
     beforeEach(() => {
       submitDealCancellationMock.mockResolvedValueOnce({
-        cancelledDeal: { dealSnapshot: { dealType: DEAL_TYPE.GEF, ukefDealId } } as TfmDeal,
-        riskExpiredFacilities: ukefFacilityIds.map((ukefFacilityId) => ({ facilitySnapshot: { ukefFacilityId } }) as TfmFacility),
-      });
+        cancelledDeal: { dealSnapshot: { dealType: DEAL_TYPE.GEF, ukefDealId } },
+        riskExpiredFacilityUkefIds: ukefFacilityIds,
+      } as TfmDealCancellationResponse);
     });
 
     describe('when effective date is in the future', () => {

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.test.ts
@@ -1,4 +1,4 @@
-import { AnyObject, DATE_FORMATS, DEAL_TYPE, TfmDealCancellation, TfmDealCancellationResponse } from '@ukef/dtfs2-common';
+import { AnyObject, DATE_FORMATS, DEAL_TYPE, TfmDeal, TfmDealCancellation, TfmFacility } from '@ukef/dtfs2-common';
 import { generateTfmAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { add, format } from 'date-fns';
 import { CANCEL_DEAL_FUTURE_DATE, CANCEL_DEAL_PAST_DATE } from '../../../constants/email-template-ids';
@@ -11,7 +11,7 @@ const mockPimEmailAddress = 'pim@example.com';
 const ukefDealId = 'ukefDealId';
 const ukefFacilityIds = ['aFacilityId'];
 
-const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<TfmDealCancellationResponse>>;
+const submitDealCancellationMock = jest.fn() as jest.Mock<Promise<{ cancelledDeal: TfmDeal; riskExpiredFacilities: TfmFacility[] }>>;
 
 jest.mock('../send-tfm-email');
 jest.mock('../../api', () => ({
@@ -32,9 +32,9 @@ describe('deal cancellation service', () => {
   describe('submitDealCancellation', () => {
     beforeEach(() => {
       submitDealCancellationMock.mockResolvedValueOnce({
-        cancelledDeal: { dealSnapshot: { dealType: DEAL_TYPE.GEF, ukefDealId } },
-        riskExpiredFacilityUkefIds: ukefFacilityIds,
-      } as TfmDealCancellationResponse);
+        cancelledDeal: { dealSnapshot: { dealType: DEAL_TYPE.GEF, ukefDealId } } as TfmDeal,
+        riskExpiredFacilities: ukefFacilityIds.map((ukefFacilityId) => ({ facilitySnapshot: { ukefFacilityId } }) as TfmFacility),
+      });
     });
 
     describe('when effective date is in the future', () => {

--- a/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.ts
+++ b/trade-finance-manager-api/src/v1/services/deal-cancellation/deal-cancellation.service.ts
@@ -1,5 +1,5 @@
 import { endOfDay, format, isAfter, toDate } from 'date-fns';
-import { AuditDetails, DATE_FORMATS, getUkefDealId, TEAMS, TfmDealCancellation } from '@ukef/dtfs2-common';
+import { AuditDetails, DATE_FORMATS, TEAMS, TfmDealCancellation } from '@ukef/dtfs2-common';
 import sendTfmEmail from '../send-tfm-email';
 import { CANCEL_DEAL_PAST_DATE, CANCEL_DEAL_FUTURE_DATE } from '../../../constants/email-template-ids';
 import * as api from '../../api';
@@ -61,13 +61,7 @@ export class DealCancellationService {
   public static async submitDealCancellation({ dealId, cancellation, auditDetails }: SubmitDealCancellationParams) {
     console.info(`Submitting deal cancellation for ${dealId}`);
 
-    const { cancelledDeal, riskExpiredFacilityUkefIds } = await api.submitDealCancellation({ dealId, cancellation, auditDetails });
-
-    const ukefDealId = getUkefDealId(cancelledDeal.dealSnapshot);
-
-    if (!ukefDealId) {
-      throw new Error(`Failed to find deal Id on deal ${dealId} when submitting deal cancellation. No email has been sent`);
-    }
+    const { cancelledDealUkefId, riskExpiredFacilityUkefIds } = await api.submitDealCancellation({ dealId, cancellation, auditDetails });
 
     if (!riskExpiredFacilityUkefIds.length) {
       throw new Error(`Failed to find facility ids on deal ${dealId} when submitting deal cancellation. No email has been sent`);
@@ -77,6 +71,6 @@ export class DealCancellationService {
       throw new Error(`Some UKEF facility ids were invalid when submitting deal ${dealId} for cancellation. No email has been sent`);
     }
 
-    await this.sendDealCancellationEmail(ukefDealId, cancellation, riskExpiredFacilityUkefIds);
+    await this.sendDealCancellationEmail(cancelledDealUkefId.toString(), cancellation, riskExpiredFacilityUkefIds);
   }
 }


### PR DESCRIPTION
## Introduction :pencil2:
When a deal is cancelled in tfm, the portal facilities should show `risk expired`

## Resolution :heavy_check_mark:
- Modify the repo return type to send facilities
- Add new facilities service to update BSS and GEF facilities
- Update facilities in deal cancellation service

## Screenshots 📸 
BSS/EWCS Facilities
![image](https://github.com/user-attachments/assets/b37fd6de-6dae-4e83-8441-969c678355ce)


## Miscellaneous :heavy_plus_sign:
- Add `FacilityStatus` type
- Modify `TfmDealCancellationResponse` type back to a previous version & update controllers/tests to handle this

## Note ⚠️ 
This PR doesnt cover front end changes, gef-ui will need some refactoring to render the new status
