### PR TITLE
feat(DTFS2-7598): display risk expired facility status in GEF ui

### DIFF
--- a/gef-ui/server/utils/deal-helpers.test.js
+++ b/gef-ui/server/utils/deal-helpers.test.js
@@ -1,4 +1,5 @@
 import CONSTANTS from '../constants';
+import { CHECKER } from '../constants/roles';
 
 import { isNotice, isUkefReviewAvailable, isUkefReviewPositive, makerCanReSubmit, isDealNotice } from './deal-helpers';
 
@@ -112,6 +113,21 @@ describe('makerCanReSubmit', () => {
     const result = makerCanReSubmit(MOCK_REQUEST, application);
 
     expect(result).toEqual(false);
+  });
+
+  it('Should return false as the Maker is from a different Bank', () => {
+    MOCK_REQUEST.bank.id = 10;
+    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_BASIC_DEAL)).toEqual(false);
+  });
+
+  it('Should return false as the user does not have `maker` role', () => {
+    MOCK_REQUEST.roles = [CHECKER];
+    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_BASIC_DEAL)).toEqual(false);
+  });
+
+  it('Should return false as the Application maker is from a different current logged-in maker', () => {
+    MOCK_BASIC_DEAL.bank = { id: 1 };
+    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_BASIC_DEAL)).toEqual(false);
   });
 });
 

--- a/gef-ui/server/utils/display-items.js
+++ b/gef-ui/server/utils/display-items.js
@@ -58,7 +58,7 @@ const eligibilityCriteriaItems = (coverUrl) => [
 
 const facilityItems = (
   facilityUrl,
-  { type, hasBeenIssued, shouldCoverStartOnSubmission, ukefFacilityId, feeType, issueDate, isUsingFacilityEndDate },
+  { type, hasBeenIssued, shouldCoverStartOnSubmission, ukefFacilityId, feeType, issueDate, isUsingFacilityEndDate, status },
   dealVersion,
 ) => {
   const AT_MATURITY = 'At maturity';
@@ -77,7 +77,12 @@ const facilityItems = (
       label: 'Stage',
       id: 'hasBeenIssued',
       href: `${facilityUrl}?status=change`,
-      method: (value) => (isTrueSet(value) ? STAGE.ISSUED : STAGE.UNISSUED),
+      method: (value) => {
+        if (status) {
+          return status;
+        }
+        return isTrueSet(value) ? STAGE.ISSUED : STAGE.UNISSUED;
+      },
     },
     {
       label: 'Date issued to exporter',

--- a/gef-ui/server/utils/display-items.js
+++ b/gef-ui/server/utils/display-items.js
@@ -81,6 +81,7 @@ const facilityItems = (
         if (status) {
           return status;
         }
+
         return isTrueSet(value) ? STAGE.ISSUED : STAGE.UNISSUED;
       },
     },

--- a/gef-ui/server/utils/display-items.test.js
+++ b/gef-ui/server/utils/display-items.test.js
@@ -1,11 +1,13 @@
+import { FACILITY_STATUS } from '@ukef/dtfs2-common';
 import { facilityItems } from './display-items';
 import { MOCK_FACILITY } from './mocks/mock-facilities';
+import { STAGE } from '../constants';
 
 describe('facilityItems', () => {
   describe('when the deal version is undefined', () => {
     it('should hide all the facility end date rows', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY };
+      const facility = { ...MOCK_FACILITY.items[0].details };
 
       // Act
       const result = facilityItems('testUrl', facility, undefined);
@@ -20,7 +22,7 @@ describe('facilityItems', () => {
   describe('when the deal version is <1', () => {
     it('should hide all the facility end date rows', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY };
+      const facility = { ...MOCK_FACILITY.items[0].details };
 
       // Act
       const result = facilityItems('testUrl', facility, 0);
@@ -35,7 +37,7 @@ describe('facilityItems', () => {
   describe('when the deal version is >=1', () => {
     it('should show the "Has a facility end date" field when isUsingFacilityEndDate is null', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: null };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: null };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -46,7 +48,7 @@ describe('facilityItems', () => {
 
     it('should hide the facility end date and bank review date row when the isUsingFacilityEndDate is null', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: null };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: null };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -58,7 +60,7 @@ describe('facilityItems', () => {
 
     it('should show "Has a facility end date" and facility end date row when when isUsingFacilityEndDate is true', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: true };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -70,7 +72,7 @@ describe('facilityItems', () => {
 
     it('should hide the bank review date row when isUsingFacilityEndDate is true', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: true };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -81,7 +83,7 @@ describe('facilityItems', () => {
 
     it('should show "Has a facility end date" and bank review date row when isUsingFacilityEndDate is false', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: false };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: false };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -93,7 +95,7 @@ describe('facilityItems', () => {
 
     it('should hide facility end date row when isUsingFacilityEndDate is false', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: false };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: false };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -106,7 +108,7 @@ describe('facilityItems', () => {
       // Arrange
       const testFacilityEndDate = '2025-09-12T00:00:00.000Z';
       const expectedFormat = '12 September 2025';
-      const facility = { ...MOCK_FACILITY, facilityEndDate: testFacilityEndDate };
+      const facility = { ...MOCK_FACILITY.items[0].details, facilityEndDate: testFacilityEndDate };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -119,7 +121,7 @@ describe('facilityItems', () => {
       // Arrange
       const testBankReviewDate = '2026-08-04T00:00:00.000Z';
       const expectedFormat = '4 August 2026';
-      const facility = { ...MOCK_FACILITY, bankReviewDate: testBankReviewDate };
+      const facility = { ...MOCK_FACILITY.items[0].details, bankReviewDate: testBankReviewDate };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -130,7 +132,7 @@ describe('facilityItems', () => {
 
     it('should provide the correct URL for the "Has a facility end date" row', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: true };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -141,7 +143,7 @@ describe('facilityItems', () => {
 
     it('should provide the correct URL for the "Facility end date" row', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: true, facilityEndDate: '2026-08-04T00:00:00.000Z' };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true, facilityEndDate: '2026-08-04T00:00:00.000Z' };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -152,13 +154,51 @@ describe('facilityItems', () => {
 
     it('should provide the correct URL for the "Bank review date" row', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY, isUsingFacilityEndDate: false, bankReviewDate: '2026-08-04T00:00:00.000Z' };
+      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: false, bankReviewDate: '2026-08-04T00:00:00.000Z' };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
 
       // Assert
       expect(result.find((item) => item.id === 'bankReviewDate').href).toEqual('testUrl/bank-review-date?status=change');
+    });
+  });
+
+  describe(`when the facility has status ${FACILITY_STATUS.RISK_EXPIRED}`, () => {
+    it(`should show the stage as ${FACILITY_STATUS.RISK_EXPIRED}`, () => {
+      // Arrange
+      const status = FACILITY_STATUS.RISK_EXPIRED;
+      const facility = { ...MOCK_FACILITY.items[0].details, status };
+
+      // Act
+      const result = facilityItems('testUrl', facility, 1);
+
+      // Assert
+      expect(result.find((item) => item.label === 'Stage').method(facility.hasBeenIssued)).toEqual(status);
+    });
+  });
+
+  describe(`when the facility does not have a status`, () => {
+    it(`should show the stage as ${STAGE.ISSUED} if hasBeenIssued is 'true'`, () => {
+      // Arrange
+      const facility = { ...MOCK_FACILITY.items[0].details, hasBeenIssued: 'true' };
+
+      // Act
+      const result = facilityItems('testUrl', facility, 1);
+
+      // Assert
+      expect(result.find((item) => item.label === 'Stage').method(facility.hasBeenIssued)).toEqual(STAGE.ISSUED);
+    });
+
+    it(`should show the stage as ${STAGE.UNISSUED} if hasBeenIssued is 'false'`, () => {
+      // Arrange
+      const facility = { ...MOCK_FACILITY.items[0].details, hasBeenIssued: 'false' };
+
+      // Act
+      const result = facilityItems('testUrl', facility, 1);
+
+      // Assert
+      expect(result.find((item) => item.label === 'Stage').method(facility.hasBeenIssued)).toEqual(STAGE.UNISSUED);
     });
   });
 });

--- a/gef-ui/server/utils/display-items.test.js
+++ b/gef-ui/server/utils/display-items.test.js
@@ -1,13 +1,15 @@
 import { FACILITY_STATUS } from '@ukef/dtfs2-common';
 import { facilityItems } from './display-items';
-import { MOCK_FACILITY } from './mocks/mock-facilities';
+import { MOCK_FACILITY as MOCK_FACILITIES } from './mocks/mock-facilities';
 import { STAGE } from '../constants';
+
+const MOCK_FACILITY_ONE = MOCK_FACILITIES.items[0].details;
 
 describe('facilityItems', () => {
   describe('when the deal version is undefined', () => {
     it('should hide all the facility end date rows', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details };
+      const facility = { ...MOCK_FACILITY_ONE };
 
       // Act
       const result = facilityItems('testUrl', facility, undefined);
@@ -22,7 +24,7 @@ describe('facilityItems', () => {
   describe('when the deal version is <1', () => {
     it('should hide all the facility end date rows', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details };
+      const facility = { ...MOCK_FACILITY_ONE };
 
       // Act
       const result = facilityItems('testUrl', facility, 0);
@@ -37,7 +39,7 @@ describe('facilityItems', () => {
   describe('when the deal version is >=1', () => {
     it('should show the "Has a facility end date" field when isUsingFacilityEndDate is null', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: null };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: null };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -48,7 +50,7 @@ describe('facilityItems', () => {
 
     it('should hide the facility end date and bank review date row when the isUsingFacilityEndDate is null', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: null };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: null };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -60,7 +62,7 @@ describe('facilityItems', () => {
 
     it('should show "Has a facility end date" and facility end date row when when isUsingFacilityEndDate is true', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: true };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -72,7 +74,7 @@ describe('facilityItems', () => {
 
     it('should hide the bank review date row when isUsingFacilityEndDate is true', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: true };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -83,7 +85,7 @@ describe('facilityItems', () => {
 
     it('should show "Has a facility end date" and bank review date row when isUsingFacilityEndDate is false', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: false };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: false };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -95,7 +97,7 @@ describe('facilityItems', () => {
 
     it('should hide facility end date row when isUsingFacilityEndDate is false', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: false };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: false };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -108,7 +110,7 @@ describe('facilityItems', () => {
       // Arrange
       const testFacilityEndDate = '2025-09-12T00:00:00.000Z';
       const expectedFormat = '12 September 2025';
-      const facility = { ...MOCK_FACILITY.items[0].details, facilityEndDate: testFacilityEndDate };
+      const facility = { ...MOCK_FACILITY_ONE, facilityEndDate: testFacilityEndDate };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -121,7 +123,7 @@ describe('facilityItems', () => {
       // Arrange
       const testBankReviewDate = '2026-08-04T00:00:00.000Z';
       const expectedFormat = '4 August 2026';
-      const facility = { ...MOCK_FACILITY.items[0].details, bankReviewDate: testBankReviewDate };
+      const facility = { ...MOCK_FACILITY_ONE, bankReviewDate: testBankReviewDate };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -132,7 +134,7 @@ describe('facilityItems', () => {
 
     it('should provide the correct URL for the "Has a facility end date" row', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: true };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -143,7 +145,7 @@ describe('facilityItems', () => {
 
     it('should provide the correct URL for the "Facility end date" row', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: true, facilityEndDate: '2026-08-04T00:00:00.000Z' };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: true, facilityEndDate: '2026-08-04T00:00:00.000Z' };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -154,7 +156,7 @@ describe('facilityItems', () => {
 
     it('should provide the correct URL for the "Bank review date" row', () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, isUsingFacilityEndDate: false, bankReviewDate: '2026-08-04T00:00:00.000Z' };
+      const facility = { ...MOCK_FACILITY_ONE, isUsingFacilityEndDate: false, bankReviewDate: '2026-08-04T00:00:00.000Z' };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -168,7 +170,7 @@ describe('facilityItems', () => {
     it(`should show the stage as ${FACILITY_STATUS.RISK_EXPIRED}`, () => {
       // Arrange
       const status = FACILITY_STATUS.RISK_EXPIRED;
-      const facility = { ...MOCK_FACILITY.items[0].details, status };
+      const facility = { ...MOCK_FACILITY_ONE, status };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -181,7 +183,7 @@ describe('facilityItems', () => {
   describe(`when the facility does not have a status`, () => {
     it(`should show the stage as ${STAGE.ISSUED} if hasBeenIssued is 'true'`, () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, hasBeenIssued: 'true' };
+      const facility = { ...MOCK_FACILITY_ONE, hasBeenIssued: 'true' };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);
@@ -192,7 +194,7 @@ describe('facilityItems', () => {
 
     it(`should show the stage as ${STAGE.UNISSUED} if hasBeenIssued is 'false'`, () => {
       // Arrange
-      const facility = { ...MOCK_FACILITY.items[0].details, hasBeenIssued: 'false' };
+      const facility = { ...MOCK_FACILITY_ONE, hasBeenIssued: 'false' };
 
       // Act
       const result = facilityItems('testUrl', facility, 1);

--- a/gef-ui/server/utils/helpers.js
+++ b/gef-ui/server/utils/helpers.js
@@ -1,4 +1,4 @@
-const { FACILITY_PROVIDED_DETAILS } = require('@ukef/dtfs2-common');
+const { FACILITY_PROVIDED_DETAILS, DEAL_STATUS } = require('@ukef/dtfs2-common');
 const httpError = require('http-errors');
 const lodashIsEmpty = require('lodash/isEmpty');
 const commaNumber = require('comma-number');
@@ -31,7 +31,7 @@ const userToken = (req) => {
 const isObject = (el) => typeof el === 'object' && el !== null && !(el instanceof Array);
 
 const isMIAWithoutChangedToIssuedFacilities = (app) =>
-  app.status === CONSTANTS.DEAL_STATUS.CHANGES_REQUIRED && app.submissionType === CONSTANTS.DEAL_SUBMISSION_TYPE.MIA && app.submissionCount > 0;
+  app.status === DEAL_STATUS.CHANGES_REQUIRED && app.submissionType === CONSTANTS.DEAL_SUBMISSION_TYPE.MIA && app.submissionCount > 0;
 
 // Converts Api errors into more manageable objects
 const apiErrorHandler = ({ code, response }) => {
@@ -126,7 +126,7 @@ const calculateShouldDisplayChangeLinkOnceIssued = (id) => {
 };
 
 const returnToMakerNoFacilitiesChanged = (app, hasChangedFacilities) => {
-  const acceptableStatus = [CONSTANTS.DEAL_STATUS.CHANGES_REQUIRED];
+  const acceptableStatus = [DEAL_STATUS.CHANGES_REQUIRED];
 
   return (
     (app.submissionType === CONSTANTS.DEAL_SUBMISSION_TYPE.AIN || app.submissionType === CONSTANTS.DEAL_SUBMISSION_TYPE.MIN) &&
@@ -174,8 +174,8 @@ const generateActionsArrayForItem = ({ href, visuallyHiddenText, text, id }) => 
 const previewItemConditions = (previewParams) => {
   const { issuedHref, unissuedHref, issuedToUnissuedHref, shouldDisplayChangeLinkIfIssued, shouldDisplayChangeLinkIfUnissued, item, app } = previewParams;
   let summaryItems = [];
-  const statusMIA = [CONSTANTS.DEAL_STATUS.READY_FOR_APPROVAL, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF];
-  const statusAIN = [...statusMIA, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF, CONSTANTS.DEAL_STATUS.CHANGES_REQUIRED];
+  const statusMIA = [DEAL_STATUS.READY_FOR_APPROVAL, DEAL_STATUS.SUBMITTED_TO_UKEF];
+  const statusAIN = [...statusMIA, DEAL_STATUS.UKEF_ACKNOWLEDGED, DEAL_STATUS.SUBMITTED_TO_UKEF, DEAL_STATUS.CHANGES_REQUIRED, DEAL_STATUS.CANCELLED];
 
   const validStatus =
     app.submissionType === CONSTANTS.DEAL_SUBMISSION_TYPE.AIN
@@ -285,10 +285,10 @@ const detailItemConditions = (params) => {
 const summaryItemsConditions = (summaryItemsObj) => {
   const { preview, item, details, app, user, data, hasChangedFacilities } = summaryItemsObj;
   const acceptableStatus = [
-    CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED,
-    CONSTANTS.DEAL_STATUS.CHANGES_REQUIRED,
-    CONSTANTS.DEAL_STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS,
-    CONSTANTS.DEAL_STATUS.UKEF_APPROVED_WITH_CONDITIONS,
+    DEAL_STATUS.UKEF_ACKNOWLEDGED,
+    DEAL_STATUS.CHANGES_REQUIRED,
+    DEAL_STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS,
+    DEAL_STATUS.UKEF_APPROVED_WITH_CONDITIONS,
   ];
   const acceptableRole = [MAKER];
   const { id, href, shouldCoverStartOnSubmission } = item;

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -1,5 +1,5 @@
-/* eslint-disable max-len */
 import { format } from 'date-fns';
+import { DEAL_STATUS } from '@ukef/dtfs2-common';
 import {
   userToken,
   isObject,
@@ -25,13 +25,10 @@ import { getFacilityCoverStartDate } from './facility-helpers';
 
 import { MOCK_ISSUED_FACILITY, MOCK_FACILITY, MOCK_ISSUED_FACILITY_UNCHANGED, MOCK_UNISSUED_FACILITY } from './mocks/mock-facilities';
 
-import { makerCanReSubmit } from './deal-helpers';
-
 import {
   MOCK_AIN_APPLICATION,
   MOCK_AIN_APPLICATION_RETURN_MAKER,
   MOCK_AIN_APPLICATION_CHECKER,
-  MOCK_BASIC_DEAL,
   MOCK_AIN_APPLICATION_ISSUED_ONLY,
   MOCK_AIN_APPLICATION_FALSE_COMMENTS,
   MOCK_AIN_APPLICATION_SUPPORTING_INFO,
@@ -39,7 +36,6 @@ import {
 } from './mocks/mock-applications';
 
 import { MOCK_REQUEST } from './mocks/mock-requests';
-import { CHECKER } from '../constants/roles';
 
 const CONSTANTS = require('../constants');
 
@@ -1156,19 +1152,69 @@ describe('summaryItemsConditions()', () => {
     });
   });
 
-  it('Should return FALSE as the Maker is from a different Bank', () => {
-    MOCK_REQUEST.bank.id = 10;
-    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_BASIC_DEAL)).toEqual(false);
-  });
+  describe(`if deal has status ${DEAL_STATUS.CANCELLED}`, () => {
+    describe('if deal is AIN', () => {
+      const deal = {
+        ...MOCK_AIN_APPLICATION,
+        status: DEAL_STATUS.CANCELLED,
+      };
 
-  it('Should return FALSE as the user does not have `maker` role', () => {
-    MOCK_REQUEST.roles = [CHECKER];
-    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_BASIC_DEAL)).toEqual(false);
-  });
+      it.each(['name', 'coverStartDate', 'coverEndDate', 'isUsingFacilityEndDate', 'bankReviewDate', 'facilityEndDate', 'hasBeenIssued'])(
+        'Should not be able to change %s',
+        (id) => {
+          const summaryItemsObj = {
+            preview: true,
+            item: mockDisplayItems[id],
+            details: MOCK_UNISSUED_FACILITY,
+            app: deal,
+            user: MOCK_REQUEST,
+            data: deal.facilities.items[0],
+          };
 
-  it('Should return FALSE as the Application maker is from a different current logged-in maker', () => {
-    MOCK_BASIC_DEAL.bank = { id: 1 };
-    expect(makerCanReSubmit(MOCK_REQUEST, MOCK_BASIC_DEAL)).toEqual(false);
+          const result = summaryItemsConditions(summaryItemsObj);
+          expect(result).toEqual([
+            {
+              attributes: {
+                'data-cy': `${id}-action`,
+              },
+              classes: 'govuk-!-display-none',
+            },
+          ]);
+        },
+      );
+    });
+
+    describe('if deal is MIN', () => {
+      const deal = {
+        ...MOCK_AIN_APPLICATION,
+        submissionType: CONSTANTS.DEAL_SUBMISSION_TYPE.MIN,
+        status: DEAL_STATUS.CANCELLED,
+      };
+
+      it.each(['name', 'coverStartDate', 'coverEndDate', 'isUsingFacilityEndDate', 'bankReviewDate', 'facilityEndDate', 'hasBeenIssued'])(
+        'Should not be able to change %s',
+        (id) => {
+          const summaryItemsObj = {
+            preview: true,
+            item: mockDisplayItems[id],
+            details: MOCK_UNISSUED_FACILITY,
+            app: deal,
+            user: MOCK_REQUEST,
+            data: deal.facilities.items[0],
+          };
+
+          const result = summaryItemsConditions(summaryItemsObj);
+          expect(result).toEqual([
+            {
+              attributes: {
+                'data-cy': `${id}-action`,
+              },
+              classes: 'govuk-!-display-none',
+            },
+          ]);
+        },
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Introduction :pencil2:
GEF deals have not historically had a deal status. The new `risk expired` status needs to be rendered in the frontend

## Resolution :heavy_check_mark:
- modify `facilityItems` function to get the facility status and, when it exists, render it instead of `Issued` or `unissued`
- Hide `Change` links when deal has been cancelled

## Screenshots 📸 
![image](https://github.com/user-attachments/assets/76aa8bf7-e1f2-4225-be23-c245541d2f7c)

## Misc ➕ 
- Use commonised `DEAL_STATUS` constant in `helpers.js` file