### PR TITLE
feat(FN-3638): turn off fixed fee adjustments

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -372,8 +372,9 @@ describe(`POST ${BASE_URL}`, () => {
   });
 
   /**
-   * This skip should be removed when the fixed fee adjustments are turned back on
-   * and can take non-zero values.
+   * This test is skipped because fixed fee adjustments are temporarily turned off.
+   *
+   * TODO FN-3639: Remove this skip and update with new calculation requirements.
    */
   it.skip('calculates the new fixed fee using the effective amendment at the report period end', async () => {
     // Arrange

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-keying-data.api-test.ts
@@ -325,7 +325,57 @@ describe(`POST ${BASE_URL}`, () => {
     expect(joinTableEntities[0].paymentAmountUsedForFeeRecord).not.toBeNull();
   });
 
-  it('calculates the new fixed fee using the effective amendment at the report period end', async () => {
+  it('should set the fixed fee to zero', async () => {
+    // Arrange
+    const facilityId = '11111111';
+
+    const tfmFacility: TfmFacility = {
+      ...aTfmFacility(),
+      facilitySnapshot: {
+        ...aFacility(),
+        ukefFacilityId: facilityId,
+        coverPercentage: 80,
+      },
+    };
+
+    const tfmFacilitiesCollection = await mongoDbClient.getCollection('tfm-facilities');
+    await tfmFacilitiesCollection.insertOne(tfmFacility);
+
+    const report = UtilisationReportEntityMockBuilder.forStatus(RECONCILIATION_IN_PROGRESS).withId(reportId).build();
+
+    const utilisationData = FacilityUtilisationDataEntityMockBuilder.forId(facilityId).withFixedFee(1).build();
+    const feeRecords = [
+      FeeRecordEntityMockBuilder.forReport(report)
+        .withId(1)
+        .withFacilityId(facilityId)
+        .withFacilityUtilisationData(utilisationData)
+        .withStatus(FEE_RECORD_STATUS.MATCH)
+        .build(),
+    ];
+    report.feeRecords = feeRecords;
+    await SqlDbHelper.saveNewEntry('UtilisationReport', report);
+
+    await insertMatchingPaymentsForFeeRecords(feeRecords);
+
+    const requestBody = aValidRequestBody();
+
+    // Act
+    const response = await testApi.post(requestBody).to(getUrl(reportId));
+
+    // Assert
+    expect(response.status).toEqual(HttpStatusCode.Ok);
+
+    const entities = await SqlDbHelper.manager.find(FacilityUtilisationDataEntity, {});
+    expect(entities).toHaveLength(1);
+    expect(entities[0].id).toEqual(facilityId);
+    expect(entities[0].fixedFee).toEqual(0);
+  });
+
+  /**
+   * This skip should be removed when the fixed fee adjustments are turned back on
+   * and can take non-zero values.
+   */
+  it.skip('calculates the new fixed fee using the effective amendment at the report period end', async () => {
     // Arrange
     const reportPeriod = { start: { month: 12, year: 2023 }, end: { month: 2, year: 2024 } };
     const dateWithinReportPeriod = new Date('2024-01-01');

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/post-upload-utilisation-report.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/post-upload-utilisation-report.api-test.ts
@@ -171,12 +171,7 @@ describe(`POST ${getUrl()}`, () => {
         ...aTfmFacility().facilitySnapshot,
         ukefFacilityId,
         coverPercentage: 80,
-        coverStartDate: new Date('2024-01-01'),
-        // 366 days after cover start date because 2024 is a leap year
-        coverEndDate: new Date('2025-01-01'),
         value: 500000,
-        interestPercentage: 5,
-        dayCountBasis: 360,
       },
     };
 
@@ -199,12 +194,7 @@ describe(`POST ${getUrl()}`, () => {
      *             = 40000
      */
     expect(facilityUtilisationData?.utilisation).toEqual(40000);
-    /**
-     * Initial fixed fee = initial utilisation * bank margin rate * interest * days in cover period / day count basis
-     *                   = 40000 * 0.9 * (5 / 100) * 366 / 360
-     *                   = 1830
-     */
-    expect(facilityUtilisationData?.fixedFee).toEqual(1830);
+    expect(facilityUtilisationData?.fixedFee).toEqual(0);
   });
 
   it('creates an entry in the AzureFileInfo table', async () => {

--- a/dtfs-central-api/src/helpers/get-keying-sheet-calculation-facility-values.test.ts
+++ b/dtfs-central-api/src/helpers/get-keying-sheet-calculation-facility-values.test.ts
@@ -1,48 +1,21 @@
-import { addDays, subDays } from 'date-fns';
 import { getKeyingSheetCalculationFacilityValues } from './get-keying-sheet-calculation-facility-values';
 import { TfmFacilitiesRepo } from '../repositories/tfm-facilities-repo';
 import { NotFoundError } from '../errors';
-import { aTfmFacility, aFacility, aCompletedTfmFacilityAmendment } from '../../test-helpers';
-import { convertTimestampToDate } from './convert-timestamp-to-date';
+import { aTfmFacility, aFacility } from '../../test-helpers';
 
 jest.mock('../repositories/tfm-facilities-repo');
 
 describe('getKeyingSheetCalculationFacilityValues', () => {
   const findOneByUkefFacilityIdSpy = jest.spyOn(TfmFacilitiesRepo, 'findOneByUkefFacilityId');
   const facilityId = '123';
-  const today = new Date();
 
   const mockFacility = {
     ...aTfmFacility(),
     facilitySnapshot: {
       ...aFacility(),
       ukefFacilityId: facilityId,
-      interestPercentage: 5,
-      dayCountBasis: 365,
-      coverEndDate: today,
-      coverStartDate: today,
       coverPercentage: 5,
     },
-  };
-
-  const reportPeriod = {
-    start: { month: today.getMonth() + 1, year: today.getFullYear() },
-    end: { month: today.getMonth() + 1, year: today.getFullYear() },
-  };
-
-  const dateBeforeReportPeriodEnd = new Date(subDays(today, 1));
-
-  const mockFacilityWithAmendment = {
-    ...mockFacility,
-    amendments: [
-      {
-        ...aCompletedTfmFacilityAmendment(),
-        value: 350000,
-        effectiveDate: dateBeforeReportPeriodEnd.getTime(),
-        // 365 days after report period end
-        coverEndDate: new Date(addDays(today, 365)).getTime(),
-      },
-    ],
   };
 
   afterEach(() => {
@@ -55,133 +28,26 @@ describe('getKeyingSheetCalculationFacilityValues', () => {
     });
 
     it('should throw a NotFoundError', async () => {
-      await expect(getKeyingSheetCalculationFacilityValues(facilityId, reportPeriod)).rejects.toThrow(
+      await expect(getKeyingSheetCalculationFacilityValues(facilityId)).rejects.toThrow(
         new NotFoundError(`TFM facility with ukefFacilityId '${facilityId}' could not be found`),
       );
     });
   });
 
-  describe('when the found tfm facility does not contain a cover start date', () => {
-    beforeEach(() => {
-      findOneByUkefFacilityIdSpy.mockResolvedValue({
-        ...mockFacility,
-        facilitySnapshot: {
-          ...mockFacility.facilitySnapshot,
-          coverStartDate: null,
-        },
-      });
-    });
-
-    it('should throw a NotFoundError', async () => {
-      // Act / Assert
-      await expect(getKeyingSheetCalculationFacilityValues(facilityId, reportPeriod)).rejects.toThrow(
-        new NotFoundError(`Failed to find a cover start date for the tfm facility with ukef facility id '${facilityId}`),
-      );
-    });
-  });
-
-  describe('when the found tfm facility does not contain a cover end date', () => {
-    beforeEach(() => {
-      findOneByUkefFacilityIdSpy.mockResolvedValue({
-        ...mockFacility,
-        facilitySnapshot: {
-          ...mockFacility.facilitySnapshot,
-          coverEndDate: null,
-        },
-      });
-    });
-
-    it('should throw a NotFoundError', async () => {
-      // Act / Assert
-      await expect(getKeyingSheetCalculationFacilityValues(facilityId, reportPeriod)).rejects.toThrow(
-        new NotFoundError(`Failed to find a cover end date for the tfm facility with ukef facility id '${facilityId}`),
-      );
-    });
-  });
-
-  describe('when the report period is provided', () => {
+  describe('when a tfm facility with the supplied facility id can be found', () => {
     beforeEach(() => {
       findOneByUkefFacilityIdSpy.mockResolvedValue(mockFacility);
     });
 
-    describe('when the facility does not contain a completed amendment', () => {
-      it("should return a populated object with the facility's cover end date", async () => {
-        const result = await getKeyingSheetCalculationFacilityValues(facilityId, reportPeriod);
-
-        const expected = {
-          coverEndDate: convertTimestampToDate(today),
-          coverStartDate: convertTimestampToDate(today),
-          dayCountBasis: 365,
-          interestPercentage: 5,
-          coverPercentage: 5,
-          value: mockFacility.facilitySnapshot.value,
-        };
-
-        expect(result).toEqual(expected);
-      });
-    });
-
-    describe('when the facility contains a completed amendment', () => {
-      beforeEach(() => {
-        findOneByUkefFacilityIdSpy.mockResolvedValue(mockFacilityWithAmendment);
-      });
-
-      it("should return a populated object with the amendment's cover end date", async () => {
-        const result = await getKeyingSheetCalculationFacilityValues(facilityId, reportPeriod);
-
-        const expected = {
-          coverEndDate: convertTimestampToDate(mockFacilityWithAmendment.amendments[0].coverEndDate),
-          coverStartDate: convertTimestampToDate(today),
-          dayCountBasis: 365,
-          interestPercentage: 5,
-          coverPercentage: 5,
-          value: mockFacility.facilitySnapshot.value,
-        };
-
-        expect(result).toEqual(expected);
-      });
-    });
-  });
-
-  describe('when the report period is not provided', () => {
-    beforeEach(() => {
-      findOneByUkefFacilityIdSpy.mockResolvedValue(mockFacility);
-    });
-
-    it("should return a populated object with the facility's cover end date", async () => {
+    it('should return a populated object', async () => {
       const result = await getKeyingSheetCalculationFacilityValues(facilityId);
 
       const expected = {
-        coverEndDate: convertTimestampToDate(today),
-        coverStartDate: convertTimestampToDate(today),
-        dayCountBasis: 365,
-        interestPercentage: 5,
-        coverPercentage: 5,
+        coverPercentage: mockFacility.facilitySnapshot.coverPercentage,
         value: mockFacility.facilitySnapshot.value,
       };
 
       expect(result).toEqual(expected);
-    });
-
-    describe('when the facility contains a completed amendment', () => {
-      beforeEach(() => {
-        findOneByUkefFacilityIdSpy.mockResolvedValue(mockFacilityWithAmendment);
-      });
-
-      it("should return a populated object with the facility's cover end date", async () => {
-        const result = await getKeyingSheetCalculationFacilityValues(facilityId);
-
-        const expected = {
-          coverEndDate: convertTimestampToDate(today),
-          coverStartDate: convertTimestampToDate(today),
-          dayCountBasis: 365,
-          interestPercentage: 5,
-          coverPercentage: 5,
-          value: mockFacility.facilitySnapshot.value,
-        };
-
-        expect(result).toEqual(expected);
-      });
     });
   });
 });

--- a/dtfs-central-api/src/helpers/get-keying-sheet-calculation-facility-values.ts
+++ b/dtfs-central-api/src/helpers/get-keying-sheet-calculation-facility-values.ts
@@ -1,55 +1,21 @@
-import { endOfMonth } from 'date-fns';
-import { getDateFromMonthAndYear, ReportPeriod } from '@ukef/dtfs2-common';
 import { TfmFacilitiesRepo } from '../repositories/tfm-facilities-repo';
 import { NotFoundError } from '../errors';
-import { convertTimestampToDate } from './convert-timestamp-to-date';
-import { getEffectiveCoverEndDateAmendment } from './amendments/get-effective-cover-end-date-amendment';
 import { KeyingSheetCalculationFacilityValues } from '../types/tfm/tfm-facility';
 
 /**
  * Gets TFM facility values with the supplied facility id for keying sheet calculations
- * if a report period is supplied, the cover end date returned will take into account any amendments that came into effect before the end of the report period passed in.
- * else will return the cover end date as they were at facility creation ignoring all amendments
- * all other returned values will be as they were at facility creation
  * @param facilityId - The facility id
  * @param reportPeriod - The report period
- * @returns TFM facility values - coverEndDate, coverStartDate, dayCountBasis, interestPercentage, coverPercentage, value
+ * @returns TFM facility values - coverPercentage, value
  */
-export const getKeyingSheetCalculationFacilityValues = async (
-  facilityId: string,
-  reportPeriod?: ReportPeriod,
-): Promise<KeyingSheetCalculationFacilityValues> => {
+export const getKeyingSheetCalculationFacilityValues = async (facilityId: string): Promise<KeyingSheetCalculationFacilityValues> => {
   const tfmFacility = await TfmFacilitiesRepo.findOneByUkefFacilityId(facilityId);
 
   if (!tfmFacility) {
     throw new NotFoundError(`TFM facility with ukefFacilityId '${facilityId}' could not be found`);
   }
 
-  const { coverEndDate: snapshotCoverEndDate, coverStartDate, dayCountBasis, interestPercentage, coverPercentage, value } = tfmFacility.facilitySnapshot;
+  const { value, coverPercentage } = tfmFacility.facilitySnapshot;
 
-  let latestAmendedCoverEndDate;
-
-  if (reportPeriod) {
-    const endDateOfReportPeriod = endOfMonth(getDateFromMonthAndYear(reportPeriod.end));
-    latestAmendedCoverEndDate = getEffectiveCoverEndDateAmendment(tfmFacility, endDateOfReportPeriod);
-  }
-
-  const coverEndDate = latestAmendedCoverEndDate ?? snapshotCoverEndDate;
-
-  if (!coverEndDate) {
-    throw new NotFoundError(`Failed to find a cover end date for the tfm facility with ukef facility id '${facilityId}`);
-  }
-
-  if (!coverStartDate) {
-    throw new NotFoundError(`Failed to find a cover start date for the tfm facility with ukef facility id '${facilityId}`);
-  }
-
-  return {
-    coverEndDate: convertTimestampToDate(coverEndDate),
-    coverStartDate: convertTimestampToDate(coverStartDate),
-    dayCountBasis,
-    interestPercentage,
-    coverPercentage,
-    value,
-  };
+  return { value, coverPercentage };
 };

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.test.ts
@@ -140,8 +140,9 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
     });
 
     /**
-     * This skip should be removed and the mocks reinstated when the fixed fee adjustments
-     * are turned back on and can take non-zero values.
+     * This test is skipped because fixed fee adjustments are temporarily turned off.
+     *
+     * TODO FN-3639: Remove this skip and reenable mocks.
      */
     it.skip(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fixed fee adjustment is greater than zero`, async () => {
       // Arrange
@@ -165,8 +166,9 @@ describe('handleFeeRecordGenerateKeyingDataEvent', () => {
     });
 
     /**
-     * This skip should be removed and the mocks reinstated when the fixed fee adjustments
-     * are turned back on and can take non-zero values.
+     * This test is skipped because fixed fee adjustments are temporarily turned off.
+     *
+     * TODO FN-3639: Remove this skip and reenable mocks.
      */
     it.skip(`updates the fee record status to '${FEE_RECORD_STATUS.READY_TO_KEY}' if the fixed fee adjustment is less than zero`, async () => {
       // Arrange

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/generate-keying-data/generate-keying-data.event-handler.ts
@@ -1,7 +1,7 @@
 import { EntityManager } from 'typeorm';
 import { DbRequestSource, FEE_RECORD_STATUS, FeeRecordEntity, FeeRecordStatus, ReportPeriod } from '@ukef/dtfs2-common';
 import { BaseFeeRecordEvent } from '../../event/base-fee-record.event';
-import { calculatePrincipalBalanceAdjustment, calculateFixedFeeAdjustment, updateFacilityUtilisationData, calculateFixedFee } from '../helpers';
+import { calculatePrincipalBalanceAdjustment, updateFacilityUtilisationData } from '../helpers';
 import { calculateUkefShareOfUtilisation, getKeyingSheetCalculationFacilityValues } from '../../../../../helpers';
 
 type GenerateKeyingDataEventPayload = {
@@ -33,22 +33,13 @@ export const handleFeeRecordGenerateKeyingDataEvent = async (
     return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
   }
 
-  const { coverPercentage, coverEndDate, interestPercentage, dayCountBasis } = await getKeyingSheetCalculationFacilityValues(
-    feeRecord.facilityId,
-    reportPeriod,
-  );
+  const { coverPercentage } = await getKeyingSheetCalculationFacilityValues(feeRecord.facilityId);
 
   const ukefShareOfUtilisation = calculateUkefShareOfUtilisation(feeRecord.facilityUtilisation, coverPercentage);
 
-  const fixedFee = calculateFixedFee({
-    ukefShareOfUtilisation,
-    reportPeriod,
-    coverEndDate,
-    interestPercentage,
-    dayCountBasis,
-  });
+  const fixedFee = 0;
 
-  const fixedFeeAdjustment = calculateFixedFeeAdjustment(feeRecord, feeRecord.facilityUtilisationData, reportPeriod, fixedFee);
+  const fixedFeeAdjustment = 0;
 
   const principalBalanceAdjustment = calculatePrincipalBalanceAdjustment(ukefShareOfUtilisation, feeRecord.facilityUtilisationData);
 

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
@@ -5,6 +5,8 @@ const hasFacilityUtilisationDataAlreadyBeenUpdated = (facilityUtilisationData: F
   isEqualReportPeriod(facilityUtilisationData.reportPeriod, reportPeriod);
 
 /**
+ * This is currently unused because fixed fee calculations are currently turned off.
+ *
  * Calculates the fixed fee adjustment
  * @param feeRecord - The fee record entity
  * @param facilityUtilisationData - The facility utilisation data entity

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee-adjustment.ts
@@ -7,6 +7,8 @@ const hasFacilityUtilisationDataAlreadyBeenUpdated = (facilityUtilisationData: F
 /**
  * This is currently unused because fixed fee calculations are currently turned off.
  *
+ * TODO FN-3639: Remove this function if unused with new calculation requirements.
+ *
  * Calculates the fixed fee adjustment
  * @param feeRecord - The fee record entity
  * @param facilityUtilisationData - The facility utilisation data entity

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee.ts
@@ -18,6 +18,8 @@ const getNumberOfDaysRemainingInCoverPeriod = (reportPeriodEnd: MonthAndYear, co
 };
 
 /**
+ * This is currently unused because fixed fee calculations are currently turned off.
+ *
  * Calculates the fixed fee for the given parameters
  * @param param - The parameters to calculate the fixed fee with
  * @param param.utilisation - The facility utilisation

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/helpers/calculate-fixed-fee.ts
@@ -20,6 +20,8 @@ const getNumberOfDaysRemainingInCoverPeriod = (reportPeriodEnd: MonthAndYear, co
 /**
  * This is currently unused because fixed fee calculations are currently turned off.
  *
+ * TODO FN-3639: Remove this function if unused with new calculation requirements.
+ *
  * Calculates the fixed fee for the given parameters
  * @param param - The parameters to calculate the fixed fee with
  * @param param.utilisation - The facility utilisation

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-fixed-fee.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-fixed-fee.ts
@@ -12,6 +12,8 @@ import { calculateFixedFeeFromDaysRemaining } from '../../../../../helpers/calcu
 export const getNumberOfDaysInCoverPeriod = (coverStartDate: Date, coverEndDate: Date): number => differenceInDays(coverEndDate, coverStartDate);
 
 /**
+ * This is currently unused because fixed fee calculations are currently turned off.
+ *
  * calculateFixedFee
  * Calculates the fixed fee for the utilisation report
  * gets the number of days in the cover period

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-fixed-fee.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-fixed-fee.ts
@@ -14,6 +14,8 @@ export const getNumberOfDaysInCoverPeriod = (coverStartDate: Date, coverEndDate:
 /**
  * This is currently unused because fixed fee calculations are currently turned off.
  *
+ * TODO FN-3639: Remove this function if unused with new calculation requirements.
+ *
  * calculateFixedFee
  * Calculates the fixed fee for the utilisation report
  * gets the number of days in the cover period

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-utilisation-and-fixed-fee.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-utilisation-and-fixed-fee.test.ts
@@ -2,10 +2,7 @@ import * as dtfsCommon from '@ukef/dtfs2-common';
 import { calculateInitialUtilisationAndFixedFee, parseDate, hasRequiredValues, RequiredParams } from './calculate-initial-utilisation-and-fixed-fee';
 import { NotFoundError } from '../../../../../errors';
 import { aTfmFacility } from '../../../../../../test-helpers';
-import * as fixedFeeHelpers from './calculate-initial-fixed-fee';
 import * as helpers from '../../../../../helpers';
-
-jest.mock('./calculate-initial-fixed-fee');
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock('@ukef/dtfs2-common', () => ({
@@ -57,10 +54,6 @@ describe('helpers/calculate-initial-utilisation-and-fixed-fee', () => {
   describe('hasRequiredValues', () => {
     const baseParams = {
       value: 1,
-      interestPercentage: 2,
-      dayCountBasis: 3,
-      coverStartDate: new Date(),
-      coverEndDate: new Date(),
       coverPercentage: 4,
     } as RequiredParams;
 
@@ -74,38 +67,8 @@ describe('helpers/calculate-initial-utilisation-and-fixed-fee', () => {
       expect(result).toEqual(false);
     });
 
-    it('should return false if the interestPercentage is not provided', () => {
-      const result = hasRequiredValues({ ...baseParams, interestPercentage: null });
-      expect(result).toEqual(false);
-    });
-
-    it('should return false if the dayCountBasis is not provided', () => {
-      const result = hasRequiredValues({ ...baseParams, dayCountBasis: null });
-      expect(result).toEqual(false);
-    });
-
     it('should return false if the coverPercentage is not provided', () => {
       const result = hasRequiredValues({ ...baseParams, coverPercentage: null });
-      expect(result).toEqual(false);
-    });
-
-    it('should return false if the coverEndDate is not provided', () => {
-      const result = hasRequiredValues({ ...baseParams, coverEndDate: null });
-      expect(result).toEqual(false);
-    });
-
-    it('should return false if the coverStartDate is not provided', () => {
-      const result = hasRequiredValues({ ...baseParams, coverStartDate: null });
-      expect(result).toEqual(false);
-    });
-
-    it('should return false if the coverStartDate is the wrong format', () => {
-      const result = hasRequiredValues({ ...baseParams, coverStartDate: 'a' });
-      expect(result).toEqual(false);
-    });
-
-    it('should return false if the coverEndDate is the wrong format', () => {
-      const result = hasRequiredValues({ ...baseParams, coverEndDate: 'a' });
       expect(result).toEqual(false);
     });
   });
@@ -116,10 +79,6 @@ describe('helpers/calculate-initial-utilisation-and-fixed-fee', () => {
     const { facilitySnapshot } = aTfmFacility();
 
     const keyingSheetCalculationFacilityValues = {
-      coverEndDate: new Date(),
-      coverStartDate: new Date(),
-      dayCountBasis: facilitySnapshot.dayCountBasis,
-      interestPercentage: facilitySnapshot.interestPercentage,
       coverPercentage: facilitySnapshot.coverPercentage,
       value: facilitySnapshot.value,
     };
@@ -159,7 +118,6 @@ describe('helpers/calculate-initial-utilisation-and-fixed-fee', () => {
 
       beforeEach(() => {
         getKeyingSheetCalculationFacilityValuesSpy.mockResolvedValue(keyingSheetCalculationFacilityValues);
-        jest.mocked(fixedFeeHelpers.calculateInitialFixedFee).mockReturnValue(999.99);
         jest.mocked(dtfsCommon.calculateDrawnAmount).mockReturnValue(drawnAmount);
       });
 
@@ -183,23 +141,12 @@ describe('helpers/calculate-initial-utilisation-and-fixed-fee', () => {
         expect(result.utilisation).toEqual(drawnAmountRoundedToTwoDecimalPlaces);
       });
 
-      it('should calculate and return the initial fixed fee', async () => {
-        // Arrange
-        const drawnAmountRoundedToTwoDecimalPlaces = 12345.68;
-        const calculateInitialFixedFeeSpy = jest.spyOn(fixedFeeHelpers, 'calculateInitialFixedFee').mockReturnValue(999.99);
-
+      it('should return the initial fixed fee as 0', async () => {
         // Act
         const result = await calculateInitialUtilisationAndFixedFee(facilityId);
 
         // Assert
-        expect(calculateInitialFixedFeeSpy).toHaveBeenCalledWith({
-          ukefShareOfUtilisation: drawnAmountRoundedToTwoDecimalPlaces,
-          coverStartDate: keyingSheetCalculationFacilityValues.coverStartDate,
-          coverEndDate: keyingSheetCalculationFacilityValues.coverEndDate,
-          interestPercentage: keyingSheetCalculationFacilityValues.interestPercentage,
-          dayCountBasis: keyingSheetCalculationFacilityValues.dayCountBasis,
-        });
-        expect(result.fixedFee).toEqual(999.99);
+        expect(result.fixedFee).toEqual(0);
       });
     });
   });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-utilisation-and-fixed-fee.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/calculate-initial-utilisation-and-fixed-fee.ts
@@ -1,6 +1,5 @@
-import { calculateDrawnAmount, isValidDate } from '@ukef/dtfs2-common';
+import { calculateDrawnAmount } from '@ukef/dtfs2-common';
 import Big from 'big.js';
-import { calculateInitialFixedFee } from './calculate-initial-fixed-fee';
 import { getKeyingSheetCalculationFacilityValues } from '../../../../../helpers';
 
 export type RequiredParams = {
@@ -27,25 +26,11 @@ export const parseDate = (date: string | Date | number | null): Date => {
 
 /**
  * checks that all required values are present
- * checks that cover start and end dates are in date format
  * @param value
- * @param interestPercentage
- * @param dayCountBasis
- * @param coverStartDate
- * @param coverEndDate
+ * @param coverPercentage
  * @returns true if all values are present and in the correct format
  */
-export const hasRequiredValues = ({ value, interestPercentage, dayCountBasis, coverStartDate, coverEndDate, coverPercentage }: RequiredParams): boolean =>
-  Boolean(
-    value &&
-      coverStartDate &&
-      coverEndDate &&
-      interestPercentage &&
-      dayCountBasis &&
-      coverPercentage &&
-      isValidDate(new Date(coverStartDate)) &&
-      isValidDate(new Date(coverEndDate)),
-  );
+export const hasRequiredValues = ({ value, coverPercentage }: RequiredParams): boolean => Boolean(value && coverPercentage);
 
 /**
  * calculateInitialUtilisationAndFixedFee
@@ -58,21 +43,15 @@ export const hasRequiredValues = ({ value, interestPercentage, dayCountBasis, co
  * @returns {Object} fixedFee and utilisation values
  */
 export const calculateInitialUtilisationAndFixedFee = async (facilityId: string) => {
-  const { value, coverStartDate, coverEndDate, interestPercentage, dayCountBasis, coverPercentage } = await getKeyingSheetCalculationFacilityValues(facilityId);
+  const { value, coverPercentage } = await getKeyingSheetCalculationFacilityValues(facilityId);
 
-  if (!hasRequiredValues({ value, interestPercentage, dayCountBasis, coverStartDate, coverEndDate, coverPercentage })) {
+  if (!hasRequiredValues({ value, coverPercentage })) {
     throw new Error(`TFM facility values for ${facilityId} are missing`);
   }
 
   const ukefShareOfInitialUtilisation = new Big(calculateDrawnAmount(value, coverPercentage)).round(2).toNumber();
 
-  const fixedFee = calculateInitialFixedFee({
-    ukefShareOfUtilisation: ukefShareOfInitialUtilisation,
-    coverStartDate: parseDate(coverStartDate),
-    coverEndDate: parseDate(coverEndDate),
-    interestPercentage,
-    dayCountBasis,
-  });
+  const fixedFee = 0;
 
   return {
     fixedFee,

--- a/dtfs-central-api/src/types/tfm/tfm-facility.ts
+++ b/dtfs-central-api/src/types/tfm/tfm-facility.ts
@@ -1,8 +1,4 @@
 export type KeyingSheetCalculationFacilityValues = {
-  coverEndDate: Date;
-  coverStartDate: Date;
-  dayCountBasis: number;
-  interestPercentage: number;
   coverPercentage: number;
   value: number;
 };

--- a/dtfs-central-api/test-helpers/test-data/tfm-facility.ts
+++ b/dtfs-central-api/test-helpers/test-data/tfm-facility.ts
@@ -4,16 +4,13 @@ import { generateMockPortalUserAuditDatabaseRecord } from '@ukef/dtfs2-common/ch
 import { aFacility } from './facility';
 import { KeyingSheetCalculationFacilityValues } from '../../src/types/tfm/tfm-facility';
 
-const facility = aFacility();
-const { dayCountBasis, interestPercentage, coverPercentage, value } = facility;
-
 export const aTfmFacility = (): TfmFacility => {
   const tfmFacilityId = new ObjectId();
 
   return {
     _id: tfmFacilityId,
     facilitySnapshot: {
-      ...facility,
+      ...aFacility(),
       _id: tfmFacilityId,
     },
     amendments: [],
@@ -23,10 +20,6 @@ export const aTfmFacility = (): TfmFacility => {
 };
 
 export const keyingSheetCalculationFacilityValues: KeyingSheetCalculationFacilityValues = {
-  coverEndDate: new Date(),
-  coverStartDate: new Date(),
-  dayCountBasis,
-  interestPercentage,
-  coverPercentage,
-  value,
+  coverPercentage: 80,
+  value: 500000,
 };

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-fixed-fee-adjustment-with-amendments.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-fixed-fee-adjustment-with-amendments.spec.js
@@ -14,7 +14,11 @@ import USERS from '../../../../fixtures/users';
 import { NODE_TASKS } from '../../../../../../e2e-fixtures';
 import relative from '../../../relativeURL';
 
-context('Fixed fee calculation uses effective amendment to cover end date at report period end', () => {
+/**
+ * This skip should be removed when the fixed fee adjustments are turned back on
+ * and can take non-zero values.
+ */
+context.skip('Fixed fee calculation uses effective amendment to cover end date at report period end', () => {
   const bankId = '961';
   const reportId = 1;
   const facilityId = '12345678';

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-fixed-fee-adjustment-with-amendments.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-fixed-fee-adjustment-with-amendments.spec.js
@@ -15,8 +15,9 @@ import { NODE_TASKS } from '../../../../../../e2e-fixtures';
 import relative from '../../../relativeURL';
 
 /**
- * This skip should be removed when the fixed fee adjustments are turned back on
- * and can take non-zero values.
+ * This test is skipped because fixed fee adjustments are temporarily turned off.
+ *
+ * TODO FN-3639: Remove this skip and update with new calculation requirements.
  */
 context.skip('Fixed fee calculation uses effective amendment to cover end date at report period end', () => {
   const bankId = '961';

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-keying-sheet.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-keying-sheet.spec.js
@@ -174,8 +174,7 @@ context('PDC_RECONCILE users can generate keying data', () => {
      * Fixed fee adjustments are currently turned off and so should always be
      * zero, which is displayed as a dash.
      *
-     * When fixed fee adjustments are turned back on and can take non-zero values
-     * this test should go back to checking for a calculated value.
+     * TODO FN-3639: update with new calculation requirements.
      */
     const expectedFixedFeeAdjustment = '-';
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-keying-sheet.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/generate-keying-sheet.spec.js
@@ -171,22 +171,13 @@ context('PDC_RECONCILE users can generate keying data', () => {
     const expectedPrincipalBalanceAdjustment = '128,000.00'; // 200000 - (180000 * 0.4), DECREASE
 
     /**
-     * The fixed fee adjustment is the difference between
-     * the current fixed fee and the previous fixed fee,
-     * where the previous fixed fee is equal to the value
-     * stored on the FacilityUtilisationData table, and the
-     * current fixed fee is given by the product of the below
-     * values:
-     * - utilisation: 180000
-     * - cover percentage: 40
-     * - ukef utilisation: 180000 * 0.4 = 72000
-     * - bank margin: 0.9 (this is a fixed, constant value)
-     * - interest percentage: 0.05
-     * - number of days left in cover period divided by day count basis: 365 / 365 = 1
-     * - (72000 * 0.9 * 0.05 * 1) = 3240
-     * This yields a current utilisation value of 3240
+     * Fixed fee adjustments are currently turned off and so should always be
+     * zero, which is displayed as a dash.
+     *
+     * When fixed fee adjustments are turned back on and can take non-zero values
+     * this test should go back to checking for a calculated value.
      */
-    const expectedFixedFeeAdjustment = '2,240.00'; // 3240  - 1000, INCREASE
+    const expectedFixedFeeAdjustment = '-';
 
     pages.utilisationReportPage.keyingSheetTab.fixedFeeAdjustmentDecrease(FIRST_FEE_RECORD_ID).should('contain', '-');
     pages.utilisationReportPage.keyingSheetTab.fixedFeeAdjustmentIncrease(FIRST_FEE_RECORD_ID).should('contain', expectedFixedFeeAdjustment);


### PR DESCRIPTION
## Introduction :pencil2:
Fixed fee adjustments rely on cover end dates existing which we discovered is not the case for all facilities banks are reporting on. This was preventing upload of reports and complete use of the utilisation report service for certain banks. However, the fixed fee calculation has not been finalised and so is not being used by PDC.

In this PR we disable fixed fee completely. Removing any dependency on facility values other than 'value' and 'coverPercentage' from the utilisation reporting service. This should make the service usable for all banks, just without the fixed fee functionality. Fixed fee adjustments will be reimplemented when the calculation is finalised with support for facilities with no cover end date.

## Resolution :heavy_check_mark:
- Remove usages of facility fields other than 'coverPercentage' and 'value' from utilisation report related code
- Turn off fixed fee by:
	- defaulting fixed fee to zero for new facilities
	- storing fixed fee as zero when generating keying data
	- directly setting the adjustment to always be zero instead of using a calculation
- Add test skips to tests that will be reenabled pretty much as is when we turn fixed fee back on
- Add comments to unused functions which are left in as will be used pretty much as is when we turn fixed fee back on
