### PR TITLE
fix(DTFS2-6616): variable consistency

### DIFF
--- a/azure-functions/acbs-function/src/functions/activity-get-facility-loan-id.js
+++ b/azure-functions/acbs-function/src/functions/activity-get-facility-loan-id.js
@@ -32,7 +32,7 @@ const { isHttpErrorStatus } = require('../../helpers/http');
  */
 const handler = async (payload) => {
   try {
-    const { facilityId: facilityIdentifier } = payload;
+    const { facilityIdentifier } = payload;
 
     if (!facilityIdentifier) {
       throw new Error('Invalid facility ID');

--- a/azure-functions/acbs-function/src/functions/activity-get-facility-master.js
+++ b/azure-functions/acbs-function/src/functions/activity-get-facility-master.js
@@ -16,7 +16,7 @@ const { isHttpErrorStatus } = require('../../helpers/http');
  */
 const handler = async (payload) => {
   try {
-    const { facilityId: facilityIdentifier } = payload;
+    const { facilityIdentifier } = payload;
 
     if (!facilityIdentifier) {
       throw new Error('Invalid facility ID');


### PR DESCRIPTION
## Introduction :pencil2:
Ensure `facilityIdentifier` is used as a standard name for facility ID.

