### PR TITLE
feat(FN-3640): require bank report facilities be GEF facilities

### DIFF
--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -1,5 +1,5 @@
 import { ObjectId, UpdateFilter, WithoutId, FindOneAndUpdateOptions, Collection, Document, UpdateResult, Filter } from 'mongodb';
-import { AuditDetails, TfmFacility, TfmFacilityAmendment, AmendmentStatus } from '@ukef/dtfs2-common';
+import { AuditDetails, TfmFacility, TfmFacilityAmendment, AmendmentStatus, GEF_FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { deleteMany } from '@ukef/dtfs2-common/change-stream';
 import { mongoDbClient } from '../../drivers/db-client';
 import { aggregatePipelines, AllFacilitiesAndFacilityCountAggregatePipelineOptions } from './aggregate-pipelines';
@@ -281,13 +281,16 @@ export class TfmFacilitiesRepo {
   }
 
   /**
-   * Checks whether or not a facility exists which has a matching UKEF facility ID
+   * Checks whether or not a GEF facility exists which has a matching UKEF facility ID
    * @param ukefFacilityId - The UKEF facility ID
-   * @returns Whether a not a facility with that UKEF facility ID exists
+   * @returns Whether a not a GEF facility with that UKEF facility ID exists
    */
-  public static async ukefFacilityIdExists(ukefFacilityId: string): Promise<boolean> {
+  public static async ukefGefFacilityExists(ukefFacilityId: string): Promise<boolean> {
     const collection = await this.getCollection();
-    const numberOfFoundDocuments = await collection.count({ 'facilitySnapshot.ukefFacilityId': { $eq: ukefFacilityId } });
+    const numberOfFoundDocuments = await collection.count({
+      'facilitySnapshot.ukefFacilityId': { $eq: ukefFacilityId },
+      'facilitySnapshot.type': { $in: Object.values(GEF_FACILITY_TYPE) },
+    });
     return numberOfFoundDocuments > 0;
   }
 }

--- a/dtfs-central-api/src/services/utilisation-report-data-validator/utilisation-report-cell-validators/generate-ukef-facility-id-error.test.ts
+++ b/dtfs-central-api/src/services/utilisation-report-data-validator/utilisation-report-cell-validators/generate-ukef-facility-id-error.test.ts
@@ -35,6 +35,7 @@ describe('generateUkefFacilityIdError', () => {
 
     // Assert
     expect(ukefFacilityIdError).toEqual(expectedError);
+    expect(gefFacilityExistsSpy).not.toHaveBeenCalled();
   });
 
   it('returns an error when the value is not an 8 to 10 digit string', async () => {
@@ -57,12 +58,15 @@ describe('generateUkefFacilityIdError', () => {
 
     // Assert
     expect(ukefFacilityIdError).toEqual(expectedError);
+    expect(gefFacilityExistsSpy).not.toHaveBeenCalled();
   });
 
   it('returns an error when the value could not be found in the TFM facilities collection', async () => {
     // Arrange
+    const facilityIdValue = '12345678';
+
     const validFacilityId = {
-      value: '12345678',
+      value: facilityIdValue,
       column: 'Z',
       row: 1,
     };
@@ -70,23 +74,27 @@ describe('generateUkefFacilityIdError', () => {
       errorMessage: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
       column: 'Z',
       row: 1,
-      value: '12345678',
+      value: facilityIdValue,
       exporter: testExporterName,
     };
 
-    when(gefFacilityExistsSpy).calledWith('12345678').mockResolvedValue(false);
+    when(gefFacilityExistsSpy).calledWith(facilityIdValue).mockResolvedValue(false);
 
     // Act
     const ukefFacilityIdError = await generateUkefFacilityIdError(validFacilityId, testExporterName);
 
     // Assert
     expect(ukefFacilityIdError).toEqual(expectedError);
+    expect(gefFacilityExistsSpy).toHaveBeenCalledTimes(1);
+    expect(gefFacilityExistsSpy).toHaveBeenCalledWith(facilityIdValue);
   });
 
   it('returns null if the value is a valid UKEF GEF Facility ID', async () => {
     // Arrange
+    const facilityIdValue = '12345678';
+
     const validFacilityId = {
-      value: '12345678',
+      value: facilityIdValue,
       column: 'Z',
       row: 1,
     };
@@ -96,6 +104,8 @@ describe('generateUkefFacilityIdError', () => {
 
     // Assert
     expect(ukefFacilityIdError).toBeNull();
+    expect(gefFacilityExistsSpy).toHaveBeenCalledTimes(1);
+    expect(gefFacilityExistsSpy).toHaveBeenCalledWith(facilityIdValue);
   });
 
   it('returns the correct column and row when an error is found', async () => {
@@ -118,5 +128,6 @@ describe('generateUkefFacilityIdError', () => {
 
     // Assert
     expect(ukefFacilityIdError).toEqual(expectedError);
+    expect(gefFacilityExistsSpy).not.toHaveBeenCalled();
   });
 });

--- a/dtfs-central-api/src/services/utilisation-report-data-validator/utilisation-report-cell-validators/generate-ukef-facility-id-error.test.ts
+++ b/dtfs-central-api/src/services/utilisation-report-data-validator/utilisation-report-cell-validators/generate-ukef-facility-id-error.test.ts
@@ -5,10 +5,10 @@ import { TfmFacilitiesRepo } from '../../../repositories/tfm-facilities-repo';
 describe('generateUkefFacilityIdError', () => {
   const testExporterName = 'test exporter';
 
-  const facilityIdExistsSpy = jest.spyOn(TfmFacilitiesRepo, 'ukefFacilityIdExists');
+  const gefFacilityExistsSpy = jest.spyOn(TfmFacilitiesRepo, 'ukefGefFacilityExists');
 
   beforeEach(() => {
-    facilityIdExistsSpy.mockResolvedValue(true);
+    gefFacilityExistsSpy.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -67,14 +67,14 @@ describe('generateUkefFacilityIdError', () => {
       row: 1,
     };
     const expectedError = {
-      errorMessage: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+      errorMessage: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
       column: 'Z',
       row: 1,
       value: '12345678',
       exporter: testExporterName,
     };
 
-    when(facilityIdExistsSpy).calledWith('12345678').mockResolvedValue(false);
+    when(gefFacilityExistsSpy).calledWith('12345678').mockResolvedValue(false);
 
     // Act
     const ukefFacilityIdError = await generateUkefFacilityIdError(validFacilityId, testExporterName);
@@ -83,7 +83,7 @@ describe('generateUkefFacilityIdError', () => {
     expect(ukefFacilityIdError).toEqual(expectedError);
   });
 
-  it('returns null if the value is a valid UKEF Facility ID', async () => {
+  it('returns null if the value is a valid UKEF GEF Facility ID', async () => {
     // Arrange
     const validFacilityId = {
       value: '12345678',

--- a/dtfs-central-api/src/services/utilisation-report-data-validator/utilisation-report-cell-validators/generate-ukef-facility-id-error.ts
+++ b/dtfs-central-api/src/services/utilisation-report-data-validator/utilisation-report-cell-validators/generate-ukef-facility-id-error.ts
@@ -29,11 +29,11 @@ export const generateUkefFacilityIdError: UtilisationReportCellValidationErrorGe
     };
   }
 
-  const ukefFacilityIdExists = await TfmFacilitiesRepo.ukefFacilityIdExists(facilityIdCellData.value);
+  const ukefGefFacilityExists = await TfmFacilitiesRepo.ukefGefFacilityExists(facilityIdCellData.value);
 
-  if (!ukefFacilityIdExists) {
+  if (!ukefGefFacilityExists) {
     return {
-      errorMessage: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+      errorMessage: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
       column: facilityIdCellData?.column,
       row: facilityIdCellData?.row,
       value: facilityIdCellData?.value,

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
@@ -13,7 +13,7 @@ context('Monthly utilisation report upload', () => {
   beforeEach(() => {
     cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
     cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [march2023ReportDetails, february2023ReportDetails]);
-    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacilityForReport]);
+    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacilityForReport, ewcsTfmFacilityForReport]);
 
     cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
     cy.visit(relativeURL('/utilisation-report-upload'));
@@ -106,8 +106,6 @@ context('Monthly utilisation report upload', () => {
 
   describe('Failing data validation on file upload', () => {
     it('should display a summary of errors for an invalid .xlsx file', () => {
-      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
-
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2023_monthly.xlsx');
       cy.clickContinueButton();
 
@@ -242,8 +240,6 @@ context('Monthly utilisation report upload', () => {
     });
 
     it('should display a summary of errors for an invalid .csv file', () => {
-      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
-
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2023_monthly.csv');
       cy.clickContinueButton();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
@@ -148,7 +148,7 @@ context('Monthly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 7,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Fish Exporter',
         row: '4',
         column: 'B',
@@ -164,7 +164,7 @@ context('Monthly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 9,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Potato Exporter',
         row: '5',
         column: 'B',
@@ -283,7 +283,7 @@ context('Monthly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 7,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Fish Exporter',
         row: '4',
         column: 'B',
@@ -291,7 +291,7 @@ context('Monthly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 8,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Potato Exporter',
         row: '5',
         column: 'B',

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-monthly-utilisation-report.spec.js
@@ -2,7 +2,12 @@ const { errorSummary, mainHeading } = require('../../../partials');
 const { utilisationReportUpload } = require('../../../pages');
 const { NODE_TASKS, BANK1_PAYMENT_REPORT_OFFICER1 } = require('../../../../../../e2e-fixtures');
 const relativeURL = require('../../../relativeURL');
-const { february2023ReportDetails, march2023ReportDetails, tfmFacilityForReport } = require('../../../../fixtures/mockUtilisationReportDetails');
+const {
+  february2023ReportDetails,
+  march2023ReportDetails,
+  tfmFacilityForReport,
+  ewcsTfmFacilityForReport,
+} = require('../../../../fixtures/mockUtilisationReportDetails');
 
 context('Monthly utilisation report upload', () => {
   beforeEach(() => {
@@ -101,6 +106,8 @@ context('Monthly utilisation report upload', () => {
 
   describe('Failing data validation on file upload', () => {
     it('should display a summary of errors for an invalid .xlsx file', () => {
+      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
+
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2023_monthly.xlsx');
       cy.clickContinueButton();
 
@@ -235,6 +242,8 @@ context('Monthly utilisation report upload', () => {
     });
 
     it('should display a summary of errors for an invalid .csv file', () => {
+      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
+
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2023_monthly.csv');
       cy.clickContinueButton();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-quarterly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-quarterly-utilisation-report.spec.js
@@ -12,7 +12,7 @@ context('Quarterly utilisation report upload', () => {
   beforeEach(() => {
     cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
     cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [december2023ToFebruary2024ReportDetails]);
-    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacilityForReport]);
+    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [tfmFacilityForReport, ewcsTfmFacilityForReport]);
 
     cy.login(BANK2_PAYMENT_REPORT_OFFICER1);
     cy.visit(relativeURL('/utilisation-report-upload'));
@@ -93,8 +93,6 @@ context('Quarterly utilisation report upload', () => {
 
   describe('Failing data validation on file upload', () => {
     it('should display a summary of errors for an invalid .xlsx file', () => {
-      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
-
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2024_quarterly.xlsx');
       cy.clickContinueButton();
 
@@ -167,8 +165,6 @@ context('Quarterly utilisation report upload', () => {
     });
 
     it('should display a summary of errors for an invalid .csv file', () => {
-      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
-
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2024_quarterly.csv');
       cy.clickContinueButton();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-quarterly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-quarterly-utilisation-report.spec.js
@@ -2,7 +2,11 @@ const { errorSummary, mainHeading } = require('../../../partials');
 const { utilisationReportUpload } = require('../../../pages');
 const { NODE_TASKS, BANK2_PAYMENT_REPORT_OFFICER1 } = require('../../../../../../e2e-fixtures');
 const relativeURL = require('../../../relativeURL');
-const { december2023ToFebruary2024ReportDetails, tfmFacilityForReport } = require('../../../../fixtures/mockUtilisationReportDetails');
+const {
+  december2023ToFebruary2024ReportDetails,
+  tfmFacilityForReport,
+  ewcsTfmFacilityForReport,
+} = require('../../../../fixtures/mockUtilisationReportDetails');
 
 context('Quarterly utilisation report upload', () => {
   beforeEach(() => {
@@ -89,6 +93,8 @@ context('Quarterly utilisation report upload', () => {
 
   describe('Failing data validation on file upload', () => {
     it('should display a summary of errors for an invalid .xlsx file', () => {
+      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
+
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2024_quarterly.xlsx');
       cy.clickContinueButton();
 
@@ -161,6 +167,8 @@ context('Quarterly utilisation report upload', () => {
     });
 
     it('should display a summary of errors for an invalid .csv file', () => {
+      cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, [ewcsTfmFacilityForReport]);
+
       utilisationReportUpload.utilisationReportFileInput().attachFile('invalid-utilisation-report-February_2024_quarterly.csv');
       cy.clickContinueButton();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-quarterly-utilisation-report.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/utilisation-report-upload/can-upload-quarterly-utilisation-report.spec.js
@@ -136,7 +136,7 @@ context('Quarterly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 7,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Fish Exporter',
         row: '4',
         column: 'B',
@@ -152,7 +152,7 @@ context('Quarterly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 9,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Potato Exporter',
         row: '5',
         column: 'B',
@@ -209,7 +209,7 @@ context('Quarterly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 7,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Fish Exporter',
         row: '4',
         column: 'B',
@@ -217,7 +217,7 @@ context('Quarterly utilisation report upload', () => {
       });
       cy.assertValidationErrorTableRowContains({
         tableRowIndex: 8,
-        message: 'The Facility ID has not been recognised. Enter a valid Facility ID between 8 and 10 characters.',
+        message: 'The facility ID has not been recognised. Enter a facility ID for a general export facility.',
         exporter: 'Potato Exporter',
         row: '5',
         column: 'B',

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -6,6 +6,7 @@ const {
   REQUEST_PLATFORM_TYPE,
   PENDING_RECONCILIATION,
   REPORT_NOT_RECEIVED,
+  GEF_FACILITY_TYPE,
 } = require('@ukef/dtfs2-common');
 const { BANK1_PAYMENT_REPORT_OFFICER1, BANK2_PAYMENT_REPORT_OFFICER1 } = require('../../../e2e-fixtures');
 
@@ -110,7 +111,7 @@ const tfmFacilityForReport = {
     interestPercentage: 5,
     dayCountBasis: 5,
     coverPercentage: 80,
-    type: 'Cash',
+    type: GEF_FACILITY_TYPE.CASH,
   },
 };
 

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -6,7 +6,7 @@ const {
   REQUEST_PLATFORM_TYPE,
   PENDING_RECONCILIATION,
   REPORT_NOT_RECEIVED,
-  GEF_FACILITY_TYPE,
+  FACILITY_TYPE,
 } = require('@ukef/dtfs2-common');
 const { BANK1_PAYMENT_REPORT_OFFICER1, BANK2_PAYMENT_REPORT_OFFICER1 } = require('../../../e2e-fixtures');
 
@@ -104,6 +104,7 @@ const upToDateReportDetails = generateUpToDateReportDetails();
  */
 const tfmFacilityForReport = {
   facilitySnapshot: {
+    type: FACILITY_TYPE.CASH,
     ukefFacilityId: '20001371',
     value: 1000,
     coverStartDate: new Date().getTime(),
@@ -111,7 +112,23 @@ const tfmFacilityForReport = {
     interestPercentage: 5,
     dayCountBasis: 5,
     coverPercentage: 80,
-    type: GEF_FACILITY_TYPE.CASH,
+  },
+};
+
+/**
+ * There are multiple reports in the fixtures which require an existing EWCS facility with
+ * matching UKEF facility ID to test the invalid upload journey.
+ * The UKEF facility ID for the below facility is used in the following fixtures files:
+ * - invalid-utilisation-report-February_2023_monthly.xlsx
+ * - invalid-utilisation-report-February_2023_monthly.csv
+ * - invalid-utilisation-report-February_2024_quarterly.xlsx
+ * - invalid-utilisation-report-February_2024_quarterly.csv
+ */
+const ewcsTfmFacilityForReport = {
+  facilitySnapshot: {
+    ...tfmFacilityForReport.facilitySnapshot,
+    type: FACILITY_TYPE.LOAN,
+    ukefFacilityId: '20001507',
   },
 };
 
@@ -122,4 +139,5 @@ module.exports = {
   upToDateReportDetails,
   december2023ToFebruary2024ReportDetails,
   tfmFacilityForReport,
+  ewcsTfmFacilityForReport,
 };

--- a/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
+++ b/e2e-tests/portal/cypress/fixtures/mockUtilisationReportDetails.js
@@ -110,6 +110,7 @@ const tfmFacilityForReport = {
     interestPercentage: 5,
     dayCountBasis: 5,
     coverPercentage: 80,
+    type: 'Cash',
   },
 };
 

--- a/e2e-tests/ukef/cypress/fixtures/tfm-facility.js
+++ b/e2e-tests/ukef/cypress/fixtures/tfm-facility.js
@@ -1,4 +1,5 @@
 const { addMonths } = require('date-fns');
+const { FACILITY_TYPE } = require('@ukef/dtfs2-common');
 
 /**
  * There are utilisation reports in the fixtures which require an existing facility with matching
@@ -9,6 +10,7 @@ const { addMonths } = require('date-fns');
  */
 export const tfmFacilityForReport = {
   facilitySnapshot: {
+    type: FACILITY_TYPE.CASH,
     ukefFacilityId: '20001371',
     value: 1000,
     coverStartDate: new Date().getTime(),


### PR DESCRIPTION
## Introduction :pencil2:
During bank report upload, facility types should be restricted to GEF facilities as we are unable to store information such as 'value' and 'coverPercentage' on other facility types (e.g., EWCS facilities).

The valid facility types, with this information, are `CASH` and `CONTINGENT` - together these make up the `GEF_FACILITY_TYPE` const in `libs/common/src/constants/facility-type.ts`

## Resolution :heavy_check_mark:
- Modified facility ID existence check to require that the facility be a GEF facility.
- Adapted error messaging for this case in line with designer preference.
- Added API tests to check the different types of facility.
- Adapted E2E tests to match new messaging and ensure an error message is displayed for a stored EWCS facility.

## Miscellaneous :heavy_plus_sign:
N/A