### PR TITLE
fix(FN-3641): improve report upload reliability

### DIFF
--- a/dtfs-central-api/src/constants/batch-saving.ts
+++ b/dtfs-central-api/src/constants/batch-saving.ts
@@ -1,0 +1,1 @@
+export const CHUNK_SIZE_FOR_SQL_BATCH_SAVING = 100;

--- a/dtfs-central-api/src/constants/index.ts
+++ b/dtfs-central-api/src/constants/index.ts
@@ -5,3 +5,4 @@ export * from './amendments';
 export * as REGEX from './regex';
 export * from './activityConstants';
 export * from './csv';
+export * from './batch-saving';

--- a/dtfs-central-api/src/helpers/execute-with-sql-transaction.test.ts
+++ b/dtfs-central-api/src/helpers/execute-with-sql-transaction.test.ts
@@ -144,7 +144,7 @@ describe('executeWithSqlTransaction', () => {
     await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(TransactionFailedError.forApiError(customError));
   });
 
-  it('logs error even if rolling back the transaction fails', async () => {
+  it('logs error if rolling back the transaction fails', async () => {
     // Arrange
     const originalError = new Error('Some error');
     const functionToExecute = jest.fn().mockRejectedValue(originalError);

--- a/dtfs-central-api/src/helpers/execute-with-sql-transaction.test.ts
+++ b/dtfs-central-api/src/helpers/execute-with-sql-transaction.test.ts
@@ -155,7 +155,7 @@ describe('executeWithSqlTransaction', () => {
     // Act / Assert
     await expect(executeWithSqlTransaction(functionToExecute)).rejects.toThrow(secondaryError);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error thrown within SQL transaction: %s', originalError);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error thrown within SQL transaction: %o', originalError);
   });
 
   it('returns the return value of the supplied function', async () => {

--- a/dtfs-central-api/src/helpers/execute-with-sql-transaction.ts
+++ b/dtfs-central-api/src/helpers/execute-with-sql-transaction.ts
@@ -71,7 +71,7 @@ export const executeWithSqlTransaction = async <ReturnValue>(functionToExecute: 
 
     return result;
   } catch (error) {
-    console.error('Error thrown within SQL transaction: %s', error);
+    console.error('Error thrown within SQL transaction: %o', error);
 
     await queryRunner.rollbackTransaction();
     if (error instanceof ApiError) {

--- a/dtfs-central-api/src/helpers/execute-with-sql-transaction.ts
+++ b/dtfs-central-api/src/helpers/execute-with-sql-transaction.ts
@@ -71,6 +71,8 @@ export const executeWithSqlTransaction = async <ReturnValue>(functionToExecute: 
 
     return result;
   } catch (error) {
+    console.error('Error thrown within SQL transaction: %s', error);
+
     await queryRunner.rollbackTransaction();
     if (error instanceof ApiError) {
       throw TransactionFailedError.forApiError(error);

--- a/dtfs-central-api/src/helpers/get-previous-report-period.ts
+++ b/dtfs-central-api/src/helpers/get-previous-report-period.ts
@@ -1,4 +1,4 @@
-import { UtilisationReportEntity, getPreviousReportPeriodForBankScheduleByMonth, ReportPeriod } from '@ukef/dtfs2-common';
+import { getPreviousReportPeriodForBankScheduleByMonth, ReportPeriod } from '@ukef/dtfs2-common';
 import { getBankById } from '../repositories/banks-repo';
 import { NotFoundError } from '../errors';
 
@@ -8,10 +8,10 @@ import { NotFoundError } from '../errors';
  * constructs the month formatted to ISO 8601 month string in format 'yyyy-MM'
  * returns the previous report period from getPreviousReportPeriodForBankScheduleByMonth
  * @param bankId
- * @param report
+ * @param reportPeriod
  * @returns previous report period from getPreviousReportPeriodForBankScheduleByMonth
  */
-export const getPreviousReportPeriod = async (bankId: string, report: UtilisationReportEntity): Promise<ReportPeriod> => {
+export const getPreviousReportPeriod = async (bankId: string, reportPeriod: ReportPeriod): Promise<ReportPeriod> => {
   try {
     const bank = await getBankById(bankId);
 
@@ -20,7 +20,7 @@ export const getPreviousReportPeriod = async (bankId: string, report: Utilisatio
       throw new NotFoundError(`Bank not found: ${bankId}`);
     }
 
-    const { start } = report.reportPeriod;
+    const { start } = reportPeriod;
     const paddedMonth = String(start.month).padStart(2, '0');
     const monthFormatted = `${start.year}-${paddedMonth}`;
 

--- a/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.test.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.test.ts
@@ -1,0 +1,203 @@
+import { EntityManager } from 'typeorm';
+import { FacilityUtilisationDataEntity, FacilityUtilisationDataEntityMockBuilder } from '@ukef/dtfs2-common';
+import { when } from 'jest-when';
+import { FacilityUtilisationDataService } from './facility-utilisation-data.service';
+import { aDbRequestSource, aReportPeriod } from '../../../test-helpers';
+import { calculateInitialUtilisationAndFixedFee } from './helpers';
+import { getPreviousReportPeriod } from '../../helpers/get-previous-report-period';
+
+jest.mock('./helpers');
+jest.mock('../../helpers/get-previous-report-period');
+
+describe('FacilityUtilisationDataService', () => {
+  const bankId = '1';
+
+  const mockSave = jest.fn();
+  const mockFindBy = jest.fn();
+  const mockEntityManager = {
+    save: mockSave,
+    findBy: mockFindBy,
+  } as unknown as EntityManager;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('initialiseFacilityUtilisationData', () => {
+    beforeEach(() => {
+      jest.mocked(calculateInitialUtilisationAndFixedFee).mockResolvedValue({ fixedFee: 123.45, utilisation: 678.9 });
+      jest.mocked(getPreviousReportPeriod).mockResolvedValue(aReportPeriod());
+    });
+
+    describe('when all facility ids are associated with existing FacilityUtilisationDataEntities', () => {
+      const facilityIds = new Set(['01', '02', '03']);
+
+      beforeEach(() => {
+        mockFindBy.mockResolvedValue([
+          FacilityUtilisationDataEntityMockBuilder.forId('01').build(),
+          FacilityUtilisationDataEntityMockBuilder.forId('02').build(),
+          FacilityUtilisationDataEntityMockBuilder.forId('03').build(),
+        ]);
+      });
+
+      it('should not create any new FacilityUtilisationDataEntities', async () => {
+        // Arrange
+        const saveSpy = jest.spyOn(mockEntityManager, 'save');
+
+        // Act
+        await FacilityUtilisationDataService.initialiseFacilityUtilisationData(facilityIds, bankId, aReportPeriod(), aDbRequestSource(), mockEntityManager);
+
+        // Assert
+        expect(saveSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when some facility ids are associated with existing FacilityUtilisationDataEntities', () => {
+      const facilityIdWithExistingUtilisationData = '01';
+      const facilityIdWithoutExistingUtilisationData = '02';
+      const facilityIds = new Set([facilityIdWithExistingUtilisationData, facilityIdWithoutExistingUtilisationData]);
+
+      beforeEach(() => {
+        mockFindBy.mockResolvedValue([FacilityUtilisationDataEntityMockBuilder.forId(facilityIdWithExistingUtilisationData).build()]);
+      });
+
+      it('should create new FacilityUtilisationDataEntities for the facilities without existing FacilityUtilisationDataEntities', async () => {
+        // Arrange
+        const utilisation = 111.11;
+        const fixedFee = 222.22;
+        const requestSource = aDbRequestSource();
+        const reportPeriod = { start: { month: 1, year: 2023 }, end: { month: 2, year: 2023 } };
+        const previousReportPeriod = { start: { month: 11, year: 2022 }, end: { month: 12, year: 2022 } };
+
+        jest.mocked(calculateInitialUtilisationAndFixedFee).mockResolvedValue({ fixedFee, utilisation });
+        jest.mocked(getPreviousReportPeriod).mockResolvedValue(previousReportPeriod);
+
+        // Act
+        await FacilityUtilisationDataService.initialiseFacilityUtilisationData(facilityIds, bankId, reportPeriod, requestSource, mockEntityManager);
+
+        // Assert
+        expect(mockSave).toHaveBeenCalledTimes(1);
+        const expectedEntities = [
+          FacilityUtilisationDataEntity.create({
+            id: facilityIdWithoutExistingUtilisationData,
+            reportPeriod: previousReportPeriod,
+            requestSource,
+            utilisation,
+            fixedFee,
+          }),
+        ];
+        expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: 100 });
+      });
+    });
+
+    describe('when all facility ids are not associated with existing FacilityUtilisationDataEntities', () => {
+      const firstFacilityId = '01';
+      const secondFacilityId = '02';
+      const facilityIds = new Set([firstFacilityId, secondFacilityId]);
+
+      beforeEach(() => {
+        mockFindBy.mockResolvedValue([]);
+      });
+
+      it('should create new FacilityUtilisationDataEntities for all facilities', async () => {
+        // Arrange
+        const firstUtilisation = 111.11;
+        const secondUtilisation = 222.22;
+        const firstFixedFee = 333.33;
+        const secondFixedFee = 444.44;
+
+        const requestSource = aDbRequestSource();
+        const reportPeriod = { start: { month: 1, year: 2023 }, end: { month: 2, year: 2023 } };
+        const previousReportPeriod = { start: { month: 11, year: 2022 }, end: { month: 12, year: 2022 } };
+
+        when(calculateInitialUtilisationAndFixedFee).calledWith(firstFacilityId).mockResolvedValue({ fixedFee: firstFixedFee, utilisation: firstUtilisation });
+        when(calculateInitialUtilisationAndFixedFee)
+          .calledWith(secondFacilityId)
+          .mockResolvedValue({ fixedFee: secondFixedFee, utilisation: secondUtilisation });
+
+        jest.mocked(getPreviousReportPeriod).mockResolvedValue(previousReportPeriod);
+
+        // Act
+        await FacilityUtilisationDataService.initialiseFacilityUtilisationData(facilityIds, bankId, reportPeriod, requestSource, mockEntityManager);
+
+        // Assert
+        expect(mockSave).toHaveBeenCalledTimes(1);
+        const expectedEntities = [
+          FacilityUtilisationDataEntity.create({
+            id: firstFacilityId,
+            reportPeriod: previousReportPeriod,
+            requestSource,
+            utilisation: firstUtilisation,
+            fixedFee: firstFixedFee,
+          }),
+          FacilityUtilisationDataEntity.create({
+            id: secondFacilityId,
+            reportPeriod: previousReportPeriod,
+            requestSource,
+            utilisation: secondUtilisation,
+            fixedFee: secondFixedFee,
+          }),
+        ];
+        expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: 100 });
+      });
+    });
+  });
+
+  describe('filterOutFacilitiesWithExistingUtilisationData', () => {
+    describe('when all facility ids are associated with existing FacilityUtilisationDataEntities', () => {
+      const facilityIds = new Set(['01', '02', '03']);
+
+      beforeEach(() => {
+        mockFindBy.mockResolvedValue([
+          FacilityUtilisationDataEntityMockBuilder.forId('01').build(),
+          FacilityUtilisationDataEntityMockBuilder.forId('02').build(),
+          FacilityUtilisationDataEntityMockBuilder.forId('03').build(),
+        ]);
+      });
+
+      it('should return an empty set', async () => {
+        // Act
+        const result = await FacilityUtilisationDataService.filterOutFacilitiesWithExistingUtilisationData(facilityIds, mockEntityManager);
+
+        // Assert
+        expect(result).toEqual(new Set());
+      });
+    });
+
+    describe('when some facility ids are associated with existing FacilityUtilisationDataEntities', () => {
+      const facilityIdWithExistingUtilisationData = '01';
+      const facilityIdWithoutExistingUtilisationData = '02';
+      const facilityIds = new Set([facilityIdWithExistingUtilisationData, facilityIdWithoutExistingUtilisationData]);
+
+      beforeEach(() => {
+        mockFindBy.mockResolvedValue([FacilityUtilisationDataEntityMockBuilder.forId(facilityIdWithExistingUtilisationData).build()]);
+      });
+
+      it('should return the facility ids not associated with existing FacilityUtilisationDataEntities', async () => {
+        // Act
+        const result = await FacilityUtilisationDataService.filterOutFacilitiesWithExistingUtilisationData(facilityIds, mockEntityManager);
+
+        // Assert
+        expect(result).toEqual(new Set([facilityIdWithoutExistingUtilisationData]));
+      });
+    });
+
+    describe('when all facility ids are not associated with existing FacilityUtilisationDataEntities', () => {
+      const firstFacilityId = '01';
+      const secondFacilityId = '02';
+      const facilityIds = new Set([firstFacilityId, secondFacilityId]);
+
+      beforeEach(() => {
+        mockFindBy.mockResolvedValue([]);
+      });
+
+      it('should return all facility ids', async () => {
+        // Act
+        const result = await FacilityUtilisationDataService.filterOutFacilitiesWithExistingUtilisationData(facilityIds, mockEntityManager);
+
+        // Assert
+        expect(result).toEqual(facilityIds);
+      });
+    });
+  });
+});

--- a/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.test.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.test.ts
@@ -5,6 +5,7 @@ import { FacilityUtilisationDataService } from './facility-utilisation-data.serv
 import { aDbRequestSource, aReportPeriod } from '../../../test-helpers';
 import { calculateInitialUtilisationAndFixedFee } from './helpers';
 import { getPreviousReportPeriod } from '../../helpers/get-previous-report-period';
+import { CHUNK_SIZE_FOR_SQL_BATCH_SAVING } from '../../constants';
 
 jest.mock('./helpers');
 jest.mock('../../helpers/get-previous-report-period');
@@ -86,7 +87,7 @@ describe('FacilityUtilisationDataService', () => {
             fixedFee,
           }),
         ];
-        expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: 100 });
+        expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: CHUNK_SIZE_FOR_SQL_BATCH_SAVING });
       });
     });
 
@@ -138,7 +139,7 @@ describe('FacilityUtilisationDataService', () => {
             fixedFee: secondFixedFee,
           }),
         ];
-        expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: 100 });
+        expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: CHUNK_SIZE_FOR_SQL_BATCH_SAVING });
       });
     });
   });

--- a/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.test.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.test.ts
@@ -1,4 +1,4 @@
-import { EntityManager } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
 import { FacilityUtilisationDataEntity, FacilityUtilisationDataEntityMockBuilder } from '@ukef/dtfs2-common';
 import { when } from 'jest-when';
 import { FacilityUtilisationDataService } from './facility-utilisation-data.service';
@@ -143,7 +143,7 @@ describe('FacilityUtilisationDataService', () => {
     });
   });
 
-  describe('filterOutFacilitiesWithExistingUtilisationData', () => {
+  describe('filterOutFacilityIdsWithExistingUtilisationData', () => {
     describe('when all facility ids are associated with existing FacilityUtilisationDataEntities', () => {
       const facilityIds = new Set(['01', '02', '03']);
 
@@ -157,10 +157,12 @@ describe('FacilityUtilisationDataService', () => {
 
       it('should return an empty set', async () => {
         // Act
-        const result = await FacilityUtilisationDataService.filterOutFacilitiesWithExistingUtilisationData(facilityIds, mockEntityManager);
+        const result = await FacilityUtilisationDataService.filterOutFacilityIdsWithExistingUtilisationData(facilityIds, mockEntityManager);
 
         // Assert
         expect(result).toEqual(new Set());
+        expect(mockFindBy).toHaveBeenCalledTimes(1);
+        expect(mockFindBy).toHaveBeenCalledWith(FacilityUtilisationDataEntity, { id: In(Array.from(facilityIds)) });
       });
     });
 
@@ -175,10 +177,12 @@ describe('FacilityUtilisationDataService', () => {
 
       it('should return the facility ids not associated with existing FacilityUtilisationDataEntities', async () => {
         // Act
-        const result = await FacilityUtilisationDataService.filterOutFacilitiesWithExistingUtilisationData(facilityIds, mockEntityManager);
+        const result = await FacilityUtilisationDataService.filterOutFacilityIdsWithExistingUtilisationData(facilityIds, mockEntityManager);
 
         // Assert
         expect(result).toEqual(new Set([facilityIdWithoutExistingUtilisationData]));
+        expect(mockFindBy).toHaveBeenCalledTimes(1);
+        expect(mockFindBy).toHaveBeenCalledWith(FacilityUtilisationDataEntity, { id: In(Array.from(facilityIds)) });
       });
     });
 
@@ -193,10 +197,12 @@ describe('FacilityUtilisationDataService', () => {
 
       it('should return all facility ids', async () => {
         // Act
-        const result = await FacilityUtilisationDataService.filterOutFacilitiesWithExistingUtilisationData(facilityIds, mockEntityManager);
+        const result = await FacilityUtilisationDataService.filterOutFacilityIdsWithExistingUtilisationData(facilityIds, mockEntityManager);
 
         // Assert
         expect(result).toEqual(facilityIds);
+        expect(mockFindBy).toHaveBeenCalledTimes(1);
+        expect(mockFindBy).toHaveBeenCalledWith(FacilityUtilisationDataEntity, { id: In(Array.from(facilityIds)) });
       });
     });
   });

--- a/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.ts
@@ -23,6 +23,13 @@ export class FacilityUtilisationDataService {
   ) {
     const facilityIdsToInitialise = await this.filterOutFacilityIdsWithExistingUtilisationData(facilityIds, entityManager);
 
+    /**
+     * If all facilities have existing utilisation data then we would expect there to
+     * not be any facility ids needing initialisation.
+     * In this case we return early to avoid making any unnecessary db calls,
+     * e.g. we don't need to fetch previous report period from the bank's
+     * utilisation reporting schedule stored in mongo.
+     */
     if (facilityIdsToInitialise.size === 0) {
       return;
     }

--- a/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.ts
@@ -1,0 +1,57 @@
+import { DbRequestSource, FacilityUtilisationDataEntity, ReportPeriod } from '@ukef/dtfs2-common';
+import { EntityManager, In } from 'typeorm';
+import { getPreviousReportPeriod } from '../../helpers';
+import { calculateInitialUtilisationAndFixedFee } from './helpers';
+import { CHUNK_SIZE_FOR_SQL_BATCH_SAVING } from '../../constants';
+
+export class FacilityUtilisationDataService {
+  /**
+   * Create and save initial facility utilisation data for any
+   * facilities that do not already have any.
+   * @param facilityIds - facility ids
+   * @param bankId - bank id
+   * @param reportPeriod - report period
+   * @param requestSource - request source
+   * @param entityManager - entity manager
+   */
+  public static async initialiseFacilityUtilisationData(
+    facilityIds: Set<string>,
+    bankId: string,
+    reportPeriod: ReportPeriod,
+    requestSource: DbRequestSource,
+    entityManager: EntityManager,
+  ) {
+    const facilityIdsToInitialise = await this.filterOutFacilitiesWithExistingUtilisationData(facilityIds, entityManager);
+
+    if (facilityIdsToInitialise.size === 0) {
+      return;
+    }
+
+    const previousReportPeriod = await getPreviousReportPeriod(bankId, reportPeriod);
+    const entities: FacilityUtilisationDataEntity[] = [];
+
+    for (const id of facilityIdsToInitialise) {
+      const { utilisation, fixedFee } = await calculateInitialUtilisationAndFixedFee(id);
+
+      entities.push(
+        FacilityUtilisationDataEntity.create({
+          id,
+          reportPeriod: previousReportPeriod,
+          requestSource,
+          utilisation,
+          fixedFee,
+        }),
+      );
+    }
+
+    await entityManager.save(FacilityUtilisationDataEntity, entities, { chunk: CHUNK_SIZE_FOR_SQL_BATCH_SAVING });
+  }
+
+  public static async filterOutFacilitiesWithExistingUtilisationData(facilityIds: Set<string>, entityManager: EntityManager): Promise<Set<string>> {
+    const existingFacilityUtilisationDataEntities = await entityManager.findBy(FacilityUtilisationDataEntity, { id: In(Array.from(facilityIds)) });
+
+    const facilityIdsWithExistingUtilisationData = new Set(existingFacilityUtilisationDataEntities.map((entity) => entity.id));
+
+    return facilityIds.difference(facilityIdsWithExistingUtilisationData);
+  }
+}

--- a/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/facility-utilisation-data.service.ts
@@ -21,7 +21,7 @@ export class FacilityUtilisationDataService {
     requestSource: DbRequestSource,
     entityManager: EntityManager,
   ) {
-    const facilityIdsToInitialise = await this.filterOutFacilitiesWithExistingUtilisationData(facilityIds, entityManager);
+    const facilityIdsToInitialise = await this.filterOutFacilityIdsWithExistingUtilisationData(facilityIds, entityManager);
 
     if (facilityIdsToInitialise.size === 0) {
       return;
@@ -47,7 +47,13 @@ export class FacilityUtilisationDataService {
     await entityManager.save(FacilityUtilisationDataEntity, entities, { chunk: CHUNK_SIZE_FOR_SQL_BATCH_SAVING });
   }
 
-  public static async filterOutFacilitiesWithExistingUtilisationData(facilityIds: Set<string>, entityManager: EntityManager): Promise<Set<string>> {
+  /**
+   * Filter out facility ids with existing facility utilisation data
+   * @param facilityIds - facility ids to filter
+   * @param entityManager - transaction entity manager
+   * @returns the filtered set
+   */
+  public static async filterOutFacilityIdsWithExistingUtilisationData(facilityIds: Set<string>, entityManager: EntityManager): Promise<Set<string>> {
     const existingFacilityUtilisationDataEntities = await entityManager.findBy(FacilityUtilisationDataEntity, { id: In(Array.from(facilityIds)) });
 
     const facilityIdsWithExistingUtilisationData = new Set(existingFacilityUtilisationDataEntities.map((entity) => entity.id));

--- a/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-fixed-fee.test.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-fixed-fee.test.ts
@@ -1,6 +1,6 @@
 import { addDays } from 'date-fns';
 import { calculateInitialFixedFee, getNumberOfDaysInCoverPeriod } from './calculate-initial-fixed-fee';
-import { calculateFixedFeeFromDaysRemaining } from '../../../../../helpers/calculate-fixed-fee-from-days-remaining';
+import { calculateFixedFeeFromDaysRemaining } from '../../../helpers/calculate-fixed-fee-from-days-remaining';
 
 describe('helpers/calculate-fixed-fee', () => {
   describe('getNumberOfDaysInCoverPeriod', () => {

--- a/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-fixed-fee.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-fixed-fee.ts
@@ -1,6 +1,6 @@
 import { differenceInDays } from 'date-fns';
 import { CalculateFixedFeeUtilisationReportParams } from '@ukef/dtfs2-common';
-import { calculateFixedFeeFromDaysRemaining } from '../../../../../helpers/calculate-fixed-fee-from-days-remaining';
+import { calculateFixedFeeFromDaysRemaining } from '../../../helpers/calculate-fixed-fee-from-days-remaining';
 
 /**
  * getNumberOfDaysInCoverPeriod

--- a/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-utilisation-and-fixed-fee.test.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-utilisation-and-fixed-fee.test.ts
@@ -1,8 +1,8 @@
 import * as dtfsCommon from '@ukef/dtfs2-common';
 import { calculateInitialUtilisationAndFixedFee, parseDate, hasRequiredValues, RequiredParams } from './calculate-initial-utilisation-and-fixed-fee';
-import { NotFoundError } from '../../../../../errors';
-import { aTfmFacility } from '../../../../../../test-helpers';
-import * as helpers from '../../../../../helpers';
+import { NotFoundError } from '../../../errors';
+import { aTfmFacility } from '../../../../test-helpers';
+import * as helpers from '../../../helpers';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock('@ukef/dtfs2-common', () => ({

--- a/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-utilisation-and-fixed-fee.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/helpers/calculate-initial-utilisation-and-fixed-fee.ts
@@ -1,6 +1,6 @@
 import { calculateDrawnAmount } from '@ukef/dtfs2-common';
 import Big from 'big.js';
-import { getKeyingSheetCalculationFacilityValues } from '../../../../../helpers';
+import { getKeyingSheetCalculationFacilityValues } from '../../../helpers';
 
 export type RequiredParams = {
   value?: number | null;

--- a/dtfs-central-api/src/services/facility-utilisation-data/helpers/index.ts
+++ b/dtfs-central-api/src/services/facility-utilisation-data/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './calculate-initial-utilisation-and-fixed-fee';

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/index.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/helpers/index.ts
@@ -1,3 +1,2 @@
 export * from './fee-records-match-attached-payments';
 export * from './get-keying-sheet-fee-payment-shares-for-fee-records';
-export * from './calculate-initial-utilisation-and-fixed-fee';

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
@@ -7,19 +7,14 @@ import {
   UtilisationReportEntity,
   FeeRecordEntity,
   AzureFileInfoEntity,
-  FacilityUtilisationDataEntity,
-  ReportPeriod,
   UtilisationReportRawCsvData,
   REPORT_NOT_RECEIVED,
 } from '@ukef/dtfs2-common';
 import { handleUtilisationReportReportUploadedEvent } from './report-uploaded.event-handler';
-import { calculateInitialUtilisationAndFixedFee } from '../helpers';
-import { getPreviousReportPeriod } from '../../../../../helpers';
-import { aUtilisationReportRawCsvData, aTfmFacility, aBank } from '../../../../../../test-helpers';
-import { TfmFacilitiesRepo } from '../../../../../repositories/tfm-facilities-repo';
-import { getBankById } from '../../../../../repositories/banks-repo';
+import { aUtilisationReportRawCsvData, aReportPeriod } from '../../../../../../test-helpers';
+import { FacilityUtilisationDataService } from '../../../../facility-utilisation-data/facility-utilisation-data.service';
 
-jest.mock('../../../../../repositories/banks-repo');
+jest.mock('../../../../facility-utilisation-data/facility-utilisation-data.service');
 
 describe('handleUtilisationReportReportUploadedEvent', () => {
   const mockSave = jest.fn();
@@ -30,14 +25,8 @@ describe('handleUtilisationReportReportUploadedEvent', () => {
     existsBy: mockExistsBy,
   } as unknown as EntityManager;
 
-  const mockGetBankByIdResponse = aBank();
-
   afterEach(() => {
     jest.resetAllMocks();
-  });
-
-  beforeEach(() => {
-    jest.mocked(getBankById).mockImplementation(jest.fn().mockResolvedValue(mockGetBankByIdResponse));
   });
 
   it('calls the repo method to update the report', async () => {
@@ -76,68 +65,38 @@ describe('handleUtilisationReportReportUploadedEvent', () => {
     expect(mockSave).toHaveBeenCalledWith(FeeRecordEntity, [], { chunk: 100 });
   });
 
-  it('creates and saves new FacilityUtilisationData entities using the report reportPeriod for the supplied facility ids which do not have existing entries', async () => {
-    const findOneByUkefFacilityIdSpy = jest.spyOn(TfmFacilitiesRepo, 'findOneByUkefFacilityId');
-    const facility = aTfmFacility();
-    findOneByUkefFacilityIdSpy.mockResolvedValue(facility);
-
+  it('initialises FacilityUtilisationData for all facility ids in the report', async () => {
     // Arrange
-    const reportReportPeriod: ReportPeriod = {
-      start: { month: 5, year: 2024 },
-      end: { month: 6, year: 2024 },
-    };
-    const report = UtilisationReportEntityMockBuilder.forStatus(REPORT_NOT_RECEIVED).withReportPeriod(reportReportPeriod).build();
+    const initialiseFacilityUtilisationDataSpy = jest.spyOn(FacilityUtilisationDataService, 'initialiseFacilityUtilisationData');
+    const bankId = '10';
+    const reportPeriod = aReportPeriod();
+    const report = UtilisationReportEntityMockBuilder.forStatus(REPORT_NOT_RECEIVED).withReportPeriod(reportPeriod).withBankId(bankId).build();
 
-    const reportCsvDataWithExistingFacilityUtilisationData: UtilisationReportRawCsvData = { ...aUtilisationReportRawCsvData(), 'ukef facility id': '11111111' };
-    const reportCsvDataWithoutExistingFacilityUtilisationData: UtilisationReportRawCsvData[] = [
-      { ...aUtilisationReportRawCsvData(), 'ukef facility id': '22222222' },
-      { ...aUtilisationReportRawCsvData(), 'ukef facility id': '33333333' },
+    const allFacilityIds = ['11111111', '22222222', '33333333'];
+    const reportCsvData: UtilisationReportRawCsvData[] = [
+      { ...aUtilisationReportRawCsvData(), 'ukef facility id': allFacilityIds[0] },
+      { ...aUtilisationReportRawCsvData(), 'ukef facility id': allFacilityIds[1] },
+      { ...aUtilisationReportRawCsvData(), 'ukef facility id': allFacilityIds[2] },
+      { ...aUtilisationReportRawCsvData(), 'ukef facility id': allFacilityIds[2] },
     ];
+
     const uploadedByUserId = 'abc123';
     const requestSource: DbRequestSource = {
       platform: REQUEST_PLATFORM_TYPE.PORTAL,
       userId: uploadedByUserId,
     };
 
-    mockExistsBy.mockImplementation((_entity: unknown, { id }: { id: string }) => {
-      switch (id) {
-        case '11111111':
-          return Promise.resolve(true);
-        default:
-          return Promise.resolve(false);
-      }
-    });
-
     // Act
     await handleUtilisationReportReportUploadedEvent(report, {
       azureFileInfo: MOCK_AZURE_FILE_INFO,
-      reportCsvData: [reportCsvDataWithExistingFacilityUtilisationData, ...reportCsvDataWithoutExistingFacilityUtilisationData],
+      reportCsvData,
       uploadedByUserId,
       requestSource,
       transactionEntityManager: mockEntityManager,
     });
 
     // Assert
-    expect(mockExistsBy).toHaveBeenCalledWith(FacilityUtilisationDataEntity, { id: reportCsvDataWithExistingFacilityUtilisationData['ukef facility id'] });
-
-    const createdFacilityUtilisationDataEntities = reportCsvDataWithoutExistingFacilityUtilisationData.map(async ({ 'ukef facility id': facilityId }) => {
-      expect(mockExistsBy).toHaveBeenCalledWith(FacilityUtilisationDataEntity, { id: facilityId });
-
-      const previousReportPeriod = await getPreviousReportPeriod(report.bankId, report);
-
-      const { utilisation, fixedFee } = await calculateInitialUtilisationAndFixedFee(facilityId);
-
-      return FacilityUtilisationDataEntity.create({
-        id: facilityId,
-        reportPeriod: previousReportPeriod,
-        requestSource,
-        utilisation,
-        fixedFee,
-      });
-    });
-
-    const expectedEntities = await Promise.all(createdFacilityUtilisationDataEntities);
-
-    expect(mockSave).toHaveBeenCalledWith(FacilityUtilisationDataEntity, expectedEntities, { chunk: 100 });
+    expect(initialiseFacilityUtilisationDataSpy).toHaveBeenCalledTimes(1);
+    expect(initialiseFacilityUtilisationDataSpy).toHaveBeenCalledWith(new Set(allFacilityIds), bankId, reportPeriod, requestSource, mockEntityManager);
   });
 });

--- a/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/utilisation-report/event-handlers/report-uploaded/report-uploaded.event-handler.test.ts
@@ -96,7 +96,8 @@ describe('handleUtilisationReportReportUploadedEvent', () => {
     });
 
     // Assert
+    const expectedFacilityIds = new Set(allFacilityIds);
     expect(initialiseFacilityUtilisationDataSpy).toHaveBeenCalledTimes(1);
-    expect(initialiseFacilityUtilisationDataSpy).toHaveBeenCalledWith(new Set(allFacilityIds), bankId, reportPeriod, requestSource, mockEntityManager);
+    expect(initialiseFacilityUtilisationDataSpy).toHaveBeenCalledWith(expectedFacilityIds, bankId, reportPeriod, requestSource, mockEntityManager);
   });
 });


### PR DESCRIPTION
## Introduction :pencil2:
When errors were being thrown as part of the report upload on production the logs were not displaying the originating error because we were running lots of queries in parallel which caused rolling the transaction back to fail and so the surfaced error message was a generic transaction error message.

In this PR we resolve that by adding in an additional console.error of the thrown error so we can view the original error if rolling back the transaction ever fails. As well as serialising the facility utilisation data initialisation so that if an error is thrown in a similar way again the transaction will roll back happily.

To ensure serialising the queries does not have a performance hit I timed the implementation before and after these changes for the facility utilisation data initialisation:
- For a 300 row report with all newly reported on facilities (a lot more than we ever expect to actually happen):
	- before: 1119.7767919999897 milliseconds
	- after: 595.2127079998609 milliseconds
- For a 303 row report with 3 newly reported on facilities (this is a more realistic use case):
	- before: 475.7242509999778 milliseconds
	- after: 95.49562500001048 milliseconds

Overall these changes are actually a fair amount quicker and more robust.

## Resolution :heavy_check_mark:
- Add `console.error` to `executeWithSqlTransaction` error handling before attempting to rollback
- Create `FacilityUtiliastionDataEntity`s for new facilities in a for loop rather than a map so the db queries don't try and run in parallel when there is a single connection
- Refactor the SQL existence check into just one db query to make the insertion more performant

