### PR TITLE
feat(FN-3578): add record correction check the information page

### DIFF
--- a/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/check-the-information.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/check-the-information.component-test.ts
@@ -1,0 +1,162 @@
+import { aRecordCorrectionRequestInformationViewModel } from '../../../test-helpers/test-data/view-models/record-corrections/record-correction-request-information-view-model';
+import { RecordCorrectionRequestInformationViewModel } from '../../../server/types/view-models';
+import { pageRenderer } from '../../pageRenderer';
+import { aTfmSessionUser } from '../../../test-helpers';
+
+const page = '../templates/utilisation-reports/record-corrections/check-the-information.njk';
+const render = pageRenderer<RecordCorrectionRequestInformationViewModel>(page);
+
+const definitionDescriptionSelector = (definitionTerm: string) => `[data-cy="summary-list"] dt:contains("${definitionTerm}") + dd`;
+
+describe('page', () => {
+  it('should render the page heading', () => {
+    // Arrange
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      bank: { name: 'Test bank' },
+      formattedReportPeriod: 'May 2032',
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText('h1').toRead('Check the information before submitting the record correction request');
+    wrapper.expectText('span[data-cy="heading-caption"]').toRead('Test bank, May 2032');
+  });
+
+  it('should render the facility id', () => {
+    // Arrange
+    const facilityId = '0012345678';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      facilityId,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Facility ID')).toRead(facilityId);
+  });
+
+  it('should render the exporter', () => {
+    // Arrange
+    const exporter = 'Sample Company Ltd';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      exporter,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Exporter')).toRead(exporter);
+  });
+
+  it('should render the users name for the requested by field', () => {
+    // Arrange
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      user: {
+        ...aTfmSessionUser(),
+        firstName: 'Jane',
+        lastName: 'Smith',
+      },
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Requested by')).toRead('Jane Smith');
+  });
+
+  it('should render the reason for record correction', () => {
+    // Arrange
+    const reason = 'a reason';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      reasonForRecordCorrection: reason,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Reason for record correction')).toRead(reason);
+  });
+
+  it('should render the provided more information', () => {
+    // Arrange
+    const moreInformation = 'The record needs changing because of the provided reason. Please correct as per the reason.';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      moreInformation,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Provide more information')).toRead(moreInformation);
+  });
+
+  it('should render the contact email address', () => {
+    // Arrange
+    const email = 'this is my email';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      contactEmailAddress: email,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Contact email address')).toRead(email);
+  });
+
+  it('should render send request button', () => {
+    // Act
+    const wrapper = render(aRecordCorrectionRequestInformationViewModel());
+
+    // Assert
+    wrapper.expectElement('[data-cy="continue-button"]').toExist();
+    wrapper.expectText('[data-cy="continue-button"]').toRead('Send record correction request');
+  });
+
+  it('should render cancel button', () => {
+    // Arrange
+    const cancelLink = '/utilisation-reports/cancel-record-correction-request';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      cancelLink,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectSecondaryButton('[data-cy="cancel-button"]').toLinkTo(cancelLink, 'Cancel record correction request');
+  });
+
+  it('should render the back link', () => {
+    // Arrange
+    const reportId = '123';
+    const feeRecordId = '456';
+    const viewModel: RecordCorrectionRequestInformationViewModel = {
+      ...aRecordCorrectionRequestInformationViewModel(),
+      reportId,
+      feeRecordId,
+    };
+
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    const expectedHref = `/utilisation-reports/${reportId}/create-record-correction-request/${feeRecordId}`;
+    wrapper.expectLink('[data-cy="back-link"]').toLinkTo(expectedHref, 'Back');
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.test.ts
@@ -1,0 +1,46 @@
+import httpMocks from 'node-mocks-http';
+import { aTfmSessionUser } from '../../../../../test-helpers';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../../constants';
+import { getLinkToPremiumPaymentsTab } from '../../add-to-an-existing-payment/get-link-to-premium-payments-tab';
+import { getRecordCorrectionRequestInformation } from '.';
+
+describe('controllers/utilisation-reports/record-corrections/check-the-information', () => {
+  const userToken = 'user-token';
+  const user = aTfmSessionUser();
+  const requestSession = {
+    userToken,
+    user,
+  };
+
+  describe('getRecordCorrectionRequestInformation', () => {
+    it('should render check the information page', () => {
+      // Arrange
+      const reportId = '123';
+      const feeRecordId = '456';
+      const { req, res } = httpMocks.createMocks({
+        session: requestSession,
+        params: { reportId, feeRecordId: feeRecordId.toString() },
+      });
+
+      // Act
+      getRecordCorrectionRequestInformation(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toEqual('utilisation-reports/record-corrections/check-the-information.njk');
+      expect(res._getRenderData()).toEqual({
+        user,
+        activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+        bank: { name: 'Test bank' },
+        reportId,
+        feeRecordId: '456',
+        facilityId: '0012345678',
+        exporter: 'Test company',
+        formattedReportPeriod: 'July 2024',
+        reasonForRecordCorrection: 'Facility ID is incorrect',
+        moreInformation: 'The facility ID does not match the facility ID held on file',
+        contactEmailAddress: 'email address',
+        cancelLink: getLinkToPremiumPaymentsTab(reportId, [Number(feeRecordId)]),
+      });
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.ts
@@ -1,0 +1,35 @@
+import { Response, Request } from 'express';
+import { RecordCorrectionRequestInformationViewModel } from '../../../../types/view-models';
+import { asUserSession } from '../../../../helpers/express-session';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../../constants';
+import { getLinkToPremiumPaymentsTab } from '../../add-to-an-existing-payment/get-link-to-premium-payments-tab';
+
+const renderCheckTheInformationPage = (res: Response, viewModel: RecordCorrectionRequestInformationViewModel) =>
+  res.render('utilisation-reports/record-corrections/check-the-information.njk', viewModel);
+
+export const getRecordCorrectionRequestInformation = (req: Request, res: Response) => {
+  try {
+    const { reportId, feeRecordId } = req.params;
+    const { user } = asUserSession(req.session);
+
+    return renderCheckTheInformationPage(res, {
+      user,
+      activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+      bank: {
+        name: 'Test bank',
+      },
+      reportId,
+      feeRecordId,
+      facilityId: '0012345678',
+      exporter: 'Test company',
+      formattedReportPeriod: 'July 2024',
+      reasonForRecordCorrection: 'Facility ID is incorrect',
+      moreInformation: 'The facility ID does not match the facility ID held on file',
+      contactEmailAddress: 'email address',
+      cancelLink: getLinkToPremiumPaymentsTab(reportId, [Number(feeRecordId)]),
+    });
+  } catch (error) {
+    console.error('Failed to render record correction request check the information page', error);
+    return res.render('_partials/problem-with-service.njk', { user: req.session.user });
+  }
+};

--- a/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
+++ b/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
@@ -23,6 +23,7 @@ import { getConfirmDeletePayment, postConfirmDeletePayment } from '../../control
 import { postRemoveFeesFromPayment } from '../../controllers/utilisation-reports/remove-fees-from-payment';
 import { addToAnExistingPayment } from '../../controllers/utilisation-reports/add-to-an-existing-payment';
 import { createRecordCorrectionRequest } from '../../controllers/utilisation-reports/record-corrections/create-record-correction-request';
+import { getRecordCorrectionRequestInformation } from '../../controllers/utilisation-reports/record-corrections/check-the-information';
 
 export const utilisationReportsRoutes = express.Router();
 
@@ -149,4 +150,13 @@ utilisationReportsRoutes.get(
   validateSqlId('reportId'),
   validateSqlId('feeRecordId'),
   createRecordCorrectionRequest,
+);
+
+utilisationReportsRoutes.get(
+  '/:reportId/create-record-correction-request/:feeRecordId/check-the-information',
+  validateTfmFeeRecordCorrectionFeatureFlagIsEnabled,
+  validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
+  validateSqlId('reportId'),
+  validateSqlId('feeRecordId'),
+  getRecordCorrectionRequestInformation,
 );

--- a/trade-finance-manager-ui/server/types/view-models/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/index.ts
@@ -16,4 +16,4 @@ export * from './deal-cancellation/bank-request-date-view-model';
 export * from './deal-cancellation/effective-from-date-view-model';
 export * from './deal-cancellation/cancel-cancellation-view-model';
 export * from './deal-cancellation/check-details-view-model';
-export * from './record-correction/create-record-correction-request-view-model';
+export * from './record-correction';

--- a/trade-finance-manager-ui/server/types/view-models/record-correction/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/record-correction/index.ts
@@ -1,0 +1,2 @@
+export * from './create-record-correction-request-view-model';
+export * from './record-correction-request-information-view-model';

--- a/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-request-information-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-request-information-view-model.ts
@@ -1,0 +1,14 @@
+import { BaseViewModel } from '../base-view-model';
+
+export type RecordCorrectionRequestInformationViewModel = BaseViewModel & {
+  bank: { name: string };
+  formattedReportPeriod: string;
+  reportId: string;
+  feeRecordId: string;
+  facilityId: string;
+  exporter: string;
+  reasonForRecordCorrection: string;
+  moreInformation: string;
+  contactEmailAddress: string;
+  cancelLink: string;
+};

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
@@ -1,0 +1,93 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "index.njk" %}
+
+{% set backLink = { "href": "/utilisation-reports/" + reportId + "/create-record-correction-request/" + feeRecordId } %}
+
+{% block pageTitle %}Check the information before submitting the record correction request{% endblock %}
+
+{% block content %}
+  <div class="govuk-!-padding-top-7">
+      <span class="govuk-caption-l" data-cy="heading-caption">{{ bank.name }}, {{ formattedReportPeriod }}</span>
+      <h1 class="govuk-heading-l">Check the information before submitting the record correction request</h1>
+  </div>
+
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Facility ID"
+        },
+        value: {
+          text: facilityId
+        }
+      },
+      {
+        key: {
+          text: "Exporter"
+        },
+        value: {
+          text: exporter
+        }
+      },
+      {
+        key: {
+          text: "Requested by"
+        },
+        value: {
+          text: user.firstName + " " + user.lastName
+        }
+      },
+      {
+        key: {
+          text: "Reason for record correction"
+        },
+        value: {
+          text: reasonForRecordCorrection
+        }
+      },
+      {
+        key: {
+          text: "Provide more information"
+        },
+        value: {
+          text: moreInformation
+        }
+      },
+      {
+        key: {
+          text: "Contact email address"
+        },
+        value: {
+          text: contactEmailAddress
+        }
+      }
+    ],
+    attributes: { 
+      'data-cy': 'summary-list' 
+    }
+  }) }}
+
+  <form method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Send record correction request",
+        attributes: { 
+          'data-cy': 'continue-button'
+        }
+      }) }}
+
+      {{ govukButton({
+        text: "Cancel record correction request",
+        href: cancelLink,
+        classes: "govuk-button--secondary",
+        attributes: { 
+          'data-cy': 'cancel-button'
+        }
+      }) }}
+    </div>
+  </form>
+
+{% endblock %}
+{% block sub_content %}{% endblock %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/create-record-correction-request.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/create-record-correction-request.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% import "./_macros/fee-record-summary.njk" as feeRecordSummary %}
 {% extends "index.njk" %}
-{% set backLink = {"href": "/utilisation-reports/" + reportId} %}
+{% set backLink = { "href": "/utilisation-reports/" + reportId } %}
 
 {% block pageTitle %}Create record correction request{% endblock %}
 {% block content %}

--- a/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/record-correction-request-information-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/record-correction-request-information-view-model.ts
@@ -1,0 +1,18 @@
+import { PRIMARY_NAVIGATION_KEYS } from '../../../../server/constants';
+import { RecordCorrectionRequestInformationViewModel } from '../../../../server/types/view-models';
+import { aTfmSessionUser } from '../../tfm-session-user';
+
+export const aRecordCorrectionRequestInformationViewModel = (): RecordCorrectionRequestInformationViewModel => ({
+  user: aTfmSessionUser(),
+  activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+  bank: { name: 'Test bank' },
+  formattedReportPeriod: 'May 2024',
+  reportId: '123',
+  feeRecordId: '456',
+  facilityId: '12345678',
+  exporter: 'exporter name',
+  reasonForRecordCorrection: 'not valid',
+  moreInformation: 'this is some more information',
+  contactEmailAddress: 'an email',
+  cancelLink: 'a cancel link',
+});


### PR DESCRIPTION
## Introduction :pencil2:
Once the user has filled in the record correction form they need to check the information that will be sent to the bank user before sending.

## Resolution :heavy_check_mark:
- Add new route `GET utilisation-reports/:reportId/create-record-correction-request/:feeRecordId/check-the-information`
- Add controller for the new route
- Add template for create record correction request check the information screen.

## Out of scope
- For this PR we are adding hardcoded data since the work to save the form values and use them on future pages is not done yet. A second PR will follow at that time to add the real data.
- e2e-tests for the page will be added in the follow on PR linking this page to the data from the form.

