### PR TITLE
chore(FN): enable release-2.6.0 deployments to feature

### DIFF
--- a/.github/workflows/feature_deploy.yml
+++ b/.github/workflows/feature_deploy.yml
@@ -5,7 +5,7 @@ name: Feature environment deployment
 on:
   push:
     branches:
-      - main
+      - release-2.6.0
     paths:
       - 'portal/**'
       - 'portal-api/**'


### PR DESCRIPTION
## Introduction :pencil2:
Release 2.6.0 needs to be tested on feature environment. Raising a separate PR on main to prevent any overwrites from merges to main.

## Resolution :heavy_check_mark:
- Switch feature deploy to be for the release-2.6.0 branch

