### PR TITLE
feat(FN-3567): fix no-border style not applying to reported fees

### DIFF
--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/premium-payments-table-row.njk
@@ -61,12 +61,12 @@
         {{ feeRecord.facilityId }}
       </th>
       <td aria-hidden="true"
-          class="govuk-table__cell{{ "no-border" if not isLastFeeRecordInGroup }}"
+          class="govuk-table__cell{{ " no-border" if not isLastFeeRecordInGroup }}"
           data-cy="exporter">
         {{ feeRecord.exporter }}
       </td>
       <td aria-hidden="true"
-          class="govuk-table__cell govuk-table__cell--numeric{{ "no-border" if not isLastFeeRecordInGroup }}"
+          class="govuk-table__cell govuk-table__cell--numeric{{ " no-border" if not isLastFeeRecordInGroup }}"
           data-cy="reported-fees">
         {{ feeRecord.reportedFees }}
       </td>


### PR DESCRIPTION
## Introduction :pencil2:
The numeric and no-border class were not applying correctly in some cases where they should be present due to a missing space between the class names.

## Resolution :heavy_check_mark:
- Add a space before the no-border class name
