### PR TITLE
fix(FN-3631): enable deletion of payments against fees below tolerance

### DIFF
--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.test.ts
@@ -49,36 +49,24 @@ describe('handleFeeRecordPaymentDeletedEvent', () => {
     expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.DOES_NOT_MATCH);
   });
 
-  it(`sets the fee record status to ${FEE_RECORD_STATUS.TO_DO} when the event payload 'feeRecordsAndPaymentsMatch' is false and 'hasAttachedPayments' is false`, async () => {
-    // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
+  it.each([true, false])(
+    `sets the fee record status to ${FEE_RECORD_STATUS.TO_DO} when the event payload 'hasAttachedPayments' is false and 'feeRecordsAndPaymentsMatch' is %s`,
+    async (feeRecordsAndPaymentsMatch: boolean) => {
+      // Arrange
+      const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
 
-    // Act
-    await handleFeeRecordPaymentDeletedEvent(feeRecord, {
-      transactionEntityManager: mockEntityManager,
-      feeRecordsAndPaymentsMatch: false,
-      hasAttachedPayments: false,
-      requestSource: aDbRequestSource(),
-    });
-
-    // Assert
-    expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.TO_DO);
-  });
-
-  it("throws an error when the event payload 'feeRecordsAndPaymentsMatch' is true and 'hasAttachedPayments' is false", async () => {
-    // Arrange
-    const feeRecord = FeeRecordEntityMockBuilder.forReport(PENDING_RECONCILIATION_REPORT).withStatus(FEE_RECORD_STATUS.MATCH).build();
-
-    // Act / Assert
-    await expect(
-      handleFeeRecordPaymentDeletedEvent(feeRecord, {
+      // Act
+      await handleFeeRecordPaymentDeletedEvent(feeRecord, {
         transactionEntityManager: mockEntityManager,
-        feeRecordsAndPaymentsMatch: true,
+        feeRecordsAndPaymentsMatch,
         hasAttachedPayments: false,
         requestSource: aDbRequestSource(),
-      }),
-    ).rejects.toThrow(new Error('Fee records and payments cannot match when there are no attached payments'));
-  });
+      });
+
+      // Assert
+      expect(feeRecord.status).toEqual(FEE_RECORD_STATUS.TO_DO);
+    },
+  );
 
   it('updates the last updated by fields to the request source', async () => {
     // Arrange

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/payment-deleted/payment-deleted.event-handler.ts
@@ -31,10 +31,6 @@ export const handleFeeRecordPaymentDeletedEvent = async (
     return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
   }
 
-  if (feeRecordsAndPaymentsMatch) {
-    throw new Error('Fee records and payments cannot match when there are no attached payments');
-  }
-
   feeRecord.updateWithStatus({ status: FEE_RECORD_STATUS.TO_DO, requestSource });
   return await transactionEntityManager.save(FeeRecordEntity, feeRecord);
 };

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/delete-payment.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/delete-payment.spec.js
@@ -5,6 +5,7 @@ import {
   PaymentEntityMockBuilder,
   RECONCILIATION_IN_PROGRESS,
   UtilisationReportEntityMockBuilder,
+  PaymentMatchingToleranceEntityMockBuilder,
 } from '@ukef/dtfs2-common';
 import pages from '../../../pages';
 import { PDC_TEAMS } from '../../../../fixtures/teams';
@@ -40,7 +41,12 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
       .build();
 
   before(() => {
-    cy.task(NODE_TASKS.REINSERT_ZERO_THRESHOLD_PAYMENT_MATCHING_TOLERANCES);
+    cy.task(NODE_TASKS.INSERT_PAYMENT_MATCHING_TOLERANCES_INTO_DB, [
+      PaymentMatchingToleranceEntityMockBuilder.forCurrency(CURRENCY.GBP).withThreshold(1).withIsActive(true).withId(1).build(),
+      PaymentMatchingToleranceEntityMockBuilder.forCurrency(CURRENCY.EUR).withThreshold(1).withIsActive(true).withId(2).build(),
+      PaymentMatchingToleranceEntityMockBuilder.forCurrency(CURRENCY.JPY).withThreshold(1).withIsActive(true).withId(3).build(),
+      PaymentMatchingToleranceEntityMockBuilder.forCurrency(CURRENCY.USD).withThreshold(1).withIsActive(true).withId(4).build(),
+    ]);
   });
 
   beforeEach(() => {
@@ -157,6 +163,37 @@ context(`${PDC_TEAMS.PDC_RECONCILE} users can delete payments`, () => {
     const payment = aPaymentWithAmount(100);
 
     const feeRecord = aFeeRecordForReportWithAmountStatusAndPayments(report, 300, FEE_RECORD_STATUS.DOES_NOT_MATCH, [payment]);
+
+    const editPaymentUrl = `/utilisation-reports/${report.id}/edit-payment/${payment.id}`;
+
+    cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+    cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+    cy.task(NODE_TASKS.INSERT_TFM_FACILITIES_INTO_DB, getMatchingTfmFacilitiesForFeeRecords([feeRecord]));
+
+    cy.visit(`/utilisation-reports/${report.id}`);
+
+    pages.utilisationReportPage.premiumPaymentsTab.clickPaymentLink(payment.id);
+
+    cy.url().should('eq', relative(`${editPaymentUrl}?redirectTab=premium-payments`));
+
+    pages.utilisationReportEditPaymentPage.clickDeletePaymentButton();
+
+    cy.url().should('eq', relative(`${editPaymentUrl}/confirm-delete?redirectTab=premium-payments`));
+
+    pages.utilisationReportConfirmDeletePaymentPage.selectYesRadio();
+    pages.utilisationReportConfirmDeletePaymentPage.clickContinueButton();
+
+    pages.utilisationReportPage.premiumPaymentsTab.getPaymentLink(payment.id).should('not.exist');
+    cy.get('strong[data-cy="fee-record-status"]:contains("TO DO")').should('exist');
+  });
+
+  it(`allows the user to delete all payments from a fee record with reported payments below the tolerance and resets the status to '${FEE_RECORD_STATUS.TO_DO}'`, () => {
+    const report = aUtilisationReport();
+
+    const payment = aPaymentWithAmount(0.9);
+
+    // The amount here is chosen to be below the tolerance of 1
+    const feeRecord = aFeeRecordForReportWithAmountStatusAndPayments(report, 0.9, FEE_RECORD_STATUS.MATCH, [payment]);
 
     const editPaymentUrl = `/utilisation-reports/${report.id}/edit-payment/${payment.id}`;
 


### PR DESCRIPTION
## Introduction :pencil2:
Bug description: If a fee has reported payments less than the tolerance then once a payment was added, an error was being thrown when trying to delete the payment, since there was a check for matching that was not updated when tolerance's were introduced.

This PR fixes this by removing the check and always setting the status of a fee to TO_DO if it has no payments after a payment deletion.

## Resolution :heavy_check_mark:
- Remove incorrect check for error state that is actually a valid state in the system.

