### PR TITLE
feat(DTFS2-7668): add bank abc to portal

### DIFF
--- a/azure-functions/acbs-function/src/functions/acbs-amend-facility.js
+++ b/azure-functions/acbs-function/src/functions/acbs-amend-facility.js
@@ -138,23 +138,28 @@ df.app.orchestration('acbs-amend-facility', function* amendFacility(context) {
       amendments,
     });
 
+    /**
+     * TODO: DTFS2-7581
+     * Below have been disabled for release 2.4.0.
+     * Enable below two alongside with investor and fixed fee records.
+     */
     // 3. SOF: Facility Covenant Record (FCR)
-    const facilityCovenantRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-covenant-record', {
-      facilityIdentifier,
-      amendments,
-    });
+    // const facilityCovenantRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-covenant-record', {
+    //   facilityIdentifier,
+    //   amendments,
+    // });
 
     // 4. SOF: Facility Guarantee Record (FGR)
-    const facilityGuaranteeRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-guarantee-record', {
-      facilityIdentifier,
-      amendments,
-    });
+    // const facilityGuaranteeRecord = yield context.df.callSubOrchestrator('acbs-amend-facility-guarantee-record', {
+    //   facilityIdentifier,
+    //   amendments,
+    // });
 
     return {
       facilityIdentifier,
       facilityMasterRecord: facilityMasterRecord.result,
-      facilityCovenantRecord: facilityCovenantRecord.result,
-      facilityGuaranteeRecord: facilityGuaranteeRecord.result,
+      // facilityCovenantRecord: facilityCovenantRecord.result,
+      // facilityGuaranteeRecord: facilityGuaranteeRecord.result,
       facilityLoanRecord: facilityLoanRecord.result,
     };
   } catch (error) {

--- a/e2e-tests/e2e-fixtures/dateConstants.js
+++ b/e2e-tests/e2e-fixtures/dateConstants.js
@@ -39,7 +39,6 @@ export const sevenDays = getFormattedValues(add(todayDate, { days: 7 }));
 export const twentyEightDays = getFormattedValues(add(todayDate, { days: 28 }));
 export const oneMonth = getFormattedValues(add(todayDate, { months: 1 }));
 export const twoMonths = getFormattedValues(add(todayDate, { months: 2 }));
-export const threeMonthsMinusThreeDays = getFormattedValues(add(todayDate, { months: 3, days: -3 }));
 export const threeMonths = getFormattedValues(add(todayDate, { months: 3 }));
 export const threeMonthsOneDay = getFormattedValues(add(todayDate, { months: 3, days: 1 }));
 export const oneYear = getFormattedValues(add(todayDate, { years: 1 }));
@@ -59,6 +58,12 @@ export const thirtyFiveDaysAgo = getFormattedValues(sub(todayDate, { days: 35 })
 export const twelveMonthsOneDayAgo = getFormattedValues(sub(todayDate, { months: 12, days: 1 }));
 export const oneYearAgo = getFormattedValues(sub(todayDate, { years: 1 }));
 export const twoYearsAgo = getFormattedValues(sub(todayDate, { years: 2 }));
+
+// Dates calculated from other values
+/**
+ * This constant is used for calculating the deadling for issuing a facility with submission date three days ago.
+ */
+export const threeDaysAgoPlusThreeMonths = getFormattedValues(add(threeDaysAgo.date, { months: 3 }));
 
 // Times
 export const todayTimeHours = format(todayDate, TIME_HOURS_FORMAT);

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-all-AIN.spec.js
@@ -2,7 +2,7 @@ import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
 import {
   fourDaysAgo,
-  threeMonthsMinusThreeDays,
+  threeDaysAgoPlusThreeMonths,
   today,
   tomorrow,
   twoMonths,
@@ -97,7 +97,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
-import { today, twoMonths, threeDaysAgo, threeMonthsMinusThreeDays, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
+import { today, twoMonths, threeDaysAgo, threeDaysAgoPlusThreeMonths, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../../fixtures/mocks/mock-deals';
 import { multipleMockGefFacilities } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { backLink, cancelLink, continueButton, headingCaption, mainHeading, submitButton } from '../../../../partials';
@@ -80,7 +80,9 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
-import { threeDaysAgo, threeMonthsMinusThreeDays, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgo, threeDaysAgoPlusThreeMonths, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { anUnissuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -61,7 +61,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-all-AIN.spec.js
@@ -3,7 +3,7 @@ import CONSTANTS from '../../../../../fixtures/constants';
 import {
   fourDaysAgo,
   threeDaysAgo,
-  threeMonthsMinusThreeDays,
+  threeDaysAgoPlusThreeMonths,
   threeMonthsOneDay,
   threeMonths,
   today,
@@ -100,7 +100,10 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
+
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -9,7 +9,7 @@ import aboutFacilityUnissued from '../../../../pages/unissued-facilities-about-f
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import statusBanner from '../../../../pages/application-status-banner';
 import facilities from '../../../../pages/facilities';
-import { threeDaysAgo, threeMonthsMinusThreeDays, threeMonths, threeMonthsOneDay, today, twoMonths } from '../../../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgo, threeDaysAgoPlusThreeMonths, threeMonths, threeMonthsOneDay, today, twoMonths } from '../../../../../../../e2e-fixtures/dateConstants';
 
 let dealId;
 let token;
@@ -82,7 +82,10 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
+
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
-import { threeMonthsMinusThreeDays, threeDaysAgo, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgoPlusThreeMonths, threeDaysAgo, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { anUnissuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -61,7 +61,10 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
+
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/portal/cypress/e2e/journeys/homepage/content.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/homepage/content.spec.js
@@ -29,6 +29,7 @@ context('Portal homepage', () => {
     login.banks().contains('Virgin Money');
     login.banks().contains('Shawbrook Bank');
     login.banks().contains('ICICI');
+    login.banks().contains('ABC Bank');
   });
 
   it('Ensure product text is visible on the portal login page', () => {

--- a/portal/templates/_partials/before-you-start.njk
+++ b/portal/templates/_partials/before-you-start.njk
@@ -19,6 +19,7 @@
   <li>Virgin Money</li>
   <li>Shawbrook Bank</li>
   <li>ICICI</li>
+  <li>ABC Bank</li>
 </ul>
 
 <p>Guarantees are provided by UK Export Finance under the terms of the master guarantee agreement (MGA) for either the:</p>

--- a/utils/mock-data-loader/banks/index.js
+++ b/utils/mock-data-loader/banks/index.js
@@ -174,6 +174,21 @@ const MOCK_BANKS = [
     utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
     isVisibleInTfmUtilisationReports: true,
   },
+  {
+    id: '13',
+    name: 'ABC Bank',
+    mga: ['Test.pdf'],
+    emails: ['maker1@ukexportfinance.gov.uk'],
+    companiesHouseNo: '02564490',
+    partyUrn: '00313709',
+    hasGefAccessOnly: false,
+    paymentOfficerTeam: {
+      teamName: 'Payment Reporting Team',
+      emails: ['payment-officer4@ukexportfinance.gov.uk'],
+    },
+    utilisationReportPeriodSchedule: MONTHLY_REPORT_PERIOD_SCHEDULE,
+    isVisibleInTfmUtilisationReports: true,
+  },
 ];
 
 module.exports = MOCK_BANKS;


### PR DESCRIPTION
## Introduction :pencil2:
Add `ABC` to the portal and revert facility amendment guarantee and covenant record (#3918)

## Resolution :heavy_check_mark:
* Added `ABC` bank.
* Reverted commit [79c2a736c17bac27cb8e4529c96158cba28324d0](https://github.com/UK-Export-Finance/dtfs2/commit/79c2a736c17bac27cb8e4529c96158cba28324d0)
* Added https://github.com/UK-Export-Finance/dtfs2/pull/4015/commits for faulty failing tests resolution.

