### PR TITLE
chore(DTFS2-7680): update threeDaysAgoPlusThreeMonths date constant

### DIFF
--- a/e2e-tests/e2e-fixtures/dateConstants.js
+++ b/e2e-tests/e2e-fixtures/dateConstants.js
@@ -39,7 +39,6 @@ export const sevenDays = getFormattedValues(add(todayDate, { days: 7 }));
 export const twentyEightDays = getFormattedValues(add(todayDate, { days: 28 }));
 export const oneMonth = getFormattedValues(add(todayDate, { months: 1 }));
 export const twoMonths = getFormattedValues(add(todayDate, { months: 2 }));
-export const threeMonthsMinusThreeDays = getFormattedValues(add(todayDate, { months: 3, days: -3 }));
 export const threeMonths = getFormattedValues(add(todayDate, { months: 3 }));
 export const threeMonthsOneDay = getFormattedValues(add(todayDate, { months: 3, days: 1 }));
 export const oneYear = getFormattedValues(add(todayDate, { years: 1 }));
@@ -59,6 +58,12 @@ export const thirtyFiveDaysAgo = getFormattedValues(sub(todayDate, { days: 35 })
 export const twelveMonthsOneDayAgo = getFormattedValues(sub(todayDate, { months: 12, days: 1 }));
 export const oneYearAgo = getFormattedValues(sub(todayDate, { years: 1 }));
 export const twoYearsAgo = getFormattedValues(sub(todayDate, { years: 2 }));
+
+// Dates calculated from other values
+/**
+ * This constant is used for calculating the deadling for issuing a facility with submission date three days ago.
+ */
+export const threeDaysAgoPlusThreeMonths = getFormattedValues(add(threeDaysAgo.date, { months: 3 }));
 
 // Times
 export const todayTimeHours = format(todayDate, TIME_HOURS_FORMAT);

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-all-AIN.spec.js
@@ -2,7 +2,7 @@ import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
 import {
   fourDaysAgo,
-  threeMonthsMinusThreeDays,
+  threeDaysAgoPlusThreeMonths,
   today,
   tomorrow,
   twoMonths,
@@ -97,7 +97,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
-import { today, twoMonths, threeDaysAgo, threeMonthsMinusThreeDays, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
+import { today, twoMonths, threeDaysAgo, threeDaysAgoPlusThreeMonths, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../../fixtures/mocks/mock-deals';
 import { multipleMockGefFacilities } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { backLink, cancelLink, continueButton, headingCaption, mainHeading, submitButton } from '../../../../partials';
@@ -80,7 +80,9 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-disabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
-import { threeDaysAgo, threeMonthsMinusThreeDays, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgo, threeDaysAgoPlusThreeMonths, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { anUnissuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -61,7 +61,9 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-all-AIN.spec.js
@@ -3,7 +3,7 @@ import CONSTANTS from '../../../../../fixtures/constants';
 import {
   fourDaysAgo,
   threeDaysAgo,
-  threeMonthsMinusThreeDays,
+  threeDaysAgoPlusThreeMonths,
   threeMonthsOneDay,
   threeMonths,
   today,
@@ -100,7 +100,10 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
+
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -9,7 +9,7 @@ import aboutFacilityUnissued from '../../../../pages/unissued-facilities-about-f
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import statusBanner from '../../../../pages/application-status-banner';
 import facilities from '../../../../pages/facilities';
-import { threeDaysAgo, threeMonthsMinusThreeDays, threeMonths, threeMonthsOneDay, today, twoMonths } from '../../../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgo, threeDaysAgoPlusThreeMonths, threeMonths, threeMonthsOneDay, today, twoMonths } from '../../../../../../../e2e-fixtures/dateConstants';
 
 let dealId;
 let token;
@@ -82,7 +82,10 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
+
       statusBanner.applicationBanner().should('exist');
     });
 

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/facility-end-date-enabled/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../../relativeURL';
 import CONSTANTS from '../../../../../fixtures/constants';
-import { threeMonthsMinusThreeDays, threeDaysAgo, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgoPlusThreeMonths, threeDaysAgo, threeMonthsOneDay } from '../../../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_AIN } from '../../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { anUnissuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -61,7 +61,10 @@ context('Unissued Facilities AIN - change all to issued from unissued table - fe
       cy.url().should('eq', relative(`/gef/application-details/${dealId}/unissued-facilities`));
       unissuedFacilityTable.updateFacilitiesLater().contains('Update facility stage later');
       unissuedFacilityTable.rows().should('have.length', unissuedFacilitiesArray.length);
-      unissuedFacilityTable.rows().contains(threeMonthsMinusThreeDays.dd_MMM_yyyy);
+
+      const deadlineForIssuing = threeDaysAgoPlusThreeMonths.dd_MMM_yyyy;
+      unissuedFacilityTable.rows().contains(deadlineForIssuing);
+
       statusBanner.applicationBanner().should('exist');
     });
 


### PR DESCRIPTION
## Introduction :pencil2:
Unissued facilities e2e tests are failing because they arent calculating three months after the submission date correctly.

## Resolution :heavy_check_mark:
- Update threeDaysAgoPlusThreeMonths constant to calculate the date in the correct order
- Add more self-documentation to the e2e tests by assigning `deadlineForIssuing` constants


