### PR TITLE
fix(DTFS2-7647): add missing test to yml file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -957,7 +957,7 @@ jobs:
             './tfm/cypress/e2e/journeys/case-amendments/facility-end-date/feature-flag-enabled/*.spec.js',
             './tfm/cypress/e2e/journeys/case-amendments/in-progress/*.spec.js',
             './tfm/cypress/e2e/journeys/case-amendments/request-when-previously-submitted/*.spec.js',
-            './tfm/cypress/e2e/journeys/case-amendments/show-amendment-button/*.spec.js',
+            './tfm/cypress/e2e/journeys/case-amendments/show-amendment-button/**/*.spec.js',
             './tfm/cypress/e2e/journeys/case-amendments/tasks/*.spec.js',
             './tfm/cypress/e2e/journeys/case-amendments/underwriting-page-unassigned/*.spec.js',
             './tfm/cypress/e2e/journeys/case-amendments/user-flow/*.spec.js',


### PR DESCRIPTION
## Introduction :pencil2:
A test was being skipped on the pipeline due to incorrect config in the test.yml file

## Resolution :heavy_check_mark:
Fix the config in the test.yml file to pick up all the tests when the deal cancellation FF is enabled

## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

