### PR TITLE
feat(DTFS2-7616): production ready release candidate deployment

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -27,7 +27,7 @@ if [ -n "$selection" ]; then
             branch=main
         ############### FEATURE ###############
         elif [ "$destination" = "feature" ]; then
-            branch=main-application
+            branch=main
         ############### STAGING ###############
         elif [ "$destination" = "staging" ]; then
             branch=dev

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -74,7 +74,9 @@ jobs:
       - name: Environment 🧪
         id: environment
         run: |
-          if [[ "${{ env.ENVIRONMENT }}" == *release* ]]; then
+          if [[ "${{ env.ENVIRONMENT }}" =~ ^release-.*-rc$ ]]; then
+            echo "environment=prod" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ env.ENVIRONMENT }}" == *release* ]]; then
             echo "environment=staging" >> "$GITHUB_OUTPUT"
           else
             echo "environment=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -51,8 +51,6 @@ on:
     branches:
       - dev
       - feature
-      - staging
-      - prod
       - release-*
       - '!release-please*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,12 @@ on:
     branches:
       - dev
       - feature
-      - staging
-      - prod
       - release-*
+
+  create:
+    branches:
+      # Production ready release candidates
+      - release-*-rc
 
     paths:
       - '.github/workflows/deployment.yml'


### PR DESCRIPTION
## Introduction :pencil2:
Effective deployment strategy to ensrure production ready (QA passed) release branches can be deployed to production enviornment using `*-rc` as an appropriate suffix for release branch ready for production deployment.

## Resolution :heavy_check_mark:
* QAT and deployment GHA will refer to `release-*-rc` for production deployment.

## Miscellaneous :heavy_plus_sign:
* Minor updates to `deploy.sh`.

