### PR TITLE
feat(DTFS2-7616): avoid release please branches for deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ on:
       - dev
       - feature
       - release-*
+      - '!release-please*'
 
   create:
     branches:


### PR DESCRIPTION
## Introduction :pencil2:
Avoid release please branches for QAT

## Resolution :heavy_check_mark:
* Added `release-please*` branches ignore branch name.

