### PR TITLE
fix(DTFS2-7684): gov design library - update beta phase banner copy

### DIFF
--- a/e2e-tests/gef/cypress/e2e/page-header.spec.js
+++ b/e2e-tests/gef/cypress/e2e/page-header.spec.js
@@ -69,8 +69,9 @@ context('Check GEF GOVUK header displays correctly', () => {
     it('displays the beta banner correctly', () => {
       pageBanner.userName().contains(`${BANK1_MAKER1.firstname} ${BANK1_MAKER1.surname}`);
       pageBanner.betaBanner().contains('This is a new service – your feedback will help us to improve it.');
-      pageBanner.betaBanner().contains('beta');
+      cy.assertText(pageBanner.betaBannerTag(), 'Beta');
       pageBanner.betaBannerHref().contains('feedback');
+
       pageBanner
         .betaBannerHref()
         .invoke('attr', 'href')

--- a/e2e-tests/gef/cypress/e2e/pages/page-banner.js
+++ b/e2e-tests/gef/cypress/e2e/pages/page-banner.js
@@ -8,6 +8,7 @@ const pageBanner = {
   userName: () => cy.get('[data-cy="username-header"]'),
   profile: () => cy.get('[data-cy="profile-header"]'),
   betaBanner: () => cy.get('[data-cy="beta-banner"]'),
+  betaBannerTag: () => cy.get('[data-cy="beta-banner"] strong'),
   betaBannerHref: () => cy.get('[data-cy="beta-feedback-link"]'),
   logout: () => cy.get('[data-cy="logout-header"]'),
 };

--- a/e2e-tests/portal/cypress/e2e/journeys/portal-header.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/portal-header.spec.js
@@ -60,7 +60,7 @@ context('Portal GOVUK header displays correctly', () => {
 
     it('displays the beta banner correctly', () => {
       page.betaBanner().contains('This is a new service – your feedback will help us to improve it.');
-      page.betaBanner().contains('beta');
+      cy.assertText(page.betaBannerTag(), 'Beta');
       page.betaBannerHref().contains('feedback');
       page
         .betaBannerHref()

--- a/e2e-tests/portal/cypress/e2e/journeys/portal-header.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/portal-header.spec.js
@@ -112,7 +112,7 @@ context('Portal GOVUK header displays correctly', () => {
 
     it('displays the beta banner correctly', () => {
       page.betaBanner().contains('This is a new service – your feedback will help us to improve it.');
-      page.betaBanner().contains('beta');
+      cy.assertText(page.betaBannerTag(), 'Beta');
       page.betaBannerHref().contains('feedback');
       page
         .betaBannerHref()

--- a/e2e-tests/portal/cypress/e2e/pages/header.js
+++ b/e2e-tests/portal/cypress/e2e/pages/header.js
@@ -18,6 +18,7 @@ const page = {
   logoutLink: () => cy.get('[data-cy="logout-header"]'),
 
   betaBanner: () => cy.get('[data-cy="beta-banner"]'),
+  betaBannerTag: () => cy.get('[data-cy="beta-banner"] strong'),
   betaBannerHref: () => cy.get('[data-cy="beta-feedback-link"]'),
 };
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/login/login.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/login/login.spec.js
@@ -82,7 +82,7 @@ context('User can login', () => {
 
   it('displays the beta banner correctly', () => {
     header.betaBanner().contains('This is a new service – your feedback will help us to improve it.');
-    header.betaBanner().contains('beta');
+    cy.assertText(header.betaBannerTag(), 'Beta');
     header.betaBannerHref().contains('feedback');
     header
       .betaBannerHref()

--- a/e2e-tests/tfm/cypress/e2e/partials/header.js
+++ b/e2e-tests/tfm/cypress/e2e/partials/header.js
@@ -4,6 +4,7 @@ const partial = {
   ukefLogo: () => cy.get('[data-cy="header-ukef-logo"]'),
   headerName: () => cy.get('[data-cy="header-TFM-header-name"]'),
   betaBanner: () => cy.get('[data-cy="beta-banner"]'),
+  betaBannerTag: () => cy.get('[data-cy="beta-banner"] strong'),
   betaBannerHref: () => cy.get('[data-cy="beta-feedback-link"]'),
 };
 

--- a/gef-ui/templates/includes/beta-banner.njk
+++ b/gef-ui/templates/includes/beta-banner.njk
@@ -3,7 +3,7 @@
 <div class="govuk-width-container">
   {{ govukPhaseBanner({
     tag: {
-      text: "beta"
+      text: "Beta"
     },
     attributes: {
       "data-cy": "beta-banner"

--- a/gef-ui/templates/partials/application-activity.njk
+++ b/gef-ui/templates/partials/application-activity.njk
@@ -9,7 +9,7 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {{ govukPhaseBanner({
   tag: {
-    text: "beta"
+    text: "Beta"
   },
   html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
 }) }}

--- a/gef-ui/templates/partials/application-preview.njk
+++ b/gef-ui/templates/partials/application-preview.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {{ govukPhaseBanner({
   tag: {
-    text: "beta"
+    text: "Beta"
   },
   html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
 }) }}

--- a/portal/templates/_partials/beta-banner.njk
+++ b/portal/templates/_partials/beta-banner.njk
@@ -3,7 +3,7 @@
 <div class="govuk-width-container">
   {{ govukPhaseBanner({
     tag: {
-      text: "beta"
+      text: "Beta"
     },
     attributes: {
       "data-cy": "beta-banner"

--- a/trade-finance-manager-ui/templates/_partials/beta-banner.njk
+++ b/trade-finance-manager-ui/templates/_partials/beta-banner.njk
@@ -3,7 +3,7 @@
 <div class="moj-header__container">
   {{ govukPhaseBanner({
     tag: {
-      text: "beta"
+      text: "Beta"
     },
     attributes: {
       "data-cy": "beta-banner"


### PR DESCRIPTION
## Introduction :pencil2:
- GOV design library has been updated.
- The phase banner (in all UI microservices) have incorrect "beta" copy. It should render "Beta" instead of "beta".

## Resolution :heavy_check_mark:
- Update nunjucks instances of "beta".
- Update E2E tests.
