### PR TITLE
fix(DTFS2-7694): argument as an object

### DIFF
--- a/azure-functions/acbs-function/src/functions/acbs-amend-facility-master-record.js
+++ b/azure-functions/acbs-function/src/functions/acbs-amend-facility-master-record.js
@@ -60,7 +60,7 @@ df.app.orchestration('acbs-amend-facility-master-record', function* amendFacilit
     // 2.2.2 - Cover end date
     if (amendment.coverEndDate) {
       // 2.2.3. DAF : get-facility-master: Retrieve ACBS `Facility Master Record` with new eTag
-      const updatedFmr = yield context.df.callActivityWithRetry('get-facility-master', retryOptions, facilityIdentifier);
+      const updatedFmr = yield context.df.callActivityWithRetry('get-facility-master', retryOptions, { facilityIdentifier });
 
       if (updatedFmr.etag) {
         const coverEndDate = yield context.df.callActivityWithRetry('update-facility-master', retryOptions, {

--- a/azure-functions/acbs-function/src/functions/acbs-issue-facility.js
+++ b/azure-functions/acbs-function/src/functions/acbs-issue-facility.js
@@ -42,7 +42,7 @@ df.app.orchestration('acbs-issue-facility', function* issueFacility(context) {
 
     if (facilityIdentifier) {
       // 1. GET Facility master record object
-      const { acbsFacility, etag } = yield context.df.callActivityWithRetry('get-facility-master', retryOptions, facilityIdentifier);
+      const { acbsFacility, etag } = yield context.df.callActivityWithRetry('get-facility-master', retryOptions, { facilityIdentifier });
 
       if (acbsFacility && etag) {
         // 2.1. Create updated facility master record object

--- a/azure-functions/acbs-function/src/functions/activity-get-facility-loan-id.js
+++ b/azure-functions/acbs-function/src/functions/activity-get-facility-loan-id.js
@@ -32,7 +32,7 @@ const { isHttpErrorStatus } = require('../../helpers/http');
  */
 const handler = async (payload) => {
   try {
-    const { facilityId: facilityIdentifier } = payload;
+    const { facilityIdentifier } = payload;
 
     if (!facilityIdentifier) {
       throw new Error('Invalid facility ID');

--- a/azure-functions/acbs-function/src/functions/activity-get-facility-master.js
+++ b/azure-functions/acbs-function/src/functions/activity-get-facility-master.js
@@ -16,7 +16,7 @@ const { isHttpErrorStatus } = require('../../helpers/http');
  */
 const handler = async (payload) => {
   try {
-    const { facilityId: facilityIdentifier } = payload;
+    const { facilityIdentifier } = payload;
 
     if (!facilityIdentifier) {
       throw new Error('Invalid facility ID');


### PR DESCRIPTION
## Introduction :pencil2:
Facility issuance and amendments are failing due to invalid property name and argument type being supplied to DAF pertinent to extracting facility master record and facility loan identifier.

## Resolution :heavy_check_mark:
* Corrected durable activity function argument as an object.
* Removed object destructuring aliasing, since `facilityIdentifier` is the supplied property name.

