### PR TITLE
feat(DTFS2-7689): add PATCH portal amendment endpoint to dtfs-central-api

### DIFF
--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-get.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-get.api-test.ts
@@ -133,7 +133,7 @@ describe('GET /v1/portal/facilities/:facilityId/amendments/:amendmentId', () => 
       expect(status).toEqual(HttpStatusCode.NotFound);
       expect(body).toEqual({
         status: HttpStatusCode.NotFound,
-        message: `Amendment not found: ${aValidButNonExistentAmendmentId}`,
+        message: `Amendment not found: ${aValidButNonExistentAmendmentId} on facility: ${facilityId}`,
       });
     });
 

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-get.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-get.api-test.ts
@@ -67,7 +67,7 @@ describe('GET /v1/portal/facilities/:facilityId/amendments/:amendmentId', () => 
       process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
     });
 
-    it('should return 404', async () => {
+    it(`should return ${HttpStatusCode.NotFound}`, async () => {
       const { status } = (await testApi.get(generateUrl(facilityId, new ObjectId().toString()))) as FacilityAmendmentResponse;
 
       expect(status).toEqual(HttpStatusCode.NotFound);
@@ -87,7 +87,7 @@ describe('GET /v1/portal/facilities/:facilityId/amendments/:amendmentId', () => 
       process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'true';
     });
 
-    it('should return 400 when the facility id is invalid', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the facility id is invalid`, async () => {
       const anInvalidFacilityId = 'InvalidId';
 
       const { status, body } = (await testApi.get(generateUrl(anInvalidFacilityId, amendmentId))) as FacilityAmendmentResponse;
@@ -100,7 +100,7 @@ describe('GET /v1/portal/facilities/:facilityId/amendments/:amendmentId', () => 
       });
     });
 
-    it('should return 400 when the amendment id is invalid', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the amendment id is invalid`, async () => {
       const anInvalidAmendmentId = 'InvalidId';
 
       const { status, body } = (await testApi.get(generateUrl(facilityId, anInvalidAmendmentId))) as FacilityAmendmentResponse;
@@ -113,7 +113,7 @@ describe('GET /v1/portal/facilities/:facilityId/amendments/:amendmentId', () => 
       });
     });
 
-    it('should return 404 when the facility does not exist', async () => {
+    it(`should return ${HttpStatusCode.NotFound} when the facility does not exist`, async () => {
       const aValidButNonExistentFacilityId = new ObjectId().toString();
 
       const { status, body } = (await testApi.get(generateUrl(aValidButNonExistentFacilityId, amendmentId))) as FacilityAmendmentResponse;
@@ -125,7 +125,7 @@ describe('GET /v1/portal/facilities/:facilityId/amendments/:amendmentId', () => 
       });
     });
 
-    it('should return 404 when the amendment does not exist', async () => {
+    it(`should return ${HttpStatusCode.NotFound} when the amendment does not exist`, async () => {
       const aValidButNonExistentAmendmentId = new ObjectId().toString();
 
       const { status, body } = (await testApi.get(generateUrl(facilityId, aValidButNonExistentAmendmentId))) as FacilityAmendmentResponse;

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import { HttpStatusCode } from 'axios';
 import { AnyObject, API_ERROR_CODE, DEAL_SUBMISSION_TYPE, DEAL_TYPE, FACILITY_TYPE, MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
 import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { aPortalFacilityAmendmentUserValues } from '@ukef/dtfs2-common/mock-data-backend';
 import wipeDB from '../../wipeDB';
 import { testApi } from '../../test-api';
 import { createDeal, submitDealToTfm } from '../../helpers/create-deal';
@@ -10,7 +11,6 @@ import aDeal from '../deal-builder';
 import { aPortalUser } from '../../mocks/test-users/portal-user';
 import { createPortalUser } from '../../helpers/create-portal-user';
 import { createPortalFacilityAmendment } from '../../helpers/create-portal-facility-amendment';
-import { PatchPortalFacilityAmendmentPayload } from '../../../src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload';
 
 const originalEnv = { ...process.env };
 
@@ -26,10 +26,6 @@ const newDeal = aDeal({
   dealType: DEAL_TYPE.GEF,
   submissionType: DEAL_SUBMISSION_TYPE.AIN,
 }) as AnyObject;
-
-const anAmendmentUpdate = (): PatchPortalFacilityAmendmentPayload['update'] => ({
-  changeFacilityValue: true,
-});
 
 describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
   let dealId: string;
@@ -68,7 +64,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       const amendmentId = new ObjectId().toString();
 
       const { status } = await testApi
-        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId, amendmentId));
 
       expect(status).toEqual(HttpStatusCode.NotFound);
@@ -92,7 +88,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       const anInvalidFacilityId = 'InvalidId';
 
       const { body, status } = (await testApi
-        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(anInvalidFacilityId, amendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.BadRequest);
@@ -107,7 +103,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       const anInvalidAmendmentId = 'InvalidId';
 
       const { body, status } = (await testApi
-        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId, anInvalidAmendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.BadRequest);
@@ -120,7 +116,10 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
 
     it('should return 400 when the update has extra fields', async () => {
       const { body, status } = (await testApi
-        .patch({ update: { ...(anAmendmentUpdate() as AnyObject), additional: 'property' }, auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({
+          update: { ...(aPortalFacilityAmendmentUserValues() as AnyObject), additional: 'property' },
+          auditDetails: generatePortalAuditDetails(portalUserId),
+        })
         .to(generateUrl(facilityId, amendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.BadRequest);
@@ -135,7 +134,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       const aValidButNonExistentFacilityId = new ObjectId().toString();
 
       const { body, status } = (await testApi
-        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(aValidButNonExistentFacilityId, amendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.NotFound);
@@ -149,7 +148,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       const aValidButNonExistentAmendmentId = new ObjectId().toString();
 
       const { body, status } = (await testApi
-        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId, aValidButNonExistentAmendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.NotFound);
@@ -161,7 +160,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
 
     it('should return 200 when the payload is valid & the amendment exists', async () => {
       const { status } = (await testApi
-        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId, amendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.Ok);

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -140,7 +140,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       expect(status).toEqual(HttpStatusCode.NotFound);
       expect(body).toEqual({
         status: HttpStatusCode.NotFound,
-        message: `Facility not found: ${aValidButNonExistentFacilityId}`,
+        message: `Amendment not found: ${amendmentId} on facility: ${aValidButNonExistentFacilityId}`,
       });
     });
 

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -59,7 +59,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
     process.env = originalEnv;
   });
 
-  describe('with FF_PORTAL_FACILITY_AMENDMENTS_ENABLED set to `false`', () => {
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is set to `false`', () => {
     beforeAll(() => {
       process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
     });
@@ -75,7 +75,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
     });
   });
 
-  describe('with FF_PORTAL_FACILITY_AMENDMENTS_ENABLED set to `true`', () => {
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is set to `true`', () => {
     let amendmentId: string;
 
     beforeAll(() => {
@@ -120,7 +120,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
 
     it('should return 400 when the update has extra fields', async () => {
       const { body, status } = (await testApi
-        .patch({ update: { ...anAmendmentUpdate(), additional: 'property' }, auditDetails: generatePortalAuditDetails(portalUserId) })
+        .patch({ update: { ...(anAmendmentUpdate() as AnyObject), additional: 'property' }, auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId, amendmentId))) as ErrorResponse;
 
       expect(status).toEqual(HttpStatusCode.BadRequest);

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -84,7 +84,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       amendmentId = existingAmendment.amendmentId.toString();
     });
 
-    it('should return 400 when the amendment id is invalid', async () => {
+    it('should return 400 when the facility id is invalid', async () => {
       const anInvalidFacilityId = 'InvalidId';
 
       const { body, status } = (await testApi
@@ -99,7 +99,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 400 when the facility id is invalid', async () => {
+    it('should return 400 when the amendment id is invalid', async () => {
       const anInvalidAmendmentId = 'InvalidId';
 
       const { body, status } = (await testApi

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -154,7 +154,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       expect(status).toEqual(HttpStatusCode.NotFound);
       expect(body).toEqual({
         status: HttpStatusCode.NotFound,
-        message: `Facility not found: ${facilityId}`,
+        message: `Amendment not found: ${aValidButNonExistentAmendmentId} on facility: ${facilityId}`,
       });
     });
 

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -1,0 +1,170 @@
+import { Response } from 'supertest';
+import { ObjectId } from 'mongodb';
+import { HttpStatusCode } from 'axios';
+import { AnyObject, API_ERROR_CODE, DEAL_SUBMISSION_TYPE, DEAL_TYPE, FACILITY_TYPE, MONGO_DB_COLLECTIONS } from '@ukef/dtfs2-common';
+import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import wipeDB from '../../wipeDB';
+import { testApi } from '../../test-api';
+import { createDeal, submitDealToTfm } from '../../helpers/create-deal';
+import aDeal from '../deal-builder';
+import { aPortalUser } from '../../mocks/test-users/portal-user';
+import { createPortalUser } from '../../helpers/create-portal-user';
+import { createPortalFacilityAmendment } from '../../helpers/create-portal-facility-amendment';
+import { PatchPortalFacilityAmendmentPayload } from '../../../src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload';
+
+const originalEnv = { ...process.env };
+
+interface ErrorResponse extends Response {
+  body: { status?: number; message: string; code?: string };
+}
+
+const generateUrl = (facilityId: string, amendmentId: string): string => {
+  return `/v1/portal/facilities/${facilityId}/amendments/${amendmentId}`;
+};
+
+const newDeal = aDeal({
+  dealType: DEAL_TYPE.GEF,
+  submissionType: DEAL_SUBMISSION_TYPE.AIN,
+}) as AnyObject;
+
+const anAmendmentUpdate = (): PatchPortalFacilityAmendmentPayload['update'] => ({
+  changeFacilityValue: true,
+});
+
+describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
+  let dealId: string;
+  let facilityId: string;
+  let portalUserId: string;
+
+  beforeAll(async () => {
+    await wipeDB.wipe([MONGO_DB_COLLECTIONS.FACILITIES, MONGO_DB_COLLECTIONS.TFM_FACILITIES]);
+
+    portalUserId = (await createPortalUser())._id;
+  });
+
+  beforeEach(async () => {
+    const createDealResponse: { body: { _id: string } } = await createDeal({ deal: newDeal, user: aPortalUser() });
+    dealId = createDealResponse.body._id;
+
+    const createFacilityResponse: { body: { _id: string } } = await testApi
+      .post({ dealId, type: FACILITY_TYPE.CASH, hasBeenIssued: false })
+      .to('/v1/portal/gef/facilities');
+
+    facilityId = createFacilityResponse.body._id;
+
+    await submitDealToTfm({ dealId, dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, dealType: DEAL_TYPE.GEF });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('with FF_PORTAL_FACILITY_AMENDMENTS_ENABLED set to `false`', () => {
+    beforeAll(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
+    });
+
+    it('should return 404', async () => {
+      const amendmentId = new ObjectId().toString();
+
+      const { status } = await testApi
+        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(facilityId, amendmentId));
+
+      expect(status).toEqual(HttpStatusCode.NotFound);
+    });
+  });
+
+  describe('with FF_PORTAL_FACILITY_AMENDMENTS_ENABLED set to `true`', () => {
+    let amendmentId: string;
+
+    beforeAll(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'true';
+    });
+
+    beforeEach(async () => {
+      const existingAmendment = await createPortalFacilityAmendment({ facilityId, dealId, userId: portalUserId });
+
+      amendmentId = existingAmendment.amendmentId.toString();
+    });
+
+    it('should return 400 when the amendment id is invalid', async () => {
+      const anInvalidFacilityId = 'InvalidId';
+
+      const { body, status } = (await testApi
+        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(anInvalidFacilityId, amendmentId))) as ErrorResponse;
+
+      expect(status).toEqual(HttpStatusCode.BadRequest);
+
+      expect(body).toEqual({
+        message: "Expected path parameter 'facilityId' to be a valid mongo id",
+        code: API_ERROR_CODE.INVALID_MONGO_ID_PATH_PARAMETER,
+      });
+    });
+
+    it('should return 400 when the facility id is invalid', async () => {
+      const anInvalidAmendmentId = 'InvalidId';
+
+      const { body, status } = (await testApi
+        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(facilityId, anInvalidAmendmentId))) as ErrorResponse;
+
+      expect(status).toEqual(HttpStatusCode.BadRequest);
+
+      expect(body).toEqual({
+        message: "Expected path parameter 'amendmentId' to be a valid mongo id",
+        code: API_ERROR_CODE.INVALID_MONGO_ID_PATH_PARAMETER,
+      });
+    });
+
+    it('should return 400 when the update has extra fields', async () => {
+      const { body, status } = (await testApi
+        .patch({ update: { ...anAmendmentUpdate(), additional: 'property' }, auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(facilityId, amendmentId))) as ErrorResponse;
+
+      expect(status).toEqual(HttpStatusCode.BadRequest);
+      expect(body).toEqual({
+        status: HttpStatusCode.BadRequest,
+        message: ["update: Unrecognized key(s) in object: 'additional' (unrecognized_keys)"],
+        code: API_ERROR_CODE.INVALID_PAYLOAD,
+      });
+    });
+
+    it('should return 404 when the facility does not exist', async () => {
+      const aValidButNonExistentFacilityId = new ObjectId().toString();
+
+      const { body, status } = (await testApi
+        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(aValidButNonExistentFacilityId, amendmentId))) as ErrorResponse;
+
+      expect(status).toEqual(HttpStatusCode.NotFound);
+      expect(body).toEqual({
+        status: HttpStatusCode.NotFound,
+        message: `Facility not found: ${aValidButNonExistentFacilityId}`,
+      });
+    });
+
+    it('should return 404 when the amendment does not exist', async () => {
+      const aValidButNonExistentAmendmentId = new ObjectId().toString();
+
+      const { body, status } = (await testApi
+        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(facilityId, aValidButNonExistentAmendmentId))) as ErrorResponse;
+
+      expect(status).toEqual(HttpStatusCode.NotFound);
+      expect(body).toEqual({
+        status: HttpStatusCode.NotFound,
+        message: `Facility not found: ${facilityId}`,
+      });
+    });
+
+    it('should return 200 when the payload is valid & the amendment exists', async () => {
+      const { status } = (await testApi
+        .patch({ update: anAmendmentUpdate(), auditDetails: generatePortalAuditDetails(portalUserId) })
+        .to(generateUrl(facilityId, amendmentId))) as ErrorResponse;
+
+      expect(status).toEqual(HttpStatusCode.Ok);
+    });
+  });
+});

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-patch.api-test.ts
@@ -60,7 +60,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
     });
 
-    it('should return 404', async () => {
+    it(`should return ${HttpStatusCode.NotFound}`, async () => {
       const amendmentId = new ObjectId().toString();
 
       const { status } = await testApi
@@ -84,7 +84,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       amendmentId = existingAmendment.amendmentId.toString();
     });
 
-    it('should return 400 when the facility id is invalid', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the facility id is invalid`, async () => {
       const anInvalidFacilityId = 'InvalidId';
 
       const { body, status } = (await testApi
@@ -99,7 +99,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 400 when the amendment id is invalid', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the amendment id is invalid`, async () => {
       const anInvalidAmendmentId = 'InvalidId';
 
       const { body, status } = (await testApi
@@ -114,7 +114,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 400 when the update has extra fields', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the update has extra fields`, async () => {
       const { body, status } = (await testApi
         .patch({
           update: { ...(aPortalFacilityAmendmentUserValues() as AnyObject), additional: 'property' },
@@ -130,7 +130,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 404 when the facility does not exist', async () => {
+    it(`should return ${HttpStatusCode.NotFound} when the facility does not exist`, async () => {
       const aValidButNonExistentFacilityId = new ObjectId().toString();
 
       const { body, status } = (await testApi
@@ -144,7 +144,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 404 when the amendment does not exist', async () => {
+    it(`should return ${HttpStatusCode.NotFound} when the amendment does not exist`, async () => {
       const aValidButNonExistentAmendmentId = new ObjectId().toString();
 
       const { body, status } = (await testApi
@@ -158,7 +158,7 @@ describe('PATCH /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 200 when the payload is valid & the amendment exists', async () => {
+    it(`should return ${HttpStatusCode.Ok} when the payload is valid & the amendment exists`, async () => {
       const { status } = (await testApi
         .patch({ update: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId, amendmentId))) as ErrorResponse;

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-put.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-put.api-test.ts
@@ -147,7 +147,7 @@ describe('PUT /v1/portal/facilities/:facilityId/amendments/', () => {
       expect(getExistingAmendmentResponse.status).toEqual(HttpStatusCode.NotFound);
       expect(getExistingAmendmentResponse.body).toEqual({
         status: HttpStatusCode.NotFound,
-        message: `Amendment not found: ${existingAmendmentId}`,
+        message: `Amendment not found: ${existingAmendmentId} on facility: ${facilityId}`,
       });
     });
   });

--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-put.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-put.api-test.ts
@@ -60,7 +60,7 @@ describe('PUT /v1/portal/facilities/:facilityId/amendments/', () => {
       process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
     });
 
-    it('should return 404', async () => {
+    it(`should return ${HttpStatusCode.NotFound}`, async () => {
       const { status } = (await testApi
         .put({ dealId, amendment: aPortalFacilityAmendmentUserValues(), auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId))) as FacilityAmendmentResponse;
@@ -74,7 +74,7 @@ describe('PUT /v1/portal/facilities/:facilityId/amendments/', () => {
       process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'true';
     });
 
-    it('should return 400 when the facility id is invalid', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the facility id is invalid`, async () => {
       const anInvalidFacilityId = 'InvalidId';
 
       const { body, status } = (await testApi
@@ -89,7 +89,7 @@ describe('PUT /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 404 when the facility does not exist', async () => {
+    it(`should return ${HttpStatusCode.NotFound} when the facility does not exist`, async () => {
       const aValidButNonExistentFacilityId = new ObjectId().toString();
 
       const { body, status } = (await testApi
@@ -103,7 +103,7 @@ describe('PUT /v1/portal/facilities/:facilityId/amendments/', () => {
       });
     });
 
-    it('should return 400 when the payload has extra fields', async () => {
+    it(`should return ${HttpStatusCode.BadRequest} when the payload has extra fields`, async () => {
       const { body, status } = (await testApi
         .put({ dealId, amendment: { extraField: 'This field should not exist' }, auditDetails: generatePortalAuditDetails(portalUserId) })
         .to(generateUrl(facilityId))) as FacilityAmendmentResponse;

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -6,6 +6,7 @@ import {
   FacilityAmendment,
   AmendmentStatus,
   FacilityNotFoundError,
+  AmendmentNotFoundError,
   AMENDMENT_TYPES,
   AMENDMENT_STATUS,
   PortalFacilityAmendment,
@@ -391,7 +392,7 @@ export class TfmFacilitiesRepo {
     const updateResult = await collection.updateOne(findFilter, updateFilter);
 
     if (updateResult.modifiedCount === 0) {
-      throw new FacilityNotFoundError(facilityId.toString());
+      throw new AmendmentNotFoundError(amendmentId.toString(), facilityId.toString());
     }
 
     return updateResult;

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -311,7 +311,7 @@ export class TfmFacilitiesRepo {
   }
 
   /**
-   * Upserts a draft amendment for a portal facility in the database.
+   * Upserts a portal draft amendment for a facility in the database.
    *
    * This function first removes any existing portal amendments for the specified facility
    * that are not completed, and then inserts the new amendment.
@@ -352,6 +352,19 @@ export class TfmFacilitiesRepo {
     return updateResult;
   }
 
+  /**
+   * Updates a portal amendment for a facility in the database.
+   *
+   * This function finds the facility and portal amendment matching the ids & updates it.
+   *
+   * @param updatePortalFacilityAmendmentByAmendmentIdParams
+   * @param updatePortalFacilityAmendmentByAmendmentIdParams.amendmentId - the amendment id
+   * @param updatePortalFacilityAmendmentByAmendmentIdParams.facilityId - the facility id
+   * @param updatePortalFacilityAmendmentByAmendmentIdParams.update - the update to apply
+   * @param updatePortalFacilityAmendmentByAmendmentIdParams.auditDetails - the users audit details
+   *
+   * @returns The update result.
+   */
   public static async updatePortalFacilityAmendmentByAmendmentId({
     amendmentId,
     facilityId,

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -373,8 +373,8 @@ export class TfmFacilitiesRepo {
     auditDetails,
   }: {
     update: Partial<PortalFacilityAmendment>;
-    amendmentId: string | ObjectId;
-    facilityId: string | ObjectId;
+    amendmentId: ObjectId;
+    facilityId: ObjectId;
     auditDetails: AuditDetails;
   }): Promise<UpdateResult> {
     const collection = await this.getCollection();

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.updatePortalFacilityAmendmentByAmendmentId.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.updatePortalFacilityAmendmentByAmendmentId.test.ts
@@ -1,6 +1,6 @@
 import { ObjectId, UpdateResult } from 'mongodb';
 import { flatten } from 'mongo-dot-notation';
-import { MONGO_DB_COLLECTIONS, FacilityNotFoundError, AMENDMENT_TYPES } from '@ukef/dtfs2-common';
+import { MONGO_DB_COLLECTIONS, AMENDMENT_TYPES, AmendmentNotFoundError } from '@ukef/dtfs2-common';
 import { generateAuditDatabaseRecordFromAuditDetails, generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { TfmFacilitiesRepo } from './tfm-facilities.repo';
 import { mongoDbClient } from '../../drivers/db-client';
@@ -83,13 +83,13 @@ describe('TfmFacilitiesRepo', () => {
       expect(response).toEqual(mockUpdateResult);
     });
 
-    it('should throw a FacilityNotFoundError if no documents are matched', async () => {
+    it('should throw an AmendmentNotFoundError if no documents are matched', async () => {
       // Arrange
       mockUpdateOne.mockResolvedValue({ ...mockUpdateResult, modifiedCount: 0 });
 
       // Act + Assert
       await expect(() => TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update, auditDetails })).rejects.toThrow(
-        FacilityNotFoundError,
+        AmendmentNotFoundError,
       );
     });
   });

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.updatePortalFacilityAmendmentByAmendmentId.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.updatePortalFacilityAmendmentByAmendmentId.test.ts
@@ -1,0 +1,96 @@
+import { ObjectId, UpdateResult } from 'mongodb';
+import { flatten } from 'mongo-dot-notation';
+import { MONGO_DB_COLLECTIONS, FacilityNotFoundError, AMENDMENT_TYPES } from '@ukef/dtfs2-common';
+import { generateAuditDatabaseRecordFromAuditDetails, generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { TfmFacilitiesRepo } from './tfm-facilities.repo';
+import { mongoDbClient } from '../../drivers/db-client';
+import { aPortalUser } from '../../../test-helpers';
+
+const mockGetCollection = jest.fn();
+const mockUpdateOne = jest.fn() as jest.Mock<Promise<UpdateResult>>;
+
+const facilityId = new ObjectId();
+
+const update = {
+  changeFacilityValue: true,
+};
+const amendmentId = new ObjectId().toString();
+const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
+
+const mockUpdateResult = {
+  modifiedCount: 1,
+  acknowledged: true,
+  upsertedId: facilityId,
+  matchedCount: 1,
+  upsertedCount: 1,
+};
+
+describe('TfmFacilitiesRepo', () => {
+  describe('updatePortalFacilityAmendmentByAmendmentId', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      jest.spyOn(mongoDbClient, 'getCollection').mockImplementation(mockGetCollection);
+      mockGetCollection.mockResolvedValue({
+        updateOne: mockUpdateOne,
+      });
+
+      mockUpdateOne.mockResolvedValue(mockUpdateResult);
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    it(`should call getCollection with ${MONGO_DB_COLLECTIONS.TFM_FACILITIES}`, async () => {
+      // Act
+      await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update, auditDetails });
+
+      // Assert
+      expect(mockGetCollection).toHaveBeenCalledTimes(1);
+      expect(mockGetCollection).toHaveBeenCalledWith(MONGO_DB_COLLECTIONS.TFM_FACILITIES);
+    });
+
+    it(`should call updateOne with the correct parameters`, async () => {
+      // Act
+      await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update, auditDetails });
+
+      // Assert
+
+      const expectedFindFilter = {
+        _id: { $eq: new ObjectId(facilityId) },
+        amendments: { $elemMatch: { amendmentId: { $eq: new ObjectId(amendmentId) }, type: AMENDMENT_TYPES.PORTAL } },
+      };
+
+      const expectedUpdateFilter = flatten({
+        'amendments.$': update,
+        auditRecord: generateAuditDatabaseRecordFromAuditDetails(auditDetails),
+      });
+
+      expect(mockUpdateOne).toHaveBeenCalledTimes(1);
+      expect(mockUpdateOne).toHaveBeenCalledWith(expectedFindFilter, expectedUpdateFilter);
+    });
+
+    it(`should return the updateResult`, async () => {
+      // Act
+      const response = await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update, auditDetails });
+
+      // Assert
+      expect(response).toEqual(mockUpdateResult);
+    });
+
+    it('should throw a FacilityNotFoundError if no documents are matched', async () => {
+      // Arrange
+      mockUpdateOne.mockResolvedValue({ ...mockUpdateResult, modifiedCount: 0 });
+
+      // Act + Assert
+      await expect(() => TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update, auditDetails })).rejects.toThrow(
+        FacilityNotFoundError,
+      );
+    });
+  });
+});

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.updatePortalFacilityAmendmentByAmendmentId.test.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.updatePortalFacilityAmendmentByAmendmentId.test.ts
@@ -14,7 +14,7 @@ const facilityId = new ObjectId();
 const update = {
   changeFacilityValue: true,
 };
-const amendmentId = new ObjectId().toString();
+const amendmentId = new ObjectId();
 const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
 
 const mockUpdateResult = {

--- a/dtfs-central-api/src/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.service.ts
@@ -68,8 +68,6 @@ export class PortalFacilityAmendmentService {
     const amendmentUpdate: Partial<PortalFacilityAmendment> = {
       ...update,
       updatedAt: getUnixTime(new Date()),
-      facilityEndDate: update.facilityEndDate ? fromUnixTime(update.facilityEndDate) : undefined,
-      bankReviewDate: update.bankReviewDate ? fromUnixTime(update.bankReviewDate) : undefined,
     };
 
     await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update: amendmentUpdate, auditDetails });

--- a/dtfs-central-api/src/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.service.ts
@@ -1,10 +1,15 @@
-import { AMENDMENT_STATUS, AMENDMENT_TYPES, InvalidAuditDetailsError, PortalAuditDetails, PortalFacilityAmendment } from '@ukef/dtfs2-common';
+import {
+  AMENDMENT_STATUS,
+  AMENDMENT_TYPES,
+  InvalidAuditDetailsError,
+  PortalAuditDetails,
+  PortalFacilityAmendment,
+  PortalFacilityAmendmentUserValues,
+} from '@ukef/dtfs2-common';
 import { ObjectId } from 'mongodb';
 import { getUnixTime } from 'date-fns';
 import { findOneUser } from '../../v1/controllers/user/get-user.controller';
 import { TfmFacilitiesRepo } from '../../repositories/tfm-facilities-repo';
-import { PutPortalFacilityAmendmentPayload } from '../../v1/routes/middleware/payload-validation/validate-put-portal-facility-amendment-payload';
-import { PatchPortalFacilityAmendmentPayload } from '../../v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload';
 
 export class PortalFacilityAmendmentService {
   /**
@@ -24,7 +29,7 @@ export class PortalFacilityAmendmentService {
   }: {
     dealId: string;
     facilityId: string;
-    amendment: PutPortalFacilityAmendmentPayload['amendment'];
+    amendment: PortalFacilityAmendmentUserValues;
     auditDetails: PortalAuditDetails;
   }): Promise<PortalFacilityAmendment> {
     const user = await findOneUser(auditDetails.id);
@@ -54,6 +59,16 @@ export class PortalFacilityAmendmentService {
     return amendmentToInsert;
   }
 
+  /**
+   * Updates a portal facility amendment with the provided details.
+   *
+   * @param params
+   * @param params.amendmentId - The amendment id
+   * @param params.facilityId - The facility id
+   * @param params.update - The update payload for the amendment.
+   * @param params.auditDetails - The audit details for the update operation.
+   * @returns A promise that resolves when the update operation is complete.
+   */
   public static async updatePortalFacilityAmendment({
     amendmentId,
     facilityId,
@@ -62,7 +77,7 @@ export class PortalFacilityAmendmentService {
   }: {
     amendmentId: string;
     facilityId: string;
-    update: PatchPortalFacilityAmendmentPayload['update'];
+    update: PortalFacilityAmendmentUserValues;
     auditDetails: PortalAuditDetails;
   }): Promise<void> {
     const amendmentUpdate: Partial<PortalFacilityAmendment> = {

--- a/dtfs-central-api/src/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.service.ts
@@ -4,6 +4,7 @@ import { getUnixTime } from 'date-fns';
 import { findOneUser } from '../../v1/controllers/user/get-user.controller';
 import { TfmFacilitiesRepo } from '../../repositories/tfm-facilities-repo';
 import { PutPortalFacilityAmendmentPayload } from '../../v1/routes/middleware/payload-validation/validate-put-portal-facility-amendment-payload';
+import { PatchPortalFacilityAmendmentPayload } from '../../v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload';
 
 export class PortalFacilityAmendmentService {
   /**
@@ -51,5 +52,26 @@ export class PortalFacilityAmendmentService {
     await TfmFacilitiesRepo.upsertPortalFacilityAmendmentDraft(amendmentToInsert, auditDetails);
 
     return amendmentToInsert;
+  }
+
+  public static async updatePortalFacilityAmendment({
+    amendmentId,
+    facilityId,
+    update,
+    auditDetails,
+  }: {
+    amendmentId: string;
+    facilityId: string;
+    update: PatchPortalFacilityAmendmentPayload['update'];
+    auditDetails: PortalAuditDetails;
+  }): Promise<void> {
+    const amendmentUpdate: Partial<PortalFacilityAmendment> = {
+      ...update,
+      updatedAt: getUnixTime(new Date()),
+      facilityEndDate: update.facilityEndDate ? fromUnixTime(update.facilityEndDate) : undefined,
+      bankReviewDate: update.bankReviewDate ? fromUnixTime(update.bankReviewDate) : undefined,
+    };
+
+    await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update: amendmentUpdate, auditDetails });
   }
 }

--- a/dtfs-central-api/src/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.service.ts
@@ -85,6 +85,11 @@ export class PortalFacilityAmendmentService {
       updatedAt: getUnixTime(new Date()),
     };
 
-    await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({ amendmentId, facilityId, update: amendmentUpdate, auditDetails });
+    await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({
+      amendmentId: new ObjectId(amendmentId),
+      facilityId: new ObjectId(facilityId),
+      update: amendmentUpdate,
+      auditDetails,
+    });
   }
 }

--- a/dtfs-central-api/src/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.service.ts
@@ -1,13 +1,13 @@
 import {
   AMENDMENT_STATUS,
   AMENDMENT_TYPES,
+  getUnixTimestampSeconds,
   InvalidAuditDetailsError,
   PortalAuditDetails,
   PortalFacilityAmendment,
   PortalFacilityAmendmentUserValues,
 } from '@ukef/dtfs2-common';
 import { ObjectId } from 'mongodb';
-import { getUnixTime } from 'date-fns';
 import { findOneUser } from '../../v1/controllers/user/get-user.controller';
 import { TfmFacilitiesRepo } from '../../repositories/tfm-facilities-repo';
 
@@ -45,8 +45,8 @@ export class PortalFacilityAmendmentService {
       amendmentId: new ObjectId(),
       type: AMENDMENT_TYPES.PORTAL,
       status: AMENDMENT_STATUS.IN_PROGRESS,
-      createdAt: getUnixTime(new Date()),
-      updatedAt: getUnixTime(new Date()),
+      createdAt: getUnixTimestampSeconds(new Date()),
+      updatedAt: getUnixTimestampSeconds(new Date()),
       createdBy: {
         username: user.username,
         name: `${user.firstname} ${user.surname}`,
@@ -82,7 +82,7 @@ export class PortalFacilityAmendmentService {
   }): Promise<void> {
     const amendmentUpdate: Partial<PortalFacilityAmendment> = {
       ...update,
-      updatedAt: getUnixTime(new Date()),
+      updatedAt: getUnixTimestampSeconds(new Date()),
     };
 
     await TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId({

--- a/dtfs-central-api/src/services/portal/facility-amendment.updatePortalFacilityAmendment.service.test.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.updatePortalFacilityAmendment.service.test.ts
@@ -14,12 +14,12 @@ import { TfmFacilitiesRepo } from '../../repositories/tfm-facilities-repo';
 
 const mockUpdatePortalFacilityAmendmentByAmendmentId = jest.fn();
 
-const facilityEndDate = new Date(2030, 1, 1);
-
 const amendmentId = new ObjectId().toString();
 const facilityId = new ObjectId().toString();
 const update = {
-  facilityEndDate: getUnixTime(facilityEndDate),
+  changeCoverStartDate: true,
+  isUsingFacilityEndDate: true,
+  facilityEndDate: new Date(),
 };
 const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
 
@@ -53,7 +53,7 @@ describe('PortalFacilityAmendmentService', () => {
 
       // Assert
       const expectedUpdate = {
-        facilityEndDate,
+        ...update,
         updatedAt: getUnixTime(new Date()),
       };
 

--- a/dtfs-central-api/src/services/portal/facility-amendment.updatePortalFacilityAmendment.service.test.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.updatePortalFacilityAmendment.service.test.ts
@@ -1,0 +1,64 @@
+/* eslint-disable import/first */
+const mockFindOneUser = jest.fn();
+
+jest.mock('../../v1/controllers/user/get-user.controller', () => ({
+  findOneUser: mockFindOneUser,
+}));
+
+import { ObjectId } from 'mongodb';
+import { getUnixTime } from 'date-fns';
+import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { PortalFacilityAmendmentService } from './facility-amendment.service';
+import { aPortalUser } from '../../../test-helpers';
+import { TfmFacilitiesRepo } from '../../repositories/tfm-facilities-repo';
+
+const mockUpdatePortalFacilityAmendmentByAmendmentId = jest.fn();
+
+const facilityEndDate = new Date(2030, 1, 1);
+
+const amendmentId = new ObjectId().toString();
+const facilityId = new ObjectId().toString();
+const update = {
+  facilityEndDate: getUnixTime(facilityEndDate),
+};
+const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
+
+describe('PortalFacilityAmendmentService', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    jest.spyOn(TfmFacilitiesRepo, 'updatePortalFacilityAmendmentByAmendmentId').mockImplementation(mockUpdatePortalFacilityAmendmentByAmendmentId);
+
+    mockFindOneUser.mockResolvedValue(aPortalUser());
+    mockUpdatePortalFacilityAmendmentByAmendmentId.mockResolvedValue({});
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe('updatePortalFacilityAmendment', () => {
+    it('should call TfmFacilitiesRepo.updatePortalFacilityAmendmentByAmendmentId with correct params', async () => {
+      // Act
+      await PortalFacilityAmendmentService.updatePortalFacilityAmendment({
+        amendmentId,
+        facilityId,
+        update,
+        auditDetails,
+      });
+
+      // Assert
+      const expectedUpdate = {
+        facilityEndDate,
+        updatedAt: getUnixTime(new Date()),
+      };
+
+      expect(mockUpdatePortalFacilityAmendmentByAmendmentId).toHaveBeenCalledTimes(1);
+      expect(mockUpdatePortalFacilityAmendmentByAmendmentId).toHaveBeenCalledWith({ update: expectedUpdate, facilityId, amendmentId, auditDetails });
+    });
+  });
+});

--- a/dtfs-central-api/src/services/portal/facility-amendment.updatePortalFacilityAmendment.service.test.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.updatePortalFacilityAmendment.service.test.ts
@@ -58,7 +58,12 @@ describe('PortalFacilityAmendmentService', () => {
       };
 
       expect(mockUpdatePortalFacilityAmendmentByAmendmentId).toHaveBeenCalledTimes(1);
-      expect(mockUpdatePortalFacilityAmendmentByAmendmentId).toHaveBeenCalledWith({ update: expectedUpdate, facilityId, amendmentId, auditDetails });
+      expect(mockUpdatePortalFacilityAmendmentByAmendmentId).toHaveBeenCalledWith({
+        update: expectedUpdate,
+        facilityId: new ObjectId(facilityId),
+        amendmentId: new ObjectId(amendmentId),
+        auditDetails,
+      });
     });
   });
 });

--- a/dtfs-central-api/src/services/portal/facility-amendment.upsertPortalFacilityAmendmentDraft.service.test.ts
+++ b/dtfs-central-api/src/services/portal/facility-amendment.upsertPortalFacilityAmendmentDraft.service.test.ts
@@ -36,6 +36,10 @@ describe('PortalFacilityAmendmentService', () => {
     mockUpsertPortalFacilityAmendmentDraft.mockResolvedValue({});
   });
 
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   describe('upsertPortalFacilityAmendmentDraft', () => {
     it('should call findOneUser with auditDetails.id', async () => {
       // Act

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-amendment.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-amendment.controller.ts
@@ -1,4 +1,4 @@
-import { AMENDMENT_TYPES, ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { AMENDMENT_TYPES, AmendmentNotFoundError, ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { Response } from 'express';
 import { TfmFacilitiesRepo } from '../../../../repositories/tfm-facilities-repo';
@@ -18,7 +18,7 @@ export const getAmendment = async (req: GetAmendmentRequest, res: Response) => {
     const amendment = await TfmFacilitiesRepo.findOneAmendmentByFacilityIdAndAmendmentId(facilityId, amendmentId);
 
     if (!amendment || amendment.type !== AMENDMENT_TYPES.PORTAL) {
-      return res.status(HttpStatusCode.NotFound).send({ status: HttpStatusCode.NotFound, message: `Amendment not found: ${amendmentId}` });
+      throw new AmendmentNotFoundError(amendmentId, facilityId);
     }
 
     return res.status(HttpStatusCode.Ok).send(amendment);

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-amendment.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-amendment.controller.ts
@@ -17,7 +17,7 @@ export const getAmendment = async (req: GetAmendmentRequest, res: Response) => {
   try {
     const amendment = await TfmFacilitiesRepo.findOneAmendmentByFacilityIdAndAmendmentId(facilityId, amendmentId);
 
-    if (!amendment || amendment.type !== AMENDMENT_TYPES.PORTAL) {
+    if (amendment?.type !== AMENDMENT_TYPES.PORTAL) {
       throw new AmendmentNotFoundError(amendmentId, facilityId);
     }
 

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-amendment.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-amendment.controller.ts
@@ -23,12 +23,12 @@ export const getAmendment = async (req: GetAmendmentRequest, res: Response) => {
 
     return res.status(HttpStatusCode.Ok).send(amendment);
   } catch (error) {
+    console.error(`Error getting amendment with facilityId ${facilityId} and amendment id ${amendmentId}: %o`, error);
+
     if (error instanceof ApiError) {
       const { status, message, code } = error;
       return res.status(status).send({ status, message, code });
     }
-
-    console.error(`Error getting amendment with facilityId ${facilityId} and amendment id ${amendmentId}: %o`, error);
 
     return res.status(HttpStatusCode.InternalServerError).send({
       status: HttpStatusCode.InternalServerError,

--- a/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
@@ -1,21 +1,19 @@
 import { createMocks } from 'node-mocks-http';
-import { API_ERROR_CODE, TestApiError } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
+import { API_ERROR_CODE, TestApiError } from '@ukef/dtfs2-common';
 import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { aPortalFacilityAmendmentUserValues } from '@ukef/dtfs2-common/mock-data-backend';
 import { aPortalUser } from '../../../../../test-helpers';
 import { PortalFacilityAmendmentService } from '../../../../services/portal/facility-amendment.service';
 import { patchAmendment, PatchAmendmentRequest } from './patch-amendment.controller';
 
 const facilityId = 'facilityId';
 const amendmentId = 'amendmentId';
-const update = {
-  changeFacilityValue: true,
-};
 
 const mockUpdatePortalFacilityAmendment = jest.fn();
 
 const generateHttpMocks = ({ auditDetails }: { auditDetails: unknown }) =>
-  createMocks<PatchAmendmentRequest>({ params: { facilityId, amendmentId }, body: { auditDetails, update } });
+  createMocks<PatchAmendmentRequest>({ params: { facilityId, amendmentId }, body: { auditDetails, update: aPortalFacilityAmendmentUserValues() } });
 
 describe('patchAmendment', () => {
   beforeEach(() => {
@@ -55,7 +53,7 @@ describe('patchAmendment', () => {
     expect(mockUpdatePortalFacilityAmendment).toHaveBeenCalledWith({
       amendmentId,
       facilityId,
-      update,
+      update: req.body.update,
       auditDetails,
     });
   });

--- a/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
@@ -76,7 +76,7 @@ describe('patchAmendment', () => {
     // Arrange
     const status = HttpStatusCode.Forbidden;
     const message = 'Test error message';
-    mockUpdatePortalFacilityAmendment.mockRejectedValue(new TestApiError(status, message));
+    mockUpdatePortalFacilityAmendment.mockRejectedValue(new TestApiError({ status, message }));
 
     const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
     const { req, res } = generateHttpMocks({ auditDetails });

--- a/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
@@ -1,0 +1,113 @@
+import { createMocks } from 'node-mocks-http';
+import { API_ERROR_CODE, TestApiError } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { aPortalUser } from '../../../../../test-helpers';
+import { PortalFacilityAmendmentService } from '../../../../services/portal/facility-amendment.service';
+import { patchAmendment, PatchAmendmentRequest } from './patch-amendment.controller';
+
+const facilityId = 'facilityId';
+const amendmentId = 'amendmentId';
+const update = {
+  changeFacilityValue: true,
+};
+
+const mockUpdatePortalFacilityAmendment = jest.fn();
+
+const generateHttpMocks = ({ auditDetails }: { auditDetails: unknown }) =>
+  createMocks<PatchAmendmentRequest>({ params: { facilityId, amendmentId }, body: { auditDetails, update } });
+
+describe('patchAmendment', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    jest.spyOn(PortalFacilityAmendmentService, 'updatePortalFacilityAmendment').mockImplementation(mockUpdatePortalFacilityAmendment);
+  });
+
+  it('should return 400 if the audit details are invalid', async () => {
+    // Arrange
+    const auditDetails = { type: 'not a type' };
+    const { req, res } = generateHttpMocks({ auditDetails });
+
+    // Act
+    await patchAmendment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._getData()).toEqual({
+      status: HttpStatusCode.BadRequest,
+      message: "Supplied auditDetails must contain a 'userType' property",
+      code: API_ERROR_CODE.INVALID_AUDIT_DETAILS,
+    });
+  });
+
+  it('should call PortalFacilityAmendmentService.updatePortalFacilityAmendment with the correct params', async () => {
+    // Arrange
+    const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
+    const { req, res } = generateHttpMocks({ auditDetails });
+
+    // Act
+    await patchAmendment(req, res);
+
+    // Assert
+
+    expect(mockUpdatePortalFacilityAmendment).toHaveBeenCalledTimes(1);
+    expect(mockUpdatePortalFacilityAmendment).toHaveBeenCalledWith({
+      amendmentId,
+      facilityId,
+      update,
+      auditDetails,
+    });
+  });
+
+  it('should return 200', async () => {
+    // Arrange
+    const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
+    const { req, res } = generateHttpMocks({ auditDetails });
+
+    // Act
+    await patchAmendment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+  });
+
+  it('should return the correct status and body if PortalFacilityAmendmentService.updatePortalFacilityAmendment throws an api error', async () => {
+    // Arrange
+    const status = HttpStatusCode.Forbidden;
+    const message = 'Test error message';
+    mockUpdatePortalFacilityAmendment.mockRejectedValue(new TestApiError(status, message));
+
+    const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
+    const { req, res } = generateHttpMocks({ auditDetails });
+
+    // Act
+    await patchAmendment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(status);
+    expect(res._getData()).toEqual({
+      status,
+      message,
+    });
+  });
+
+  it('should return 500 if PortalFacilityAmendmentService.updatePortalFacilityAmendment throws an unknown error', async () => {
+    // Arrange
+    const message = 'Test error message';
+    mockUpdatePortalFacilityAmendment.mockRejectedValue(new Error(message));
+
+    const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
+    const { req, res } = generateHttpMocks({ auditDetails });
+
+    // Act
+    await patchAmendment(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._getData()).toEqual({
+      status: HttpStatusCode.InternalServerError,
+      message: 'Unknown error occurred when updating amendment',
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.test.ts
@@ -22,7 +22,7 @@ describe('patchAmendment', () => {
     jest.spyOn(PortalFacilityAmendmentService, 'updatePortalFacilityAmendment').mockImplementation(mockUpdatePortalFacilityAmendment);
   });
 
-  it('should return 400 if the audit details are invalid', async () => {
+  it(`should return ${HttpStatusCode.BadRequest} if the audit details are invalid`, async () => {
     // Arrange
     const auditDetails = { type: 'not a type' };
     const { req, res } = generateHttpMocks({ auditDetails });
@@ -58,7 +58,7 @@ describe('patchAmendment', () => {
     });
   });
 
-  it('should return 200', async () => {
+  it(`should return ${HttpStatusCode.Ok}`, async () => {
     // Arrange
     const auditDetails = generatePortalAuditDetails(aPortalUser()._id);
     const { req, res } = generateHttpMocks({ auditDetails });
@@ -90,7 +90,7 @@ describe('patchAmendment', () => {
     });
   });
 
-  it('should return 500 if PortalFacilityAmendmentService.updatePortalFacilityAmendment throws an unknown error', async () => {
+  it(`should return ${HttpStatusCode.InternalServerError} if PortalFacilityAmendmentService.updatePortalFacilityAmendment throws an unknown error`, async () => {
     // Arrange
     const message = 'Test error message';
     mockUpdatePortalFacilityAmendment.mockRejectedValue(new Error(message));

--- a/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.ts
@@ -1,0 +1,39 @@
+import { ApiError, AUDIT_USER_TYPES, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { Response } from 'express';
+import { validateAuditDetailsAndUserType } from '@ukef/dtfs2-common/change-stream';
+import { PortalFacilityAmendmentService } from '../../../../services/portal/facility-amendment.service';
+import { PatchPortalFacilityAmendmentPayload } from '../../../routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload';
+
+type PatchAmendmentRequestParams = { facilityId: string; amendmentId: string };
+export type PatchAmendmentRequest = CustomExpressRequest<{ params: PatchAmendmentRequestParams; reqBody: PatchPortalFacilityAmendmentPayload }>;
+
+/**
+ * patch portal facility amendment
+ * @param req - request
+ * @param res - response
+ */
+export const patchAmendment = async (req: PatchAmendmentRequest, res: Response) => {
+  const { facilityId, amendmentId } = req.params;
+  const { auditDetails, update } = req.body;
+
+  try {
+    validateAuditDetailsAndUserType(auditDetails, AUDIT_USER_TYPES.PORTAL);
+
+    await PortalFacilityAmendmentService.updatePortalFacilityAmendment({ amendmentId, facilityId, update, auditDetails });
+
+    return res.sendStatus(HttpStatusCode.Ok);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const { status, message, code } = error;
+      return res.status(status).send({ status, message, code });
+    }
+
+    console.error(`Error updating amendment with id ${amendmentId} on facilityId ${facilityId}: %o`, error);
+
+    return res.status(HttpStatusCode.InternalServerError).send({
+      status: HttpStatusCode.InternalServerError,
+      message: 'Unknown error occurred when updating amendment',
+    });
+  }
+};

--- a/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/patch-amendment.controller.ts
@@ -29,7 +29,7 @@ export const patchAmendment = async (req: PatchAmendmentRequest, res: Response) 
       return res.status(status).send({ status, message, code });
     }
 
-    console.error(`Error updating amendment with id ${amendmentId} on facilityId ${facilityId}: %o`, error);
+    console.error(`Error updating amendment with id %s on facilityId %s: %o`, amendmentId, facilityId, error);
 
     return res.status(HttpStatusCode.InternalServerError).send({
       status: HttpStatusCode.InternalServerError,

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
@@ -1,204 +1,196 @@
-import { ObjectId } from 'mongodb';
 import { createMocks } from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
-import { AnyObject, AUDIT_USER_TYPES } from '@ukef/dtfs2-common';
-import { aPortalFacilityAmendmentUserValues } from '@ukef/dtfs2-common/mock-data-backend';
+import { getUnixTime } from 'date-fns';
+import { AUDIT_USER_TYPES, CURRENCY } from '@ukef/dtfs2-common';
 import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { aPortalUser } from '../../../../../test-helpers';
-import { validatePutPortalFacilityAmendmentPayload } from './validate-put-portal-facility-amendment-payload';
+import { validatePatchPortalFacilityAmendmentPayload } from './validate-patch-portal-facility-amendment-payload';
 
-const validDealId = new ObjectId().toString();
 const validAuditDetails = generatePortalAuditDetails(aPortalUser()._id);
-const validAmendment = JSON.parse(JSON.stringify(aPortalFacilityAmendmentUserValues())) as AnyObject;
+const validUpdate = {
+  changeCoverEndDate: true,
+  coverEndDate: getUnixTime(new Date()),
+  currentCoverEndDate: getUnixTime(new Date()),
+  isUsingFacilityEndDate: true,
+  facilityEndDate: getUnixTime(new Date()),
+  bankReviewDate: getUnixTime(new Date()),
+  changeFacilityValue: true,
+  value: 1800,
+  currentValue: 1500,
+  currency: CURRENCY.GBP,
+  ukefExposure: 10,
+  coveredPercentage: 23,
+};
 
-describe('validatePutPortalFacilityAmendmentPayload', () => {
+describe('validatePatchPortalFacilityAmendmentPayload', () => {
   const invalidPayloads = [
     {
-      description: 'no amendment is provided',
+      description: 'no update is provided',
       payload: {
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment is not an object',
+      description: 'update is not an object',
       payload: {
-        amendment: 'not an object',
+        update: 'not an object',
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment has additional properties',
+      description: 'update has additional properties',
       payload: {
-        amendment: {
+        update: {
           extra: 'property',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.changeCoverEndDate is not a boolean',
+      description: 'update.changeCoverEndDate is not a boolean',
       payload: {
-        amendment: {
+        update: {
           changeCoverEndDate: 'true',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.coverEndDate is not an integer',
+      description: 'update.coverEndDate is not an integer',
       payload: {
-        amendment: {
+        update: {
           coverEndDate: 'not an integer',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.currentCoverEndDate is not an integer',
+      description: 'update.currentCoverEndDate is not an integer',
       payload: {
-        amendment: {
+        update: {
           currentCoverEndDate: 'not an integer',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.isUsingFacilityEndDate is not a boolean',
+      description: 'update.isUsingFacilityEndDate is not a boolean',
       payload: {
-        amendment: {
+        update: {
           isUsingFacilityEndDate: 'not a boolean',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.facilityEndDate is not a number',
+      description: 'update.facilityEndDate is not a number',
       payload: {
-        amendment: {
+        update: {
           facilityEndDate: 'not a number',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.facilityEndDate is negative',
+      description: 'update.facilityEndDate is negative',
       payload: {
-        amendment: {
+        update: {
           facilityEndDate: -23,
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.bankReviewDate is not a number',
+      description: 'update.bankReviewDate is not a number',
       payload: {
-        amendment: {
+        update: {
           bankReviewDate: 'not a number',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.bankReviewDate is negative',
+      description: 'update.bankReviewDate is negative',
       payload: {
-        amendment: {
+        update: {
           bankReviewDate: -23,
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.changeFacilityValue is not a boolean',
+      description: 'update.changeFacilityValue is not a boolean',
       payload: {
-        amendment: {
+        update: {
           changeFacilityValue: 'not a boolean',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.value is not a number',
+      description: 'update.value is not a number',
       payload: {
-        amendment: {
+        update: {
           value: 'not a number',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.currentValue is not a number',
+      description: 'update.currentValue is not a number',
       payload: {
-        amendment: {
+        update: {
           currentValue: 'not a number',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.currency is not a valid enum value',
+      description: 'update.currency is not a valid enum value',
       payload: {
-        amendment: {
+        update: {
           currency: 'invalid currency',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.ukefExposure is not a number',
+      description: 'update.ukefExposure is not a number',
       payload: {
-        amendment: {
+        update: {
           ukefExposure: 'not a number',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
-      description: 'amendment.coveredPercentage is not a number',
+      description: 'update.coveredPercentage is not a number',
       payload: {
-        amendment: {
+        update: {
           coveredPercentage: 'not a number',
         },
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
     {
       description: 'auditDetails is undefined',
       payload: {
-        amendment: validAmendment,
-        dealId: validDealId,
+        update: validUpdate,
         auditDetails: undefined,
       },
     },
     {
       description: 'auditDetails is an empty object',
       payload: {
-        amendment: validAmendment,
+        update: validUpdate,
         auditDetails: {},
-        dealId: validDealId,
       },
     },
     {
       description: 'auditDetails.userType is undefined',
       payload: {
-        amendment: validAmendment,
-        dealId: validDealId,
+        update: validUpdate,
+
         auditDetails: {
           userType: undefined,
         },
@@ -207,28 +199,12 @@ describe('validatePutPortalFacilityAmendmentPayload', () => {
     {
       description: 'auditDetails.id is invalid and type is portal',
       payload: {
-        amendment: validAmendment,
-        dealId: validDealId,
+        update: validUpdate,
+
         auditDetails: {
           userType: AUDIT_USER_TYPES.PORTAL,
           id: 'invalid',
         },
-      },
-    },
-    {
-      description: 'dealId is not a string',
-      payload: {
-        amendment: validAmendment,
-        dealId: 123456123456123456,
-        auditDetails: validAuditDetails,
-      },
-    },
-    {
-      description: 'dealId is not an object Id',
-      payload: {
-        amendment: validAmendment,
-        dealId: 'invalid deal id',
-        auditDetails: validAuditDetails,
       },
     },
   ];
@@ -239,7 +215,7 @@ describe('validatePutPortalFacilityAmendmentPayload', () => {
     const next = jest.fn();
 
     // Act
-    validatePutPortalFacilityAmendmentPayload(req, res, next);
+    validatePatchPortalFacilityAmendmentPayload(req, res, next);
 
     // Assert
     expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
@@ -251,18 +227,16 @@ describe('validatePutPortalFacilityAmendmentPayload', () => {
     {
       description: 'the payload is valid',
       payload: {
-        amendment: validAmendment,
+        update: validUpdate,
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
 
     {
-      description: 'the amendment is an empty object',
+      description: 'the update is an empty object',
       payload: {
-        amendment: {},
+        update: {},
         auditDetails: validAuditDetails,
-        dealId: validDealId,
       },
     },
   ];
@@ -273,7 +247,7 @@ describe('validatePutPortalFacilityAmendmentPayload', () => {
     const next = jest.fn();
 
     // Act
-    validatePutPortalFacilityAmendmentPayload(req, res, next);
+    validatePatchPortalFacilityAmendmentPayload(req, res, next);
 
     // Assert
     expect(next).toHaveBeenCalled();

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
@@ -1,26 +1,12 @@
 import { createMocks } from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
-import { getUnixTime } from 'date-fns';
-import { AUDIT_USER_TYPES, CURRENCY } from '@ukef/dtfs2-common';
+import { AUDIT_USER_TYPES } from '@ukef/dtfs2-common';
 import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+import { aPortalFacilityAmendmentUserValues } from '@ukef/dtfs2-common/mock-data-backend';
 import { aPortalUser } from '../../../../../test-helpers';
 import { validatePatchPortalFacilityAmendmentPayload } from './validate-patch-portal-facility-amendment-payload';
 
 const validAuditDetails = generatePortalAuditDetails(aPortalUser()._id);
-const validUpdate = {
-  changeCoverEndDate: true,
-  coverEndDate: getUnixTime(new Date()),
-  currentCoverEndDate: getUnixTime(new Date()),
-  isUsingFacilityEndDate: true,
-  facilityEndDate: getUnixTime(new Date()),
-  bankReviewDate: getUnixTime(new Date()),
-  changeFacilityValue: true,
-  value: 1800,
-  currentValue: 1500,
-  currency: CURRENCY.GBP,
-  ukefExposure: 10,
-  coveredPercentage: 23,
-};
 
 describe('validatePatchPortalFacilityAmendmentPayload', () => {
   const invalidPayloads = [
@@ -175,21 +161,21 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     {
       description: 'auditDetails is undefined',
       payload: {
-        update: validUpdate,
+        update: aPortalFacilityAmendmentUserValues(),
         auditDetails: undefined,
       },
     },
     {
       description: 'auditDetails is an empty object',
       payload: {
-        update: validUpdate,
+        update: aPortalFacilityAmendmentUserValues(),
         auditDetails: {},
       },
     },
     {
       description: 'auditDetails.userType is undefined',
       payload: {
-        update: validUpdate,
+        update: aPortalFacilityAmendmentUserValues(),
 
         auditDetails: {
           userType: undefined,
@@ -199,7 +185,7 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     {
       description: 'auditDetails.id is invalid and type is portal',
       payload: {
-        update: validUpdate,
+        update: aPortalFacilityAmendmentUserValues(),
 
         auditDetails: {
           userType: AUDIT_USER_TYPES.PORTAL,
@@ -227,7 +213,7 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     {
       description: 'the payload is valid',
       payload: {
-        update: validUpdate,
+        update: aPortalFacilityAmendmentUserValues(),
         auditDetails: validAuditDetails,
       },
     },

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
@@ -1,12 +1,13 @@
 import { createMocks } from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
-import { AUDIT_USER_TYPES } from '@ukef/dtfs2-common';
+import { AUDIT_USER_TYPES, AnyObject } from '@ukef/dtfs2-common';
 import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
 import { aPortalFacilityAmendmentUserValues } from '@ukef/dtfs2-common/mock-data-backend';
 import { aPortalUser } from '../../../../../test-helpers';
 import { validatePatchPortalFacilityAmendmentPayload } from './validate-patch-portal-facility-amendment-payload';
 
 const validAuditDetails = generatePortalAuditDetails(aPortalUser()._id);
+const validAmendment = JSON.parse(JSON.stringify(aPortalFacilityAmendmentUserValues())) as AnyObject;
 
 describe('validatePatchPortalFacilityAmendmentPayload', () => {
   const invalidPayloads = [
@@ -161,21 +162,21 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     {
       description: 'auditDetails is undefined',
       payload: {
-        update: aPortalFacilityAmendmentUserValues(),
+        update: validAmendment,
         auditDetails: undefined,
       },
     },
     {
       description: 'auditDetails is an empty object',
       payload: {
-        update: aPortalFacilityAmendmentUserValues(),
+        update: validAmendment,
         auditDetails: {},
       },
     },
     {
       description: 'auditDetails.userType is undefined',
       payload: {
-        update: aPortalFacilityAmendmentUserValues(),
+        update: validAmendment,
 
         auditDetails: {
           userType: undefined,
@@ -185,7 +186,7 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     {
       description: 'auditDetails.id is invalid and type is portal',
       payload: {
-        update: aPortalFacilityAmendmentUserValues(),
+        update: validAmendment,
 
         auditDetails: {
           userType: AUDIT_USER_TYPES.PORTAL,
@@ -213,7 +214,7 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     {
       description: 'the payload is valid',
       payload: {
-        update: aPortalFacilityAmendmentUserValues(),
+        update: validAmendment,
         auditDetails: validAuditDetails,
       },
     },

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.test.ts
@@ -196,7 +196,7 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     },
   ];
 
-  it.each(invalidPayloads)('should return 400 when $description', ({ payload }) => {
+  it.each(invalidPayloads)(`should return ${HttpStatusCode.BadRequest} when $description`, ({ payload }) => {
     // Arrange
     const { req, res } = createMocks({ body: payload });
     const next = jest.fn();
@@ -237,7 +237,7 @@ describe('validatePatchPortalFacilityAmendmentPayload', () => {
     validatePatchPortalFacilityAmendmentPayload(req, res, next);
 
     // Assert
-    expect(next).toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
     expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.ts
@@ -1,0 +1,13 @@
+import z from 'zod';
+import { createValidationMiddlewareForSchema } from '@ukef/dtfs2-common';
+import { PORTAL_FACILITY_AMENDMENT } from '@ukef/dtfs2-common/schemas';
+import { AuditDetailsSchema } from './schemas';
+
+const PatchPortalFacilityAmendmentSchema = z.object({
+  update: PORTAL_FACILITY_AMENDMENT.partial(),
+  auditDetails: AuditDetailsSchema,
+});
+
+export type PatchPortalFacilityAmendmentPayload = z.infer<typeof PatchPortalFacilityAmendmentSchema>;
+
+export const validatePatchPortalFacilityAmendmentPayload = createValidationMiddlewareForSchema(PatchPortalFacilityAmendmentSchema);

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-patch-portal-facility-amendment-payload.ts
@@ -1,10 +1,10 @@
 import z from 'zod';
 import { createValidationMiddlewareForSchema } from '@ukef/dtfs2-common';
-import { PORTAL_FACILITY_AMENDMENT } from '@ukef/dtfs2-common/schemas';
+import { PORTAL_FACILITY_AMENDMENT_USER_VALUES } from '@ukef/dtfs2-common/schemas';
 import { AuditDetailsSchema } from './schemas';
 
 const PatchPortalFacilityAmendmentSchema = z.object({
-  update: PORTAL_FACILITY_AMENDMENT.partial(),
+  update: PORTAL_FACILITY_AMENDMENT_USER_VALUES.partial(),
   auditDetails: AuditDetailsSchema,
 });
 

--- a/dtfs-central-api/src/v1/routes/portal-routes.js
+++ b/dtfs-central-api/src/v1/routes/portal-routes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { validatePortalFacilityAmendmentsEnabled } = require('@ukef/dtfs2-common');
 const validation = require('../validation/route-validators/route-validators');
 const { validatePutPortalFacilityAmendmentPayload } = require('./middleware/payload-validation/validate-put-portal-facility-amendment-payload');
+const { validatePatchPortalFacilityAmendmentPayload } = require('./middleware/payload-validation/validate-patch-portal-facility-amendment-payload');
 
 const portalRouter = express.Router();
 const createDealController = require('../controllers/portal/deal/create-deal.controller');
@@ -32,6 +33,7 @@ const updateGefFacilityController = require('../controllers/portal/gef-facility/
 
 const getFacilityAmendmentController = require('../controllers/portal/facility/get-amendment.controller');
 const putFacilityAmendmentController = require('../controllers/portal/facility/put-amendment.controller');
+const patchFacilityAmendmentController = require('../controllers/portal/facility/patch-amendment.controller');
 
 const durableFunctionsController = require('../controllers/durable-functions/durable-functions.controller');
 const cronJobsController = require('../controllers/cron-jobs/cron-jobs.controller');
@@ -541,19 +543,60 @@ portalRouter.route('/facilities/:id/status').put(updateFacilityStatusController.
  *                $ref: '#/definitions/PortalAmendment'
  *       404:
  *         description: Not found
+ *   patch:
+ *     summary: Update a Portal GEF facility amendment
+ *     tags: [Portal - Amendments]
+ *     description: Update a Portal GEF facility amendment
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: Facility ID amendment should exist on
+ *       - in: path
+ *         name: amendmentId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: Amendment ID to get
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               update:
+ *                 type: object
+ *                 $ref: '#/definitions/PortalAmendmentUserInput'
+ *               auditDetails:
+ *                 type: object
+ *                 $ref: '#/definitions/PortalAuditDetails'
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               $ref: '#/definitions/PortalAmendment'
+ *       404:
+ *         description: Not found
  */
 portalRouter
   .route('/facilities/:facilityId/amendments/:amendmentId')
   .all(validatePortalFacilityAmendmentsEnabled, validation.mongoIdValidation('facilityId'), validation.mongoIdValidation('amendmentId'))
-  .get(getFacilityAmendmentController.getAmendment);
+  .get(getFacilityAmendmentController.getAmendment)
+  .patch(validatePatchPortalFacilityAmendmentPayload, patchFacilityAmendmentController.patchAmendment);
 
 /**
  * @openapi
  * /facilities/:facilityId/amendments:
  *   put:
- *     summary: update a Portal facility amendment
+ *     summary: upsert a Portal facility amendment
  *     tags: [Portal - Amendments]
- *     description: Update a Portal facility amendment
+ *     description: Upsert a Portal facility amendment
  *     parameters:
  *       - in: path
  *         name: facilityId
@@ -568,6 +611,9 @@ portalRouter
  *           schema:
  *             type: object
  *             properties:
+ *               dealId:
+ *                type: string
+ *                example: '123456abcdef123456abcdef'
  *               amendment:
  *                 type: object
  *                 $ref: '#/definitions/PortalAmendmentUserInput'
@@ -587,8 +633,8 @@ portalRouter
  */
 portalRouter
   .route('/facilities/:facilityId/amendments')
-  .all(validatePortalFacilityAmendmentsEnabled, validation.mongoIdValidation('facilityId'), validatePutPortalFacilityAmendmentPayload)
-  .put(putFacilityAmendmentController.putAmendmentDraft);
+  .all(validatePortalFacilityAmendmentsEnabled, validation.mongoIdValidation('facilityId'))
+  .put(validatePutPortalFacilityAmendmentPayload, putFacilityAmendmentController.putAmendmentDraft);
 
 /**
  * @openapi

--- a/libs/common/src/errors/amendment-not-found.error.test.ts
+++ b/libs/common/src/errors/amendment-not-found.error.test.ts
@@ -1,0 +1,39 @@
+import { AmendmentNotFoundError } from './amendment-not-found.error';
+import { ApiError } from './api.error';
+
+describe('AmendmentNotFoundError', () => {
+  const facilityId = 'Example facility id';
+  const amendmentId = 'Example amendment id';
+
+  it('should expose the message the error was created with', () => {
+    // Act
+    const exception = new AmendmentNotFoundError(amendmentId, facilityId);
+
+    // Assert
+    expect(exception.message).toEqual(`Amendment not found: ${amendmentId} on facility: ${facilityId}`);
+  });
+
+  it('should be an instance of AmendmentNotFoundError', () => {
+    // Act
+    const exception = new AmendmentNotFoundError(amendmentId, facilityId);
+
+    // Assert
+    expect(exception).toBeInstanceOf(AmendmentNotFoundError);
+  });
+
+  it('should be an instance of ApiError', () => {
+    // Act
+    const exception = new AmendmentNotFoundError(amendmentId, facilityId);
+
+    // Assert
+    expect(exception).toBeInstanceOf(ApiError);
+  });
+
+  it('should expose the name of the exception', () => {
+    // Act
+    const exception = new AmendmentNotFoundError(amendmentId, facilityId);
+
+    // Assert
+    expect(exception.name).toEqual('AmendmentNotFoundError');
+  });
+});

--- a/libs/common/src/errors/amendment-not-found.error.ts
+++ b/libs/common/src/errors/amendment-not-found.error.ts
@@ -1,0 +1,11 @@
+import { HttpStatusCode } from 'axios';
+import { ApiError } from './api.error';
+
+export class AmendmentNotFoundError extends ApiError {
+  constructor(amendmentId: string, facilityId: string) {
+    const message = `Amendment not found: ${amendmentId} on facility: ${facilityId}`;
+    super({ message, status: HttpStatusCode.NotFound });
+
+    this.name = 'AmendmentNotFoundError';
+  }
+}

--- a/libs/common/src/errors/amendment-not-found.error.ts
+++ b/libs/common/src/errors/amendment-not-found.error.ts
@@ -1,6 +1,10 @@
 import { HttpStatusCode } from 'axios';
 import { ApiError } from './api.error';
 
+/**
+ * Error thrown when an amendment is not found, to be handled as an ApiError in the controller
+ * and return a 404 status code
+ */
 export class AmendmentNotFoundError extends ApiError {
   constructor(amendmentId: string, facilityId: string) {
     const message = `Amendment not found: ${amendmentId} on facility: ${facilityId}`;

--- a/libs/common/src/errors/index.ts
+++ b/libs/common/src/errors/index.ts
@@ -18,3 +18,4 @@ export * from './user-session.error';
 export * from './user-session-not-defined.error';
 export * from './user-token-not-defined.error';
 export * from './multiple-users-found.error';
+export * from './amendment-not-found.error';

--- a/libs/common/src/errors/invalid-audit-details.error.ts
+++ b/libs/common/src/errors/invalid-audit-details.error.ts
@@ -1,3 +1,4 @@
+import { API_ERROR_CODE } from '../constants';
 import { ApiError } from './api.error';
 
 export class InvalidAuditDetailsError extends ApiError {
@@ -5,7 +6,7 @@ export class InvalidAuditDetailsError extends ApiError {
     super({
       status: 400,
       message,
-      code: 'INVALID_AUDIT_DETAILS',
+      code: API_ERROR_CODE.INVALID_AUDIT_DETAILS,
     });
 
     this.name = this.constructor.name;

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -1,6 +1,6 @@
 import { formatInTimeZone } from 'date-fns-tz';
-import { format } from 'date-fns';
-import { IsoDateTimeStamp } from '../types/date';
+import { format, getUnixTime } from 'date-fns';
+import { IsoDateTimeStamp, OneIndexedMonth, UnixTimestampSeconds } from '../types/date';
 
 export const getNowAsUtcISOString = (): IsoDateTimeStamp =>
   `${formatInTimeZone(new Date(), '+00:00', 'yyyy-MM-dd')}T${formatInTimeZone(new Date(), '+00:00', 'HH:mm:ss.SSS xxxxxx')}`;
@@ -10,8 +10,15 @@ export const getNowAsUtcISOString = (): IsoDateTimeStamp =>
  * @param monthNumber - 1-indexed month number
  * @returns month as a string
  */
-export const getMonthName = (monthNumber: number) => {
+export const getMonthName = (monthNumber: OneIndexedMonth) => {
   const currentYear = new Date().getFullYear();
   const date = new Date(currentYear, monthNumber - 1);
   return format(date, 'MMMM');
 };
+
+/**
+ * Returns the Unix timestamp (seconds) associated with the given date
+ * @param date - date to convert
+ * @returns Unix timestamp in seconds
+ */
+export const getUnixTimestampSeconds: (date: Date) => UnixTimestampSeconds = getUnixTime;

--- a/libs/common/src/types/portal/index.ts
+++ b/libs/common/src/types/portal/index.ts
@@ -2,3 +2,4 @@ export * from './activity';
 export * from './deal-status';
 export * from './facility-status';
 export * from './roles';
+export * from './amendment';


### PR DESCRIPTION
## Introduction :pencil2:
When the user inputs each stage of the amendments flow, the values should be updated in a PATCH request

## Resolution :heavy_check_mark:
- add repo, service and controllers to handle update request
- add unit and api tests

## Miscellaneous :heavy_plus_sign:
- Add `AmendmentNotFound` error

