### PR TITLE
fix(DTFS2-7616): manual dev deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,6 +31,11 @@ run-name: 🚀 Deploying to dev
 on:
   schedule:
     - cron: '0 0 * * *'
+  
+  push:
+    branches:
+    # Manual deployment
+      - dev
 
 env:
   PRODUCT: dtfs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ on:
 
   push:
     branches:
+      # Staging ready release
       - release-*
       - '!release-please*'
 


### PR DESCRIPTION
## Introduction :pencil2:
Ensure manual deployment to `dev` can also be triggered alongside with automated CRON enabled deployment.

## Resolution :heavy_check_mark:
* Added `push` directive for `dev` branch.

## Miscellaneous :heavy_plus_sign:
* Minor documentation improvement.

