### PR TITLE
feat(dtfs2-6892): update mock builder to require complete defaults, add documentation demonstrating how to pass through mocked class methods

### DIFF
--- a/trade-finance-manager-api/src/v1/__mocks__/builders/user.service.mock.builder.ts
+++ b/trade-finance-manager-api/src/v1/__mocks__/builders/user.service.mock.builder.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { BaseMockBuilder } from '@ukef/dtfs2-common';
+import { BaseMockBuilder, EntraIdUser, UpsertTfmUserRequest } from '@ukef/dtfs2-common';
 import { aTfmUser } from '@ukef/dtfs2-common/mock-data-backend';
 import {
   UpsertTfmUserFromEntraIdUserParams,
@@ -10,8 +10,16 @@ import {
 
 export class UserServiceMockBuilder extends BaseMockBuilder<UserService> {
   constructor() {
+    const userService = new UserService();
     super({
       defaultInstance: {
+        /**
+         *  We pass through the actual service implementation for the below method here,
+         * as it is an existing pattern that we never mock synchronous methods.
+         */
+        transformEntraIdUserToUpsertTfmUserRequest(entraIdUser: EntraIdUser): UpsertTfmUserRequest {
+          return userService.transformEntraIdUserToUpsertTfmUserRequest(entraIdUser);
+        },
         upsertTfmUserFromEntraIdUser({ entraIdUser, auditDetails }: UpsertTfmUserFromEntraIdUserParams): Promise<UpsertTfmUserFromEntraIdUserResponse> {
           return Promise.resolve(aTfmUser());
         },

--- a/trade-finance-manager-api/src/v1/controllers/sso.controller.get-auth-code-url.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/sso.controller.get-auth-code-url.test.ts
@@ -31,8 +31,8 @@ describe('SsoController', () => {
 
     beforeEach(() => {
       jest.resetAllMocks();
-      entraIdService = new EntraIdServiceMockBuilder().withDefaults().with({ getAuthCodeUrl: getAuthCodeUrlMock }).build();
-      userService = new UserServiceMockBuilder().withDefaults().build();
+      entraIdService = new EntraIdServiceMockBuilder().with({ getAuthCodeUrl: getAuthCodeUrlMock }).build();
+      userService = new UserServiceMockBuilder().build();
       ssoController = new SsoController({ entraIdService, userService });
 
       ({ req, res } = getHttpMocks());

--- a/trade-finance-manager-api/src/v1/controllers/sso.controller.handle-sso-redirect-form.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/sso.controller.handle-sso-redirect-form.test.ts
@@ -38,9 +38,8 @@ describe('SsoController', () => {
 
     beforeEach(() => {
       jest.resetAllMocks();
-      entraIdService = new EntraIdServiceMockBuilder().withDefaults().with({ handleRedirect: handleRedirectMock }).build();
+      entraIdService = new EntraIdServiceMockBuilder().with({ handleRedirect: handleRedirectMock }).build();
       userService = new UserServiceMockBuilder()
-        .withDefaults()
         .with({ upsertTfmUserFromEntraIdUser: upsertTfmUserFromEntraIdUserMock, saveUserLoginInformation: saveUserLoginInformationMock })
         .build();
       ssoController = new SsoController({ entraIdService, userService });

--- a/trade-finance-manager-api/src/v1/services/entra-id.service.get-auth-code-url.test.ts
+++ b/trade-finance-manager-api/src/v1/services/entra-id.service.get-auth-code-url.test.ts
@@ -35,7 +35,6 @@ describe('EntraIdService', () => {
       });
 
       entraIdConfig = new EntraIdConfigMockBuilder()
-        .withDefaults()
         .with({
           authorityMetadataUrl: mockAuthorityMetaDataUrl,
           scopes: mockScope,
@@ -43,7 +42,7 @@ describe('EntraIdService', () => {
         })
         .build();
 
-      entraIdApi = new EntraIdApiMockBuilder().withDefaults().build();
+      entraIdApi = new EntraIdApiMockBuilder().build();
     });
 
     it('calls base64Encode with the expected stringifiedstate', async () => {


### PR DESCRIPTION
## Introduction :pencil2:
We sometimes need to include sync methods in our mock builders that are the same implementation as the service being mocked.

This is because of the existing policy of not mocking sync methods in tests

## Resolution :heavy_check_mark:
Make mock builders require all params of the mocked class/type to be specified
Add documentation and example for how to pass through existing implementation of mocked class to mock builder
Make mock builders automatically instantiate defaults instead of having to use `withDefaults`
Update documentation with examples

