### PR TITLE
feat(FN-3612): hide record correction tab behind feature flag

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-disabled/record-correction-tab-not-visible.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-disabled/record-correction-tab-not-visible.spec.js
@@ -31,7 +31,7 @@ context('When fee record correction feature flag is disabled', () => {
       cy.task(NODE_TASKS.REINSERT_ZERO_THRESHOLD_PAYMENT_MATCHING_TOLERANCES);
     });
 
-    it('should NOT display create record correction request button', () => {
+    it('should NOT display the record correction history tab', () => {
       utilisationReportPage.recordCorrectionHistoryTabLink().should('not.exist');
     });
   });

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-disabled/record-correction-tab-not-visible.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-disabled/record-correction-tab-not-visible.spec.js
@@ -1,0 +1,38 @@
+import { PENDING_RECONCILIATION, UtilisationReportEntityMockBuilder } from '@ukef/dtfs2-common';
+import pages from '../../../../pages';
+import USERS from '../../../../../fixtures/users';
+import { NODE_TASKS } from '../../../../../../../e2e-fixtures';
+
+const { utilisationReportPage } = pages;
+
+context('When fee record correction feature flag is disabled', () => {
+  context('The record correction tab is not visible for PDC_RECONCILE users', () => {
+    const bankId = '961';
+    const reportId = 1;
+
+    const report = UtilisationReportEntityMockBuilder.forStatus(PENDING_RECONCILIATION).withId(reportId).withBankId(bankId).build();
+
+    before(() => {
+      cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
+      cy.task(NODE_TASKS.REINSERT_ZERO_THRESHOLD_PAYMENT_MATCHING_TOLERANCES);
+    });
+
+    beforeEach(() => {
+      cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+
+      pages.landingPage.visit();
+      cy.login(USERS.PDC_RECONCILE);
+
+      cy.visit(`utilisation-reports/${reportId}`);
+    });
+
+    afterEach(() => {
+      cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
+      cy.task(NODE_TASKS.REINSERT_ZERO_THRESHOLD_PAYMENT_MATCHING_TOLERANCES);
+    });
+
+    it('should NOT display create record correction request button', () => {
+      utilisationReportPage.recordCorrectionHistoryTabLink().should('not.exist');
+    });
+  });
+});

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/record-correction-history-no-corrections.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/record-correction-history-no-corrections.spec.js
@@ -40,9 +40,9 @@ context('Record correction history page - no corrections', () => {
 
   describe('when navigating to the page', () => {
     it('should display the tab heading and text', () => {
-      cy.assertText(utilisationReportPage.recordCorrectionHistoryTabLink(), 'Record correction history');
-
       cy.assertText(recordCorrectionHistoryTab.heading(), 'Record correction history');
+
+      cy.assertText(utilisationReportPage.recordCorrectionHistoryTabLink(), 'Record correction history');
 
       cy.assertText(
         recordCorrectionHistoryTab.recordCorrectionAutomaticallyNotifiedText(),

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/record-correction-history-no-corrections.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/record-correction-history-no-corrections.spec.js
@@ -40,6 +40,8 @@ context('Record correction history page - no corrections', () => {
 
   describe('when navigating to the page', () => {
     it('should display the tab heading and text', () => {
+      cy.assertText(utilisationReportPage.recordCorrectionHistoryTabLink(), 'Record correction history');
+
       cy.assertText(recordCorrectionHistoryTab.heading(), 'Record correction history');
 
       cy.assertText(

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/record-correction-history-no-corrections.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/record-correction-history-no-corrections.spec.js
@@ -1,8 +1,8 @@
 import { FeeRecordEntityMockBuilder, UtilisationReportEntityMockBuilder, FEE_RECORD_STATUS, PENDING_RECONCILIATION } from '@ukef/dtfs2-common';
-import pages from '../../../pages';
-import USERS from '../../../../fixtures/users';
-import { NODE_TASKS } from '../../../../../../e2e-fixtures';
-import { getMatchingTfmFacilitiesForFeeRecords } from '../../../../support/utils/getMatchingTfmFacilitiesForFeeRecords';
+import pages from '../../../../pages';
+import USERS from '../../../../../fixtures/users';
+import { NODE_TASKS } from '../../../../../../../e2e-fixtures';
+import { getMatchingTfmFacilitiesForFeeRecords } from '../../../../../support/utils/getMatchingTfmFacilitiesForFeeRecords';
 
 const { utilisationReportPage } = pages;
 const { recordCorrectionHistoryTab } = utilisationReportPage;

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/bank-utilisation-report-page.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/report-reconciliation/bank-utilisation-report-page.spec.js
@@ -57,7 +57,6 @@ context('Bank utilisation report page', () => {
       cy.assertText(utilisationReportPage.keyingSheetTabLink(), 'Keying sheet');
       cy.assertText(utilisationReportPage.paymentDetailsTabLink(), 'Payment details');
       cy.assertText(utilisationReportPage.utilisationTabLink(), 'Utilisation');
-      cy.assertText(utilisationReportPage.recordCorrectionHistoryTabLink(), 'Record correction history');
     });
   });
 });

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -39,49 +39,50 @@
   {% include "./partials/record-correction-history-html.njk" %}
 {% endset %}
 
-{% set itemsArray = [
-      {
-        label: "Premium payments",
-        id: "premium-payments",
-        panel: {
-          html: premiumPaymentsHtml | safe
-        },
-        attributes: {
-          'data-cy': 'bank-report-tab-premium-payments'
-        }
+{% set itemsArray = 
+  [
+    {
+      label: "Premium payments",
+      id: "premium-payments",
+      panel: {
+        html: premiumPaymentsHtml | safe
       },
-      {
-        label: "Keying sheet",
-        id: "keying-sheet",
-        panel: {
-          html: keyingSheetHtml | safe
-        },
-        attributes: {
-          'data-cy': 'bank-report-tab-keying-sheet'
-        }
-      },
-      {
-        label: "Payment details",
-        id: "payment-details",
-        panel: {
-          html: paymentDetailsHtml | safe
-        },
-        attributes: {
-          'data-cy': 'bank-report-tab-payment-details'
-        }
-      },
-      {
-        label: "Utilisation",
-        id: "utilisation",
-        panel: {
-          html: utilisationHtml | safe
-        },
-        attributes: {
-          'data-cy': 'bank-report-tab-utilisation'
-        }
+      attributes: {
+        'data-cy': 'bank-report-tab-premium-payments'
       }
-    ]
-  %}
+    },
+    {
+      label: "Keying sheet",
+      id: "keying-sheet",
+      panel: {
+        html: keyingSheetHtml | safe
+      },
+      attributes: {
+        'data-cy': 'bank-report-tab-keying-sheet'
+      }
+    },
+    {
+      label: "Payment details",
+      id: "payment-details",
+      panel: {
+        html: paymentDetailsHtml | safe
+      },
+      attributes: {
+        'data-cy': 'bank-report-tab-payment-details'
+      }
+    },
+    {
+      label: "Utilisation",
+      id: "utilisation",
+      panel: {
+        html: utilisationHtml | safe
+      },
+      attributes: {
+        'data-cy': 'bank-report-tab-utilisation'
+      }
+    }
+  ]
+%}
 
   {% if isFeeRecordCorrectionFeatureFlagEnabled %}
     {% set itemsArray = (itemsArray.push({

--- a/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/utilisation-report-reconciliation-for-report.njk
@@ -39,6 +39,63 @@
   {% include "./partials/record-correction-history-html.njk" %}
 {% endset %}
 
+{% set itemsArray = [
+      {
+        label: "Premium payments",
+        id: "premium-payments",
+        panel: {
+          html: premiumPaymentsHtml | safe
+        },
+        attributes: {
+          'data-cy': 'bank-report-tab-premium-payments'
+        }
+      },
+      {
+        label: "Keying sheet",
+        id: "keying-sheet",
+        panel: {
+          html: keyingSheetHtml | safe
+        },
+        attributes: {
+          'data-cy': 'bank-report-tab-keying-sheet'
+        }
+      },
+      {
+        label: "Payment details",
+        id: "payment-details",
+        panel: {
+          html: paymentDetailsHtml | safe
+        },
+        attributes: {
+          'data-cy': 'bank-report-tab-payment-details'
+        }
+      },
+      {
+        label: "Utilisation",
+        id: "utilisation",
+        panel: {
+          html: utilisationHtml | safe
+        },
+        attributes: {
+          'data-cy': 'bank-report-tab-utilisation'
+        }
+      }
+    ]
+  %}
+
+  {% if isFeeRecordCorrectionFeatureFlagEnabled %}
+    {% set itemsArray = (itemsArray.push({
+      label: "Record correction history",
+      id: "record-correction-history",
+      panel: {
+        html: recordCorrectionHistoryHtml | safe
+      },
+      attributes: {
+        'data-cy': 'bank-report-tab-record-correction-history'
+      }
+    }), itemsArray) %}
+  {% endif %}
+
 {% block content %}
   <div class="govuk-grid-row govuk-!-padding-top-7">
     <div class="govuk-grid-column-full">
@@ -49,58 +106,7 @@
 
       <div class="ukef-tabs--no-border">
         {{ govukTabs({
-          items: [
-            {
-              label: "Premium payments",
-              id: "premium-payments",
-              panel: {
-                html: premiumPaymentsHtml | safe
-              },
-              attributes: {
-                'data-cy': 'bank-report-tab-premium-payments'
-              }
-            },
-            {
-              label: "Keying sheet",
-              id: "keying-sheet",
-              panel: {
-                html: keyingSheetHtml | safe
-              },
-              attributes: {
-                'data-cy': 'bank-report-tab-keying-sheet'
-              }
-            },
-            {
-              label: "Payment details",
-              id: "payment-details",
-              panel: {
-                html: paymentDetailsHtml | safe
-              },
-              attributes: {
-                'data-cy': 'bank-report-tab-payment-details'
-              }
-            },
-            {
-              label: "Utilisation",
-              id: "utilisation",
-              panel: {
-                html: utilisationHtml | safe
-              },
-              attributes: {
-                'data-cy': 'bank-report-tab-utilisation'
-              }
-            },
-            {
-              label: "Record correction history",
-              id: "record-correction-history",
-              panel: {
-                html: recordCorrectionHistoryHtml | safe
-              },
-              attributes: {
-                'data-cy': 'bank-report-tab-record-correction-history'
-              }
-            }
-          ]
+          items: itemsArray
         }) }}
       </div>
     </div>


### PR DESCRIPTION
## Introduction :pencil2:
This PR hides the record correction tab behind a feature flag

## Resolution :heavy_check_mark:
* Moved items array for tabs to its own set in nunjucks
* Added if for feature flag and pushed record correction tab to that array
* Updated and added e2e tests


