### PR TITLE
chore(DTFS2-7717): visit TFM url in deal cancellation tests

### DIFF
--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/AIN-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/AIN-deal-cancellation-updates-portal.spec.js
@@ -2,7 +2,7 @@ import { DEAL_STATUS, FACILITY_STAGE } from '@ukef/dtfs2-common';
 import portalPages from '../../../../../../../portal/cypress/e2e/pages';
 import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import generateAinReadyToSubmit from '../../test-data/AIN-deal/dealReadyToSubmit';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 import { yesterday } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
@@ -60,6 +60,7 @@ context('BSS/EWCS AIN deal - When TFM submits a deal cancellation - Portal statu
       cy.clearCookie('_csrf');
       cy.getCookies().should('be.empty');
 
+      cy.visit(TFM_URL);
       cy.tfmLogin(PIM_USER_1);
 
       cy.submitDealCancellation({ dealId, effectiveDate: yesterday.date });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/AIN-pending-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/AIN-pending-deal-cancellation-updates-portal.spec.js
@@ -2,7 +2,7 @@ import { DEAL_STATUS } from '@ukef/dtfs2-common';
 import portalPages from '../../../../../../../portal/cypress/e2e/pages';
 import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import generateAinReadyToSubmit from '../../test-data/AIN-deal/dealReadyToSubmit';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { TFM_URL, PIM_USER_1 } from '../../../../../../../e2e-fixtures';
 import { tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
@@ -60,6 +60,7 @@ context('BSS/EWCS AIN deal - When TFM submits a pending deal cancellation - Port
       cy.clearCookie('_csrf');
       cy.getCookies().should('be.empty');
 
+      cy.visit(TFM_URL);
       cy.tfmLogin(PIM_USER_1);
 
       cy.submitDealCancellation({ dealId, effectiveDate: tomorrow.date });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/MIN-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/MIN-deal-cancellation-updates-portal.spec.js
@@ -2,7 +2,7 @@ import { DEAL_STATUS, FACILITY_STAGE } from '@ukef/dtfs2-common';
 import portalPages from '../../../../../../../portal/cypress/e2e/pages';
 import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import generateMinReadyToSubmit from '../../test-data/MIN-deal/dealReadyToSubmit';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 import { yesterday } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
@@ -63,6 +63,7 @@ context('BSS/EWCS MIN deal - When TFM submits a deal cancellation - Portal statu
       cy.clearCookie('_csrf');
       cy.getCookies().should('be.empty');
 
+      cy.visit(TFM_URL);
       cy.tfmLogin(PIM_USER_1);
 
       cy.submitDealCancellation({ dealId, effectiveDate: yesterday.date });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/MIN-pending-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/MIN-pending-deal-cancellation-updates-portal.spec.js
@@ -2,7 +2,7 @@ import { DEAL_STATUS } from '@ukef/dtfs2-common';
 import portalPages from '../../../../../../../portal/cypress/e2e/pages';
 import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import generateMinReadyToSubmit from '../../test-data/MIN-deal/dealReadyToSubmit';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 import { tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
@@ -63,6 +63,7 @@ context('BSS/EWCS MIN deal - When TFM submits a pending deal cancellation - Port
       cy.clearCookie('_csrf');
       cy.getCookies().should('be.empty');
 
+      cy.visit(TFM_URL);
       cy.tfmLogin(PIM_USER_1);
 
       cy.submitDealCancellation({ dealId, effectiveDate: tomorrow.date });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/deal-cancellation-maker-unable-issue-facility.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/deal-cancellation-maker-unable-issue-facility.spec.js
@@ -3,8 +3,7 @@ import portalPages from '../../../../../../../portal/cypress/e2e/pages';
 import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { generateAinDealUnissuedFacilitiesWithDates } from '../../test-data/AIN-deal-unissued-facilities/dealReadyToSubmit';
 import generateMinDealUnissuedFacilitiesWithDates from '../../test-data/MIN-deal-unissued-facilities/dealReadyToSubmit';
-
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 import { yesterday, tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1 } = MOCK_USERS;
@@ -28,6 +27,7 @@ context('BSS/EWCS deals - When TFM submits a deal cancellation - Portal maker sh
           cy.clearCookie('_csrf');
           cy.getCookies().should('be.empty');
 
+          cy.visit(TFM_URL);
           cy.tfmLogin(PIM_USER_1);
           const effectiveDate = index % 2 === 0 ? tomorrow.date : yesterday.date;
           cy.submitDealCancellation({ dealId: deal._id, effectiveDate });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/AIN-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/AIN-deal-cancellation-updates-portal.spec.js
@@ -58,7 +58,7 @@ context('GEF AIN deal - When TFM submits a deal cancellation - Portal status and
   });
 
   it('should update the deal status', () => {
-    cy.assertText(statusBanner.bannerStatus(), DEAL_STATUS.DEAL_CANCELLED);
+    cy.assertText(statusBanner.bannerStatus(), DEAL_STATUS.CANCELLED);
   });
 
   describe('activity feed', () => {

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/AIN-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/AIN-deal-cancellation-updates-portal.spec.js
@@ -6,7 +6,7 @@ import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
 import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { yesterday, today } from '../../../../../../../e2e-fixtures/dateConstants';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 
 const { BANK1_MAKER1 } = MOCK_USERS;
 
@@ -29,6 +29,7 @@ context('GEF AIN deal - When TFM submits a deal cancellation - Portal status and
         cy.checkerLoginSubmitGefDealToUkef(gefDeal);
         cy.clearSessionCookies();
 
+        cy.visit(TFM_URL);
         cy.tfmLogin(PIM_USER_1);
 
         const effectiveDate = yesterday.date;

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/AIN-deal-pending-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/AIN-deal-pending-cancellation-updates-portal.spec.js
@@ -6,7 +6,7 @@ import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
 import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { today, tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 
 const { BANK1_MAKER1 } = MOCK_USERS;
 
@@ -29,6 +29,7 @@ context('GEF AIN deal - When TFM submits a pending deal cancellation - Portal st
         cy.checkerLoginSubmitGefDealToUkef(gefDeal);
         cy.clearSessionCookies();
 
+        cy.visit(TFM_URL);
         cy.tfmLogin(PIM_USER_1);
 
         const effectiveDate = tomorrow.date;

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-cancellation-updates-portal.spec.js
@@ -6,7 +6,7 @@ import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { MOCK_APPLICATION_MIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
 import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { yesterday, today } from '../../../../../../../e2e-fixtures/dateConstants';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 
 const { BANK1_MAKER1 } = MOCK_USERS;
 
@@ -29,6 +29,7 @@ context('GEF MIN deal - When TFM submits a deal cancellation - Portal status and
         cy.checkerLoginSubmitGefDealToUkef(gefDeal);
         cy.clearSessionCookies();
 
+        cy.visit(TFM_URL);
         cy.tfmLogin(PIM_USER_1);
 
         const effectiveDate = yesterday.date;

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-cancellation-updates-portal.spec.js
@@ -58,7 +58,7 @@ context('GEF MIN deal - When TFM submits a deal cancellation - Portal status and
   });
 
   it('should update the deal status', () => {
-    cy.assertText(statusBanner.bannerStatus(), DEAL_STATUS.DEAL_CANCELLED);
+    cy.assertText(statusBanner.bannerStatus(), DEAL_STATUS.CANCELLED);
   });
 
   describe('activity feed', () => {

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-pending-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-pending-cancellation-updates-portal.spec.js
@@ -6,7 +6,7 @@ import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { MOCK_APPLICATION_MIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
 import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { today, tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 
 const { BANK1_MAKER1 } = MOCK_USERS;
 
@@ -29,6 +29,7 @@ context('GEF MIN deal - When TFM submits a pending deal cancellation - Portal st
         cy.checkerLoginSubmitGefDealToUkef(gefDeal);
         cy.clearSessionCookies();
 
+        cy.visit(TFM_URL);
         cy.tfmLogin(PIM_USER_1);
 
         const effectiveDate = tomorrow.date;

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-pending-cancellation-updates-portal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/MIN-deal-pending-cancellation-updates-portal.spec.js
@@ -58,7 +58,7 @@ context('GEF MIN deal - When TFM submits a pending deal cancellation - Portal st
   });
 
   it('should update the deal status', () => {
-    cy.assertText(statusBanner.bannerStatus(), DEAL_STATUS.DEAL_CANCELLATION_PENDING);
+    cy.assertText(statusBanner.bannerStatus(), DEAL_STATUS.PENDING_CANCELLATION);
   });
 
   describe('activity feed', () => {

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/deal-cancellation-maker-unable-issue-facility.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/deal-cancellation-maker-unable-issue-facility.spec.js
@@ -5,8 +5,7 @@ import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
 import { MOCK_APPLICATION_AIN_DRAFT, MOCK_APPLICATION_MIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
 import { anIssuedCashFacility, anUnissuedCashFacility, multipleMockGefFacilities } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { yesterday, tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
-
-import { PIM_USER_1 } from '../../../../../../../e2e-fixtures';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
 
 const { BANK1_MAKER1 } = MOCK_USERS;
 
@@ -41,6 +40,7 @@ context('GEF deals - When TFM submits a deal cancellation - Portal maker should 
           cy.checkerLoginSubmitGefDealToUkef(gefDeal);
           cy.clearSessionCookies();
 
+          cy.visit(TFM_URL);
           cy.tfmLogin(PIM_USER_1);
           const effectiveDate = index % 2 === 0 ? tomorrow.date : yesterday.date;
           cy.submitDealCancellation({ dealId: gefDeal._id, effectiveDate });

--- a/libs/common/src/constants/tfm/index.ts
+++ b/libs/common/src/constants/tfm/index.ts
@@ -1,4 +1,3 @@
-export * from './url';
 export * from './team-ids';
 export * from './teams';
 export * from './deal-stage';

--- a/libs/common/src/constants/tfm/url.ts
+++ b/libs/common/src/constants/tfm/url.ts
@@ -1,1 +1,0 @@
-export const TFM_URL = 'http://localhost:5003';


### PR DESCRIPTION
## Introduction :pencil2:
The deal cancellation tests need to visit the TFM url before logging in

## Resolution :heavy_check_mark:
add `cy.vist(TFM_URL)` to all deal cancellation tests 

## Miscellaneous :heavy_plus_sign:
- remove unnecessary `url.ts` file from libs/common