### PR TITLE
chore(DTFS2-7708): fixed incorrect dependabot directory name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ version: 2
 updates:
   # NPM
   - package-ecosystem: 'npm'
-    directory: 
+    directories: 
       - '/'
       - '/external-api'
       - '/portal-api'


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes an incorrect field in dependabot.yml

## Resolution :heavy_check_mark:
* Changed from directory to directories in dependabot.yml for npm

