### PR TITLE
fix(FN-3731): fix assertion dependent on current year

### DIFF
--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/find-reports-by-year/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/find-reports-by-year/index.test.ts
@@ -1,5 +1,5 @@
 import httpMocks from 'node-mocks-http';
-import { getFormattedReportPeriodWithLongMonth, PENDING_RECONCILIATION } from '@ukef/dtfs2-common';
+import { PENDING_RECONCILIATION } from '@ukef/dtfs2-common';
 import api from '../../../api';
 import { getFindReportsByYear } from '.';
 import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user';
@@ -309,7 +309,7 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
     it("renders the 'utilisation-reports-by-bank-and-year-results.njk' view with required data when there are valid query params", async () => {
       // Arrange
       const bankQuery = BANK_ID_ONE;
-      const yearQuery = new Date().getFullYear().toString();
+      const yearQuery = '2024';
       const reportPeriod = {
         start: {
           month: 1,
@@ -341,7 +341,7 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
         dateUploaded: '2024-02-15 10:38:01.4033333',
         totalFeesReported: 3,
         reportedFeesLeftToReconcile: 3,
-        formattedReportPeriod: getFormattedReportPeriodWithLongMonth(reportPeriod),
+        formattedReportPeriod: 'January 2024',
         displayStatus: 'Pending reconciliation',
         formattedDateUploaded: '15 Feb 2024',
       };

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/find-reports-by-year/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/find-reports-by-year/index.test.ts
@@ -1,5 +1,5 @@
 import httpMocks from 'node-mocks-http';
-import { PENDING_RECONCILIATION } from '@ukef/dtfs2-common';
+import { getFormattedReportPeriodWithLongMonth, PENDING_RECONCILIATION } from '@ukef/dtfs2-common';
 import api from '../../../api';
 import { getFindReportsByYear } from '.';
 import { MOCK_TFM_SESSION_USER } from '../../../test-mocks/mock-tfm-session-user';
@@ -341,7 +341,7 @@ describe('controllers/utilisation-reports/find-reports-by-year', () => {
         dateUploaded: '2024-02-15 10:38:01.4033333',
         totalFeesReported: 3,
         reportedFeesLeftToReconcile: 3,
-        formattedReportPeriod: 'January 2024',
+        formattedReportPeriod: getFormattedReportPeriodWithLongMonth(reportPeriod),
         displayStatus: 'Pending reconciliation',
         formattedDateUploaded: '15 Feb 2024',
       };


### PR DESCRIPTION
## Introduction :pencil2:
One of the "find reports by year" unit test assertions has a fixed report period year value, whilst the report period used is dependent on the current year.

This led the test to fail when the current year changed from the fixed string in the assertion (2024):

```
***     "formattedReportPeriod": "January 2024",
  +     "formattedReportPeriod": "January 2025",
```

Related failing runs:
https://github.com/UK-Export-Finance/dtfs2/actions/runs/12584970329/job/35110286115?pr=4089#logs

## Resolution :heavy_check_mark:
- Fixed the year used for the report period

## Miscellaneous :heavy_plus_sign:
N/A

