### PR TITLE
feat(FN-3578): improve email format for pdc correction request

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/create-fee-record-correction-check-the-information.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/create-fee-record-correction-check-the-information.spec.js
@@ -90,7 +90,9 @@ context('When fee record correction feature flag is enabled', () => {
       summaryList().should('contain', additionalInfoUserInput);
 
       // The contact email addresses are taken from the bank payment officer team
-      summaryList().should('contain', expectedBankEmails.join(', '));
+      expectedBankEmails.forEach((email) => {
+        summaryList().should('contain', email);
+      });
     });
 
     context('when the user clicks the "continue" button', () => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/check-the-information.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/check-the-information.component-test.ts
@@ -154,19 +154,23 @@ describe('page', () => {
     wrapper.expectLink('[data-cy="change-record-correction-additional-info-link"]').toLinkTo(expectedHref, 'Change more information for record correction');
   });
 
-  it('should render the contact email addresses', () => {
+  it('should render the contact email addresses with line breaks', () => {
     // Arrange
-    const email = 'one@email.com, two@email.com';
+    const emails = ['one@ukexportfinance.gov.uk', 'two@ukexportfinance.gov.uk'];
     const viewModel: RecordCorrectionRequestInformationViewModel = {
       ...aRecordCorrectionRequestInformationViewModel(),
-      contactEmailAddresses: email,
+      contactEmailAddresses: emails,
     };
+
+    const emailsSelector = definitionDescriptionSelector('Contact email address(es)');
+    const expectedContent = 'one@ukexportfinance.gov.uk,<br>two@ukexportfinance.gov.uk';
 
     // Act
     const wrapper = render(viewModel);
 
     // Assert
-    wrapper.expectText(definitionDescriptionSelector('Contact email address')).toRead(email);
+    wrapper.expectElement(emailsSelector).toHaveHtmlContent(expectedContent);
+    wrapper.expectElement(emailsSelector).hasClass('ukef-word-break-break-all');
   });
 
   it('should render send request button', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.test.ts
@@ -55,7 +55,6 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
 
       // Assert
       const expectedReasons = mapReasonsToDisplayValues(correctionRequestDetails.reasons).join(', ');
-      const expectedContactEmailAddresses = correctionRequestDetails.contactEmailAddresses.join(', ');
 
       expect(res._getRenderView()).toEqual('utilisation-reports/record-corrections/check-the-information.njk');
       expect(res._getRenderData()).toEqual({
@@ -69,7 +68,7 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
         formattedReportPeriod: getFormattedReportPeriodWithLongMonth(reportPeriod),
         reasonForRecordCorrection: expectedReasons,
         additionalInfo: correctionRequestDetails.additionalInfo,
-        contactEmailAddresses: expectedContactEmailAddresses,
+        contactEmailAddresses: correctionRequestDetails.contactEmailAddresses,
       });
     });
   });

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/check-the-information/index.ts
@@ -34,7 +34,7 @@ export const getRecordCorrectionRequestInformation = async (req: Request, res: R
       formattedReportPeriod: getFormattedReportPeriodWithLongMonth(reportPeriod),
       reasonForRecordCorrection: mapReasonsToDisplayValues(reasons).join(', '),
       additionalInfo,
-      contactEmailAddresses: contactEmailAddresses.join(', '),
+      contactEmailAddresses,
     });
   } catch (error) {
     console.error('Failed to render create record correction request - "check the information" page %o', error);

--- a/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-request-information-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-request-information-view-model.ts
@@ -9,5 +9,5 @@ export type RecordCorrectionRequestInformationViewModel = BaseViewModel & {
   exporter: string;
   reasonForRecordCorrection: string;
   additionalInfo: string;
-  contactEmailAddresses: string;
+  contactEmailAddresses: string[];
 };

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
@@ -80,10 +80,11 @@
       },
       {
         key: {
-          text: "Contact email address"
+          text: "Contact email address(es)"
         },
         value: {
-          text: contactEmailAddresses
+          html: (contactEmailAddresses | join(",<br>") | safe),
+          classes: "ukef-word-break-break-all"
         }
       }
     ],

--- a/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/record-correction-request-information-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/record-correction-request-information-view-model.ts
@@ -13,5 +13,5 @@ export const aRecordCorrectionRequestInformationViewModel = (): RecordCorrection
   exporter: 'exporter name',
   reasonForRecordCorrection: 'not valid',
   additionalInfo: 'this is some more information',
-  contactEmailAddresses: 'test@testing.com, email@email.com',
+  contactEmailAddresses: ['one@ukexportfinance.gov.uk', 'two@ukexportfinance.gov.uk'],
 });


### PR DESCRIPTION
## Introduction :pencil2:
Email addresses on the "check the information" screen of the PDC "create fee record correction request" journey are comma-separated and break on dashes.

A comment in demo highlighted that is difficult to read when there are several email addresses.

Further, the key should have the suffix `(es)` to handle the case of multiple emails.

## Resolution :heavy_check_mark:
- `(es)` suffix added to emails key
- Emails separated with a comma followed by a new line, breaking on any character when the containers max width is reached
  - This is the designers preference

### Screenshots

![FN-3578_PR_one-line-email](https://github.com/user-attachments/assets/2f31a592-cfa9-444c-a083-18371b081629)

## Miscellaneous :heavy_plus_sign:
N/A

