### PR TITLE
feat(dtfs2-7693): add routes for role testing tfm

### DIFF
--- a/trade-finance-manager-ui/server/controllers/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/controllers/team-checking/index.ts
@@ -10,5 +10,5 @@ type RenderTeamsCheckerProps = {
 export const renderTeamsChecker = (req: Request, res: Response, { teamCombinations, currentPageTeamRestrictions }: RenderTeamsCheckerProps) => {
   const { user } = asUserSession(req.session);
 
-  return res.render('role-checking/index.njk', { currentUserTeams: user.teams, currentPageTeamRestrictions, teamCombinations });
+  return res.render('team-checking/team-checking-page.njk', { currentUserTeams: user.teams, currentPageTeamRestrictions, teamCombinations });
 };

--- a/trade-finance-manager-ui/server/controllers/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/controllers/team-checking/index.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from 'express';
+import { TeamToCheck } from '../../helpers/team-checking.helper';
+import { asUserSession } from '../../helpers/express-session';
+
+type RenderTeamsCheckerProps = {
+  teamCombinations: TeamToCheck[];
+  currentPageTeamRestrictions?: TeamToCheck;
+};
+
+export const renderTeamsChecker = (req: Request, res: Response, { teamCombinations, currentPageTeamRestrictions }: RenderTeamsCheckerProps) => {
+  const { user } = asUserSession(req.session);
+
+  return res.render('role-checking/index.njk', { currentUserTeams: user.teams, currentPageTeamRestrictions, teamCombinations });
+};

--- a/trade-finance-manager-ui/server/controllers/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/controllers/team-checking/index.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { TeamToCheck } from '../../helpers/team-checking.helper';
 import { asUserSession } from '../../helpers/express-session';
+import { userIsInTeam } from '../../helpers/user';
 
 type RenderTeamsCheckerProps = {
   teamCombinations: TeamToCheck[];
@@ -10,5 +11,7 @@ type RenderTeamsCheckerProps = {
 export const renderTeamsChecker = (req: Request, res: Response, { teamCombinations, currentPageTeamRestrictions }: RenderTeamsCheckerProps) => {
   const { user } = asUserSession(req.session);
 
-  return res.render('team-checking/team-checking-page.njk', { currentUserTeams: user.teams, currentPageTeamRestrictions, teamCombinations });
+  const isUserInTeam = currentPageTeamRestrictions && userIsInTeam(user, currentPageTeamRestrictions.teams);
+
+  return res.render('team-checking/team-checking-page.njk', { currentUserTeams: user.teams, currentPageTeamRestrictions, isUserInTeam, teamCombinations });
 };

--- a/trade-finance-manager-ui/server/helpers/team-checking.helper.ts
+++ b/trade-finance-manager-ui/server/helpers/team-checking.helper.ts
@@ -1,0 +1,28 @@
+import { ALL_TEAM_IDS, TeamId } from '@ukef/dtfs2-common';
+
+export type TeamToCheck = {
+  teams: TeamId[];
+  url: string;
+  description: string;
+};
+
+/** This is only used to create combinations to check team validation and is not used in the business programming */
+export const getTeamCombinations = () => {
+  const teamIdCombinations: TeamToCheck[] = [];
+
+  // We add these to the start of the array for easier navigation
+  ALL_TEAM_IDS.forEach((teamId) => {
+    teamIdCombinations.push({ teams: [teamId], url: teamId, description: teamId });
+  });
+
+  ALL_TEAM_IDS.forEach((teamId1) => {
+    ALL_TEAM_IDS.forEach((teamId2) => {
+      if (teamId1 !== teamId2) {
+        const teams = [teamId1, teamId2];
+        teamIdCombinations.push({ teams, url: teams.join('/'), description: teams.join(' and ') });
+      }
+    });
+  });
+
+  return teamIdCombinations;
+};

--- a/trade-finance-manager-ui/server/routes/index.js
+++ b/trade-finance-manager-ui/server/routes/index.js
@@ -10,6 +10,7 @@ const { userRoutes } = require('./user');
 const { loginRoutes } = require('./login');
 const { utilisationReportsRoutes } = require('./utilisation-reports');
 const footerRoutes = require('./footer');
+const { teamCheckingRoutes } = require('./team-checking');
 
 const { validateUser } = require('../middleware');
 
@@ -25,5 +26,6 @@ router.use('/thank-you-feedback', thankYouFeedbackRoutes);
 router.use('/user', userRoutes);
 router.use('/utilisation-reports', validateUser, utilisationReportsRoutes);
 router.use('/', footerRoutes);
+router.use('/team-checking', teamCheckingRoutes);
 
 module.exports = router;

--- a/trade-finance-manager-ui/server/routes/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/routes/team-checking/index.ts
@@ -18,7 +18,7 @@ function populateTeamCheckingRouter() {
 
   const teamCombinations = getTeamCombinations();
 
-  teamCheckingRoutes.get('/', validateUserTeam([]), (req: Request, res: Response) => renderTeamsChecker(req, res, { teamCombinations }));
+  teamCheckingRoutes.get('/', (req: Request, res: Response) => renderTeamsChecker(req, res, { teamCombinations }));
 
   teamCombinations.forEach((teamCombination) => {
     teamCheckingRoutes.get(`/${teamCombination.url}`, validateUserTeam(teamCombination.teams), (req: Request, res: Response) =>

--- a/trade-finance-manager-ui/server/routes/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/routes/team-checking/index.ts
@@ -1,0 +1,26 @@
+/**
+ * These routes are only used for role checking
+ */
+
+import express, { Request, Response } from 'express';
+import { validateUserTeam } from '../../middleware';
+import { renderTeamsChecker } from '../../controllers/team-checking';
+import { getTeamCombinations } from '../../helpers/team-checking.helper';
+
+export const teamCheckingRoutes = express.Router();
+
+populateTeamCheckingRouter();
+
+function populateTeamCheckingRouter() {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  const teamCombinations = getTeamCombinations();
+
+  teamCombinations.forEach((teamCombination) => {
+    teamCheckingRoutes.get(`/${teamCombination.url}`, validateUserTeam(teamCombination.teams), (req: Request, res: Response) =>
+      renderTeamsChecker(req, res, { teamCombinations, currentPageTeamRestrictions: teamCombination }),
+    );
+  });
+}

--- a/trade-finance-manager-ui/server/routes/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/routes/team-checking/index.ts
@@ -3,7 +3,6 @@
  */
 
 import express, { Request, Response } from 'express';
-import { validateUserTeam } from '../../middleware';
 import { renderTeamsChecker } from '../../controllers/team-checking';
 import { getTeamCombinations } from '../../helpers/team-checking.helper';
 

--- a/trade-finance-manager-ui/server/routes/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/routes/team-checking/index.ts
@@ -21,7 +21,7 @@ function populateTeamCheckingRouter() {
   teamCheckingRoutes.get('/', (req: Request, res: Response) => renderTeamsChecker(req, res, { teamCombinations }));
 
   teamCombinations.forEach((teamCombination) => {
-    teamCheckingRoutes.get(`/${teamCombination.url}`, validateUserTeam(teamCombination.teams), (req: Request, res: Response) =>
+    teamCheckingRoutes.get(`/${teamCombination.url}`, (req: Request, res: Response) =>
       renderTeamsChecker(req, res, { teamCombinations, currentPageTeamRestrictions: teamCombination }),
     );
   });

--- a/trade-finance-manager-ui/server/routes/team-checking/index.ts
+++ b/trade-finance-manager-ui/server/routes/team-checking/index.ts
@@ -18,6 +18,8 @@ function populateTeamCheckingRouter() {
 
   const teamCombinations = getTeamCombinations();
 
+  teamCheckingRoutes.get('/', validateUserTeam([]), (req: Request, res: Response) => renderTeamsChecker(req, res, { teamCombinations }));
+
   teamCombinations.forEach((teamCombination) => {
     teamCheckingRoutes.get(`/${teamCombination.url}`, validateUserTeam(teamCombination.teams), (req: Request, res: Response) =>
       renderTeamsChecker(req, res, { teamCombinations, currentPageTeamRestrictions: teamCombination }),

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -1,17 +1,20 @@
-{% macro renderLinks(teamCombinations) %}
-    <ul>
-        {% for teamCombination in teamCombinations %}
-            <li>
-                <a href="/team-checking/{{ teamCombination.url }}">{{ teamCombination.description }}</a>
-            </li>
-        {% endfor %}
-    </ul>
-{% endmacro %}
-<h1>Logged in user teams: {{ currentUserTeams | join(", ") }}</h1>
-{% if currentPageTeamRestrictions %}
-    <h2>
-        ✅ User has access to a page with the following team restrictions: {{ currentPageTeamRestrictions.description }}
-    </h2>
-{% endif %}
-<h2>Click below to check routes restrictions:</h2>
-{{ renderLinks(teamCombinations) }}
+{% extends "index.njk" %}
+{% block content %}
+    {% macro renderLinks(teamCombinations) %}
+        <ul>
+            {% for teamCombination in teamCombinations %}
+                <li>
+                    <a href="/team-checking/{{ teamCombination.url }}">{{ teamCombination.description }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endmacro %}
+    <h1>Logged in user teams: {{ currentUserTeams | join(", ") }}</h1>
+    {% if currentPageTeamRestrictions %}
+        <h2>
+            ✅ User has access to a page with the following team restrictions: {{ currentPageTeamRestrictions.description }}
+        </h2>
+    {% endif %}
+    <h2>Click below to check routes restrictions:</h2>
+    {{ renderLinks(teamCombinations) }}
+    {{ endblock }}

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -1,0 +1,17 @@
+{% macro renderLinks(teamCombinations) %}
+    <ul>
+        {% for teamCombination in teamCombinations %}
+            <li>
+                <a href="{{ teamCombination.url }}">{{ link.description }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+{% endmacro %}
+<h1>Logged in user teams: {{ currentUserTeams | join(", ") }}</h1>
+{% if currentPageTeamRestrictions %}
+    <h2>
+        ✅ User has access to a page with the following team restrictions: {{ currentPageTeamRestrictions.description }}
+    </h2>
+{% endif %}
+<h2>Click below to check routes restrictions:</h2>
+{{ renderLinks(teamCombinations) }}

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -14,12 +14,15 @@
         This tool is designed to aid the checking of team restrictions. It utilises the same method for our tfm-ui middleware.
     </p>
     <p>
-        Your current user has the following team assignments: {{ currentUserTeams | join(", ") }}. To get started, click the links below to see how this user behaves when visiting a page with restrictions for teams as stated.
+        Your current user has the following team assignments: <b>{{ currentUserTeams | join(", ") }}</b>.
+    </p>
+    <p>
+        To get started, click the links below to see how this user behaves when visiting a page with restrictions for teams as stated.
     </p>
     <p>
         The below links state all roles that can access them -- ie if a link is 'team1 and team2', the user can belong to either 'team1' or 'team2'. This follows Role Based Access Control (RBAC) principles.
     </p>
-    <h2>Team restrictions:</h2>
+    <h2>Current page team restrictions:</h2>
     {% if currentPageTeamRestrictions %}
         {% if isUserInTeam %}
             ✅ User has access to a page with the following team restrictions: {{ currentPageTeamRestrictions.description }}

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -17,4 +17,4 @@
     {% endif %}
     <h2>Click below to check routes restrictions:</h2>
     {{ renderLinks(teamCombinations) }}
-    {{ endblock }}
+{% endblock %}

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -2,7 +2,7 @@
     <ul>
         {% for teamCombination in teamCombinations %}
             <li>
-                <a href="/team{{ teamCombination.url }}">{{ teamCombination.description }}</a>
+                <a href="/team-checking/{{ teamCombination.url }}">{{ teamCombination.description }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -2,7 +2,7 @@
     <ul>
         {% for teamCombination in teamCombinations %}
             <li>
-                <a href="{{ teamCombination.url }}">{{ link.description }}</a>
+                <a href="{{ teamCombination.url }}">{{ teamCombination.description }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -2,7 +2,7 @@
     <ul>
         {% for teamCombination in teamCombinations %}
             <li>
-                <a href="{{ teamCombination.url }}">{{ teamCombination.description }}</a>
+                <a href="/team{{ teamCombination.url }}">{{ teamCombination.description }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
+++ b/trade-finance-manager-ui/templates/team-checking/team-checking-page.njk
@@ -9,12 +9,26 @@
             {% endfor %}
         </ul>
     {% endmacro %}
-    <h1>Logged in user teams: {{ currentUserTeams | join(", ") }}</h1>
+    <h1>Team role checker</h1>
+    <p>
+        This tool is designed to aid the checking of team restrictions. It utilises the same method for our tfm-ui middleware.
+    </p>
+    <p>
+        Your current user has the following team assignments: {{ currentUserTeams | join(", ") }}. To get started, click the links below to see how this user behaves when visiting a page with restrictions for teams as stated.
+    </p>
+    <p>
+        The below links state all roles that can access them -- ie if a link is 'team1 and team2', the user can belong to either 'team1' or 'team2'. This follows Role Based Access Control (RBAC) principles.
+    </p>
+    <h2>Team restrictions:</h2>
     {% if currentPageTeamRestrictions %}
-        <h2>
+        {% if isUserInTeam %}
             ✅ User has access to a page with the following team restrictions: {{ currentPageTeamRestrictions.description }}
-        </h2>
+        {% else %}
+            ❌ User does not have access to a page with the following team restrictions: {{ currentPageTeamRestrictions.description }}
+        {% endif %}
+    {% else %}
+        The current page does not have any team restrictions. Click a link below to check team restrictions.
     {% endif %}
     <h2>Click below to check routes restrictions:</h2>
     {{ renderLinks(teamCombinations) }}
-{% endblock %}
+{% endblock content %}


### PR DESCRIPTION
## Introduction :pencil2:
As we look to test SSO, we want to check that SSO is correctly assigning RBAC (role based access control) roles.

Currently, we don't have a comprehensive list of endpoints that cover scenarios (currently, there are only a handful that are restrictive) -- see below


## Resolution :heavy_check_mark:
To make this easier to test, I've created a quick page with all the options on, allowing QA to test quickly.

I've used the same function used in TFM UI middleware for the validation -- so we can be sure this is working as intended.

Tested locally with the PIM role.
## Miscellaneous :heavy_plus_sign:
I've not added tests as this is a testing tool, but happy to if needed.


**Note the copy has changed slightly from the below images**
### User visits `/team-checking` as a PIM user
![image](https://github.com/user-attachments/assets/2637c923-d60d-4e07-a7d1-a542e9f83671)

### User visits `/team-checking/PIM` as a PIM user
![image](https://github.com/user-attachments/assets/d50250e3-0294-4cdd-a6fa-4041e4f22ae5)

### User visits `/team-checking/PDC_READ` as a PIM user
![image](https://github.com/user-attachments/assets/049ac65d-86e6-47be-a891-1fd7afd587d4)

### User visits `/team-checking/BUSINESS_SUPPORT-UNDERWRITING` as a PIM user
![image](https://github.com/user-attachments/assets/a5ea6193-db3a-43bf-8947-c3d090b0eeaa)
 