### PR TITLE
feat(FN-3670): redirect to correction sent page on submission

### DIFF
--- a/dtfs-central-api/api-tests/helpers/custom-error-response.ts
+++ b/dtfs-central-api/api-tests/helpers/custom-error-response.ts
@@ -1,0 +1,5 @@
+import { Response } from 'supertest';
+
+export interface CustomErrorResponse extends Response {
+  body: { errors: { msg: string }[] };
+}

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction-transient-form-data.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction-transient-form-data.api-test.ts
@@ -1,5 +1,4 @@
 import { HttpStatusCode } from 'axios';
-import { Response } from 'supertest';
 import {
   CURRENCY,
   FEE_RECORD_STATUS,
@@ -17,12 +16,9 @@ import { aBank } from '../../../../test-helpers';
 import { PutFeeRecordCorrectionTransientFormDataPayload } from '../../../../src/v1/routes/middleware/payload-validation';
 import { replaceUrlParameterPlaceholders } from '../../../../test-helpers/replace-url-parameter-placeholders';
 import { mongoDbClient } from '../../../../src/drivers/db-client';
+import { CustomErrorResponse } from '../../../helpers/custom-error-response';
 
 console.error = jest.fn();
-
-interface CustomErrorResponse extends Response {
-  body: { errors: { msg: string }[] };
-}
 
 const BASE_URL = '/v1/bank/:bankId/fee-record-corrections/:correctionId/transient-form-data';
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
@@ -1,0 +1,168 @@
+import { HttpStatusCode } from 'axios';
+import { Response } from 'supertest';
+import {
+  FEE_RECORD_STATUS,
+  FeeRecordCorrectionEntityMockBuilder,
+  FeeRecordCorrectionTransientFormDataEntityMockBuilder,
+  FeeRecordEntityMockBuilder,
+  RECONCILIATION_IN_PROGRESS,
+  ReportPeriod,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
+import { withSqlIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
+import { ObjectId } from 'mongodb';
+import { testApi } from '../../../test-api';
+import { SqlDbHelper } from '../../../sql-db-helper';
+import wipeDB from '../../../wipeDB';
+import { aBank } from '../../../../test-helpers';
+import { replaceUrlParameterPlaceholders } from '../../../../test-helpers/replace-url-parameter-placeholders';
+import { mongoDbClient } from '../../../../src/drivers/db-client';
+
+console.error = jest.fn();
+
+interface CustomErrorResponse extends Response {
+  body: { errors: { msg: string }[] };
+}
+
+interface CustomSuccessResponse extends Response {
+  body: {
+    sentToEmails: string[];
+    reportPeriod: ReportPeriod;
+  };
+}
+
+const BASE_URL = '/v1/bank/:bankId/fee-record-corrections/:correctionId';
+
+describe(`PUT ${BASE_URL}`, () => {
+  const bankId = '1';
+  const correctionId = 2;
+  const userId = new ObjectId().toString();
+
+  const reportPeriod = { start: { month: 3, year: 2023 }, end: { month: 4, year: 2023 } };
+
+  const paymentOfficerTeamEmails = ['email1@ukexportfinance.gov.uk'];
+
+  const mockBank = {
+    ...aBank(),
+    id: bankId,
+    _id: new ObjectId(),
+    paymentOfficerTeam: {
+      emails: paymentOfficerTeamEmails,
+      teamName: 'Payment Officer Team',
+    },
+  };
+
+  const aValidRequestBody = () => ({
+    user: { id: userId },
+  });
+
+  beforeAll(async () => {
+    await SqlDbHelper.initialize();
+    await wipeDB.wipe(['banks']);
+
+    const banksCollection = await mongoDbClient.getCollection('banks');
+    await banksCollection.insertOne(mockBank);
+  });
+
+  beforeEach(async () => {
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrection');
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+
+    const report = UtilisationReportEntityMockBuilder.forStatus(RECONCILIATION_IN_PROGRESS).withBankId(bankId).withReportPeriod(reportPeriod).build();
+
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withStatus(FEE_RECORD_STATUS.PENDING_CORRECTION).build();
+
+    const correction = FeeRecordCorrectionEntityMockBuilder.forFeeRecord(feeRecord).withId(correctionId).withIsCompleted(false).build();
+
+    feeRecord.corrections = [correction];
+    report.feeRecords = [feeRecord];
+
+    await SqlDbHelper.saveNewEntry('UtilisationReport', report);
+
+    const formData = new FeeRecordCorrectionTransientFormDataEntityMockBuilder().withCorrectionId(correctionId).withUserId(userId).build();
+
+    await SqlDbHelper.saveNewEntry('FeeRecordCorrectionTransientFormData', formData);
+  });
+
+  afterAll(async () => {
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrection');
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+  });
+
+  withSqlIdPathParameterValidationTests({
+    baseUrl: BASE_URL.replace(':bankId', bankId),
+    makeRequest: (url) => testApi.put({}).to(url),
+  });
+
+  it(`should return ${HttpStatusCode.BadRequest} when an invalid bank id is provided`, async () => {
+    // Act
+    const response: CustomErrorResponse = await testApi
+      .put(aValidRequestBody())
+      .to(replaceUrlParameterPlaceholders(BASE_URL, { bankId: 'invalid-id', correctionId }));
+
+    // Assert
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
+    expect(response.body.errors[0]?.msg).toEqual('The bank id provided should be a string of numbers');
+  });
+
+  it(`should return '${HttpStatusCode.BadRequest}' when the user field is missing`, async () => {
+    // Arrange
+    const requestBody = {
+      user: undefined,
+    };
+
+    // Act
+    const response = await testApi.put(requestBody).to(replaceUrlParameterPlaceholders(BASE_URL, { bankId, correctionId }));
+
+    // Assert
+    expect(response.status).toEqual(HttpStatusCode.BadRequest);
+  });
+
+  it(`should return '${HttpStatusCode.NotFound}' when no correction exists with the requested bank id`, async () => {
+    // Arrange
+    const requestBody = aValidRequestBody();
+
+    // Act
+    const response = await testApi.put(requestBody).to(replaceUrlParameterPlaceholders(BASE_URL, { bankId: `${bankId}123`, correctionId }));
+
+    // Assert
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
+  });
+
+  it(`should return '${HttpStatusCode.NotFound}' if no correction exists with the requested correction id`, async () => {
+    // Arrange
+    const requestBody = aValidRequestBody();
+
+    // Act
+    const { status } = await testApi.put(requestBody).to(replaceUrlParameterPlaceholders(BASE_URL, { bankId, correctionId: correctionId + 1 }));
+
+    // Assert
+    expect(status).toEqual(HttpStatusCode.NotFound);
+  });
+
+  it(`should return '${HttpStatusCode.Ok}' if the correction exists`, async () => {
+    // Arrange
+    const requestBody = aValidRequestBody();
+
+    // Act
+    const { status } = await testApi.put(requestBody).to(replaceUrlParameterPlaceholders(BASE_URL, { bankId, correctionId }));
+
+    // Assert
+    expect(status).toEqual(HttpStatusCode.Ok);
+  });
+
+  it('should return the sent to email addresses and the report period upon success', async () => {
+    // Arrange
+    const requestBody = aValidRequestBody();
+
+    // Act
+    const response: CustomSuccessResponse = await testApi.put(requestBody).to(replaceUrlParameterPlaceholders(BASE_URL, { bankId, correctionId }));
+
+    // Assert
+    const expectedBody = {
+      sentToEmails: paymentOfficerTeamEmails,
+      reportPeriod,
+    };
+    expect(response.body).toEqual(expectedBody);
+  });
+});

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
@@ -65,6 +65,7 @@ describe(`PUT ${BASE_URL}`, () => {
   });
 
   beforeEach(async () => {
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrectionTransientFormData');
     await SqlDbHelper.deleteAllEntries('FeeRecordCorrection');
     await SqlDbHelper.deleteAllEntries('UtilisationReport');
 

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
@@ -17,12 +17,9 @@ import wipeDB from '../../../wipeDB';
 import { aBank } from '../../../../test-helpers';
 import { replaceUrlParameterPlaceholders } from '../../../../test-helpers/replace-url-parameter-placeholders';
 import { mongoDbClient } from '../../../../src/drivers/db-client';
+import { CustomErrorResponse } from '../../../helpers/custom-error-response';
 
 console.error = jest.fn();
-
-interface CustomErrorResponse extends Response {
-  body: { errors: { msg: string }[] };
-}
 
 interface CustomSuccessResponse extends Response {
   body: {
@@ -45,7 +42,6 @@ describe(`PUT ${BASE_URL}`, () => {
   const mockBank = {
     ...aBank(),
     id: bankId,
-    _id: new ObjectId(),
     paymentOfficerTeam: {
       emails: paymentOfficerTeamEmails,
       teamName: 'Payment Officer Team',

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
@@ -53,7 +53,7 @@ describe(`PUT ${BASE_URL}`, () => {
   };
 
   const aValidRequestBody = () => ({
-    user: { id: userId },
+    user: { _id: userId },
   });
 
   beforeAll(async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports-reconciliation-summary.api-test.ts
@@ -20,6 +20,7 @@ import { UtilisationReportReconciliationSummary, UtilisationReportReconciliation
 import { withoutMongoId } from '../../../src/helpers/mongodb';
 import { aPortalUser } from '../../../test-helpers';
 import { mongoDbClient } from '../../../src/drivers/db-client';
+import { CustomErrorResponse } from '../../helpers/custom-error-response';
 
 console.error = jest.fn();
 
@@ -96,10 +97,6 @@ describe(`GET ${BASE_URL}`, () => {
     expect(response.body[0].items[0].reportedFeesLeftToReconcile).toEqual(feeRecords.length);
   });
 });
-
-interface CustomErrorResponse extends Response {
-  body: { errors: { msg: string }[] };
-}
 
 interface CustomSuccessResponse extends Response {
   body: {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-utilisation-reports.api-test.ts
@@ -15,6 +15,7 @@ import { GetUtilisationReportResponse } from '../../../src/types/utilisation-rep
 import { mongoDbClient } from '../../../src/drivers/db-client';
 import { wipe } from '../../wipeDB';
 import { aPortalUser } from '../../../test-helpers';
+import { CustomErrorResponse } from '../../helpers/custom-error-response';
 
 console.error = jest.fn();
 
@@ -24,10 +25,6 @@ const saveReportsToDatabase = async (...reports: UtilisationReportEntity[]): Pro
 type UtilisationReportResponse = GetUtilisationReportResponse & {
   dateUploaded: IsoDateTimeStamp;
 };
-
-interface CustomErrorResponse extends Response {
-  body: { errors: { msg: string }[] };
-}
 
 interface CustomSuccessResponse extends Response {
   body: UtilisationReportResponse[];

--- a/dtfs-central-api/src/repositories/fee-record-correction-repo/fee-record-correction.repo.ts
+++ b/dtfs-central-api/src/repositories/fee-record-correction-repo/fee-record-correction.repo.ts
@@ -36,6 +36,22 @@ export const FeeRecordCorrectionRepo = SqlDbDataSource.getRepository(FeeRecordCo
   },
 
   /**
+   * Finds one fee record correction with correction id and bank id with
+   * the fee record and report attached
+   * @param id - The fee record correction id
+   * @returns The found fee record correction, else null
+   */
+  async findOneByIdAndBankIdWithFeeRecordAndReport(correctionId: number, bankId: string): Promise<FeeRecordCorrectionEntity | null> {
+    return await this.findOne({
+      where: {
+        id: correctionId,
+        feeRecord: { report: { bankId } },
+      },
+      relations: { feeRecord: { report: true } },
+    });
+  },
+
+  /**
    * Finds one fee record correction with the given id and bank id.
    * @param correctionId - The id of the correction.
    * @param bankId - The id of the bank.

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.test.ts
@@ -4,6 +4,7 @@ import { Response } from 'express';
 import { HttpStatusCode } from 'axios';
 import {
   FeeRecordCorrectionEntityMockBuilder,
+  FeeRecordCorrectionTransientFormDataEntityMockBuilder,
   FeeRecordEntityMockBuilder,
   PaymentOfficerTeam,
   PENDING_RECONCILIATION,
@@ -29,7 +30,7 @@ describe('putFeeRecordCorrection', () => {
   const portalUserId = new ObjectId().toString();
 
   const aValidRequestParams = () => ({ correctionId: correctionId.toString(), bankId });
-  const aValidRequestBody = () => ({ user: { id: portalUserId } });
+  const aValidRequestBody = () => ({ user: { _id: portalUserId } });
 
   let req: PutFeeRecordCorrectionRequest;
   let res: MockResponse<Response>;
@@ -105,9 +106,14 @@ describe('putFeeRecordCorrection', () => {
 
     describe('and when the transient form data is found', () => {
       const formData = { utilisation: 500000 };
+      const transientFormDataEntity = new FeeRecordCorrectionTransientFormDataEntityMockBuilder()
+        .withCorrectionId(correctionId)
+        .withUserId(portalUserId)
+        .withFormData(formData)
+        .build();
 
       beforeEach(() => {
-        mockFindCorrectionTransientFormData.mockResolvedValue({ formData });
+        mockFindCorrectionTransientFormData.mockResolvedValue(transientFormDataEntity);
       });
 
       describe('and when the bank is not found', () => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.test.ts
@@ -1,0 +1,200 @@
+import { ObjectId } from 'mongodb';
+import httpMocks, { MockResponse } from 'node-mocks-http';
+import { Response } from 'express';
+import { HttpStatusCode } from 'axios';
+import {
+  FeeRecordCorrectionEntityMockBuilder,
+  FeeRecordEntityMockBuilder,
+  PaymentOfficerTeam,
+  PENDING_RECONCILIATION,
+  TestApiError,
+  UtilisationReportEntityMockBuilder,
+} from '@ukef/dtfs2-common';
+import { FeeRecordCorrectionTransientFormDataRepo } from '../../../../../repositories/fee-record-correction-transient-form-data-repo';
+import { FeeRecordCorrectionRepo } from '../../../../../repositories/fee-record-correction-repo';
+import { putFeeRecordCorrection, PutFeeRecordCorrectionRequest } from '.';
+import { getBankById } from '../../../../../repositories/banks-repo';
+import { aBank } from '../../../../../../test-helpers';
+
+jest.mock('../../../../../repositories/fee-record-correction-transient-form-data-repo');
+jest.mock('../../../../../repositories/fee-record-correction-repo');
+jest.mock('../../../../../repositories/banks-repo');
+
+describe('putFeeRecordCorrection', () => {
+  const mockFindCorrection = jest.fn();
+  const mockFindCorrectionTransientFormData = jest.fn();
+
+  const correctionId = 1;
+  const bankId = '123';
+  const portalUserId = new ObjectId().toString();
+
+  const aValidRequestParams = () => ({ correctionId: correctionId.toString(), bankId });
+  const aValidRequestBody = () => ({ user: { id: portalUserId } });
+
+  let req: PutFeeRecordCorrectionRequest;
+  let res: MockResponse<Response>;
+
+  beforeEach(() => {
+    FeeRecordCorrectionRepo.findOneByIdAndBankIdWithFeeRecordAndReport = mockFindCorrection;
+    FeeRecordCorrectionTransientFormDataRepo.findByUserIdAndCorrectionId = mockFindCorrectionTransientFormData;
+
+    req = httpMocks.createRequest<PutFeeRecordCorrectionRequest>({
+      params: aValidRequestParams(),
+      body: aValidRequestBody(),
+    });
+    res = httpMocks.createResponse();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should call the repo to fetch the correction for the bank and correction', async () => {
+    // Act
+    await putFeeRecordCorrection(req, res);
+
+    // Assert
+    expect(mockFindCorrection).toHaveBeenCalledTimes(1);
+    expect(mockFindCorrection).toHaveBeenCalledWith(correctionId, bankId);
+  });
+
+  describe('when the correction is not found', () => {
+    beforeEach(() => {
+      mockFindCorrection.mockResolvedValue(null);
+    });
+
+    it(`should respond with ${HttpStatusCode.NotFound} if correction is not found`, async () => {
+      // Act
+      await putFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+      expect(res._getData()).toBe(`Failed to put fee record correction: Failed to find a correction with id '${correctionId}' for bank id '${bankId}'`);
+    });
+  });
+
+  describe('when the correction is found', () => {
+    const reportPeriod = { start: { month: 10, year: 2023 }, end: { month: 10, year: 2023 } };
+
+    const report = UtilisationReportEntityMockBuilder.forStatus(PENDING_RECONCILIATION).withReportPeriod(reportPeriod).withBankId(bankId).build();
+
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).build();
+
+    const correction = FeeRecordCorrectionEntityMockBuilder.forFeeRecord(feeRecord).withId(correctionId).build();
+
+    beforeEach(() => {
+      mockFindCorrection.mockResolvedValue(correction);
+    });
+
+    describe('and when the transient form data is not found', () => {
+      beforeEach(() => {
+        mockFindCorrectionTransientFormData.mockResolvedValue(null);
+      });
+
+      it(`should respond with ${HttpStatusCode.NotFound} if transient form data is not found`, async () => {
+        // Act
+        await putFeeRecordCorrection(req, res);
+
+        // Assert
+        expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+        expect(res._getData()).toBe(
+          `Failed to put fee record correction: Failed to find transient form data with user id '${portalUserId}' for correction id '${correctionId}'`,
+        );
+      });
+    });
+
+    describe('and when the transient form data is found', () => {
+      const formData = { utilisation: 500000 };
+
+      beforeEach(() => {
+        mockFindCorrectionTransientFormData.mockResolvedValue({ formData });
+      });
+
+      describe('and when the bank is not found', () => {
+        beforeEach(() => {
+          jest.mocked(getBankById).mockResolvedValue(null);
+        });
+
+        it(`should respond with ${HttpStatusCode.NotFound} if bank is not found`, async () => {
+          // Act
+          await putFeeRecordCorrection(req, res);
+
+          // Assert
+          expect(res._getStatusCode()).toBe(HttpStatusCode.NotFound);
+          expect(res._getData()).toBe(`Failed to put fee record correction: Failed to find bank with id '${bankId}'`);
+        });
+      });
+
+      describe('and when the bank is found', () => {
+        const paymentOfficerTeam: PaymentOfficerTeam = { emails: ['email1@ukexportfinance.gov.uk', 'email2@ukexportfinance.gov.uk'], teamName: 'This Team' };
+        const bank = { ...aBank(), paymentOfficerTeam };
+
+        beforeEach(() => {
+          jest.mocked(getBankById).mockResolvedValue(bank);
+        });
+
+        it(`should respond with ${HttpStatusCode.Ok}`, async () => {
+          // Act
+          await putFeeRecordCorrection(req, res);
+
+          // Assert
+          expect(res._getStatusCode()).toBe(HttpStatusCode.Ok);
+        });
+
+        it('should respond with the payment officer emails and report period', async () => {
+          // Act
+          await putFeeRecordCorrection(req, res);
+
+          // Assert
+          expect(res._getData()).toEqual({ sentToEmails: paymentOfficerTeam.emails, reportPeriod });
+        });
+      });
+    });
+
+    it("should respond with the specific error status if retrieving the correction throws an 'ApiError'", async () => {
+      // Arrange
+      const errorStatus = HttpStatusCode.RequestTimeout;
+      mockFindCorrection.mockRejectedValue(new TestApiError({ status: errorStatus }));
+
+      // Act
+      await putFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(errorStatus);
+    });
+
+    it("should respond with the specific error message if retrieving the correction throws an 'ApiError'", async () => {
+      // Arrange
+      const errorMessage = 'Some error message';
+      mockFindCorrection.mockRejectedValue(new TestApiError({ message: errorMessage }));
+
+      // Act
+      await putFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getData()).toEqual(`Failed to put fee record correction: ${errorMessage}`);
+    });
+
+    it(`should respond with a '${HttpStatusCode.InternalServerError}' if an unknown error occurs`, async () => {
+      // Arrange
+      mockFindCorrection.mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await putFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    });
+
+    it('should respond with a generic error message if an unknown error occurs', async () => {
+      // Arrange
+      mockFindCorrection.mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await putFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getData()).toEqual(`Failed to put fee record correction`);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
@@ -37,7 +37,7 @@ export const putFeeRecordCorrection = async (req: PutFeeRecordCorrectionRequest,
     const { user } = req.body;
 
     const correctionId = Number(correctionIdString);
-    const userId = user.id;
+    const userId = user._id;
 
     const correction = await FeeRecordCorrectionRepo.findOneByIdAndBankIdWithFeeRecordAndReport(correctionId, bankId);
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
@@ -1,0 +1,75 @@
+import { ApiError } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { Response } from 'express';
+import { CustomExpressRequest } from '../../../../../types/custom-express-request';
+import { NotFoundError } from '../../../../../errors';
+import { FeeRecordCorrectionRepo } from '../../../../../repositories/fee-record-correction-repo';
+import { FeeRecordCorrectionTransientFormDataRepo } from '../../../../../repositories/fee-record-correction-transient-form-data-repo';
+import { PutFeeRecordCorrectionPayload } from '../../../../routes/middleware/payload-validation';
+import { getBankById } from '../../../../../repositories/banks-repo';
+
+export type PutFeeRecordCorrectionRequest = CustomExpressRequest<{
+  params: {
+    bankId: string;
+    correctionId: string;
+  };
+  reqBody: PutFeeRecordCorrectionPayload;
+}>;
+
+/**
+ * Controller for the PUT fee record correction route.
+ *
+ * - Fetches the fee record correction transient form data for the
+ * requesting user and correction id combination.
+ * - Updates the fee record with the corrected values and sets the
+ * status back to TO_DO.
+ * - Saves the old and new values against the record correction for
+ * record correction history log.
+ * - Sends confirmation email to the bank payment report officer team.
+ * - Sends notification email to PDC team.
+ *
+ * @param req - The {@link PutFeeRecordCorrectionRequest} request object
+ * @param res - The response object
+ */
+export const putFeeRecordCorrection = async (req: PutFeeRecordCorrectionRequest, res: Response) => {
+  try {
+    const { correctionId: correctionIdString, bankId } = req.params;
+    const { user } = req.body;
+
+    const correctionId = Number(correctionIdString);
+    const userId = user.id;
+
+    const correction = await FeeRecordCorrectionRepo.findOneByIdAndBankIdWithFeeRecordAndReport(correctionId, bankId);
+
+    if (!correction) {
+      throw new NotFoundError(`Failed to find a correction with id '${correctionId}' for bank id '${bankId}'`);
+    }
+
+    const transientFormData = await FeeRecordCorrectionTransientFormDataRepo.findByUserIdAndCorrectionId(userId, correctionId);
+
+    if (!transientFormData) {
+      throw new NotFoundError(`Failed to find a transient form data with user id '${userId}' for correction id '${correctionId}'`);
+    }
+
+    const bank = await getBankById(bankId);
+
+    if (!bank) {
+      throw new NotFoundError(`Failed to find bank with id '${bankId}'`);
+    }
+
+    // TODO: FN-3675 - apply the correction to the fee record and send confirmation emails
+
+    const { reportPeriod } = correction.feeRecord.report;
+
+    const { emails: paymentOfficerEmails } = bank.paymentOfficerTeam;
+
+    return res.status(HttpStatusCode.Ok).send({ sentToEmails: paymentOfficerEmails, reportPeriod });
+  } catch (error) {
+    const errorMessage = 'Failed to put fee record correction';
+    console.error('%s %o', errorMessage, error);
+    if (error instanceof ApiError) {
+      return res.status(error.status).send(`${errorMessage}: ${error.message}`);
+    }
+    return res.status(HttpStatusCode.InternalServerError).send(errorMessage);
+  }
+};

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
@@ -48,7 +48,7 @@ export const putFeeRecordCorrection = async (req: PutFeeRecordCorrectionRequest,
     const transientFormData = await FeeRecordCorrectionTransientFormDataRepo.findByUserIdAndCorrectionId(userId, correctionId);
 
     if (!transientFormData) {
-      throw new NotFoundError(`Failed to find a transient form data with user id '${userId}' for correction id '${correctionId}'`);
+      throw new NotFoundError(`Failed to find transient form data with user id '${userId}' for correction id '${correctionId}'`);
     }
 
     const bank = await getBankById(bankId);

--- a/dtfs-central-api/src/v1/routes/bank-routes.js
+++ b/dtfs-central-api/src/v1/routes/bank-routes.js
@@ -7,10 +7,11 @@ const { getBanks } = require('../controllers/bank/get-banks.controller');
 const createBankController = require('../controllers/bank/create-bank.controller');
 const getNextReportPeriodController = require('../controllers/bank/get-next-report-period-by-bank.controller');
 const { getUtilisationReportsByBankIdAndOptions } = require('../controllers/utilisation-report-service/get-utilisation-reports.controller');
-const { validatePutFeeRecordCorrectionTransientFormDataPayload } = require('./middleware/payload-validation');
+const { validatePutFeeRecordCorrectionTransientFormDataPayload, validatePutFeeRecordCorrectionPayload } = require('./middleware/payload-validation');
 const {
   putFeeRecordCorrectionTransientFormData,
 } = require('../controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction-transient-form-data.controller');
+const { putFeeRecordCorrection } = require('../controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller');
 const {
   getUtilisationReportPendingCorrectionsByBankId,
 } = require('../controllers/utilisation-report-service/fee-record-correction/get-utilisation-report-pending-corrections.controller');
@@ -266,6 +267,63 @@ bankRouter
     handleExpressValidatorResult,
     validatePutFeeRecordCorrectionTransientFormDataPayload,
     putFeeRecordCorrectionTransientFormData,
+  );
+
+/**
+ * @openapi
+ * /bank/:bankId/fee-record-corrections/:correctionId:
+ *   put:
+ *     summary: |
+ *       Save the transient form data for the requesting user
+ *       and correction id combination to the fee record correction
+ *       and send confirmation email to the bank and UKEF
+ *     tags: [Utilisation Report]
+ *     description: |
+ *       Save the transient form data for the requesting user
+ *       and correction id combination to the fee record correction
+ *       and send confirmation email to the bank and UKEF
+ *     parameters:
+ *       - in: path
+ *         name: bankId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: the id for the bank
+ *       - in: path
+ *         name: correctionId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: the id for the fee record correction
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               user:
+ *                 type: object
+ *                 properties:
+ *                   id: string
+ *     responses:
+ *       200:
+ *         description: OK
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Not found
+ *       500:
+ *         description: Internal Server Error
+ */
+bankRouter
+  .route('/:bankId/fee-record-corrections/:correctionId')
+  .put(
+    validation.bankIdValidation,
+    validation.sqlIdValidation('correctionId'),
+    handleExpressValidatorResult,
+    validatePutFeeRecordCorrectionPayload,
+    putFeeRecordCorrection,
   );
 
 /**

--- a/dtfs-central-api/src/v1/routes/bank-routes.js
+++ b/dtfs-central-api/src/v1/routes/bank-routes.js
@@ -305,7 +305,7 @@ bankRouter
  *               user:
  *                 type: object
  *                 properties:
- *                   id: string
+ *                   _id: string
  *     responses:
  *       200:
  *         description: OK

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/index.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/index.ts
@@ -15,3 +15,4 @@ export * from './validate-post-submit-deal-cancellation-payload';
 export * from './validate-put-fee-record-correction-request-transient-form-data-payload';
 export * from './validate-put-fee-record-correction-transient-form-data-payload';
 export * from './validate-post-fee-record-correction-payload';
+export * from './validate-put-fee-record-correction-payload';

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.test.ts
@@ -1,5 +1,6 @@
 import httpMocks from 'node-mocks-http';
 import { HttpStatusCode } from 'axios';
+import { ObjectId } from 'mongodb';
 import { validatePutFeeRecordCorrectionPayload } from './validate-put-fee-record-correction-payload';
 
 describe('validatePutFeeRecordCorrectionPayload', () => {
@@ -39,5 +40,23 @@ describe('validatePutFeeRecordCorrectionPayload', () => {
     expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
     expect(res._isEndCalled()).toEqual(true);
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it("should call the 'next' function if the payload is valid", () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    const validPayload = {
+      user: { _id: new ObjectId().toString() },
+    };
+    req.body = validPayload;
+
+    // Act
+    validatePutFeeRecordCorrectionPayload(req, res, next);
+
+    // Assert
+    expect(next).toHaveBeenCalled();
+    expect(res._isEndCalled()).toEqual(false);
   });
 });

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.test.ts
@@ -28,7 +28,7 @@ describe('validatePutFeeRecordCorrectionPayload', () => {
     const next = jest.fn();
 
     const invalidPayload = {
-      user: { id: 'invalidObjectId' },
+      user: { _id: 'invalidObjectId' },
     };
     req.body = invalidPayload;
 

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.test.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.test.ts
@@ -1,0 +1,43 @@
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { validatePutFeeRecordCorrectionPayload } from './validate-put-fee-record-correction-payload';
+
+describe('validatePutFeeRecordCorrectionPayload', () => {
+  const getHttpMocks = () => httpMocks.createMocks();
+
+  it(`should respond with a '${HttpStatusCode.BadRequest}' if the user field is missing`, () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    const invalidPayload = {};
+    req.body = invalidPayload;
+
+    // Act
+    validatePutFeeRecordCorrectionPayload(req, res, next);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it(`should respond with a '${HttpStatusCode.BadRequest}' if user.id is not a valid mongo id`, () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    const next = jest.fn();
+
+    const invalidPayload = {
+      user: { id: 'invalidObjectId' },
+    };
+    req.body = invalidPayload;
+
+    // Act
+    validatePutFeeRecordCorrectionPayload(req, res, next);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.BadRequest);
+    expect(res._isEndCalled()).toEqual(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.ts
@@ -6,7 +6,7 @@ import { MongoObjectIdSchema } from './schemas';
  * Schema for validating fee record correction payload.
  */
 const PutFeeRecordCorrectionPayloadSchema = z.object({
-  user: z.object({ id: MongoObjectIdSchema }),
+  user: z.object({ _id: MongoObjectIdSchema }),
 });
 
 /**

--- a/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.ts
+++ b/dtfs-central-api/src/v1/routes/middleware/payload-validation/validate-put-fee-record-correction-payload.ts
@@ -1,0 +1,20 @@
+import z from 'zod';
+import { createValidationMiddlewareForSchema } from '@ukef/dtfs2-common';
+import { MongoObjectIdSchema } from './schemas';
+
+/**
+ * Schema for validating fee record correction payload.
+ */
+const PutFeeRecordCorrectionPayloadSchema = z.object({
+  user: z.object({ id: MongoObjectIdSchema }),
+});
+
+/**
+ * Type definition for fee record correction payload.
+ */
+export type PutFeeRecordCorrectionPayload = z.infer<typeof PutFeeRecordCorrectionPayloadSchema>;
+
+/**
+ * Middleware function to validate fee record correction payload.
+ */
+export const validatePutFeeRecordCorrectionPayload = createValidationMiddlewareForSchema(PutFeeRecordCorrectionPayloadSchema);

--- a/portal-api/api-tests/v1/utilisation-report-service/fee-record-corrections/get-fee-record-correction-transient-form-data.api-test.js
+++ b/portal-api/api-tests/v1/utilisation-report-service/fee-record-corrections/get-fee-record-correction-transient-form-data.api-test.js
@@ -6,7 +6,7 @@ const { withClientAuthenticationTests } = require('../../../common-tests/client-
 const { withRoleAuthorisationTests } = require('../../../common-tests/role-authorisation-tests.js');
 const { PAYMENT_REPORT_OFFICER } = require('../../../../src/v1/roles/roles.js');
 
-describe('GET /v1/banks/:bankId/fee-record-correction/:correctionId', () => {
+describe('GET /v1/banks/:bankId/fee-record-correction/:correctionId/transient-form-data', () => {
   const correctionFormDataUrl = (bankId, correctionId) => `/v1/banks/${bankId}/fee-record-correction/${correctionId}/transient-form-data`;
   let aPaymentReportOfficer;
   let testUsers;

--- a/portal-api/api-tests/v1/utilisation-report-service/fee-record-corrections/get-fee-record-correction-transient-form-data.api-test.js
+++ b/portal-api/api-tests/v1/utilisation-report-service/fee-record-corrections/get-fee-record-correction-transient-form-data.api-test.js
@@ -6,7 +6,7 @@ const { withClientAuthenticationTests } = require('../../../common-tests/client-
 const { withRoleAuthorisationTests } = require('../../../common-tests/role-authorisation-tests.js');
 const { PAYMENT_REPORT_OFFICER } = require('../../../../src/v1/roles/roles.js');
 
-describe('GET /v1/banks/:bankId/utilisation-reports/pending-corrections', () => {
+describe('GET /v1/banks/:bankId/fee-record-correction/:correctionId', () => {
   const correctionFormDataUrl = (bankId, correctionId) => `/v1/banks/${bankId}/fee-record-correction/${correctionId}/transient-form-data`;
   let aPaymentReportOfficer;
   let testUsers;

--- a/portal-api/api-tests/v1/utilisation-report-service/fee-record-corrections/save-fee-record-correction.api-test.js
+++ b/portal-api/api-tests/v1/utilisation-report-service/fee-record-corrections/save-fee-record-correction.api-test.js
@@ -1,0 +1,89 @@
+const { HttpStatusCode } = require('axios');
+const {
+  UtilisationReportEntityMockBuilder,
+  PENDING_RECONCILIATION,
+  FeeRecordEntityMockBuilder,
+  FEE_RECORD_STATUS,
+  FeeRecordCorrectionEntityMockBuilder,
+  RECORD_CORRECTION_REASON,
+  FeeRecordCorrectionTransientFormDataEntityMockBuilder,
+} = require('@ukef/dtfs2-common');
+const { SqlDbHelper } = require('../../../sql-db-helper.ts');
+const app = require('../../../../src/createApp.js');
+const { as, put } = require('../../../api.js')(app);
+const testUserCache = require('../../../api-test-users.js');
+const { withClientAuthenticationTests } = require('../../../common-tests/client-authentication-tests.js');
+const { withRoleAuthorisationTests } = require('../../../common-tests/role-authorisation-tests.js');
+const { PAYMENT_REPORT_OFFICER } = require('../../../../src/v1/roles/roles.js');
+
+describe('PUT /v1/banks/:bankId/fee-record-correction/:correctionId', () => {
+  const correctionUrl = (bankId, correctionId) => `/v1/banks/${bankId}/fee-record-correction/${correctionId}`;
+  let aPaymentReportOfficer;
+  let testUsers;
+  let matchingBankId;
+  const correctionId = 123;
+
+  beforeAll(async () => {
+    await SqlDbHelper.initialize();
+
+    testUsers = await testUserCache.initialise(app);
+    aPaymentReportOfficer = testUsers().withRole(PAYMENT_REPORT_OFFICER).one();
+    matchingBankId = aPaymentReportOfficer.bank.id;
+  });
+
+  beforeEach(async () => {
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrectionTransientFormData');
+
+    const report = UtilisationReportEntityMockBuilder.forStatus(PENDING_RECONCILIATION).withBankId(matchingBankId).build();
+    const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withStatus(FEE_RECORD_STATUS.PENDING_CORRECTION).build();
+    const correction = FeeRecordCorrectionEntityMockBuilder.forFeeRecord(feeRecord)
+      .withId(correctionId)
+      .withIsCompleted(false)
+      .withReasons([RECORD_CORRECTION_REASON.REPORTED_FEE_INCORRECT])
+      .build();
+
+    feeRecord.corrections = [correction];
+    report.feeRecords = [feeRecord];
+
+    const transientFormData = new FeeRecordCorrectionTransientFormDataEntityMockBuilder()
+      .withCorrectionId(correctionId)
+      .withUserId(aPaymentReportOfficer._id)
+      .withFormData({ reportedFee: 1234.56 })
+      .build();
+
+    await SqlDbHelper.saveNewEntry('UtilisationReport', report);
+    await SqlDbHelper.saveNewEntry('FeeRecordCorrectionTransientFormData', transientFormData);
+  });
+
+  afterAll(async () => {
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrectionTransientFormData');
+  });
+
+  withClientAuthenticationTests({
+    makeRequestWithoutAuthHeader: () => put(correctionUrl(matchingBankId, correctionId)),
+    makeRequestWithAuthHeader: (authHeader) => put(correctionUrl(matchingBankId, correctionId), { headers: { Authorization: authHeader } }),
+  });
+
+  withRoleAuthorisationTests({
+    allowedRoles: [PAYMENT_REPORT_OFFICER],
+    getUserWithRole: (role) => testUsers().withRole(role).one(),
+    makeRequestAsUser: (user) => as(user).put().to(correctionUrl(matchingBankId, correctionId)),
+    successStatusCode: HttpStatusCode.Ok,
+  });
+
+  it(`should respond with a ${HttpStatusCode.BadRequest} to requests that do not have a valid bank id`, async () => {
+    const { status } = await as(aPaymentReportOfficer).put().to(correctionUrl('invalid-bank-id', correctionId));
+
+    expect(status).toEqual(HttpStatusCode.BadRequest);
+  });
+
+  it(`should respond with a ${HttpStatusCode.Unauthorized} if user's bank does not match request bank`, async () => {
+    const { status } = await as(aPaymentReportOfficer)
+      .put()
+      .to(correctionUrl(matchingBankId - 1, correctionId));
+
+    expect(status).toEqual(HttpStatusCode.Unauthorized);
+  });
+});

--- a/portal-api/src/v1/api-response-types/index.ts
+++ b/portal-api/src/v1/api-response-types/index.ts
@@ -5,3 +5,4 @@ export * from './validate-utilisation-report-data-response-body';
 export * from './utilisation-report-pending-corrections-response-body';
 export * from './get-fee-record-correction-response-body';
 export * from './get-fee-record-correction-transient-form-data-response-body';
+export * from './save-fee-record-correction-response-body';

--- a/portal-api/src/v1/api-response-types/save-fee-record-correction-response-body.ts
+++ b/portal-api/src/v1/api-response-types/save-fee-record-correction-response-body.ts
@@ -1,0 +1,6 @@
+import { ReportPeriod } from '@ukef/dtfs2-common';
+
+export type SaveFeeRecordCorrectionResponseBody = {
+  sentToEmails: string[];
+  reportPeriod: ReportPeriod;
+};

--- a/portal-api/src/v1/api.js
+++ b/portal-api/src/v1/api.js
@@ -507,7 +507,7 @@ const saveFeeRecordCorrection = async (bankId, correctionId, userId) => {
       url: `${DTFS_CENTRAL_API_URL}/v1/bank/${bankId}/fee-record-corrections/${correctionId}`,
       headers: headers.central,
       data: {
-        user: { id: userId },
+        user: { _id: userId },
       },
     });
 

--- a/portal-api/src/v1/api.js
+++ b/portal-api/src/v1/api.js
@@ -490,6 +490,35 @@ const getFeeRecordCorrectionById = async (correctionId) => {
 };
 
 /**
+ * Saves a fee record correction.
+ *
+ * The user id is sent in the body as saving uses the current
+ * users saved fee record correction transient form data.
+ *
+ * @param {string} bankId - The ID of the bank
+ * @param {number} correctionId - The ID of the correction
+ * @param {string} userId - The ID of the user
+ * @returns {Promise<import('./api-response-types').SaveFeeRecordCorrectionResponseBody>} response of API call
+ */
+const saveFeeRecordCorrection = async (bankId, correctionId, userId) => {
+  try {
+    const response = await axios({
+      method: 'put',
+      url: `${DTFS_CENTRAL_API_URL}/v1/bank/${bankId}/fee-record-corrections/${correctionId}`,
+      headers: headers.central,
+      data: {
+        user: { id: userId },
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Unable to save fee record correction with id %s and bank id %s: %o', correctionId, bankId, error);
+    throw error;
+  }
+};
+
+/**
  * Gets fee record correction transient form data by correction id and user id.
  * @param {number} correctionId - The ID of the correction
  * @param {string} userId - The ID of the user
@@ -652,6 +681,7 @@ module.exports = {
   getNextReportPeriodByBankId,
   getUtilisationReportPendingCorrectionsByBankId,
   getFeeRecordCorrectionById,
+  saveFeeRecordCorrection,
   getFeeRecordCorrectionTransientFormData,
   getPortalFacilityAmendment,
   putPortalFacilityAmendment,

--- a/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/fee-record-correction.controller.test.ts
+++ b/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/fee-record-correction.controller.test.ts
@@ -1,30 +1,36 @@
 import httpMocks, { MockResponse } from 'node-mocks-http';
 import { AxiosResponse, HttpStatusCode, AxiosError } from 'axios';
 import { Response } from 'express';
-import { getFeeRecordCorrection, GetFeeRecordCorrectionRequest } from './get-fee-record-correction.controller';
+import { ObjectId } from 'mongodb';
+import { getFeeRecordCorrection, FeeRecordCorrectionRequest, saveFeeRecordCorrection } from './fee-record-correction.controller';
 import api from '../../../api';
 import { aGetFeeRecordCorrectionResponseBody } from '../../../../../test-helpers/test-data/get-fee-record-correction-response-body';
+import { SaveFeeRecordCorrectionResponseBody } from '../../../api-response-types';
 
 jest.mock('../../../api');
 
 console.error = jest.fn();
 
 describe('fee-record-correction.controller', () => {
+  const bankId = '123';
+  const correctionId = 7;
+  const portalUserId = new ObjectId().toString();
+
+  const aValidRequestParams = () => ({ correctionId: correctionId.toString(), bankId });
+
+  let req: FeeRecordCorrectionRequest;
+  let res: MockResponse<Response>;
+
+  beforeEach(() => {
+    req = httpMocks.createRequest<FeeRecordCorrectionRequest>({
+      params: aValidRequestParams(),
+      user: { _id: portalUserId },
+    });
+    res = httpMocks.createResponse();
+  });
+
   describe('getFeeRecordCorrection', () => {
-    const bankId = '123';
-    const correctionId = 7;
-
-    const aValidRequestQuery = () => ({ correctionId: correctionId.toString(), bankId });
-
-    let req: GetFeeRecordCorrectionRequest;
-    let res: MockResponse<Response>;
-
     beforeEach(() => {
-      req = httpMocks.createRequest<GetFeeRecordCorrectionRequest>({
-        params: aValidRequestQuery(),
-      });
-      res = httpMocks.createResponse();
-
       jest.mocked(api.getFeeRecordCorrectionById).mockResolvedValue(aGetFeeRecordCorrectionResponseBody());
     });
 
@@ -127,6 +133,94 @@ describe('fee-record-correction.controller', () => {
 
       // Assert
       expect(res._getData()).toEqual('Failed to get fee record correction');
+      expect(res._isEndCalled()).toEqual(true);
+    });
+  });
+
+  describe('saveFeeRecordCorrection', () => {
+    const apiResponse: SaveFeeRecordCorrectionResponseBody = {
+      sentToEmails: ['email@ukexportfinance.gov.uk'],
+      reportPeriod: {
+        start: {
+          month: 1,
+          year: 2021,
+        },
+        end: {
+          month: 2,
+          year: 2021,
+        },
+      },
+    } as const;
+
+    beforeEach(() => {
+      jest.mocked(api.saveFeeRecordCorrection).mockResolvedValue(apiResponse);
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it(`should return a ${HttpStatusCode.Ok} status code if the api request is successful`, async () => {
+      // Act
+      await saveFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    });
+
+    it(`should return the api response in the response body if the api request is successful`, async () => {
+      // Act
+      await saveFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getData()).toEqual(apiResponse);
+    });
+
+    it('should call the save fee record correction api endpoint once with the correct parameters', async () => {
+      // Act
+      await saveFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(api.saveFeeRecordCorrection).toHaveBeenCalledTimes(1);
+      expect(api.saveFeeRecordCorrection).toHaveBeenCalledWith(bankId, correctionId, portalUserId);
+    });
+
+    it(`should return a ${HttpStatusCode.InternalServerError} status code if an unknown error occurs`, async () => {
+      // Arrange
+      jest.mocked(api.saveFeeRecordCorrection).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await saveFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+      expect(res._isEndCalled()).toEqual(true);
+    });
+
+    it('should return a specific error code if an axios error is thrown', async () => {
+      // Arrange
+      const errorStatus = HttpStatusCode.BadRequest;
+      const axiosError = new AxiosError(undefined, undefined, undefined, undefined, { status: errorStatus } as AxiosResponse);
+
+      jest.mocked(api.saveFeeRecordCorrection).mockRejectedValue(axiosError);
+
+      // Act
+      await saveFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(errorStatus);
+      expect(res._isEndCalled()).toEqual(true);
+    });
+
+    it('should return an error message if an error occurs', async () => {
+      // Arrange
+      jest.mocked(api.saveFeeRecordCorrection).mockRejectedValue(new Error('Some error'));
+
+      // Act
+      await saveFeeRecordCorrection(req, res);
+
+      // Assert
+      expect(res._getData()).toEqual('Failed to save fee record correction');
       expect(res._isEndCalled()).toEqual(true);
     });
   });

--- a/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/fee-record-correction.controller.ts
+++ b/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/fee-record-correction.controller.ts
@@ -4,9 +4,9 @@ import { HttpStatusCode, isAxiosError } from 'axios';
 import api from '../../../api';
 
 /**
- * Request type for the GET fee record correction endpoint.
+ * Request type for the GET and PUT fee record correction endpoint.
  */
-export type GetFeeRecordCorrectionRequest = CustomExpressRequest<{
+export type FeeRecordCorrectionRequest = CustomExpressRequest<{
   params: {
     bankId: string;
     correctionId: string;
@@ -21,7 +21,7 @@ export type GetFeeRecordCorrectionRequest = CustomExpressRequest<{
  * @param req - The request object containing information about the HTTP request.
  * @param res - The response object used to send the HTTP response.
  */
-export const getFeeRecordCorrection = async (req: GetFeeRecordCorrectionRequest, res: Response) => {
+export const getFeeRecordCorrection = async (req: FeeRecordCorrectionRequest, res: Response) => {
   try {
     const { bankId: requestingUserBankId, correctionId } = req.params;
 
@@ -42,6 +42,30 @@ export const getFeeRecordCorrection = async (req: GetFeeRecordCorrectionRequest,
     return res.status(HttpStatusCode.Ok).send(feeRecordCorrection);
   } catch (error) {
     const errorMessage = 'Failed to get fee record correction';
+
+    console.error(errorMessage, error);
+
+    const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
+
+    return res.status(errorStatus).send(errorMessage);
+  }
+};
+
+/**
+ * Calls the DTFS Central API to submit a fee record correction.
+ * @param req - The request object containing information about the HTTP request.
+ * @param res - The response object used to send the HTTP response.
+ */
+export const saveFeeRecordCorrection = async (req: FeeRecordCorrectionRequest, res: Response) => {
+  try {
+    const { bankId, correctionId } = req.params;
+    const userId = req.user._id;
+
+    const data = await api.saveFeeRecordCorrection(bankId, Number(correctionId), userId);
+
+    return res.status(HttpStatusCode.Ok).send(data);
+  } catch (error) {
+    const errorMessage = 'Failed to save fee record correction';
 
     console.error(errorMessage, error);
 

--- a/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/fee-record-correction.controller.ts
+++ b/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/fee-record-correction.controller.ts
@@ -43,7 +43,7 @@ export const getFeeRecordCorrection = async (req: FeeRecordCorrectionRequest, re
   } catch (error) {
     const errorMessage = 'Failed to get fee record correction';
 
-    console.error(errorMessage, error);
+    console.error('%s %o', errorMessage, error);
 
     const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
 
@@ -67,7 +67,7 @@ export const saveFeeRecordCorrection = async (req: FeeRecordCorrectionRequest, r
   } catch (error) {
     const errorMessage = 'Failed to save fee record correction';
 
-    console.error(errorMessage, error);
+    console.error('%s %o', errorMessage, error);
 
     const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
 

--- a/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/index.ts
+++ b/portal-api/src/v1/controllers/utilisation-report-service/fee-record-corrections/index.ts
@@ -1,4 +1,4 @@
 export * from './pending-corrections.controller';
 export * from './fee-record-correction-transient-form-data.controller';
-export * from './get-fee-record-correction.controller';
 export * from './fee-record-correction-review.controller';
+export * from './fee-record-correction.controller';

--- a/portal-api/src/v1/routes.js
+++ b/portal-api/src/v1/routes.js
@@ -338,14 +338,15 @@ authRouter
 
 authRouter
   .route('/banks/:bankId/fee-record-correction/:correctionId')
-  .get(
+  .all(
     validateUserHasAtLeastOneAllowedRole({ allowedRoles: [PAYMENT_REPORT_OFFICER] }),
     bankIdValidation,
     sqlIdValidation('correctionId'),
     handleExpressValidatorResult,
     validateUserAndBankIdMatch,
-    utilisationReportControllers.getFeeRecordCorrection,
-  );
+  )
+  .get(utilisationReportControllers.getFeeRecordCorrection)
+  .put(utilisationReportControllers.saveFeeRecordCorrection);
 
 authRouter
   .route('/banks/:bankId/fee-record-correction/:correctionId/transient-form-data')

--- a/portal/server/api-response-types/index.ts
+++ b/portal/server/api-response-types/index.ts
@@ -3,3 +3,4 @@ export { PreviousUtilisationReportsResponseBody } from './previous-utilisation-r
 export * from './utilisation-report-pending-corrections-response-body';
 export { GetFeeRecordCorrectionResponseBody } from './get-fee-record-correction-response-body';
 export { GetFeeRecordCorrectionTransientFormDataResponseBody } from './get-fee-record-correction-transient-form-data-response-body';
+export { SaveFeeRecordCorrectionResponseBody } from './save-fee-record-correction-response-body';

--- a/portal/server/api-response-types/save-fee-record-correction-response-body.ts
+++ b/portal/server/api-response-types/save-fee-record-correction-response-body.ts
@@ -1,0 +1,6 @@
+import { ReportPeriod } from '@ukef/dtfs2-common';
+
+export type SaveFeeRecordCorrectionResponseBody = {
+  sentToEmails: string[];
+  reportPeriod: ReportPeriod;
+};

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -1090,6 +1090,24 @@ const getFeeRecordCorrectionReview = async (bankId, correctionId, userId, token)
   return data;
 };
 
+/**
+ * Saves a fee record correction.
+ * @param {string} token - The user token
+ * @param {string} bankId - The bank id
+ * @param {string} id - The correction id
+ * @returns {Promise<import('./api-response-types').SaveFeeRecordCorrectionResponseBody>} Returns a promise that resolves to the fee record correction sent data
+ */
+const saveFeeRecordCorrection = async (token, bankId, id) => {
+  const { data } = await axios.get(`${PORTAL_API_URL}/v1/banks/${bankId}/fee-record-correction/${id}`, {
+    headers: {
+      Authorization: token,
+      [HEADERS.CONTENT_TYPE.KEY]: HEADERS.CONTENT_TYPE.VALUES.JSON,
+    },
+  });
+
+  return data;
+};
+
 module.exports = {
   allDeals,
   allFacilities,
@@ -1147,4 +1165,5 @@ module.exports = {
   getFeeRecordCorrectionTransientFormData,
   getFeeRecordCorrection,
   getFeeRecordCorrectionReview,
+  saveFeeRecordCorrection,
 };

--- a/portal/server/api.js
+++ b/portal/server/api.js
@@ -1098,7 +1098,9 @@ const getFeeRecordCorrectionReview = async (bankId, correctionId, userId, token)
  * @returns {Promise<import('./api-response-types').SaveFeeRecordCorrectionResponseBody>} Returns a promise that resolves to the fee record correction sent data
  */
 const saveFeeRecordCorrection = async (token, bankId, id) => {
-  const { data } = await axios.get(`${PORTAL_API_URL}/v1/banks/${bankId}/fee-record-correction/${id}`, {
+  const { data } = await axios({
+    method: 'put',
+    url: `${PORTAL_API_URL}/v1/banks/${bankId}/fee-record-correction/${id}`,
     headers: {
       Authorization: token,
       [HEADERS.CONTENT_TYPE.KEY]: HEADERS.CONTENT_TYPE.VALUES.JSON,

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
@@ -10,8 +10,10 @@ import {
 } from '@ukef/dtfs2-common';
 import { PRIMARY_NAV_KEY } from '../../../../constants';
 import api from '../../../../api';
-import { getUtilisationReportCorrectionReview, GetUtilisationReportCorrectionReviewRequest } from '.';
+import { getUtilisationReportCorrectionReview, UtilisationReportCorrectionReviewRequest, postUtilisationReportCorrectionReview } from '.';
 import { UtilisationReportCorrectionInformationViewModel } from '../../../../types/view-models/record-correction/utilisation-report-correction-information';
+import { SaveFeeRecordCorrectionResponseBody } from '../../../../api-response-types';
+import { LoggedInUserSession } from '../../../../helpers/express-session';
 
 jest.mock('../../../../api');
 
@@ -30,32 +32,32 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
   };
 
   const userToken = 'token';
-  const requestSession = {
+  const aRequestSession = () => ({
     user: mockUser,
     userToken,
     loginStatus: PORTAL_LOGIN_STATUS.VALID_2FA,
-  };
+  });
 
   const correctionId = '7';
 
+  const getHttpMocks = () =>
+    httpMocks.createMocks<UtilisationReportCorrectionReviewRequest>({
+      params: { correctionId },
+      session: aRequestSession(),
+    });
+
+  let req: UtilisationReportCorrectionReviewRequest;
+  let res: MockResponse<Response>;
+
+  beforeEach(() => {
+    ({ req, res } = getHttpMocks());
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('getUtilisationReportCorrectionReview', () => {
-    const getHttpMocks = () =>
-      httpMocks.createMocks<GetUtilisationReportCorrectionReviewRequest>({
-        params: { correctionId },
-        session: requestSession,
-      });
-
-    let req: GetUtilisationReportCorrectionReviewRequest;
-    let res: MockResponse<Response>;
-
-    beforeEach(() => {
-      ({ req, res } = getHttpMocks());
-    });
-
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-
     it('should render the "utilisation report correction - check the information" page', async () => {
       // Arrange,
       const bankCommentary = 'Some bank commentary';
@@ -129,6 +131,60 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
 
       // Act
       await getUtilisationReportCorrectionReview(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
+      expect(res._getRenderData()).toEqual({ user: mockUser });
+    });
+  });
+
+  describe('postUtilisationReportCorrectionReview', () => {
+    const aSaveFeeRecordCorrectionResponseBody = (): SaveFeeRecordCorrectionResponseBody => ({
+      sentToEmails: ['email1@ukexportfinance.gov.uk', 'email2@ukexportfinance.gov.uk'],
+      reportPeriod: { start: { month: 1, year: 2021 }, end: { month: 3, year: 2021 } },
+    });
+
+    it('should save the fee record correction', async () => {
+      // Arrange
+      jest.mocked(api.saveFeeRecordCorrection).mockResolvedValue(aSaveFeeRecordCorrectionResponseBody());
+
+      // Act
+      await postUtilisationReportCorrectionReview(req, res);
+
+      // Assert
+      expect(api.saveFeeRecordCorrection).toHaveBeenCalledTimes(1);
+      expect(api.saveFeeRecordCorrection).toHaveBeenCalledWith(userToken, bankId, correctionId);
+    });
+
+    it('should redirect to the record correction sent page', async () => {
+      // Arrange
+      jest.mocked(api.saveFeeRecordCorrection).mockResolvedValue(aSaveFeeRecordCorrectionResponseBody());
+
+      // Act
+      await postUtilisationReportCorrectionReview(req, res);
+
+      // Assert
+      expect(res._getRedirectUrl()).toEqual('/utilisation-reports/correction-sent');
+    });
+
+    it('should save the record correction sent data to the session', async () => {
+      // Arrange
+      const recordCorrectionSentData = aSaveFeeRecordCorrectionResponseBody();
+      jest.mocked(api.saveFeeRecordCorrection).mockResolvedValue(recordCorrectionSentData);
+
+      // Act
+      await postUtilisationReportCorrectionReview(req, res);
+
+      // Assert
+      expect((req.session as LoggedInUserSession).recordCorrectionSent).toEqual(recordCorrectionSentData);
+    });
+
+    it('should render the "problem with service" page when fetching the fee record correction review information fails', async () => {
+      // Arrange
+      jest.mocked(api.saveFeeRecordCorrection).mockRejectedValue(new Error());
+
+      // Act
+      await postUtilisationReportCorrectionReview(req, res);
 
       // Assert
       expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.ts
@@ -5,7 +5,7 @@ import { asLoggedInUserSession, LoggedInUserSession } from '../../../../helpers/
 import { PRIMARY_NAV_KEY } from '../../../../constants';
 import { UtilisationReportCorrectionInformationViewModel } from '../../../../types/view-models/record-correction/utilisation-report-correction-information';
 
-export type GetUtilisationReportCorrectionReviewRequest = Request & {
+export type UtilisationReportCorrectionReviewRequest = Request & {
   params: {
     correctionId: string;
   };
@@ -16,7 +16,7 @@ export type GetUtilisationReportCorrectionReviewRequest = Request & {
  * @param req - the request
  * @param res - the response
  */
-export const getUtilisationReportCorrectionReview = async (req: GetUtilisationReportCorrectionReviewRequest, res: Response) => {
+export const getUtilisationReportCorrectionReview = async (req: UtilisationReportCorrectionReviewRequest, res: Response) => {
   const { user, userToken } = asLoggedInUserSession(req.session);
 
   try {
@@ -63,14 +63,15 @@ export const getUtilisationReportCorrectionReview = async (req: GetUtilisationRe
  * @param req - the request
  * @param res - the response
  */
-export const postUtilisationReportCorrectionReview = async (req: Request, res: Response) => {
+export const postUtilisationReportCorrectionReview = async (req: UtilisationReportCorrectionReviewRequest, res: Response) => {
   const { user, userToken } = asLoggedInUserSession(req.session);
 
   try {
-    const bankId = user.bank.id;
-    const userId = user._id;
+    const { correctionId } = req.params;
 
-    const correctionSentData = await api.saveFeeRecordCorrection(userToken, bankId, userId);
+    const bankId = user.bank.id;
+
+    const correctionSentData = await api.saveFeeRecordCorrection(userToken, bankId, correctionId);
 
     (req.session as LoggedInUserSession).recordCorrectionSent = correctionSentData;
 

--- a/portal/server/controllers/utilisation-report-service/record-correction/index.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/index.ts
@@ -1,3 +1,4 @@
 export { getProvideUtilisationReportCorrection } from './provide-utilisation-report-correction';
 export { getUtilisationReportCorrectionReview } from './check-the-information';
 export { getRecordCorrectionSent } from './record-correction-sent';
+export { postUtilisationReportCorrectionReview } from './check-the-information';

--- a/portal/server/routes/utilisation-report-service/record-correction/index.js
+++ b/portal/server/routes/utilisation-report-service/record-correction/index.js
@@ -3,6 +3,7 @@ const { ROLES, validateFeeRecordCorrectionFeatureFlagIsEnabled } = require('@uke
 const {
   getProvideUtilisationReportCorrection,
   getUtilisationReportCorrectionReview,
+  postUtilisationReportCorrectionReview,
   getRecordCorrectionSent,
 } = require('../../../controllers/utilisation-report-service/record-correction');
 const { validateRole, validateToken, validateSqlId } = require('../../middleware');
@@ -28,5 +29,10 @@ router.get(
   [validateFeeRecordCorrectionFeatureFlagIsEnabled, validateToken, validateRole({ role: [ROLES.PAYMENT_REPORT_OFFICER] })],
   (req, res) => getRecordCorrectionSent(req, res),
 );
+
+router
+  .route('/utilisation-reports/provide-correction/:correctionId/check-the-information')
+  .all(validateFeeRecordCorrectionFeatureFlagIsEnabled, validateToken, validateRole({ role: [ROLES.PAYMENT_REPORT_OFFICER] }))
+  .post((req, res) => postUtilisationReportCorrectionReview(req, res));
 
 module.exports = router;


### PR DESCRIPTION
## Introduction :pencil2:
In a previous PR I added the correction sent page and the GET controller for it.

In this PR we add the save correction route for when the bank submits a correction and call it when the confirm and send button is clicked on the review page. The endpoint in central-api doesn't actually save the correction as that falls to another ticket, instead it just returns the payment officer emails and the report period and then on success in portal we redirect to the correction sent page.

## Resolution :heavy_check_mark:
- Add PUT record correction route (which will be added to in FN-3675 to save the correction details the bank provides against the correction)
- Redirect to the correction sent page when api request to save correction is successful
- e2e-tests to follow in a separate PR when FN-3688 has been progressed further
