### PR TITLE
feat(FN-3689): handle saved values of zero on correction form

### DIFF
--- a/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/helpers.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/helpers.test.ts
@@ -190,10 +190,23 @@ describe('provide-utilisation-report-correction helpers', () => {
       expect(result.facilityId).toBeNull();
     });
 
-    it('should map utilisation to formatted monetary string when provided', () => {
+    it('should map utilisation to formatted monetary string when non-zero', () => {
       // Arrange
       const savedFormValues = {
         utilisation: 1234.56,
+      };
+
+      // Act
+      const result = mapToProvideCorrectionFormValuesViewModel(savedFormValues);
+
+      // Assert
+      expect(result.utilisation).toEqual(getFormattedMonetaryValue(savedFormValues.utilisation));
+    });
+
+    it('should map utilisation to formatted monetary string when zero', () => {
+      // Arrange
+      const savedFormValues = {
+        utilisation: 0,
       };
 
       // Act
@@ -214,10 +227,23 @@ describe('provide-utilisation-report-correction helpers', () => {
       expect(result.utilisation).toBeNull();
     });
 
-    it('should map reportedFee to formatted monetary string when provided', () => {
+    it('should map reportedFee to formatted monetary string when non-zero', () => {
       // Arrange
       const savedFormValues = {
         reportedFee: 1234.56,
+      };
+
+      // Act
+      const result = mapToProvideCorrectionFormValuesViewModel(savedFormValues);
+
+      // Assert
+      expect(result.reportedFee).toEqual(getFormattedMonetaryValue(savedFormValues.reportedFee));
+    });
+
+    it('should map reportedFee to formatted monetary string when zero', () => {
+      // Arrange
+      const savedFormValues = {
+        reportedFee: 0,
       };
 
       // Act

--- a/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/helpers.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/helpers.ts
@@ -96,9 +96,14 @@ export const getAdditionalCommentsFieldLabels = (correctionReasons: RecordCorrec
  */
 export const mapToProvideCorrectionFormValuesViewModel = (
   savedFormValues: GetFeeRecordCorrectionTransientFormDataResponseBody,
-): ProvideCorrectionFormValuesViewModel => ({
-  facilityId: savedFormValues.facilityId ?? null,
-  utilisation: savedFormValues.utilisation !== undefined ? getFormattedMonetaryValue(savedFormValues.utilisation) : null,
-  reportedFee: savedFormValues.reportedFee !== undefined ? getFormattedMonetaryValue(savedFormValues.reportedFee) : null,
-  additionalComments: savedFormValues.additionalComments ?? null,
-});
+): ProvideCorrectionFormValuesViewModel => {
+  const utilisation = savedFormValues.utilisation !== undefined ? getFormattedMonetaryValue(savedFormValues.utilisation) : null;
+  const reportedFee = savedFormValues.reportedFee !== undefined ? getFormattedMonetaryValue(savedFormValues.reportedFee) : null;
+
+  return {
+    utilisation,
+    reportedFee,
+    facilityId: savedFormValues.facilityId ?? null,
+    additionalComments: savedFormValues.additionalComments ?? null,
+  };
+};

--- a/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/helpers.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/helpers.ts
@@ -98,7 +98,7 @@ export const mapToProvideCorrectionFormValuesViewModel = (
   savedFormValues: GetFeeRecordCorrectionTransientFormDataResponseBody,
 ): ProvideCorrectionFormValuesViewModel => ({
   facilityId: savedFormValues.facilityId ?? null,
-  utilisation: savedFormValues.utilisation ? getFormattedMonetaryValue(savedFormValues.utilisation) : null,
-  reportedFee: savedFormValues.reportedFee ? getFormattedMonetaryValue(savedFormValues.reportedFee) : null,
+  utilisation: savedFormValues.utilisation !== undefined ? getFormattedMonetaryValue(savedFormValues.utilisation) : null,
+  reportedFee: savedFormValues.reportedFee !== undefined ? getFormattedMonetaryValue(savedFormValues.reportedFee) : null,
   additionalComments: savedFormValues.additionalComments ?? null,
 });


### PR DESCRIPTION
## Introduction :pencil2:
We noticed that if a user entered zero as the utilisation or reported fee amount for a correction then went to the review page and then went back the field would be empty as if they had not entered a value.

## Resolution :heavy_check_mark:
- Add handling for zero as a possible value for a persisted monetary correction value.

![Screenshot 2025-01-13 at 14 43 22](https://github.com/user-attachments/assets/5cb11c40-baa7-42cd-a694-672bd6b9e387)
