### PR TITLE
feat(DTFS2-7739): display cancelled deal status when amendment in progress

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/gef/cancel-deal-with-amendment-in-progress.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/gef/cancel-deal-with-amendment-in-progress.spec.js
@@ -6,7 +6,7 @@ import { today, yesterday } from '../../../../../../e2e-fixtures/dateConstants';
 import dealsPage from '../../../pages/dealsPage';
 import facilitiesPage from '../../../pages/facilitiesPage';
 import facilityPage from '../../../pages/facilityPage';
-import { caseSubNavigation, successBanner } from '../../../partials';
+import { caseSubNavigation, caseSummary, successBanner } from '../../../partials';
 import activitiesPage from '../../../pages/activities/activitiesPage';
 import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mock-gef-deals';
 import { anIssuedCashFacility } from '../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -70,7 +70,7 @@ context('Deal cancellation - submit cancellation with an amendment in progress',
 
         cy.clickContinueButton();
 
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.AMENDMENT_IN_PROGRESS);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.AMENDMENT_IN_PROGRESS);
       });
 
       it('should redirect you to the deal summary page with the success banner visible once', () => {
@@ -91,17 +91,27 @@ context('Deal cancellation - submit cancellation with an amendment in progress',
 
       it(`should show the deal status as ${TFM_DEAL_STAGE.CANCELLED} on all tabs`, () => {
         caseSubNavigation.tasksLink().click();
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
         caseSubNavigation.dealLink().click();
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
         caseSubNavigation.partiesLink().click();
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
         caseSubNavigation.documentsLink().click();
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
         caseSubNavigation.underwritingLink().click();
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
         caseSubNavigation.activityLink().click();
-        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
+
+        caseSubNavigation.dealLink().click();
+        caseDealPage.dealFacilitiesTable.row(facility._id).facilityId().click();
+
+        facilityPage.facilityTabAmendments().click();
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
+        facilityPage.facilityTabDetails().click();
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
+        facilityPage.facilityTabPremiumSchedule().click();
+        cy.assertText(caseSummary.ukefDealStage(), TFM_DEAL_STAGE.CANCELLED);
       });
 
       it(`should show the facility statuses as ${TFM_FACILITY_STAGE.RISK_EXPIRED}`, () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/gef/cancel-deal-with-amendment-in-progress.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/gef/cancel-deal-with-amendment-in-progress.spec.js
@@ -89,7 +89,18 @@ context('Deal cancellation - submit cancellation with an amendment in progress',
         caseDealPage.cancelDealButton().should('not.exist');
       });
 
-      it(`should show the deal status as ${TFM_DEAL_STAGE.CANCELLED}`, () => {
+      it(`should show the deal status as ${TFM_DEAL_STAGE.CANCELLED} on all tabs`, () => {
+        caseSubNavigation.tasksLink().click();
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        caseSubNavigation.dealLink().click();
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        caseSubNavigation.partiesLink().click();
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        caseSubNavigation.documentsLink().click();
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        caseSubNavigation.underwritingLink().click();
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+        caseSubNavigation.activityLink().click();
         cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
       });
 

--- a/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/gef/cancel-deal-with-amendment-in-progress.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/deal-cancellation/gef/cancel-deal-with-amendment-in-progress.spec.js
@@ -1,0 +1,128 @@
+import { TFM_DEAL_STAGE, TFM_FACILITY_STAGE } from '@ukef/dtfs2-common';
+import relative from '../../../relativeURL';
+import { ADMIN, BANK1_MAKER1, PIM_USER_1, T1_USER_1 } from '../../../../../../e2e-fixtures';
+import caseDealPage from '../../../pages/caseDealPage';
+import { today, yesterday } from '../../../../../../e2e-fixtures/dateConstants';
+import dealsPage from '../../../pages/dealsPage';
+import facilitiesPage from '../../../pages/facilitiesPage';
+import facilityPage from '../../../pages/facilityPage';
+import { caseSubNavigation, successBanner } from '../../../partials';
+import activitiesPage from '../../../pages/activities/activitiesPage';
+import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mock-gef-deals';
+import { anIssuedCashFacility } from '../../../../../../e2e-fixtures/mock-gef-facilities';
+import { DEAL_TYPE } from '../../../../../../gef/cypress/fixtures/constants';
+import amendmentsPage from '../../../pages/amendments/amendmentsPage';
+
+context('Deal cancellation - submit cancellation with an amendment in progress', () => {
+  let dealId;
+  let facility;
+  const ukefDealId = 10000001;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [anIssuedCashFacility()], BANK1_MAKER1).then((createdFacility) => {
+        facility = createdFacility.details;
+      });
+
+      cy.submitDeal(dealId, DEAL_TYPE.GEF, T1_USER_1);
+    });
+  });
+
+  beforeEach(() => {
+    cy.saveSession();
+    cy.visit(relative(`/case/${dealId}/deal`));
+  });
+
+  after(() => {
+    cy.deleteDeals(dealId, ADMIN);
+    cy.deleteFacility(facility._id, BANK1_MAKER1);
+  });
+
+  describe('when logged in as a PIM user', () => {
+    before(() => {
+      cy.login(PIM_USER_1);
+      cy.visit(relative(`/case/${dealId}/deal`));
+    });
+
+    describe('with an amendment in progress', () => {
+      before(() => {
+        cy.login(PIM_USER_1);
+        cy.visit(relative(`/case/${dealId}/facility/${facility._id}`));
+
+        facilityPage.facilityTabAmendments().click();
+        amendmentsPage.addAmendmentButton().click();
+
+        cy.completeDateFormFields({ idPrefix: 'amendment--request-date' });
+        cy.clickContinueButton();
+
+        amendmentsPage.amendmentRequestApprovalYes().click();
+        cy.clickContinueButton();
+
+        amendmentsPage.amendmentFacilityValueCheckbox().click();
+        cy.clickContinueButton();
+
+        cy.keyboardInput(amendmentsPage.amendmentFacilityValueInput(), '123');
+        cy.clickContinueButton();
+
+        cy.clickContinueButton();
+
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.AMENDMENT_IN_PROGRESS);
+      });
+
+      it('should redirect you to the deal summary page with the success banner visible once', () => {
+        cy.submitDealCancellation({ dealId, effectiveDate: yesterday.date });
+
+        cy.url().should('eq', relative(`/case/${dealId}/deal`));
+
+        successBanner().should('exist');
+        cy.assertText(successBanner(), `Deal ${ukefDealId} cancelled`);
+
+        cy.reload();
+        successBanner().should('not.exist');
+      });
+
+      it('should not show the "Cancel Deal" button', () => {
+        caseDealPage.cancelDealButton().should('not.exist');
+      });
+
+      it(`should show the deal status as ${TFM_DEAL_STAGE.CANCELLED}`, () => {
+        cy.assertText(caseDealPage.dealStage(), TFM_DEAL_STAGE.CANCELLED);
+      });
+
+      it(`should show the facility statuses as ${TFM_FACILITY_STAGE.RISK_EXPIRED}`, () => {
+        const facilityId = facility._id;
+
+        cy.assertText(caseDealPage.dealFacilitiesTable.row(facilityId).facilityStage(), TFM_FACILITY_STAGE.RISK_EXPIRED);
+      });
+
+      it(`should show the deal stage on the "All deals" page as ${TFM_DEAL_STAGE.CANCELLED}`, () => {
+        cy.visit(relative(`/deals/0`));
+
+        const row = dealsPage.dealsTable.row(dealId);
+        cy.assertText(row.stage(), TFM_DEAL_STAGE.CANCELLED);
+      });
+
+      it(`should show the facility stage on the "All facilities" page as ${TFM_FACILITY_STAGE.RISK_EXPIRED}`, () => {
+        cy.visit(relative(`/facilities/0`));
+        const facilityId = facility._id;
+
+        const row = facilitiesPage.facilitiesTable.row(facilityId);
+        cy.assertText(row.facilityStage(), TFM_FACILITY_STAGE.RISK_EXPIRED);
+      });
+
+      it('should add an entry on the activity and comments page', () => {
+        caseSubNavigation.activityLink().click();
+
+        activitiesPage.activitiesTimeline().contains('Deal stage:');
+        activitiesPage.activitiesTimeline().contains('Cancelled');
+        activitiesPage.activitiesTimeline().contains(`Bank request date: ${today.d_MMMM_yyyy}`);
+        activitiesPage.activitiesTimeline().contains(`Date effective from: ${yesterday.d_MMMM_yyyy}`);
+        activitiesPage.activitiesTimeline().contains(`Comments: -`);
+      });
+    });
+  });
+});

--- a/libs/common/src/types/mongo-db-models/tfm-deals.ts
+++ b/libs/common/src/types/mongo-db-models/tfm-deals.ts
@@ -5,6 +5,7 @@ import { AuditDatabaseRecord } from '../audit-database-record';
 import { AnyObject } from '../any-object';
 import { Prettify } from '../types-helper';
 import { TfmActivity } from './tfm-activity';
+import { TfmDealStage } from '../tfm/deal-stage';
 
 /**
  * Type of the mongo db "tfm-deals" collection
@@ -25,7 +26,7 @@ export type TfmDeal = {
     parties: AnyObject;
     probabilityOfDefault: number;
     product: string;
-    stage: string;
+    stage: TfmDealStage;
     cancellation?: TfmDealCancellationWithStatus;
     tasks?: AnyObject[];
   };

--- a/trade-finance-manager-ui/server/controllers/case/activity/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/activity/index.js
@@ -2,7 +2,7 @@ const { getUnixTime } = require('date-fns');
 const { ACTIVITY_TYPES, FLASH_TYPES } = require('@ukef/dtfs2-common');
 const api = require('../../../api');
 const { generateValidationErrors } = require('../../../helpers/validation');
-const { hasAmendmentInProgressDealStage, amendmentsInProgressByDeal } = require('../../helpers/amendments.helper');
+const { filterAmendmentsByInProgress } = require('../../helpers/amendments.helper');
 const CONSTANTS = require('../../../constants');
 const { mapActivities } = require('./helpers/map-activities');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
@@ -29,11 +29,12 @@ const getActivity = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
   if (hasAmendmentInProgress) {
     deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
   }
-  const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
 
   const activities = mapActivities(deal.tfm.activities);
 
@@ -78,11 +79,12 @@ const filterActivities = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
   if (hasAmendmentInProgress) {
     deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
   }
-  const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
 
   const activities = mapActivities(deal.tfm.activities);
 

--- a/trade-finance-manager-ui/server/controllers/case/activity/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/activity/index.js
@@ -2,7 +2,7 @@ const { getUnixTime } = require('date-fns');
 const { ACTIVITY_TYPES, FLASH_TYPES } = require('@ukef/dtfs2-common');
 const api = require('../../../api');
 const { generateValidationErrors } = require('../../../helpers/validation');
-const { filterAmendmentsByInProgress } = require('../../helpers/amendments.helper');
+const { getAmendmentsInProgress } = require('../../helpers/amendments.helper');
 const CONSTANTS = require('../../../constants');
 const { mapActivities } = require('./helpers/map-activities');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
@@ -29,7 +29,7 @@ const getActivity = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {
@@ -79,7 +79,7 @@ const filterActivities = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -13,7 +13,7 @@ const { formattedNumber } = require('../../helpers/number');
 const mapAssignToSelectOptions = require('../../helpers/map-assign-to-select-options');
 const CONSTANTS = require('../../constants');
 const { filterTasks } = require('../helpers/tasks.helper');
-const { hasAmendmentInProgressDealStage, amendmentsInProgressByDeal } = require('../helpers/amendments.helper');
+const { filterAmendmentsByInProgress } = require('../helpers/amendments.helper');
 const validatePartyURN = require('./parties/partyUrnValidation.validate');
 const { bondType, partyType, userCanEdit } = require('./parties/helpers');
 const { asUserSession } = require('../../helpers/express-session');
@@ -45,8 +45,9 @@ const getCaseDeal = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const amendmentsInProgress = amendments.filter(({ status }) => status === AMENDMENT_STATUS.IN_PROGRESS);
+    const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
     const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
     if (hasAmendmentInProgress) {
       deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
     }
@@ -107,11 +108,12 @@ const getCaseTasks = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
   if (hasAmendmentInProgress) {
     deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
   }
-  const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
 
   if (Array.isArray(amendments) && amendments.length > 0) {
     amendments.map((a) => {
@@ -171,11 +173,12 @@ const filterCaseTasks = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
   if (hasAmendmentInProgress) {
     deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
   }
-  const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
 
   if (Array.isArray(amendments) && amendments.length > 0) {
     amendments.map((a) => {
@@ -348,8 +351,9 @@ const getCaseFacility = async (req, res) => {
   const hasAmendmentInProgressButton = amendment.status === AMENDMENT_STATUS.IN_PROGRESS;
   const showContinueAmendmentButton = hasAmendmentInProgressButton && !amendment.submittedByPim && showAmendmentButton(deal, req.session.user.teams);
 
-  const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
-  const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
   if (hasAmendmentInProgress) {
     deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
   }
@@ -396,11 +400,12 @@ const getCaseDocuments = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+    const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+    const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
     if (hasAmendmentInProgress) {
       deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
     }
-    const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
 
     const { dealSnapshot } = deal;
 

--- a/trade-finance-manager-ui/server/controllers/case/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.js
@@ -13,7 +13,7 @@ const { formattedNumber } = require('../../helpers/number');
 const mapAssignToSelectOptions = require('../../helpers/map-assign-to-select-options');
 const CONSTANTS = require('../../constants');
 const { filterTasks } = require('../helpers/tasks.helper');
-const { filterAmendmentsByInProgress } = require('../helpers/amendments.helper');
+const { getAmendmentsInProgress } = require('../helpers/amendments.helper');
 const validatePartyURN = require('./parties/partyUrnValidation.validate');
 const { bondType, partyType, userCanEdit } = require('./parties/helpers');
 const { asUserSession } = require('../../helpers/express-session');
@@ -45,7 +45,7 @@ const getCaseDeal = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+    const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
     const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
     if (hasAmendmentInProgress) {
@@ -108,7 +108,7 @@ const getCaseTasks = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {
@@ -173,7 +173,7 @@ const filterCaseTasks = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {
@@ -351,7 +351,7 @@ const getCaseFacility = async (req, res) => {
   const hasAmendmentInProgressButton = amendment.status === AMENDMENT_STATUS.IN_PROGRESS;
   const showContinueAmendmentButton = hasAmendmentInProgressButton && !amendment.submittedByPim && showAmendmentButton(deal, req.session.user.teams);
 
-  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {
@@ -400,7 +400,7 @@ const getCaseDocuments = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+    const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
     const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
     if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/case/index.test.js
+++ b/trade-finance-manager-ui/server/controllers/case/index.test.js
@@ -21,8 +21,6 @@ jest.mock('../helpers/deal-cancellation-enabled.helper', () => ({
 const { DRAFT, COMPLETED } = TFM_DEAL_CANCELLATION_STATUS;
 
 const mockSuccessBannerMessage = 'mock success message';
-console.error = jest.fn();
-
 const res = mockRes();
 
 const token = 'test-token';
@@ -41,6 +39,8 @@ const session = {
 describe('controllers - case', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.restoreAllMocks();
+    jest.spyOn(console, 'error');
   });
 
   describe('GET case deal', () => {
@@ -67,7 +67,7 @@ describe('controllers - case', () => {
         {
           ukefFacilityId: '1234',
           facilityId: '12345',
-          submittedByPim: false,
+          submittedByPim: true,
           status: AMENDMENT_STATUS.IN_PROGRESS,
         },
       ];
@@ -914,12 +914,14 @@ describe('controllers - case', () => {
           ukefDealId: 'ukefDealId',
         },
         mock: true,
+        tfm: {},
       };
 
       beforeEach(() => {
         api.getDeal = () => Promise.resolve(mockDeal);
         api.getAmendmentsByDealId = () => Promise.resolve({ data: [] });
         api.getDealCancellation = jest.fn(() => Promise.resolve({}));
+        mockGetDealSuccessBannerMessage.mockResolvedValue(mockSuccessBannerMessage);
       });
 
       it('should render documents template with data', async () => {

--- a/trade-finance-manager-ui/server/controllers/case/parties/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/parties/index.js
@@ -2,7 +2,7 @@ const { FLASH_TYPES } = require('@ukef/dtfs2-common');
 const api = require('../../../api');
 const { userCanEdit, isEmptyString, partyType } = require('./helpers');
 const validatePartyURN = require('./partyUrnValidation.validate');
-const { hasAmendmentInProgressDealStage, amendmentsInProgressByDeal } = require('../../helpers/amendments.helper');
+const { filterAmendmentsByInProgress } = require('../../helpers/amendments.helper');
 const CONSTANTS = require('../../../constants');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
 
@@ -27,11 +27,12 @@ const getAllParties = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+    const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+    const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
     if (hasAmendmentInProgress) {
       deal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
     }
-    const amendmentsInProgress = amendmentsInProgressByDeal(amendments);
 
     const canEdit = userCanEdit(user);
 

--- a/trade-finance-manager-ui/server/controllers/case/parties/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/parties/index.js
@@ -2,7 +2,7 @@ const { FLASH_TYPES } = require('@ukef/dtfs2-common');
 const api = require('../../../api');
 const { userCanEdit, isEmptyString, partyType } = require('./helpers');
 const validatePartyURN = require('./partyUrnValidation.validate');
-const { filterAmendmentsByInProgress } = require('../../helpers/amendments.helper');
+const { getAmendmentsInProgress } = require('../../helpers/amendments.helper');
 const CONSTANTS = require('../../../constants');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
 
@@ -27,7 +27,7 @@ const getAllParties = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+    const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
     const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
     if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/index.js
@@ -12,7 +12,7 @@ const { formattedNumber } = require('../../../helpers/number');
 const { UNDERWRITER_MANAGER_DECISIONS_TAGS } = require('../../../constants/decisions.constant');
 const { BANK_DECISIONS_TAGS } = require('../../../constants/amendments');
 const CONSTANTS = require('../../../constants');
-const { hasAmendmentInProgressDealStage, amendmentsInProgressByDeal } = require('../../helpers/amendments.helper');
+const { filterAmendmentsByInProgress } = require('../../helpers/amendments.helper');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
 
 /**
@@ -53,8 +53,9 @@ const getUnderwriterPage = async (req, res) => {
   // filters the amendments submittedByPim and also which are not automatic
   amendments = amendments.filter(({ submittedByPim, requireUkefApproval }) => submittedByPim && requireUkefApproval);
 
-  const amendmentsInProgress = await amendmentsInProgressByDeal(amendments, userToken);
-  const hasAmendmentInProgress = hasAmendmentInProgressDealStage(amendments);
+  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const hasAmendmentInProgress = amendmentsInProgress.length > 0;
+
   if (hasAmendmentInProgress) {
     deal.tfm.stage = CONSTANTS.DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
   }

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/index.js
@@ -12,7 +12,7 @@ const { formattedNumber } = require('../../../helpers/number');
 const { UNDERWRITER_MANAGER_DECISIONS_TAGS } = require('../../../constants/decisions.constant');
 const { BANK_DECISIONS_TAGS } = require('../../../constants/amendments');
 const CONSTANTS = require('../../../constants');
-const { filterAmendmentsByInProgress } = require('../../helpers/amendments.helper');
+const { getAmendmentsInProgress } = require('../../helpers/amendments.helper');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
 
 /**
@@ -53,7 +53,7 @@ const getUnderwriterPage = async (req, res) => {
   // filters the amendments submittedByPim and also which are not automatic
   amendments = amendments.filter(({ submittedByPim, requireUkefApproval }) => submittedByPim && requireUkefApproval);
 
-  const amendmentsInProgress = filterAmendmentsByInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
@@ -1,0 +1,83 @@
+const { TFM_DEAL_STAGE, AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
+const { filterAmendmentsByInProgress } = require('./amendments.helper');
+
+const aNotStartedAmendment = () => ({
+  status: AMENDMENT_STATUS.NOT_STARTED,
+  submittedByPim: false,
+});
+
+const anInProgressAmendment = () => ({
+  status: AMENDMENT_STATUS.IN_PROGRESS,
+  submittedByPim: true,
+});
+
+const aCompletedAmendment = () => ({
+  status: AMENDMENT_STATUS.COMPLETED,
+  submittedByPim: true,
+});
+
+describe('filterAmendmentsByInProgress', () => {
+  it(`should return an empty array if the deal stage is ${TFM_DEAL_STAGE.CANCELLED}`, () => {
+    // Arrange
+    const amendments = [anInProgressAmendment()];
+    const deal = {
+      tfm: {
+        stage: TFM_DEAL_STAGE.CANCELLED,
+      },
+    };
+
+    // Act
+    const result = filterAmendmentsByInProgress({ amendments, deal });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it(`should return an empty array if the amendments is not an array`, () => {
+    // Arrange
+    const amendments = undefined;
+    const deal = {
+      tfm: {
+        stage: TFM_DEAL_STAGE.COMPLETED,
+      },
+    };
+
+    // Act
+    const result = filterAmendmentsByInProgress({ amendments, deal });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it(`should return an empty array if the amendments array is empty`, () => {
+    // Arrange
+    const amendments = [];
+    const deal = {
+      tfm: {
+        stage: TFM_DEAL_STAGE.COMPLETED,
+      },
+    };
+
+    // Act
+    const result = filterAmendmentsByInProgress({ amendments, deal });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it(`should only return the in progress amendments`, () => {
+    // Arrange
+    const amendments = [aNotStartedAmendment(), aCompletedAmendment(), anInProgressAmendment()];
+    const deal = {
+      tfm: {
+        stage: TFM_DEAL_STAGE.COMPLETED,
+      },
+    };
+
+    // Act
+    const result = filterAmendmentsByInProgress({ amendments, deal });
+
+    // Assert
+    expect(result).toEqual([anInProgressAmendment()]);
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
@@ -1,5 +1,5 @@
 const { TFM_DEAL_STAGE, AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
-const { filterAmendmentsByInProgress } = require('./amendments.helper');
+const { getAmendmentsInProgress } = require('./amendments.helper');
 
 const notStartedAmendment = () => ({
   status: AMENDMENT_STATUS.NOT_STARTED,
@@ -21,7 +21,7 @@ const completedAmendment = () => ({
   submittedByPim: true,
 });
 
-describe('filterAmendmentsByInProgress', () => {
+describe('getAmendmentsInProgress', () => {
   it(`should return an empty array if the deal stage is ${TFM_DEAL_STAGE.CANCELLED}`, () => {
     // Arrange
     const amendments = [submittedInProgressAmendment()];
@@ -32,7 +32,7 @@ describe('filterAmendmentsByInProgress', () => {
     };
 
     // Act
-    const result = filterAmendmentsByInProgress({ amendments, deal });
+    const result = getAmendmentsInProgress({ amendments, deal });
 
     // Assert
     expect(result).toEqual([]);
@@ -48,7 +48,7 @@ describe('filterAmendmentsByInProgress', () => {
     };
 
     // Act
-    const result = filterAmendmentsByInProgress({ amendments, deal });
+    const result = getAmendmentsInProgress({ amendments, deal });
 
     // Assert
     expect(result).toEqual([]);
@@ -64,7 +64,7 @@ describe('filterAmendmentsByInProgress', () => {
     };
 
     // Act
-    const result = filterAmendmentsByInProgress({ amendments, deal });
+    const result = getAmendmentsInProgress({ amendments, deal });
 
     // Assert
     expect(result).toEqual([]);
@@ -80,7 +80,7 @@ describe('filterAmendmentsByInProgress', () => {
     };
 
     // Act
-    const result = filterAmendmentsByInProgress({ amendments, deal });
+    const result = getAmendmentsInProgress({ amendments, deal });
 
     // Assert
     expect(result).toEqual([submittedInProgressAmendment()]);

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
@@ -6,7 +6,12 @@ const aNotStartedAmendment = () => ({
   submittedByPim: false,
 });
 
-const anInProgressAmendment = () => ({
+const anUnsubmittedInProgressAmendment = () => ({
+  status: AMENDMENT_STATUS.IN_PROGRESS,
+  submittedByPim: false,
+});
+
+const aSubmittedInProgressAmendment = () => ({
   status: AMENDMENT_STATUS.IN_PROGRESS,
   submittedByPim: true,
 });
@@ -19,7 +24,7 @@ const aCompletedAmendment = () => ({
 describe('filterAmendmentsByInProgress', () => {
   it(`should return an empty array if the deal stage is ${TFM_DEAL_STAGE.CANCELLED}`, () => {
     // Arrange
-    const amendments = [anInProgressAmendment()];
+    const amendments = [aSubmittedInProgressAmendment()];
     const deal = {
       tfm: {
         stage: TFM_DEAL_STAGE.CANCELLED,
@@ -67,7 +72,7 @@ describe('filterAmendmentsByInProgress', () => {
 
   it(`should only return the in progress amendments`, () => {
     // Arrange
-    const amendments = [aNotStartedAmendment(), aCompletedAmendment(), anInProgressAmendment()];
+    const amendments = [aNotStartedAmendment(), aCompletedAmendment(), aSubmittedInProgressAmendment(), anUnsubmittedInProgressAmendment()];
     const deal = {
       tfm: {
         stage: TFM_DEAL_STAGE.COMPLETED,
@@ -78,6 +83,6 @@ describe('filterAmendmentsByInProgress', () => {
     const result = filterAmendmentsByInProgress({ amendments, deal });
 
     // Assert
-    expect(result).toEqual([anInProgressAmendment()]);
+    expect(result).toEqual([aSubmittedInProgressAmendment()]);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
@@ -1,22 +1,22 @@
 const { TFM_DEAL_STAGE, AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
 const { filterAmendmentsByInProgress } = require('./amendments.helper');
 
-const aNotStartedAmendment = () => ({
+const notStartedAmendment = () => ({
   status: AMENDMENT_STATUS.NOT_STARTED,
   submittedByPim: false,
 });
 
-const anUnsubmittedInProgressAmendment = () => ({
+const unsubmittedInProgressAmendment = () => ({
   status: AMENDMENT_STATUS.IN_PROGRESS,
   submittedByPim: false,
 });
 
-const aSubmittedInProgressAmendment = () => ({
+const submittedInProgressAmendment = () => ({
   status: AMENDMENT_STATUS.IN_PROGRESS,
   submittedByPim: true,
 });
 
-const aCompletedAmendment = () => ({
+const completedAmendment = () => ({
   status: AMENDMENT_STATUS.COMPLETED,
   submittedByPim: true,
 });
@@ -24,7 +24,7 @@ const aCompletedAmendment = () => ({
 describe('filterAmendmentsByInProgress', () => {
   it(`should return an empty array if the deal stage is ${TFM_DEAL_STAGE.CANCELLED}`, () => {
     // Arrange
-    const amendments = [aSubmittedInProgressAmendment()];
+    const amendments = [submittedInProgressAmendment()];
     const deal = {
       tfm: {
         stage: TFM_DEAL_STAGE.CANCELLED,
@@ -72,7 +72,7 @@ describe('filterAmendmentsByInProgress', () => {
 
   it(`should only return the in progress amendments`, () => {
     // Arrange
-    const amendments = [aNotStartedAmendment(), aCompletedAmendment(), aSubmittedInProgressAmendment(), anUnsubmittedInProgressAmendment()];
+    const amendments = [notStartedAmendment(), completedAmendment(), submittedInProgressAmendment(), unsubmittedInProgressAmendment()];
     const deal = {
       tfm: {
         stage: TFM_DEAL_STAGE.COMPLETED,
@@ -83,6 +83,6 @@ describe('filterAmendmentsByInProgress', () => {
     const result = filterAmendmentsByInProgress({ amendments, deal });
 
     // Assert
-    expect(result).toEqual([aSubmittedInProgressAmendment()]);
+    expect(result).toEqual([submittedInProgressAmendment()]);
   });
 });

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
@@ -67,7 +67,7 @@ const validateUkefDecision = (ukefDecision, decisionType) => ukefDecision?.cover
 /**
  * A deal with one of these stages cannot be amended
  */
-const immutableDealStages = [TFM_DEAL_STAGE.CANCELLED];
+const nonAmendableDealStages = [TFM_DEAL_STAGE.CANCELLED];
 
 /**
  * @param {Object} getAmendmentsInProgress Params
@@ -76,7 +76,7 @@ const immutableDealStages = [TFM_DEAL_STAGE.CANCELLED];
  * @returns {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} - the amendments that are in progress
  */
 const getAmendmentsInProgress = ({ amendments, deal }) => {
-  if (immutableDealStages.includes(deal.tfm.stage)) {
+  if (nonAmendableDealStages.includes(deal.tfm.stage)) {
     return [];
   }
 

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
@@ -1,4 +1,4 @@
-const { TEAM_IDS, AMENDMENT_STATUS, DEAL_STATUS } = require('@ukef/dtfs2-common');
+const { TEAM_IDS, AMENDMENT_STATUS, DEAL_STATUS, TFM_DEAL_STAGE } = require('@ukef/dtfs2-common');
 const { DECISIONS, DEAL } = require('../../constants');
 const { userIsInTeam } = require('../../helpers/user');
 
@@ -64,21 +64,26 @@ const ukefDecisionRejected = (amendment) => {
  */
 const validateUkefDecision = (ukefDecision, decisionType) => ukefDecision?.coverEndDate === decisionType || ukefDecision?.value === decisionType;
 
-const hasAmendmentInProgressDealStage = (amendments) => {
-  if (Array.isArray(amendments) && amendments.length) {
-    const amendmentsInProgress = amendments.filter(({ status, submittedByPim }) => status === AMENDMENT_STATUS.IN_PROGRESS && submittedByPim);
-    const hasAmendmentInProgress = amendmentsInProgress.length > 0;
-    if (hasAmendmentInProgress) {
-      return true;
-    }
-  }
-  return false;
-};
+/**
+ * A deal with one of these stages cannot be amended
+ */
+const immutableDealStages = [TFM_DEAL_STAGE.CANCELLED];
 
-const amendmentsInProgressByDeal = (amendments) => {
+/**
+ * @param {Object} filterAmendmentsByInProgressParams
+ * @param {import('@ukef/dtfs2-common').TfmDeal} filterAmendmentsByInProgressParams.deal - the deal
+ * @param {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} filterAmendmentsByInProgressParams.amendments - the amendments
+ * @returns {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} - the amendments that are in progress
+ */
+const filterAmendmentsByInProgress = ({ amendments, deal }) => {
+  if (immutableDealStages.includes(deal.tfm.stage)) {
+    return [];
+  }
+
   if (Array.isArray(amendments) && amendments.length) {
     return amendments.filter(({ status, submittedByPim }) => status === AMENDMENT_STATUS.IN_PROGRESS && submittedByPim);
   }
+
   return [];
 };
 
@@ -88,6 +93,5 @@ module.exports = {
   userCanEditBankDecision,
   ukefDecisionRejected,
   validateUkefDecision,
-  hasAmendmentInProgressDealStage,
-  amendmentsInProgressByDeal,
+  filterAmendmentsByInProgress,
 };

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.js
@@ -70,12 +70,12 @@ const validateUkefDecision = (ukefDecision, decisionType) => ukefDecision?.cover
 const immutableDealStages = [TFM_DEAL_STAGE.CANCELLED];
 
 /**
- * @param {Object} filterAmendmentsByInProgressParams
- * @param {import('@ukef/dtfs2-common').TfmDeal} filterAmendmentsByInProgressParams.deal - the deal
- * @param {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} filterAmendmentsByInProgressParams.amendments - the amendments
+ * @param {Object} getAmendmentsInProgress Params
+ * @param {import('@ukef/dtfs2-common').TfmDeal} getAmendmentsInProgress Params.deal - the deal
+ * @param {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} getAmendmentsInProgress Params.amendments - the amendments
  * @returns {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} - the amendments that are in progress
  */
-const filterAmendmentsByInProgress = ({ amendments, deal }) => {
+const getAmendmentsInProgress = ({ amendments, deal }) => {
   if (immutableDealStages.includes(deal.tfm.stage)) {
     return [];
   }
@@ -93,5 +93,5 @@ module.exports = {
   userCanEditBankDecision,
   ukefDecisionRejected,
   validateUkefDecision,
-  filterAmendmentsByInProgress,
+  getAmendmentsInProgress,
 };

--- a/trade-finance-manager-ui/server/controllers/helpers/dealsAndFacilities.helper.deals.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/dealsAndFacilities.helper.deals.test.js
@@ -267,131 +267,131 @@ describe('controllers - deals', () => {
         });
       });
     });
+  });
 
-    describe('queryDealsOrFacilities', () => {
-      describe('when called with `deals` as its first argument', () => {
-        describe('when the pageNumber, sort field/order and search are not specified in the request', () => {
+  describe('queryDealsOrFacilities', () => {
+    describe('when called with `deals` as its first argument', () => {
+      describe('when the pageNumber, sort field/order and search are not specified in the request', () => {
+        const mockReq = structuredClone(mockReqTemplate);
+
+        it('should redirect to GET deals without query parameters', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
+
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
+        });
+      });
+
+      describe('when the pageNumber is less than 0', () => {
+        const mockReq = structuredClone(mockReqTemplate);
+
+        mockReq.params.pageNumber = '-1';
+
+        it('should redirect to GET deals (page 0) without query parameters', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
+
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
+        });
+      });
+
+      describe('when the pageNumber cannot be converted to a number', () => {
+        const mockReq = structuredClone(mockReqTemplate);
+
+        mockReq.params.pageNumber = 'hello world';
+
+        it('should redirect to GET deals (page 0) without query parameters', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
+
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
+        });
+      });
+
+      describe('when the pageNumber is a non-negative integer', () => {
+        const mockReq = structuredClone(mockReqTemplate);
+
+        mockReq.params.pageNumber = '2';
+
+        it('should redirect to GET deals (page 0) without query parameters', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
+
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
+        });
+      });
+
+      describe.each(['ascending', 'descending'])('', (order) => {
+        describe(`when a ${order} sort field is specified in the request body`, () => {
           const mockReq = structuredClone(mockReqTemplate);
 
-          it('should redirect to GET deals without query parameters', async () => {
+          mockReq.body[order] = 'dealSnapshot.ukefDealId';
+
+          it('should redirect to GET deals with the correct query parameters', async () => {
             await queryDealsOrFacilities('deals', mockReq, mockRes);
 
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
+            expect(mockRes.redirect).toHaveBeenCalledWith(`/deals/0?sortfield=dealSnapshot.ukefDealId&sortorder=${order}`);
           });
         });
 
-        describe('when the pageNumber is less than 0', () => {
+        describe(`when a ${order} sort field is specified in the query parameters`, () => {
           const mockReq = structuredClone(mockReqTemplate);
 
-          mockReq.params.pageNumber = '-1';
-
-          it('should redirect to GET deals (page 0) without query parameters', async () => {
-            await queryDealsOrFacilities('deals', mockReq, mockRes);
-
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
-          });
-        });
-
-        describe('when the pageNumber cannot be converted to a number', () => {
-          const mockReq = structuredClone(mockReqTemplate);
-
-          mockReq.params.pageNumber = 'hello world';
-
-          it('should redirect to GET deals (page 0) without query parameters', async () => {
-            await queryDealsOrFacilities('deals', mockReq, mockRes);
-
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
-          });
-        });
-
-        describe('when the pageNumber is a non-negative integer', () => {
-          const mockReq = structuredClone(mockReqTemplate);
-
-          mockReq.params.pageNumber = '2';
-
-          it('should redirect to GET deals (page 0) without query parameters', async () => {
-            await queryDealsOrFacilities('deals', mockReq, mockRes);
-
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0');
-          });
-        });
-
-        describe.each(['ascending', 'descending'])('', (order) => {
-          describe(`when a ${order} sort field is specified in the request body`, () => {
-            const mockReq = structuredClone(mockReqTemplate);
-
-            mockReq.body[order] = 'dealSnapshot.ukefDealId';
-
-            it('should redirect to GET deals with the correct query parameters', async () => {
-              await queryDealsOrFacilities('deals', mockReq, mockRes);
-
-              expect(mockRes.redirect).toHaveBeenCalledWith(`/deals/0?sortfield=dealSnapshot.ukefDealId&sortorder=${order}`);
-            });
-          });
-
-          describe(`when a ${order} sort field is specified in the query parameters`, () => {
-            const mockReq = structuredClone(mockReqTemplate);
-
-            mockReq.query.sortfield = 'dealSnapshot.ukefDealId';
-            mockReq.query.sortorder = order;
-
-            it('should redirect to GET deals with the correct query parameters', async () => {
-              await queryDealsOrFacilities('deals', mockReq, mockRes);
-
-              expect(mockRes.redirect).toHaveBeenCalledWith(`/deals/0?sortfield=dealSnapshot.ukefDealId&sortorder=${order}`);
-            });
-          });
-        });
-
-        describe('when a sort is specified in the both the request body and the query parameters', () => {
-          const mockReq = structuredClone(mockReqTemplate);
-
-          mockReq.body.descending = 'dealSnapshot.exporter.companyName';
           mockReq.query.sortfield = 'dealSnapshot.ukefDealId';
-          mockReq.query.sortorder = 'ascending';
-
-          it('should redirect to GET deals with query parameters based on the sort specified in the request body', async () => {
-            await queryDealsOrFacilities('deals', mockReq, mockRes);
-
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?sortfield=dealSnapshot.exporter.companyName&sortorder=descending');
-          });
-        });
-
-        describe('when a search is specified in the request body', () => {
-          const mockReq = structuredClone(mockReqTemplate);
-
-          mockReq.body.search = 'test';
+          mockReq.query.sortorder = order;
 
           it('should redirect to GET deals with the correct query parameters', async () => {
             await queryDealsOrFacilities('deals', mockReq, mockRes);
 
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?search=test');
+            expect(mockRes.redirect).toHaveBeenCalledWith(`/deals/0?sortfield=dealSnapshot.ukefDealId&sortorder=${order}`);
           });
         });
+      });
 
-        describe('when a search is specified in the query parameters', () => {
-          const mockReq = structuredClone(mockReqTemplate);
+      describe('when a sort is specified in the both the request body and the query parameters', () => {
+        const mockReq = structuredClone(mockReqTemplate);
 
-          mockReq.query.search = 'test';
+        mockReq.body.descending = 'dealSnapshot.exporter.companyName';
+        mockReq.query.sortfield = 'dealSnapshot.ukefDealId';
+        mockReq.query.sortorder = 'ascending';
 
-          it('should redirect to GET deals with the correct query parameters', async () => {
-            await queryDealsOrFacilities('deals', mockReq, mockRes);
+        it('should redirect to GET deals with query parameters based on the sort specified in the request body', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
 
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?search=test');
-          });
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?sortfield=dealSnapshot.exporter.companyName&sortorder=descending');
         });
+      });
 
-        describe('when a search is specified in the both the request body and the query parameters', () => {
-          const mockReq = structuredClone(mockReqTemplate);
+      describe('when a search is specified in the request body', () => {
+        const mockReq = structuredClone(mockReqTemplate);
 
-          mockReq.body.search = 'searchFromBody';
-          mockReq.query.search = 'searchFromQuery';
+        mockReq.body.search = 'test';
 
-          it('should redirect to GET deals with query parameters based on the search specified in the request body', async () => {
-            await queryDealsOrFacilities('deals', mockReq, mockRes);
+        it('should redirect to GET deals with the correct query parameters', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
 
-            expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?search=searchFromBody');
-          });
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?search=test');
+        });
+      });
+
+      describe('when a search is specified in the query parameters', () => {
+        const mockReq = structuredClone(mockReqTemplate);
+
+        mockReq.query.search = 'test';
+
+        it('should redirect to GET deals with the correct query parameters', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
+
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?search=test');
+        });
+      });
+
+      describe('when a search is specified in the both the request body and the query parameters', () => {
+        const mockReq = structuredClone(mockReqTemplate);
+
+        mockReq.body.search = 'searchFromBody';
+        mockReq.query.search = 'searchFromQuery';
+
+        it('should redirect to GET deals with query parameters based on the search specified in the request body', async () => {
+          await queryDealsOrFacilities('deals', mockReq, mockRes);
+
+          expect(mockRes.redirect).toHaveBeenCalledWith('/deals/0?search=searchFromBody');
         });
       });
     });

--- a/trade-finance-manager-ui/server/controllers/helpers/dealsAndFacilities.helper.deals.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/dealsAndFacilities.helper.deals.test.js
@@ -42,10 +42,12 @@ describe('controllers - deals', () => {
     {
       status: AMENDMENT_STATUS.IN_PROGRESS,
       dealId: '0',
+      submittedByPim: true,
     },
     {
       status: AMENDMENT_STATUS.NOT_STARTED,
       dealId: '1',
+      submittedByPim: true,
     },
   ];
   const mockApiGetAllAmendmentsInProgressResponse = {

--- a/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
@@ -2,8 +2,13 @@ const { cloneDeep } = require('lodash');
 const { getAmendmentsInProgress } = require('./amendments.helper');
 const { DEAL } = require('../../constants');
 
+/**
+ * Override the deal stage if there is an amendment in progress
+ * @param {import('@ukef/dtfs2-common').TfmDeal[]} deals - the deals
+ * @param {import('@ukef/dtfs2-common').TfmFacilityAmendment[]} amendments - the amendments
+ * @returns {import('@ukef/dtfs2-common').TfmDeal[]} the deals with deal stage overwritten if there is an amendment in progress
+ */
 const overrideDealsIfAmendmentsInProgress = (deals, amendments) => {
-  // override the deal stage if there is an amendment in progress
   if (Array.isArray(amendments) && amendments?.length > 0) {
     return deals.map((deal) => {
       const modifiedDeal = cloneDeep(deal);

--- a/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
@@ -1,5 +1,5 @@
 const { cloneDeep } = require('lodash');
-const { filterAmendmentsByInProgress } = require('./amendments.helper');
+const { getAmendmentsInProgress } = require('./amendments.helper');
 const { DEAL } = require('../../constants');
 
 const overrideDealsIfAmendmentsInProgress = (deals, amendments) => {
@@ -9,7 +9,7 @@ const overrideDealsIfAmendmentsInProgress = (deals, amendments) => {
       const modifiedDeal = cloneDeep(deal);
 
       const amendmentsForDeal = amendments.filter(({ dealId }) => dealId === deal._id);
-      const amendmentInProgressOnDeal = filterAmendmentsByInProgress({ amendments: amendmentsForDeal, deal });
+      const amendmentInProgressOnDeal = getAmendmentsInProgress({ amendments: amendmentsForDeal, deal });
 
       if (amendmentInProgressOnDeal.length > 0) {
         modifiedDeal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;

--- a/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
@@ -1,19 +1,20 @@
-const { AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
+const { cloneDeep } = require('lodash');
+const { filterAmendmentsByInProgress } = require('./amendments.helper');
 const { DEAL } = require('../../constants');
 
 const overrideDealsIfAmendmentsInProgress = (deals, amendments) => {
   // override the deal stage if there is an amendment in progress
   if (Array.isArray(amendments) && amendments?.length > 0) {
     return deals.map((deal) => {
-      const modifiedDeal = deal;
-      // eslint-disable-next-line no-restricted-syntax
-      for (const amendment of amendments) {
-        const amendmentIsInProgress = amendment.status === AMENDMENT_STATUS.IN_PROGRESS;
-        if (amendmentIsInProgress && amendment.dealId === deal._id) {
-          modifiedDeal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
-          break;
-        }
+      const modifiedDeal = cloneDeep(deal);
+
+      const amendmentsForDeal = amendments.filter(({ dealId }) => dealId === deal._id);
+      const amendmentInProgressOnDeal = filterAmendmentsByInProgress({ amendments: amendmentsForDeal, deal });
+
+      if (amendmentInProgressOnDeal.length > 0) {
+        modifiedDeal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;
       }
+
       return modifiedDeal;
     });
   }

--- a/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.test.js
@@ -27,7 +27,7 @@ describe('overrideDealsIfAmendmentsInProgress', () => {
     {
       status: AMENDMENT_STATUS.NOT_STARTED,
       dealId: '1',
-      submittedByPim: true,
+      submittedByPim: false,
     },
   ];
 
@@ -40,7 +40,7 @@ describe('overrideDealsIfAmendmentsInProgress', () => {
     {
       status: AMENDMENT_STATUS.NOT_STARTED,
       dealId: '1',
-      submittedByPim: true,
+      submittedByPim: false,
     },
   ];
 

--- a/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.test.js
@@ -22,10 +22,12 @@ describe('overrideDealsIfAmendmentsInProgress', () => {
     {
       status: AMENDMENT_STATUS.IN_PROGRESS,
       dealId: '0',
+      submittedByPim: true,
     },
     {
       status: AMENDMENT_STATUS.NOT_STARTED,
       dealId: '1',
+      submittedByPim: true,
     },
   ];
 
@@ -33,10 +35,12 @@ describe('overrideDealsIfAmendmentsInProgress', () => {
     {
       status: AMENDMENT_STATUS.IN_PROGRESS,
       dealId: '2',
+      submittedByPim: true,
     },
     {
       status: AMENDMENT_STATUS.NOT_STARTED,
       dealId: '1',
+      submittedByPim: true,
     },
   ];
 


### PR DESCRIPTION
## Introduction :pencil2:
When the deal has an amendment in progress and is cancelled, the deal stage should be cancelled

## Resolution :heavy_check_mark:
- Refactor `filterAmendmentsByInProgress` to check if the deal stage is cancelled

## Note ⚠️ 
I've tried to commonise the deal stage overriding logic and  as such have made some changes to the behaviour. Please check if any of these should remain as they were 

