### PR TITLE
feat(FN-3669): map reported fees amount to monetary value

### DIFF
--- a/libs/common/src/test-helpers/fee-record-correction-review-information.ts
+++ b/libs/common/src/test-helpers/fee-record-correction-review-information.ts
@@ -7,7 +7,7 @@ export const aFeeRecordCorrectionReviewInformation = (): FeeRecordCorrectionRevi
     exporter: 'An exporter',
     reportedFees: {
       currency: 'GBP',
-      amount: 123,
+      amount: 1234.56,
     },
   },
   reasons: [RECORD_CORRECTION_REASON.FACILITY_ID_INCORRECT, RECORD_CORRECTION_REASON.REPORTED_CURRENCY_INCORRECT, RECORD_CORRECTION_REASON.OTHER],

--- a/portal/component-tests/utilisation-report-service/record-correction/check-the-information.component-test.js
+++ b/portal/component-tests/utilisation-report-service/record-correction/check-the-information.component-test.js
@@ -64,17 +64,15 @@ describe('page', () => {
 
   it('should render the original reported fees paid', () => {
     // Arrange
-    const reportedFees = 12345.67;
+    const reportedFeesPaid = '12,345.67';
     const viewModel = aUtilisationReportCorrectionInformationViewModel();
-    viewModel.feeRecord.reportedFees.amount = reportedFees;
-
-    const expectedReportedFees = '12345.67';
+    viewModel.feeRecord.reportedFees.amount = reportedFeesPaid;
 
     // Act
     const wrapper = render(viewModel);
 
     // Assert
-    wrapper.expectText(definitionDescriptionSelector(originalValuesSelector, 'Reported fees paid')).toRead(expectedReportedFees);
+    wrapper.expectText(definitionDescriptionSelector(originalValuesSelector, 'Reported fees paid')).toRead(reportedFeesPaid);
   });
 
   it('should render the record correction details table heading', () => {

--- a/portal/component-tests/utilisation-report-service/record-correction/check-the-information.component-test.js
+++ b/portal/component-tests/utilisation-report-service/record-correction/check-the-information.component-test.js
@@ -66,7 +66,7 @@ describe('page', () => {
     // Arrange
     const reportedFeesPaid = '12,345.67';
     const viewModel = aUtilisationReportCorrectionInformationViewModel();
-    viewModel.feeRecord.reportedFees.amount = reportedFeesPaid;
+    viewModel.feeRecord.reportedFees.formattedAmount = reportedFeesPaid;
 
     // Act
     const wrapper = render(viewModel);

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
@@ -58,7 +58,7 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
     });
 
     it('should render the "utilisation report correction - check the information" page', async () => {
-      // Arrange,
+      // Arrange
       const exporter = 'An exporter';
       const reportedFeesCurrency = CURRENCY.GBP;
       const reportedFeesAmount = 1234.56;
@@ -86,7 +86,7 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
         exporter,
         reportedFees: {
           currency: reportedFeesCurrency,
-          amount: '1,234.56',
+          formattedAmount: '1,234.56',
         },
       };
 

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
@@ -4,7 +4,9 @@ import {
   aFeeRecordCorrectionReviewInformation,
   aPortalSessionBank,
   aPortalSessionUser,
+  CURRENCY,
   FeeRecordCorrectionReviewInformation,
+  getFormattedMonetaryValue,
   mapReasonsToDisplayValues,
   PORTAL_LOGIN_STATUS,
 } from '@ukef/dtfs2-common';
@@ -58,17 +60,36 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
 
     it('should render the "utilisation report correction - check the information" page', async () => {
       // Arrange,
+      const exporter = 'An exporter';
+      const reportedFeesCurrency = CURRENCY.GBP;
+      const reportedFeesAmount = 1234.56;
       const bankCommentary = 'Some bank commentary';
+
       const feeRecordCorrectionReviewResponse = {
         ...aFeeRecordCorrectionReviewInformation(),
         bankCommentary,
+        feeRecord: {
+          exporter,
+          reportedFees: {
+            currency: reportedFeesCurrency,
+            amount: reportedFeesAmount,
+          },
+        },
       };
 
       jest.mocked(api.getFeeRecordCorrectionReview).mockResolvedValue(feeRecordCorrectionReviewResponse);
 
-      const { errorSummary, feeRecord, formattedOldValues, formattedNewValues, reasons } = feeRecordCorrectionReviewResponse;
+      const { errorSummary, formattedOldValues, formattedNewValues, reasons } = feeRecordCorrectionReviewResponse;
 
       const expectedFormattedReasons = mapReasonsToDisplayValues(reasons).join(', ');
+
+      const expectedFeeRecord = {
+        exporter,
+        reportedFees: {
+          currency: reportedFeesCurrency,
+          amount: getFormattedMonetaryValue(reportedFeesAmount),
+        },
+      };
 
       // Act
       await getUtilisationReportCorrectionReview(req, res);
@@ -78,7 +99,7 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
         user: mockUser,
         primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
         backLinkHref: `/utilisation-reports/provide-correction/${correctionId}`,
-        feeRecord,
+        feeRecord: expectedFeeRecord,
         formattedReasons: expectedFormattedReasons,
         errorSummary,
         formattedOldValues,

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
@@ -6,6 +6,7 @@ import {
   aPortalSessionUser,
   CURRENCY,
   FeeRecordCorrectionReviewInformation,
+  getFormattedMonetaryValue,
   mapReasonsToDisplayValues,
   PORTAL_LOGIN_STATUS,
 } from '@ukef/dtfs2-common';
@@ -88,7 +89,7 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
         exporter,
         reportedFees: {
           currency: reportedFeesCurrency,
-          formattedAmount: '1,234.56',
+          formattedAmount: getFormattedMonetaryValue(reportedFeesAmount),
         },
       };
 

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.test.ts
@@ -6,7 +6,6 @@ import {
   aPortalSessionUser,
   CURRENCY,
   FeeRecordCorrectionReviewInformation,
-  getFormattedMonetaryValue,
   mapReasonsToDisplayValues,
   PORTAL_LOGIN_STATUS,
 } from '@ukef/dtfs2-common';
@@ -87,7 +86,7 @@ describe('controllers/utilisation-reports/record-corrections/check-the-informati
         exporter,
         reportedFees: {
           currency: reportedFeesCurrency,
-          amount: getFormattedMonetaryValue(reportedFeesAmount),
+          amount: '1,234.56',
         },
       };
 

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.ts
@@ -41,7 +41,7 @@ export const getUtilisationReportCorrectionReview = async (req: GetUtilisationRe
       exporter,
       reportedFees: {
         currency,
-        amount: getFormattedMonetaryValue(amount),
+        formattedAmount: getFormattedMonetaryValue(amount),
       },
     };
 

--- a/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/check-the-information/index.ts
@@ -1,5 +1,5 @@
 import { Response, Request } from 'express';
-import { mapReasonsToDisplayValues } from '@ukef/dtfs2-common';
+import { getFormattedMonetaryValue, mapReasonsToDisplayValues } from '@ukef/dtfs2-common';
 import api from '../../../../api';
 import { asLoggedInUserSession } from '../../../../helpers/express-session';
 import { PRIMARY_NAV_KEY } from '../../../../constants';
@@ -34,11 +34,22 @@ export const getUtilisationReportCorrectionReview = async (req: GetUtilisationRe
 
     const backLinkHref = `/utilisation-reports/provide-correction/${correctionId}`;
 
+    const { exporter, reportedFees } = feeRecord;
+    const { currency, amount } = reportedFees;
+
+    const mappedFeeRecord = {
+      exporter,
+      reportedFees: {
+        currency,
+        amount: getFormattedMonetaryValue(amount),
+      },
+    };
+
     const viewModel: UtilisationReportCorrectionInformationViewModel = {
       user,
       primaryNav: PRIMARY_NAV_KEY.UTILISATION_REPORT_UPLOAD,
       backLinkHref,
-      feeRecord,
+      feeRecord: mappedFeeRecord,
       formattedReasons: mapReasonsToDisplayValues(reasons).join(', '),
       errorSummary,
       formattedOldValues,

--- a/portal/server/types/view-models/record-correction/utilisation-report-correction-information.ts
+++ b/portal/server/types/view-models/record-correction/utilisation-report-correction-information.ts
@@ -1,11 +1,14 @@
-import { CurrencyAndAmount } from '@ukef/dtfs2-common';
+import { Currency } from '@ukef/dtfs2-common';
 import { BaseViewModel } from '../base-view-model';
 
 export type UtilisationReportCorrectionInformationViewModel = BaseViewModel & {
   backLinkHref: string;
   feeRecord: {
     exporter: string;
-    reportedFees: CurrencyAndAmount;
+    reportedFees: {
+      currency: Currency;
+      amount: string;
+    };
   };
   formattedReasons: string;
   errorSummary: string;

--- a/portal/server/types/view-models/record-correction/utilisation-report-correction-information.ts
+++ b/portal/server/types/view-models/record-correction/utilisation-report-correction-information.ts
@@ -7,7 +7,7 @@ export type UtilisationReportCorrectionInformationViewModel = BaseViewModel & {
     exporter: string;
     reportedFees: {
       currency: Currency;
-      amount: string;
+      formattedAmount: string;
     };
   };
   formattedReasons: string;

--- a/portal/templates/utilisation-report-service/record-correction/check-the-information.njk
+++ b/portal/templates/utilisation-report-service/record-correction/check-the-information.njk
@@ -36,7 +36,7 @@
             text: "Reported fees paid"
           },
           value: {
-            text: feeRecord.reportedFees.amount
+            text: feeRecord.reportedFees.formattedAmount
           }
         }
       ],

--- a/portal/test-helpers/test-data/view-models/record-corrections/utilisation-report-correction-information-view-model.ts
+++ b/portal/test-helpers/test-data/view-models/record-corrections/utilisation-report-correction-information-view-model.ts
@@ -10,7 +10,7 @@ export const aUtilisationReportCorrectionInformationViewModel = (): UtilisationR
     exporter: 'An exporter',
     reportedFees: {
       currency: 'GBP',
-      amount: 123,
+      amount: '1,234.56',
     },
   },
   formattedReasons: 'Facility ID is incorrect, Reported currency is incorrect',

--- a/portal/test-helpers/test-data/view-models/record-corrections/utilisation-report-correction-information-view-model.ts
+++ b/portal/test-helpers/test-data/view-models/record-corrections/utilisation-report-correction-information-view-model.ts
@@ -10,7 +10,7 @@ export const aUtilisationReportCorrectionInformationViewModel = (): UtilisationR
     exporter: 'An exporter',
     reportedFees: {
       currency: 'GBP',
-      amount: '1,234.56',
+      formattedAmount: '1,234.56',
     },
   },
   formattedReasons: 'Facility ID is incorrect, Reported currency is incorrect',


### PR DESCRIPTION
## Introduction :pencil2:
The reported fees on the bank correction "check the information" screen needs to be formatted as a monetary value. At present, the raw number will be rendered.

Examples:
- Before: `123`, After: `123.00`
- Before: `1234.56`, After: `1,234.56`

## Resolution :heavy_check_mark:
- Updated view model "amount" type to string
- Called monetary value formatting helper in the controller

## Miscellaneous :heavy_plus_sign:
N/A

