### PR TITLE
feat(FN-3689): add e2e-tests for persistence of correction form values

### DIFF
--- a/e2e-tests/portal/cypress/e2e/pages/index.js
+++ b/e2e-tests/portal/cypress/e2e/pages/index.js
@@ -56,6 +56,7 @@ module.exports = {
   confirmAndSend: require('./utilisation-report-service/confirmAndSend'),
   confirmation: require('./utilisation-report-service/confirmation'),
   provideCorrection: require('./utilisation-report-service/record-corrections/provideCorrection'),
+  reviewCorrection: require('./utilisation-report-service/record-corrections/reviewCorrection'),
   problemWithService: require('./problem-with-service'),
   pendingCorrections: require('./utilisation-report-service/record-corrections/pendingCorrections'),
 };

--- a/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/record-corrections/reviewCorrection.js
+++ b/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/record-corrections/reviewCorrection.js
@@ -1,0 +1,5 @@
+const page = {
+  changeNewValuesLink: () => cy.get('a[data-cy="change-record-correction-new-values-link"]'),
+};
+
+module.exports = page;


### PR DESCRIPTION
## Introduction :pencil2:
When the work for persistence was done the e2e-tests were blocked on other tickets to allow us to test the user flow. That work has now progressed enough.

## Resolution :heavy_check_mark:
- Add an e2e-test to cover the scenario where a user save and review the correction but then decides to go back and change them from the review screen

