### PR TITLE
feat(FN-3736): remaining delete transient form data scenarios

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
@@ -158,7 +158,7 @@ describe(`PUT ${BASE_URL}`, () => {
 
     // Assert
     const allTransientFormData = await SqlDbHelper.manager.find(FeeRecordCorrectionTransientFormDataEntity);
-    expect(allTransientFormData).toHaveLength(1);
+    expect(allTransientFormData).toHaveLength(0);
   });
 
   it('should return the sent to email addresses and the report period upon success', async () => {

--- a/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/fee-record-corrections/put-fee-record-correction.api-test.ts
@@ -3,6 +3,7 @@ import { Response } from 'supertest';
 import {
   FEE_RECORD_STATUS,
   FeeRecordCorrectionEntityMockBuilder,
+  FeeRecordCorrectionTransientFormDataEntity,
   FeeRecordCorrectionTransientFormDataEntityMockBuilder,
   FeeRecordEntityMockBuilder,
   RECONCILIATION_IN_PROGRESS,
@@ -146,6 +147,18 @@ describe(`PUT ${BASE_URL}`, () => {
 
     // Assert
     expect(status).toEqual(HttpStatusCode.Ok);
+  });
+
+  it('should delete the transient form data', async () => {
+    // Arrange
+    const requestBody = aValidRequestBody();
+
+    // Act
+    await testApi.put(requestBody).to(replaceUrlParameterPlaceholders(BASE_URL, { bankId, correctionId }));
+
+    // Assert
+    const allTransientFormData = await SqlDbHelper.manager.find(FeeRecordCorrectionTransientFormDataEntity);
+    expect(allTransientFormData).toHaveLength(1);
   });
 
   it('should return the sent to email addresses and the report period upon success', async () => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.test.ts
@@ -24,6 +24,7 @@ jest.mock('../../../../../repositories/banks-repo');
 describe('putFeeRecordCorrection', () => {
   const mockFindCorrection = jest.fn();
   const mockFindCorrectionTransientFormData = jest.fn();
+  const mockDeleteTransientFormData = jest.fn();
 
   const correctionId = 1;
   const bankId = '123';
@@ -38,6 +39,7 @@ describe('putFeeRecordCorrection', () => {
   beforeEach(() => {
     FeeRecordCorrectionRepo.findOneByIdAndBankIdWithFeeRecordAndReport = mockFindCorrection;
     FeeRecordCorrectionTransientFormDataRepo.findByUserIdAndCorrectionId = mockFindCorrectionTransientFormData;
+    FeeRecordCorrectionTransientFormDataRepo.deleteByUserIdAndCorrectionId = mockDeleteTransientFormData;
 
     req = httpMocks.createRequest<PutFeeRecordCorrectionRequest>({
       params: aValidRequestParams(),
@@ -137,6 +139,15 @@ describe('putFeeRecordCorrection', () => {
 
         beforeEach(() => {
           jest.mocked(getBankById).mockResolvedValue(bank);
+        });
+
+        it('should call the repo to delete the transient form data', async () => {
+          // Act
+          await putFeeRecordCorrection(req, res);
+
+          // Assert
+          expect(mockDeleteTransientFormData).toHaveBeenCalledTimes(1);
+          expect(mockDeleteTransientFormData).toHaveBeenCalledWith(portalUserId, correctionId);
         });
 
         it(`should respond with ${HttpStatusCode.Ok}`, async () => {

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/put-fee-record-correction.controller/index.ts
@@ -25,6 +25,7 @@ export type PutFeeRecordCorrectionRequest = CustomExpressRequest<{
  * status back to TO_DO.
  * - Saves the old and new values against the record correction for
  * record correction history log.
+ * - Deletes the transient form data.
  * - Sends confirmation email to the bank payment report officer team.
  * - Sends notification email to PDC team.
  *
@@ -58,6 +59,8 @@ export const putFeeRecordCorrection = async (req: PutFeeRecordCorrectionRequest,
     }
 
     // TODO: FN-3675 - apply the correction to the fee record and send confirmation emails
+
+    await FeeRecordCorrectionTransientFormDataRepo.deleteByUserIdAndCorrectionId(userId, correctionId);
 
     const { reportPeriod } = correction.feeRecord.report;
 

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/provide-correction.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/provide-correction.spec.js
@@ -103,7 +103,7 @@ context('Provide correction - Fee record correction feature flag enabled', () =>
           provideCorrection.additionalComments.input().should('exist');
         });
 
-        context('and when the user has entered values, clicked save and review changes and clicked change', () => {
+        context('and when the user has entered values and clicked save and review changes', () => {
           const newFacilityId = '77777777';
           const newReportedFee = '12345.67';
           const newReportedCurrency = CURRENCY.JPY;
@@ -116,15 +116,37 @@ context('Provide correction - Fee record correction feature flag enabled', () =>
             cy.keyboardInput(provideCorrection.additionalComments.input(), additionalComments);
 
             cy.clickContinueButton();
-
-            reviewCorrection.changeNewValuesLink().click();
           });
 
-          it('should retain the values entered by the user', () => {
+          it('should retain the values entered by the user when they return to the page via the review page change link', () => {
+            reviewCorrection.changeNewValuesLink().click();
+
             provideCorrection.facilityIdInput().should('have.value', newFacilityId);
             provideCorrection.reportedFeeInput().should('have.value', getFormattedMonetaryValue(newReportedFee));
             provideCorrection.reportedCurrency.radioInput(newReportedCurrency).should('be.checked');
             provideCorrection.additionalComments.input().should('have.value', additionalComments);
+          });
+
+          it('should NOT retain the values entered by the user when they navigate away and restart the journey', () => {
+            cy.visit(relative(`/utilisation-report-upload`));
+
+            pendingCorrections.row(1).correctionLink().click();
+
+            provideCorrection.facilityIdInput().should('have.value', '');
+            provideCorrection.reportedFeeInput().should('have.value', '');
+            provideCorrection.reportedCurrency.radioInput(newReportedCurrency).should('not.be.checked');
+            provideCorrection.additionalComments.input().should('have.value', '');
+          });
+
+          it('should NOT retain the values entered by the user when they cancel on the review page then navigate back directly via url', () => {
+            cy.clickCancelButton();
+
+            cy.visit(relative(`/utilisation-reports/provide-correction/${pendingCorrectionDetails.id}`));
+
+            provideCorrection.facilityIdInput().should('have.value', '');
+            provideCorrection.reportedFeeInput().should('have.value', '');
+            provideCorrection.reportedCurrency.radioInput(newReportedCurrency).should('not.be.checked');
+            provideCorrection.additionalComments.input().should('have.value', '');
           });
         });
       });

--- a/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/index.test.ts
+++ b/portal/server/controllers/utilisation-report-service/record-correction/provide-utilisation-report-correction/index.test.ts
@@ -81,6 +81,17 @@ describe('controllers/utilisation-reports/record-corrections/create-record-corre
         expect(api.deleteFeeRecordCorrectionTransientFormData).toHaveBeenCalledWith(userToken, bankId, correctionId);
       });
 
+      it('should NOT attempt to fetch saved form data', async () => {
+        // Arrange
+        jest.mocked(api.getFeeRecordCorrection).mockResolvedValue(aGetFeeRecordCorrectionResponseBody());
+
+        // Act
+        await getProvideUtilisationReportCorrection(req, res);
+
+        // Assert
+        expect(api.getFeeRecordCorrectionTransientFormData).not.toHaveBeenCalled();
+      });
+
       it('should render the "provide utilisation report correction" page', async () => {
         // Arrange
         const reasons = [RECORD_CORRECTION_REASON.OTHER];
@@ -120,6 +131,30 @@ describe('controllers/utilisation-reports/record-corrections/create-record-corre
     describe('when the user visits the page from a page other than the Report GEF utilisation and fees page', () => {
       beforeEach(() => {
         req.headers.referer = 'some-other-page';
+      });
+
+      it('should fetch the fee record correction transient form data using the correction id and users bank id', async () => {
+        // Arrange
+        jest.mocked(api.getFeeRecordCorrection).mockResolvedValue(aGetFeeRecordCorrectionResponseBody());
+        jest.mocked(api.getFeeRecordCorrectionTransientFormData).mockResolvedValue({});
+
+        // Act
+        await getProvideUtilisationReportCorrection(req, res);
+
+        // Assert
+        expect(api.getFeeRecordCorrectionTransientFormData).toHaveBeenCalledTimes(1);
+        expect(api.getFeeRecordCorrectionTransientFormData).toHaveBeenCalledWith(userToken, bankId, correctionId);
+      });
+
+      it('should NOT attempt to delete saved form data', async () => {
+        // Arrange
+        jest.mocked(api.getFeeRecordCorrection).mockResolvedValue(aGetFeeRecordCorrectionResponseBody());
+
+        // Act
+        await getProvideUtilisationReportCorrection(req, res);
+
+        // Assert
+        expect(api.deleteFeeRecordCorrectionTransientFormData).not.toHaveBeenCalled();
       });
 
       describe('when there are NOT any saved form values', () => {
@@ -224,19 +259,6 @@ describe('controllers/utilisation-reports/record-corrections/create-record-corre
       // Assert
       expect(api.getFeeRecordCorrection).toHaveBeenCalledTimes(1);
       expect(api.getFeeRecordCorrection).toHaveBeenCalledWith(userToken, bankId, correctionId);
-    });
-
-    it('should fetch the fee record correction transient form data using the correction id and users bank id', async () => {
-      // Arrange
-      jest.mocked(api.getFeeRecordCorrection).mockResolvedValue(aGetFeeRecordCorrectionResponseBody());
-      jest.mocked(api.getFeeRecordCorrectionTransientFormData).mockResolvedValue({});
-
-      // Act
-      await getProvideUtilisationReportCorrection(req, res);
-
-      // Assert
-      expect(api.getFeeRecordCorrectionTransientFormData).toHaveBeenCalledTimes(1);
-      expect(api.getFeeRecordCorrectionTransientFormData).toHaveBeenCalledWith(userToken, bankId, correctionId);
     });
 
     describe.each`


### PR DESCRIPTION
## Introduction :pencil2:
When a user abandons the correction journey without clicking cancel they might start the journey again with form data already saved. When they start a new journey we therefore need to make an api call to delete any old saved data.

Also in this PR, add deletion of correction transient form data to the endpoint that will be responsible for saving the values and completes the journey so any unused old data is not hanging around.

## Resolution :heavy_check_mark:
- Add repo delete call to the PUT fee record correction endpoint
- Add call to the transient form data delete endpoint when user is starting the provide correction journey anew
- Add e2e-tests for the changes in this PR and the initial PR for this ticket which covers deleting the form data when the user clicks cancel on the review page

