### PR TITLE
feat(FN-3670): correction sent page e2e-tests

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/correction-sent.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/correction-sent.spec.js
@@ -1,0 +1,91 @@
+import {
+  UtilisationReportEntityMockBuilder,
+  FeeRecordCorrectionEntityMockBuilder,
+  PENDING_RECONCILIATION,
+  FeeRecordEntityMockBuilder,
+  FEE_RECORD_STATUS,
+  RECORD_CORRECTION_REASON,
+  getFormattedReportPeriodWithLongMonth,
+} from '@ukef/dtfs2-common';
+import { NODE_TASKS, BANK1_PAYMENT_REPORT_OFFICER1 } from '../../../../../../../e2e-fixtures';
+import relative from '../../../../relativeURL';
+import { provideCorrection, pendingCorrections, correctionSent } from '../../../../pages';
+import { mainHeading } from '../../../../partials';
+
+context('Correction sent page - Fee record correction feature flag enabled', () => {
+  context('When a correction has been provided', () => {
+    const reportPeriod = { start: { month: 1, year: 2021 }, end: { month: 1, year: 2021 } };
+
+    beforeEach(() => {
+      cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
+
+      cy.task('getUserFromDbByEmail', BANK1_PAYMENT_REPORT_OFFICER1.email).then((user) => {
+        const { _id, bank } = user;
+        const bankId = bank.id;
+
+        const report = UtilisationReportEntityMockBuilder.forStatus(PENDING_RECONCILIATION)
+          .withUploadedByUserId(_id.toString())
+          .withBankId(bankId)
+          .withReportPeriod(reportPeriod)
+          .build();
+
+        const feeRecord = FeeRecordEntityMockBuilder.forReport(report).withStatus(FEE_RECORD_STATUS.PENDING_CORRECTION).build();
+
+        const pendingCorrection = FeeRecordCorrectionEntityMockBuilder.forFeeRecord(feeRecord)
+          .withId(3)
+          .withIsCompleted(false)
+          .withReasons([RECORD_CORRECTION_REASON.UTILISATION_INCORRECT])
+          .build();
+
+        cy.task(NODE_TASKS.INSERT_UTILISATION_REPORTS_INTO_DB, [report]);
+        cy.task(NODE_TASKS.INSERT_FEE_RECORDS_INTO_DB, [feeRecord]);
+        cy.task(NODE_TASKS.INSERT_FEE_RECORD_CORRECTIONS_INTO_DB, [pendingCorrection]);
+      });
+
+      cy.login(BANK1_PAYMENT_REPORT_OFFICER1);
+      cy.visit(relative(`/utilisation-report-upload`));
+
+      pendingCorrections.row(1).correctionLink().click();
+
+      cy.keyboardInput(provideCorrection.utilisationInput(), '12345.67');
+
+      // Click continue the first time to save and review.
+      cy.clickContinueButton();
+
+      // Click continue again on the review page to submit the correction.
+      cy.clickContinueButton();
+    });
+
+    after(() => {
+      cy.task(NODE_TASKS.DELETE_ALL_FROM_SQL_DB);
+    });
+
+    it('should display confirmation of the record correction submission', () => {
+      const expectedHeading = `${getFormattedReportPeriodWithLongMonth(reportPeriod)} record correction sent to UKEF`;
+
+      cy.assertText(mainHeading(), expectedHeading);
+
+      cy.assertText(correctionSent.emailText(), 'A confirmation email has been sent to:');
+
+      cy.task('getUserFromDbByEmail', BANK1_PAYMENT_REPORT_OFFICER1.email).then((user) => {
+        const { id } = user.bank;
+
+        cy.task(NODE_TASKS.GET_ALL_BANKS).then((banks) => {
+          const bank = banks.find((b) => b.id === id);
+
+          bank.paymentOfficerTeam.emails.forEach((email) => {
+            correctionSent.emailListItem(email).should('exist');
+          });
+        });
+      });
+
+      cy.assertText(correctionSent.ukefNotifiedText(), 'UKEF will be notified via email that a record has been updated.');
+    });
+
+    it('should redirect to the Report GEF utilisation and fees paid when continue is clicked', () => {
+      cy.clickContinueButton();
+
+      cy.assertText(mainHeading(), 'Report GEF utilisation and fees');
+    });
+  });
+});

--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/correction-sent.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/correction-sent.spec.js
@@ -74,7 +74,7 @@ context('Correction sent page - Fee record correction feature flag enabled', () 
           const bank = banks.find((b) => b.id === id);
 
           bank.paymentOfficerTeam.emails.forEach((email) => {
-            correctionSent.emailListItem(email).should('exist');
+            correctionSent.emailList().should('contain', email);
           });
         });
       });

--- a/e2e-tests/portal/cypress/e2e/pages/index.js
+++ b/e2e-tests/portal/cypress/e2e/pages/index.js
@@ -57,6 +57,7 @@ module.exports = {
   confirmation: require('./utilisation-report-service/confirmation'),
   provideCorrection: require('./utilisation-report-service/record-corrections/provideCorrection'),
   reviewCorrection: require('./utilisation-report-service/record-corrections/reviewCorrection'),
+  correctionSent: require('./utilisation-report-service/record-corrections/correctionSent'),
   problemWithService: require('./problem-with-service'),
   pendingCorrections: require('./utilisation-report-service/record-corrections/pendingCorrections'),
 };

--- a/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/record-corrections/correctionSent.js
+++ b/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/record-corrections/correctionSent.js
@@ -1,6 +1,6 @@
 const page = {
   emailText: () => cy.get('[data-cy="email-text"]'),
-  emailListItem: (email) => cy.get(`[data-cy="email-list"] li:contains(${email})`),
+  emailList: () => cy.get('[data-cy="email-list"]'),
   ukefNotifiedText: () => cy.get('[data-cy="ukef-notified-text"]'),
 };
 

--- a/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/record-corrections/correctionSent.js
+++ b/e2e-tests/portal/cypress/e2e/pages/utilisation-report-service/record-corrections/correctionSent.js
@@ -1,0 +1,7 @@
+const page = {
+  emailText: () => cy.get('[data-cy="email-text"]'),
+  emailListItem: (email) => cy.get(`[data-cy="email-list"] li:contains(${email})`),
+  ukefNotifiedText: () => cy.get('[data-cy="ukef-notified-text"]'),
+};
+
+module.exports = page;

--- a/portal/component-tests/utilisation-report-service/confirmation.component-test.js
+++ b/portal/component-tests/utilisation-report-service/confirmation.component-test.js
@@ -16,8 +16,8 @@ describe(page, () => {
     wrapper.expectText('[data-cy="main-heading"]').toRead(`${reportPeriod} GEF report sent to UKEF`);
   });
 
-  it('should render paragraph', () => {
-    wrapper.expectText('[data-cy="paragraph"]').toRead('A confirmation email has been sent to:');
+  it('should render email confirmation list', () => {
+    wrapper.expectText('[data-cy="email-text"]').toRead('A confirmation email has been sent to:');
     for (const paymentOfficerEmail of paymentOfficerEmails) {
       wrapper.expectElement(`ul.govuk-list > li:contains("${paymentOfficerEmail}")`).toExist();
     }

--- a/portal/templates/utilisation-report-service/_macros/email-confirmation-list.njk
+++ b/portal/templates/utilisation-report-service/_macros/email-confirmation-list.njk
@@ -1,7 +1,7 @@
 {% macro render(params) %}
   {% set emails = params.emails %}
 
-  <p class="govuk-body" data-cy="paragraph">
+  <p class="govuk-body" data-cy="email-text">
     A confirmation email has been sent to:
     <ul class="govuk-list govuk-list--bullet" data-cy="email-list">
       {% for email in emails %}

--- a/portal/templates/utilisation-report-service/record-correction/correction-sent.njk
+++ b/portal/templates/utilisation-report-service/record-correction/correction-sent.njk
@@ -16,7 +16,7 @@
         emails: sentToEmails
       }) }}
 
-      <p class="govuk-body">UKEF will be notified via email that a record has been updated.</p>
+      <p class="govuk-body" data-cy="ukef-notified-text">UKEF will be notified via email that a record has been updated.</p>
 
       <a href="/utilisation-report-upload" role="button" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button" data-cy="continue-button">Continue</a>
     </div>


### PR DESCRIPTION
## Introduction :pencil2:
The correction sent page was added before there was a complete journey for the user to get to the page. This PR adds those e2e-tests now that the user journey is complete enough for them.

## Resolution :heavy_check_mark:
- Add e2e-tests for the correction sent page

## Miscellaneous :heavy_plus_sign:
- Update data-cy that was just 'paragraph' to a more descriptive name

