### PR TITLE
feat(DTFS2-7498): add amendments eligibility page template

### DIFF
--- a/gef-ui/api-tests/amendments/eligibility.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/eligibility.get.api-test.ts
@@ -1,0 +1,205 @@
+import { Headers } from 'node-mocks-http';
+import { NextFunction, Request, Response } from 'express';
+import { DEAL_STATUS, DEAL_SUBMISSION_TYPE, ROLES } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { withRoleValidationApiTests } from '../common-tests/role-validation-api-tests';
+import app from '../../server/createApp';
+import { createApi } from '../create-api';
+import api from '../../server/services/api';
+import * as storage from '../test-helpers/storage/storage';
+import { PortalFacilityAmendmentWithUkefIdMockBuilder } from '../../test-helpers/mock-amendment';
+import { PORTAL_AMENDMENT_PAGES } from '../../server/constants/amendments';
+import { MOCK_BASIC_DEAL } from '../../server/utils/mocks/mock-applications';
+import { MOCK_ISSUED_FACILITY, MOCK_UNISSUED_FACILITY } from '../../server/utils/mocks/mock-facilities';
+
+const originalEnv = { ...process.env };
+
+const { get } = createApi(app);
+
+jest.mock('csurf', () => () => (_req: Request, _res: Response, next: NextFunction) => next());
+jest.mock('../../server/middleware/csrf', () => ({
+  csrfToken: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+const mockGetFacility = jest.fn();
+const mockGetApplication = jest.fn();
+const mockGetAmendment = jest.fn();
+
+const dealId = '123';
+const facilityId = '111';
+const amendmentId = '111';
+
+const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
+
+const url = `/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/${PORTAL_AMENDMENT_PAGES.ELIGIBILITY}`;
+
+describe(`GET ${url}`, () => {
+  let sessionCookie: string;
+
+  beforeEach(async () => {
+    await storage.flush();
+    jest.resetAllMocks();
+
+    ({ sessionCookie } = await storage.saveUserSession([ROLES.MAKER]));
+    jest.spyOn(api, 'getFacility').mockImplementation(mockGetFacility);
+    jest.spyOn(api, 'getApplication').mockImplementation(mockGetApplication);
+    jest.spyOn(api, 'getAmendment').mockImplementation(mockGetAmendment);
+
+    mockGetFacility.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    mockGetApplication.mockResolvedValue(mockDeal);
+    mockGetAmendment.mockResolvedValue(
+      new PortalFacilityAmendmentWithUkefIdMockBuilder().withDealId(dealId).withFacilityId(facilityId).withAmendmentId(amendmentId).build(),
+    );
+  });
+
+  afterAll(async () => {
+    jest.resetAllMocks();
+    await storage.flush();
+    process.env = originalEnv;
+  });
+
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is disabled', () => {
+    beforeEach(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
+    });
+
+    it('should redirect to /not-found', async () => {
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+  });
+
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED feature flag is not set', () => {
+    beforeEach(() => {
+      delete process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED;
+    });
+
+    it('should redirect to /not-found', async () => {
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+  });
+
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is enabled', () => {
+    beforeEach(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'true';
+    });
+
+    withRoleValidationApiTests({
+      makeRequestWithHeaders: (headers: Headers) => get(url, {}, headers),
+      whitelistedRoles: [ROLES.MAKER],
+      successCode: HttpStatusCode.Ok,
+    });
+
+    it('should render `Eligibility` page', async () => {
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Eligibility');
+    });
+
+    it('should redirect to /not-found when facility not found', async () => {
+      // Arrange
+      mockGetFacility.mockResolvedValue({ details: undefined });
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when deal not found', async () => {
+      // Arrange
+      mockGetApplication.mockResolvedValue(undefined);
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when amendment not found', async () => {
+      // Arrange
+      mockGetAmendment.mockResolvedValue(undefined);
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to deal summary page when facility cannot be amended', async () => {
+      // Arrange
+      mockGetApplication.mockResolvedValue(MOCK_UNISSUED_FACILITY);
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual(`/gef/application-details/${dealId}`);
+    });
+
+    it('should render `problem with service` if getApplication throws an error', async () => {
+      // Arrange
+      mockGetApplication.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+
+    it('should render `problem with service` if getFacility throws an error', async () => {
+      // Arrange
+      mockGetFacility.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+
+    it('should render `problem with service` if getAmendment throws an error', async () => {
+      // Arrange
+      mockGetAmendment.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await getWithSessionCookie(sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+  });
+});
+
+function getWithSessionCookie(sessionCookie: string) {
+  return get(
+    url,
+    {},
+    {
+      Cookie: [`dtfs-session=${encodeURIComponent(sessionCookie)}`],
+    },
+  );
+}

--- a/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
@@ -1,6 +1,6 @@
 import { validationErrorHandler } from '../../../server/utils/helpers';
 import pageRenderer from '../../pageRenderer';
-import { EligibilityViewModel } from '../../../server/types/view-models/amendments/eligibility-view-model.ts';
+import { EligibilityCriterion, EligibilityViewModel } from '../../../server/types/view-models/amendments/eligibility-view-model.ts';
 
 const page = 'partials/amendments/eligibility.njk';
 const render = pageRenderer(page);
@@ -8,10 +8,10 @@ const render = pageRenderer(page);
 describe(page, () => {
   const previousPage = 'previousPage';
   const cancelUrl = 'cancelUrl';
-  const criteria = [
-    { id: 1, description: 'Test first criteria' },
-    { id: 2, description: 'Test second criteria' },
-    { id: 3, description: 'Test third criteria' },
+  const criteria: EligibilityCriterion[] = [
+    { id: 1, text: 'Test first criteria', textList: ['criterion 1 bullet point 1', 'criterion 1 bullet point 2'] },
+    { id: 2, text: 'Test second criteria' },
+    { id: 3, text: 'Test third criteria', textList: ['criterion 3 bullet point 1', 'criterion 3 bullet point 2', 'criterion 3 bullet point 3'] },
   ];
   const exporterName = 'exporterName';
 
@@ -60,6 +60,17 @@ describe(page, () => {
     wrapper.expectText('[data-cy="radio-wrapper-3"]').toContain('3. Test third criteria');
   });
 
+  it('should render the textList as bullet points for each criterion if it exists', () => {
+    const wrapper = render(params);
+
+    wrapper.expectText('[data-cy="radio-wrapper-1"]').toContain('criterion 1 bullet point 1');
+    wrapper.expectText('[data-cy="radio-wrapper-1"]').toContain('criterion 1 bullet point 2');
+
+    wrapper.expectText('[data-cy="radio-wrapper-3"]').toContain('criterion 3 bullet point 1');
+    wrapper.expectText('[data-cy="radio-wrapper-3"]').toContain('criterion 3 bullet point 2');
+    wrapper.expectText('[data-cy="radio-wrapper-3"]').toContain('criterion 3 bullet point 3');
+  });
+
   it('should render all the radio boxes unchecked', () => {
     const wrapper = render(params);
 
@@ -83,10 +94,10 @@ describe(page, () => {
   });
 
   it('should render the radio boxes checked as per the passed in answers', () => {
-    const criteriaWithAnswers = [
-      { id: 1, description: 'Test first criteria', answer: true },
-      { id: 2, description: 'Test second criteria', answer: false },
-      { id: 3, description: 'Test third criteria' },
+    const criteriaWithAnswers: EligibilityCriterion[] = [
+      { id: 1, text: 'Test first criteria', answer: true },
+      { id: 2, text: 'Test second criteria', answer: false },
+      { id: 3, text: 'Test third criteria' },
     ];
 
     const wrapper = render({ ...params, criteria: criteriaWithAnswers });

--- a/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
@@ -1,0 +1,188 @@
+import { validationErrorHandler } from '../../../server/utils/helpers';
+import pageRenderer from '../../pageRenderer';
+import { EligibilityViewModel } from '../../../server/types/view-models/amendments/eligibility-view-model.ts';
+
+const page = 'partials/amendments/eligibility.njk';
+const render = pageRenderer(page);
+
+describe(page, () => {
+  const previousPage = 'previousPage';
+  const cancelUrl = 'cancelUrl';
+  const criteria = [
+    { id: 1, description: 'Test first criteria' },
+    { id: 2, description: 'Test second criteria' },
+    { id: 3, description: 'Test third criteria' },
+  ];
+  const exporterName = 'exporterName';
+
+  const params: EligibilityViewModel = {
+    previousPage,
+    cancelUrl,
+    criteria,
+    exporterName,
+  };
+
+  it('should render the page heading', () => {
+    const wrapper = render(params);
+
+    wrapper.expectText('[data-cy="page-heading"]').toRead('Eligibility');
+  });
+
+  it(`should render the 'Back' link`, () => {
+    const wrapper = render(params);
+
+    wrapper.expectLink('[data-cy="back-link"]').toLinkTo(previousPage, 'Back');
+  });
+
+  it(`should render the continue button`, () => {
+    const wrapper = render(params);
+
+    wrapper.expectPrimaryButton('[data-cy="continue-button"]').toLinkTo(undefined, 'Continue');
+  });
+
+  it(`should render the cancel link`, () => {
+    const wrapper = render(params);
+
+    wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(cancelUrl, 'Cancel');
+  });
+
+  it('should render the exporter name in the heading caption', () => {
+    const wrapper = render(params);
+
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+  });
+
+  it('should render all the criteria descriptions', () => {
+    const wrapper = render(params);
+
+    wrapper.expectText('[data-cy="radio-wrapper-1"]').toContain('1. Test first criteria');
+    wrapper.expectText('[data-cy="radio-wrapper-2"]').toContain('2. Test second criteria');
+    wrapper.expectText('[data-cy="radio-wrapper-3"]').toContain('3. Test third criteria');
+  });
+
+  it('should render all the radio boxes unchecked', () => {
+    const wrapper = render(params);
+
+    wrapper.expectText('[data-cy="radios-criterion-1"]').toContain('True');
+    wrapper.expectInput('[data-cy="true-radio-criterion-1"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-1"]').toContain('False');
+    wrapper.expectInput('[data-cy="false-radio-criterion-1"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-2"]').toContain('True');
+    wrapper.expectInput('[data-cy="true-radio-criterion-2"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-2"]').toContain('False');
+    wrapper.expectInput('[data-cy="false-radio-criterion-2"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-3"]').toContain('True');
+    wrapper.expectInput('[data-cy="true-radio-criterion-3"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-3"]').toContain('False');
+    wrapper.expectInput('[data-cy="false-radio-criterion-3"]').toNotBeChecked();
+  });
+
+  it('should render the radio boxes checked as per the passed in answers', () => {
+    const criteriaWithAnswers = [
+      { id: 1, description: 'Test first criteria', answer: true },
+      { id: 2, description: 'Test second criteria', answer: false },
+      { id: 3, description: 'Test third criteria' },
+    ];
+
+    const wrapper = render({ ...params, criteria: criteriaWithAnswers });
+
+    wrapper.expectText('[data-cy="radios-criterion-1"]').toContain('True');
+    wrapper.expectInput('[data-cy="true-radio-criterion-1"]').toBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-1"]').toContain('False');
+    wrapper.expectInput('[data-cy="false-radio-criterion-1"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-2"]').toContain('True');
+    wrapper.expectInput('[data-cy="true-radio-criterion-2"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-2"]').toContain('False');
+    wrapper.expectInput('[data-cy="false-radio-criterion-2"]').toBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-3"]').toContain('True');
+    wrapper.expectInput('[data-cy="true-radio-criterion-3"]').toNotBeChecked();
+
+    wrapper.expectText('[data-cy="radios-criterion-3"]').toContain('False');
+    wrapper.expectInput('[data-cy="false-radio-criterion-3"]').toNotBeChecked();
+  });
+
+  it('should not render the error summary if there is no error', () => {
+    const wrapper = render(params);
+
+    wrapper.expectElement('[data-cy="error-summary"]').notToExist();
+  });
+
+  it('should not render any in-line errors if there are no errors', () => {
+    const wrapper = render(params);
+
+    wrapper.expectElement('[data-cy="inline-error-criterion-1"]').notToExist();
+    wrapper.expectElement('[data-cy="inline-error-criterion-2"]').notToExist();
+    wrapper.expectElement('[data-cy="inline-error-criterion-3"]').notToExist();
+  });
+
+  it('should render the error summary if there is a single error', () => {
+    const errMsg = 'error 2';
+    const paramsWithError = {
+      ...params,
+      errors: validationErrorHandler([{ errRef: '2', errMsg }]),
+    };
+
+    const wrapper = render(paramsWithError);
+
+    wrapper.expectText('[data-cy="error-summary"]').toContain(errMsg);
+  });
+
+  it('should render the error summary if there is more than one error', () => {
+    const errMsgCriterion1 = 'error 1';
+    const errMsgCriterion3 = 'error 3';
+    const paramsWithError = {
+      ...params,
+      errors: validationErrorHandler([
+        { errRef: '1', errMsg: errMsgCriterion1 },
+        { errRef: '3', errMsg: errMsgCriterion3 },
+      ]),
+    };
+
+    const wrapper = render(paramsWithError);
+
+    wrapper.expectText('[data-cy="error-summary"]').toContain(errMsgCriterion1);
+    wrapper.expectText('[data-cy="error-summary"]').toContain(errMsgCriterion3);
+  });
+
+  it('should render a single inline error if there is one field error', () => {
+    const errMsgCriterion2 = 'error 2';
+    const paramsWithError = {
+      ...params,
+      errors: validationErrorHandler([{ errRef: '2', errMsg: errMsgCriterion2 }]),
+    };
+
+    const wrapper = render(paramsWithError);
+
+    wrapper.expectElement('[data-cy="inline-error-criterion-1"]').notToExist();
+    wrapper.expectText('[data-cy="inline-error-criterion-2"]').toContain(errMsgCriterion2);
+    wrapper.expectElement('[data-cy="inline-error-criterion-3"]').notToExist();
+  });
+
+  it('should render a multiple inline errors if there is more than one field error', () => {
+    const errMsgCriterion1 = 'error 1';
+    const errMsgCriterion3 = 'error 3';
+
+    const paramsWithError = {
+      ...params,
+      errors: validationErrorHandler([
+        { errRef: '1', errMsg: errMsgCriterion1 },
+        { errRef: '3', errMsg: errMsgCriterion3 },
+      ]),
+    };
+
+    const wrapper = render(paramsWithError);
+
+    wrapper.expectText('[data-cy="inline-error-criterion-1"]').toContain(errMsgCriterion1);
+    wrapper.expectElement('[data-cy="inline-error-criterion-2"]').notToExist();
+    wrapper.expectText('[data-cy="inline-error-criterion-3"]').toContain(errMsgCriterion3);
+  });
+});

--- a/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
@@ -52,6 +52,15 @@ describe(page, () => {
     wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
   });
 
+  it('should render the `Help with declarations` accordion', () => {
+    const wrapper = render(params);
+
+    wrapper.expectText('[data-cy="help-with-declarations"]').toContain('Help with declarations');
+    wrapper
+      .expectText('[data-cy="help-with-declarations"]')
+      .toContain('Read the Master Guarantee Agreement (MGA) definitions and interpretation document for terminology used in the declarations.');
+  });
+
   it('should render all the criteria descriptions', () => {
     const wrapper = render(params);
 

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
@@ -1,0 +1,224 @@
+// TODO: DTFS2-7724 - remove this eslint-disable
+/* eslint-disable import/first */
+const getApplicationMock = jest.fn();
+const getFacilityMock = jest.fn();
+const getAmendmentMock = jest.fn();
+
+import * as dtfsCommon from '@ukef/dtfs2-common';
+import { aPortalSessionUser, DEAL_STATUS, DEAL_SUBMISSION_TYPE, PORTAL_LOGIN_STATUS, ROLES, PortalFacilityAmendmentWithUkefId } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { createMocks } from 'node-mocks-http';
+import { EligibilityViewModel } from '../../../types/view-models/amendments/eligibility-view-model.ts';
+import { getEligibility, GetEligibilityRequest } from './get-eligibility.ts';
+import { MOCK_BASIC_DEAL } from '../../../utils/mocks/mock-applications';
+import { MOCK_UNISSUED_FACILITY, MOCK_ISSUED_FACILITY } from '../../../utils/mocks/mock-facilities';
+import { PortalFacilityAmendmentWithUkefIdMockBuilder } from '../../../../test-helpers/mock-amendment';
+import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
+import { getPreviousPage } from '../helpers/navigation.helper';
+
+jest.mock('../../../services/api', () => ({
+  getApplication: getApplicationMock,
+  getFacility: getFacilityMock,
+  getAmendment: getAmendmentMock,
+}));
+
+const dealId = 'dealId';
+const facilityId = 'facilityId';
+const amendmentId = 'amendmentId';
+
+const aMockError = () => new Error();
+
+const getHttpMocks = () =>
+  createMocks<GetEligibilityRequest>({
+    params: { dealId, facilityId, amendmentId },
+    session: {
+      user: { ...aPortalSessionUser(), roles: [ROLES.MAKER] },
+      userToken: 'testToken',
+      loginStatus: PORTAL_LOGIN_STATUS.VALID_2FA,
+    },
+  });
+
+const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
+
+describe('getEligibilityCriteria', () => {
+  let amendment: PortalFacilityAmendmentWithUkefId;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+
+    jest.spyOn(dtfsCommon, 'isPortalFacilityAmendmentsFeatureFlagEnabled').mockReturnValue(true);
+    jest.spyOn(console, 'error');
+
+    amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder().withDealId(dealId).withFacilityId(facilityId).withAmendmentId(amendmentId).build();
+
+    getApplicationMock.mockResolvedValue(mockDeal);
+    getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    getAmendmentMock.mockResolvedValue(amendment);
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should call getApplication with the correct dealId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(getApplicationMock).toHaveBeenCalledTimes(1);
+    expect(getApplicationMock).toHaveBeenCalledWith({ dealId, userToken: req.session.userToken });
+  });
+
+  it('should call getFacility with the correct facilityId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(getFacilityMock).toHaveBeenCalledTimes(1);
+    expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should call getAmendment with the correct facilityId, amendmentId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(getAmendmentMock).toHaveBeenCalledTimes(1);
+    expect(getAmendmentMock).toHaveBeenCalledWith({ facilityId, amendmentId, userToken: req.session.userToken });
+  });
+
+  it('should render the correct template', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    const expectedRenderData: EligibilityViewModel = {
+      exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
+    };
+
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(res._getRenderView()).toEqual('partials/amendments/eligibility.njk');
+    expect(res._getRenderData()).toEqual(expectedRenderData);
+    expect(console.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('should redirect if the facility is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getFacilityMock.mockResolvedValue({ details: undefined });
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual('/not-found');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
+  });
+
+  it('should redirect if the deal is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getApplicationMock.mockResolvedValue(undefined);
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual('/not-found');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
+  });
+
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found on facility %s', amendmentId, facilityId);
+  });
+
+  it('should redirect if the facility cannot be amended', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getFacilityMock.mockResolvedValue(MOCK_UNISSUED_FACILITY);
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/gef/application-details/${dealId}`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('User cannot amend facility %s on deal %s', facilityId, dealId);
+  });
+
+  it('should render `problem with service` if getApplication throws an error', async () => {
+    // Arrange
+    const mockError = aMockError();
+    getApplicationMock.mockRejectedValue(mockError);
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Error getting amendments eligibility page %o', mockError);
+  });
+
+  it('should render `problem with service` if getFacility throws an error', async () => {
+    // Arrange
+    const mockError = aMockError();
+    getFacilityMock.mockRejectedValue(mockError);
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Error getting amendments eligibility page %o', mockError);
+  });
+
+  it('should render `problem with service` if getAmendment throws an error', async () => {
+    // Arrange
+    const mockError = aMockError();
+    getAmendmentMock.mockRejectedValue(mockError);
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getEligibility(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Error getting amendments eligibility page %o', mockError);
+  });
+});

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
@@ -1,0 +1,57 @@
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import { Response } from 'express';
+import * as api from '../../../services/api';
+import { asLoggedInUserSession } from '../../../utils/express-session';
+import { userCanAmendFacility } from '../../../utils/facility-amendments.helper';
+import { getPreviousPage } from '../helpers/navigation.helper';
+import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
+import { EligibilityViewModel } from '../../../types/view-models/amendments/eligibility-view-model.ts';
+
+export type GetEligibilityRequest = CustomExpressRequest<{
+  params: { dealId: string; facilityId: string; amendmentId: string };
+}>;
+
+/**
+ * Controller to get the `Eligibility` page
+ * @param req - the request object
+ * @param res - the response object
+ */
+export const getEligibility = async (req: GetEligibilityRequest, res: Response) => {
+  try {
+    const { dealId, facilityId, amendmentId } = req.params;
+    const { userToken, user } = asLoggedInUserSession(req.session);
+
+    const deal = await api.getApplication({ dealId, userToken });
+    const { details: facility } = await api.getFacility({ facilityId, userToken });
+
+    if (!deal || !facility) {
+      console.error('Deal %s or Facility %s was not found', dealId, facilityId);
+      return res.redirect('/not-found');
+    }
+
+    if (!userCanAmendFacility(facility, deal, user.roles)) {
+      console.error('User cannot amend facility %s on deal %s', facilityId, dealId);
+      return res.redirect(`/gef/application-details/${dealId}`);
+    }
+
+    const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
+
+    if (!amendment) {
+      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      return res.redirect('/not-found');
+    }
+
+    // TODO 7765: Fetch criteria using GET endpoint from database and add to viewModel
+
+    const viewModel: EligibilityViewModel = {
+      exporterName: deal.exporter.companyName,
+      cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
+    };
+
+    return res.render('partials/amendments/eligibility.njk', viewModel);
+  } catch (error) {
+    console.error('Error getting amendments eligibility page %o', error);
+    return res.render('partials/problem-with-service.njk');
+  }
+};

--- a/gef-ui/server/routes/facilities/amendments/index.ts
+++ b/gef-ui/server/routes/facilities/amendments/index.ts
@@ -15,8 +15,9 @@ import { getDoYouHaveAFacilityEndDate } from '../../../controllers/amendments/do
 import { postDoYouHaveAFacilityEndDate } from '../../../controllers/amendments/do-you-have-a-facility-end-date/post-do-you-have-a-facility-end-date';
 import { getFacilityEndDate } from '../../../controllers/amendments/facility-end-date/get-facility-end-date';
 import { getBankReviewDate } from '../../../controllers/amendments/bank-review-date/get-bank-review-date.ts';
+import { getEligibility } from '../../../controllers/amendments/eligibility-criteria/get-eligibility.ts';
 
-const { WHAT_DO_YOU_NEED_TO_CHANGE, COVER_END_DATE, FACILITY_VALUE, DO_YOU_HAVE_A_FACILITY_END_DATE, FACILITY_END_DATE, BANK_REVIEW_DATE } =
+const { WHAT_DO_YOU_NEED_TO_CHANGE, COVER_END_DATE, FACILITY_VALUE, DO_YOU_HAVE_A_FACILITY_END_DATE, FACILITY_END_DATE, BANK_REVIEW_DATE, ELIGIBILITY } =
   PORTAL_AMENDMENT_PAGES;
 
 const router = express.Router();
@@ -63,5 +64,10 @@ router
   .route(`/application-details/:dealId/facilities/:facilityId/amendments/:amendmentId/${BANK_REVIEW_DATE}`)
   .all([validatePortalFacilityAmendmentsEnabled, validateToken, validateBank, validateRole({ role: [MAKER] })])
   .get(getBankReviewDate);
+
+router
+  .route(`/application-details/:dealId/facilities/:facilityId/amendments/:amendmentId/${ELIGIBILITY}`)
+  .all([validatePortalFacilityAmendmentsEnabled, validateToken, validateBank, validateRole({ role: [MAKER] })])
+  .get(getEligibility);
 
 export default router;

--- a/gef-ui/server/types/view-models/amendments/eligibility-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/eligibility-view-model.ts
@@ -1,0 +1,9 @@
+import { ViewModelErrors } from '../view-model-errors';
+
+export type EligibilityViewModel = {
+  exporterName: string;
+  previousPage: string;
+  cancelUrl: string;
+  criteria?: { id: number; description: string }[]; // TODO 7765: Remove optional property when fetching this from database
+  errors?: ViewModelErrors | null;
+};

--- a/gef-ui/server/types/view-models/amendments/eligibility-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/eligibility-view-model.ts
@@ -1,9 +1,16 @@
 import { ViewModelErrors } from '../view-model-errors';
 
+export type EligibilityCriterion = {
+  id: number;
+  text: string;
+  textList?: string[];
+  answer?: boolean;
+};
+
 export type EligibilityViewModel = {
   exporterName: string;
   previousPage: string;
   cancelUrl: string;
-  criteria?: { id: number; description: string }[]; // TODO 7765: Remove optional property when fetching this from database
+  criteria?: EligibilityCriterion[]; // TODO 7765: Make required property when fetching this from database
   errors?: ViewModelErrors | null;
 };

--- a/gef-ui/templates/_macros/amendments/eligibility-criterion.njk
+++ b/gef-ui/templates/_macros/amendments/eligibility-criterion.njk
@@ -1,0 +1,16 @@
+{% macro render(id, text, textList) %}
+
+  <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-0">{{ id }}. {{ text }}</p>
+
+  {% if textList %}
+    <div class="lower-roman-with-parens govuk-!-margin-bottom-2">
+      <ol type="i" class="govuk-!-margin-bottom-0 govuk-!-margin-top-1">
+        {% for item in textList %}
+          <li>{{ item }}</li>
+        {% endfor %}
+      </ol>
+    </div>
+
+  {% endif %}
+
+{% endmacro %}

--- a/gef-ui/templates/partials/amendments/eligibility.njk
+++ b/gef-ui/templates/partials/amendments/eligibility.njk
@@ -1,0 +1,115 @@
+{% extends "index.njk" %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block pageTitle -%}
+  Eligibility
+{%- endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors.errorSummary,
+      attributes: {
+        "data-cy": "error-summary"
+      },
+      classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-4"
+    }) }}
+  {% endif %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: previousPage,
+    attributes: {
+      "data-cy": "back-link"
+    }
+  }) }}
+
+  <div class="govuk-grid-row govuk-!-margin-bottom-3">
+    <div class="govuk-grid-column-three-quarters">
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+        <input type="hidden" name="previousPage" value="{{ previousPage }}">
+
+        <header>
+          <span class="govuk-caption-l" data-cy="heading-caption">
+            {{ exporterName }}
+          </span>
+
+          <h1 class="govuk-label-wrapper" data-cy="page-heading">
+            <label class="govuk-label govuk-label--xl govuk-!-padding-bottom-3" for="eligibility">
+              Eligibility
+            </label>
+          </h1>
+        </header>
+
+        {% for criterion in criteria %}
+          <span data-cy= "radio-wrapper-{{ criterion.id }}">
+            {{ govukRadios({
+              classes: "govuk-radios--inline govuk-!-margin-top-0",
+              idPrefix: criterion.id,
+              name: criterion.id,
+              fieldset: {
+                legend: {text: criterion.id + ". " + criterion.description },
+                attributes: { 'aria-label': criterion.description,  'data-cy': 'description-criterion-' + criterion.id }
+              },
+              attributes: {
+                'data-cy': 'radios-criterion-' + criterion.id
+              },
+              errorMessage: errors and errors.fieldErrors[criterion.id] and  {
+                text: errors.fieldErrors[criterion.id].text,
+                attributes: {
+                  'data-cy': 'inline-error-criterion-' + criterion.id
+                }
+              },
+              items: [
+                {
+                  value: "true",
+                  text: "True",
+                  checked: criterion.answer === true,
+                  attributes: {
+                    'data-cy': 'true-radio-criterion-' + criterion.id,
+                    'aria-label': 'Eligibility criterion, ' + criterion.id + ', ' + criterion.description + ', true'
+                  }
+                },
+                {
+                  value: "false",
+                  text: "False",
+                  checked: criterion.answer === false,
+                  attributes: {
+                    'data-cy': 'false-radio-criterion-' + criterion.id,
+                    'aria-label': 'Eligibility criterion, ' + criterion.id + ', ' + criterion.description + ', false'
+                  }
+                }
+              ]
+            }) }}
+          </span>
+        {% endfor %}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Continue",
+            attributes: {
+              "data-cy": "continue-button"
+            }
+          }) }}
+
+          <a href="{{ cancelUrl }}"  data-cy="cancel-link" class="govuk-link">Cancel</a>
+        </div>
+
+        {{ govukDetails({
+          summaryText: "Help with declarations",
+          text: 'Read the Master Guarantee Agreement (MGA) definitions and interpretation document for terminology used in the declarations.',
+          attributes: {
+            'data-cy': 'help-with-declarations'
+          }
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/gef-ui/templates/partials/amendments/eligibility.njk
+++ b/gef-ui/templates/partials/amendments/eligibility.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% import '../../_macros/amendments/eligibility-criterion.njk' as eligibilityCriterion %}
 
 {% block pageTitle -%}
   Eligibility
@@ -54,8 +55,10 @@
               idPrefix: criterion.id,
               name: criterion.id,
               fieldset: {
-                legend: {text: criterion.id + ". " + criterion.description },
-                attributes: { 'aria-label': criterion.description,  'data-cy': 'description-criterion-' + criterion.id }
+                legend: {
+                  html: eligibilityCriterion.render(criterion.id, criterion.text, criterion.textList)
+                },
+                attributes: { 'aria-label': criterion.text,  'data-cy': 'description-criterion-' + criterion.id }
               },
               attributes: {
                 'data-cy': 'radios-criterion-' + criterion.id
@@ -73,7 +76,7 @@
                   checked: criterion.answer === true,
                   attributes: {
                     'data-cy': 'true-radio-criterion-' + criterion.id,
-                    'aria-label': 'Eligibility criterion, ' + criterion.id + ', ' + criterion.description + ', true'
+                    'aria-label': 'Eligibility criterion, ' + criterion.id + ', ' + criterion.text + ', true'
                   }
                 },
                 {
@@ -82,7 +85,7 @@
                   checked: criterion.answer === false,
                   attributes: {
                     'data-cy': 'false-radio-criterion-' + criterion.id,
-                    'aria-label': 'Eligibility criterion, ' + criterion.id + ', ' + criterion.description + ', false'
+                    'aria-label': 'Eligibility criterion, ' + criterion.id + ', ' + criterion.text + ', false'
                   }
                 }
               ]


### PR DESCRIPTION
## Introduction :pencil2:
This page adds the nunjucks template and controller for the Eligibility page. 
⚠️We are not yet fetching the Eligibility criteria from the database - this will be added as a seperate PR. I've set this page up so that when we have set up the endpoints to fetch it, it will be quick to add to the controller and pass into the nunjucks template. 

## Resolution :heavy_check_mark:
- Add nunjucks page and controller
- Add tests

## Miscellaneous :heavy_plus_sign:
Here is a screenshot of what the page looks like when you pass in eligibility criteria (hardcoded in the screenshot). In the PR we are not passing in any ECs for now, so it will be rendered as a blank page for now. 

What the template _will_ look like when we pass in ECs of the form e.g.:
```
criteria = [
    { id: 1, description: 'Test first criteria' },
    { id: 2, description: 'Test second criteria' },
    { id: 3, description: 'Test third criteria' },
  ]

```

<img width="1008" alt="image" src="https://github.com/user-attachments/assets/70d3fd81-a085-43bb-ba10-f11dae93ac15" />


What it looks like _until_ the later PR where we fetch and pass in these ECs

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/177d5ff3-7281-477a-8923-7e77cff89d0f" />


