### PR TITLE
feat(DTFS2-7498): add facility type to page captions on amendments flow

### DIFF
--- a/gef-ui/component-tests/partials/amendments/bank-review-date.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/bank-review-date.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { validationErrorHandler } from '../../../server/utils/helpers';
 import { BankReviewDateViewModel } from '../../../server/types/view-models/amendments/bank-review-date-view-model';
 import pageRenderer from '../../pageRenderer';
@@ -10,12 +11,14 @@ describe(page, () => {
   const cancelUrl = 'cancelUrl';
   const bankReviewDate = { day: '14', month: '2', year: '2024' };
   const exporterName = 'exporterName';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: BankReviewDateViewModel = {
     previousPage,
     cancelUrl,
     bankReviewDate,
     exporterName,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -99,9 +102,9 @@ describe(page, () => {
       );
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 });

--- a/gef-ui/component-tests/partials/amendments/cancel-portal-facility-amendment.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/cancel-portal-facility-amendment.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { CancelAmendmentViewModel } from '../../../server/types/view-models/amendments/cancel-amendment-view-model';
 import pageRenderer from '../../pageRenderer';
 
@@ -7,10 +8,12 @@ const render = pageRenderer(page);
 describe(page, () => {
   const exporterName = 'exporterName';
   const previousPage = 'previousPage';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: CancelAmendmentViewModel = {
     exporterName,
     previousPage,
+    facilityType,
   };
 
   it(`should render the 'Back' link`, () => {
@@ -31,9 +34,9 @@ describe(page, () => {
     wrapper.expectSecondaryButton('[data-cy="no-go-back-button"]').toLinkTo(previousPage, 'No, go back');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 });

--- a/gef-ui/component-tests/partials/amendments/cover-end-date.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/cover-end-date.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { CoverEndDateViewModel } from '../../../server/types/view-models/amendments/cover-end-date-view-model';
 import pageRenderer from '../../pageRenderer';
 
@@ -9,12 +10,14 @@ describe(page, () => {
   const exporterName = 'exporterName';
   const previousPage = 'previousPage';
   const cancelUrl = 'cancelUrl';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: CoverEndDateViewModel = {
     coverEndDate,
     exporterName,
     previousPage,
     cancelUrl,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -47,9 +50,9 @@ describe(page, () => {
     wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(cancelUrl, 'Cancel');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 });

--- a/gef-ui/component-tests/partials/amendments/do-you-have-a-facility-end-date.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/do-you-have-a-facility-end-date.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { DoYouHaveAFacilityEndDateViewModel } from '../../../server/types/view-models/amendments/do-you-have-a-facility-end-date-view-model';
 import pageRenderer from '../../pageRenderer';
 
@@ -8,11 +9,13 @@ describe(page, () => {
   const previousPage = 'previousPage';
   const cancelUrl = 'cancelUrl';
   const exporterName = 'exporterName';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: DoYouHaveAFacilityEndDateViewModel = {
     previousPage,
     cancelUrl,
     exporterName,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -87,10 +90,10 @@ describe(page, () => {
     wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(cancelUrl, 'Cancel');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 
   it('should render `What is a facility end date` details', () => {

--- a/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/eligibility.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { validationErrorHandler } from '../../../server/utils/helpers';
 import pageRenderer from '../../pageRenderer';
 import { EligibilityCriterion, EligibilityViewModel } from '../../../server/types/view-models/amendments/eligibility-view-model.ts';
@@ -14,12 +15,14 @@ describe(page, () => {
     { id: 3, text: 'Test third criteria', textList: ['criterion 3 bullet point 1', 'criterion 3 bullet point 2', 'criterion 3 bullet point 3'] },
   ];
   const exporterName = 'exporterName';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: EligibilityViewModel = {
     previousPage,
     cancelUrl,
     criteria,
     exporterName,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -46,10 +49,10 @@ describe(page, () => {
     wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(cancelUrl, 'Cancel');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 
   it('should render the `Help with declarations` accordion', () => {

--- a/gef-ui/component-tests/partials/amendments/facility-end-date.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/facility-end-date.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { validationErrorHandler } from '../../../server/utils/helpers';
 import { FacilityEndDateViewModel } from '../../../server/types/view-models/amendments/facility-end-date-view-model';
 import pageRenderer from '../../pageRenderer';
@@ -10,12 +11,14 @@ describe(page, () => {
   const cancelUrl = 'cancelUrl';
   const facilityEndDate = { day: '14', month: '2', year: '2024' };
   const exporterName = 'exporterName';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: FacilityEndDateViewModel = {
     previousPage,
     cancelUrl,
     facilityEndDate,
     exporterName,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -97,9 +100,9 @@ describe(page, () => {
       .toContain('The facility end date is the deadline for a committed loan to be repaid at which point the contract will be terminated.');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 });

--- a/gef-ui/component-tests/partials/amendments/facility-value.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/facility-value.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { validationErrorHandler } from '../../../server/utils/helpers';
 import { FacilityValueViewModel } from '../../../server/types/view-models/amendments/facility-value-view-model';
 import pageRenderer from '../../pageRenderer';
@@ -11,6 +12,7 @@ describe(page, () => {
   const facilityValue = '7000';
   const exporterName = 'exporterName';
   const currencySymbol = '£';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: FacilityValueViewModel = {
     previousPage,
@@ -18,6 +20,7 @@ describe(page, () => {
     facilityValue,
     exporterName,
     currencySymbol,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -50,10 +53,10 @@ describe(page, () => {
     wrapper.expectLink('[data-cy="cancel-link"]').toLinkTo(cancelUrl, 'Cancel');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 
   it('should render the currency symbol', () => {

--- a/gef-ui/component-tests/partials/amendments/what-needs-to-change.component-test.ts
+++ b/gef-ui/component-tests/partials/amendments/what-needs-to-change.component-test.ts
@@ -1,3 +1,4 @@
+import { FACILITY_TYPE } from '@ukef/dtfs2-common';
 import { validationErrorHandler } from '../../../server/utils/helpers';
 import pageRenderer from '../../pageRenderer';
 import { WhatNeedsToChangeViewModel } from '../../../server/types/view-models/amendments/what-needs-to-change-view-model.ts';
@@ -10,12 +11,14 @@ describe(page, () => {
   const cancelUrl = 'cancelUrl';
   const exporterName = 'exporterName';
   const amendmentFormEmail = 'amendmentFormEmail';
+  const facilityType = FACILITY_TYPE.CASH;
 
   const params: WhatNeedsToChangeViewModel = {
     previousPage,
     cancelUrl,
     amendmentFormEmail,
     exporterName,
+    facilityType,
   };
 
   it('should render the page heading', () => {
@@ -24,10 +27,10 @@ describe(page, () => {
     wrapper.expectText('[data-cy="page-heading"]').toRead('What do you need to change?');
   });
 
-  it('should render the exporter name in the heading caption', () => {
+  it('should render the exporter name and facility type in the heading caption', () => {
     const wrapper = render(params);
 
-    wrapper.expectText('[data-cy="heading-caption"]').toRead(exporterName);
+    wrapper.expectText('[data-cy="heading-caption"]').toRead(`${exporterName}, ${facilityType} facility`);
   });
 
   it(`should render the 'Back' link`, () => {

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
@@ -113,6 +113,7 @@ describe('getBankReviewDate', () => {
     // Assert
     const expectedRenderData: BankReviewDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment),
       bankReviewDate: undefined,
@@ -146,6 +147,7 @@ describe('getBankReviewDate', () => {
     // Assert
     const expectedRenderData: BankReviewDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment),
       bankReviewDate: {

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
@@ -60,6 +60,7 @@ export const getBankReviewDate = async (req: GetBankReviewDateRequest, res: Resp
 
     const viewModel: BankReviewDateViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment),
       bankReviewDate,

--- a/gef-ui/server/controllers/amendments/cancel-amendment/cancel-portal-facility-amendment.get.test.ts
+++ b/gef-ui/server/controllers/amendments/cancel-amendment/cancel-portal-facility-amendment.get.test.ts
@@ -115,6 +115,7 @@ describe('getCancelPortalFacilityAmendment', () => {
     // Assert
     const expectedRenderData: CancelAmendmentViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       previousPage: getPreviousAmendmentPageUrl(req.headers.referer, dealId, facilityId, amendmentId),
     };
 

--- a/gef-ui/server/controllers/amendments/cancel-amendment/cancel-portal-facility-amendment.ts
+++ b/gef-ui/server/controllers/amendments/cancel-amendment/cancel-portal-facility-amendment.ts
@@ -45,6 +45,7 @@ export const getCancelPortalFacilityAmendment = async (req: GetCancelPortalFacil
 
     const viewModel: CancelAmendmentViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       previousPage,
     };
 

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
@@ -107,6 +107,7 @@ describe('getCoverEndDate', () => {
     // Assert
     const expectedRenderData: CoverEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment),
     };

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
@@ -48,6 +48,7 @@ export const getCoverEndDate = async (req: GetCoverEndDateRequest, res: Response
 
     const viewModel: CoverEndDateViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment),
     };

--- a/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/get-do-you-have-a-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/get-do-you-have-a-facility-end-date.test.ts
@@ -112,6 +112,7 @@ describe('getDoYouHaveAFacilityEndDate', () => {
     // Assert
     const expectedRenderData: DoYouHaveAFacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.DO_YOU_HAVE_A_FACILITY_END_DATE, amendment),
     };
@@ -142,6 +143,7 @@ describe('getDoYouHaveAFacilityEndDate', () => {
     // Assert
     const expectedRenderData: DoYouHaveAFacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.DO_YOU_HAVE_A_FACILITY_END_DATE, amendment),
       isUsingFacilityEndDate: String(isUsingFacilityEndDate),
@@ -173,6 +175,7 @@ describe('getDoYouHaveAFacilityEndDate', () => {
     // Assert
     const expectedRenderData: DoYouHaveAFacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.DO_YOU_HAVE_A_FACILITY_END_DATE, amendment),
       isUsingFacilityEndDate: String(isUsingFacilityEndDate),

--- a/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/get-do-you-have-a-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/get-do-you-have-a-facility-end-date.ts
@@ -50,6 +50,7 @@ export const getDoYouHaveAFacilityEndDate = async (req: GetDoYouHaveAFacilityEnd
 
     const viewModel: DoYouHaveAFacilityEndDateViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.DO_YOU_HAVE_A_FACILITY_END_DATE, amendment),
       isUsingFacilityEndDate,

--- a/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/post-do-you-have-a-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/post-do-you-have-a-facility-end-date.test.ts
@@ -149,6 +149,7 @@ describe('postDoYouHaveAFacilityEndDate', () => {
     // Assert
     const expectedRenderData: DoYouHaveAFacilityEndDateViewModel = {
       exporterName: mockDeal.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage,
       errors: validationErrorHandler((validateIsUsingFacilityEndDate(isUsingFacilityEndDate) as { errors: ValidationError[] }).errors),

--- a/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/post-do-you-have-a-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/post-do-you-have-a-facility-end-date.ts
@@ -37,6 +37,7 @@ export const postDoYouHaveAFacilityEndDate = async (req: PostDoYouHaveAFacilityE
     if ('errors' in errorsOrValue) {
       const viewModel: DoYouHaveAFacilityEndDateViewModel = {
         exporterName: deal.exporter.companyName,
+        facilityType: facility.type,
         cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
         previousPage,
         errors: validationErrorHandler(errorsOrValue.errors),

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
@@ -107,6 +107,7 @@ describe('getEligibilityCriteria', () => {
     // Assert
     const expectedRenderData: EligibilityViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
     };

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
@@ -45,6 +45,7 @@ export const getEligibility = async (req: GetEligibilityRequest, res: Response) 
 
     const viewModel: EligibilityViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
     };

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
@@ -112,6 +112,7 @@ describe('getFacilityEndDate', () => {
     // Assert
     const expectedRenderData: FacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment),
       facilityEndDate: undefined,
@@ -144,6 +145,7 @@ describe('getFacilityEndDate', () => {
     // Assert
     const expectedRenderData: FacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment),
       facilityEndDate: {

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
@@ -56,6 +56,7 @@ export const getFacilityEndDate = async (req: GetFacilityEndDateRequest, res: Re
 
     const viewModel: FacilityEndDateViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment),
       facilityEndDate,

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
@@ -163,6 +163,7 @@ describe('postFacilityEndDate', () => {
     // Assert
     const expectedRenderData: FacilityEndDateViewModel = {
       exporterName: mockDeal.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
       previousPage,
       errors: validationErrorHandler(

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
@@ -49,6 +49,7 @@ export const postFacilityEndDate = async (req: PostFacilityEndDateRequest, res: 
     if ('errors' in validationErrorsOrValue) {
       const viewModel: FacilityEndDateViewModel = {
         exporterName: deal.exporter.companyName,
+        facilityType: facility.type,
         cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
         previousPage,
         facilityEndDate: facilityEndDateDayMonthYear,

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
@@ -13,6 +13,7 @@ import {
   PORTAL_LOGIN_STATUS,
   ROLES,
   PortalFacilityAmendmentWithUkefId,
+  FACILITY_TYPE,
 } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
 import { createMocks } from 'node-mocks-http';
@@ -52,6 +53,7 @@ const mockFacility = {
   currency: {
     id: CURRENCY.GBP,
   },
+  type: FACILITY_TYPE.CASH,
   hasBeenIssued: true,
 } as Facility;
 
@@ -124,6 +126,7 @@ describe('getFacilityValue', () => {
     // Assert
     const expectedRenderData: FacilityValueViewModel = {
       exporterName: companyName,
+      facilityType: mockFacility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment),
       currencySymbol: getCurrencySymbol(mockFacility.currency.id),
@@ -155,6 +158,7 @@ describe('getFacilityValue', () => {
     // Assert
     const expectedRenderData: FacilityValueViewModel = {
       exporterName: companyName,
+      facilityType: mockFacility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment),
       currencySymbol: getCurrencySymbol(mockFacility.currency.id),

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
@@ -54,6 +54,7 @@ export const getFacilityValue = async (req: GetFacilityValueRequest, res: Respon
     const viewModel: FacilityValueViewModel = {
       facilityValue,
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment),
       currencySymbol,

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.test.ts
@@ -125,6 +125,7 @@ describe('postFacilityValue', () => {
     // Assert
     const expectedRenderData: FacilityValueViewModel = {
       exporterName: mockDeal.exporter.companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage,
       currencySymbol: getCurrencySymbol(MOCK_ISSUED_FACILITY.details.currency!.id),

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
@@ -44,6 +44,7 @@ export const postFacilityValue = async (req: PostFacilityValueRequest, res: Resp
       const viewModel: FacilityValueViewModel = {
         facilityValue,
         exporterName: deal.exporter.companyName,
+        facilityType: facility.type,
         cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
         previousPage,
         currencySymbol,

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
@@ -6,16 +6,9 @@ const getAmendmentMock = jest.fn();
 
 import { createMocks } from 'node-mocks-http';
 import * as dtfsCommon from '@ukef/dtfs2-common';
-import {
-  aPortalSessionUser,
-  DEAL_STATUS,
-  DEAL_SUBMISSION_TYPE,
-  Facility,
-  PORTAL_LOGIN_STATUS,
-  PortalFacilityAmendmentWithUkefId,
-  ROLES,
-} from '@ukef/dtfs2-common';
+import { aPortalSessionUser, DEAL_STATUS, DEAL_SUBMISSION_TYPE, PORTAL_LOGIN_STATUS, PortalFacilityAmendmentWithUkefId, ROLES } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
+import { MOCK_ISSUED_FACILITY, MOCK_UNISSUED_FACILITY } from '../../../utils/mocks/mock-facilities';
 import { getAmendmentsUrl } from '../helpers/navigation.helper.ts';
 import { WhatNeedsToChangeViewModel } from '../../../types/view-models/amendments/what-needs-to-change-view-model.ts';
 import { getWhatNeedsToChange, GetWhatNeedsToChangeRequest } from './get-what-needs-to-change.ts';
@@ -59,10 +52,6 @@ const getHttpMocks = () =>
 
 const mockDeal = { exporter: { companyName }, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED } as Deal;
 
-const mockFacility = {
-  hasBeenIssued: true,
-} as Facility;
-
 describe('getWhatNeedsToChange', () => {
   let amendment: PortalFacilityAmendmentWithUkefId;
 
@@ -73,7 +62,7 @@ describe('getWhatNeedsToChange', () => {
     amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder().withDealId(dealId).withFacilityId(facilityId).withAmendmentId(amendmentId).build();
 
     getApplicationMock.mockResolvedValue(mockDeal);
-    getFacilityMock.mockResolvedValue({ details: mockFacility });
+    getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
     getAmendmentMock.mockResolvedValue(amendment);
   });
 
@@ -131,6 +120,7 @@ describe('getWhatNeedsToChange', () => {
     // Assert
     const expectedRenderData: WhatNeedsToChangeViewModel = {
       exporterName: companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       previousPage: `/gef/application-details/${dealId}`,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       amendmentFormEmail: STB_PIM_EMAIL,
@@ -161,6 +151,7 @@ describe('getWhatNeedsToChange', () => {
     // Assert
     const expectedRenderData: WhatNeedsToChangeViewModel = {
       exporterName: companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       previousPage: `/gef/application-details/${dealId}`,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       amendmentFormEmail: STB_PIM_EMAIL,
@@ -223,7 +214,7 @@ describe('getWhatNeedsToChange', () => {
   it('should redirect if the facility cannot be amended', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
-    getFacilityMock.mockResolvedValue({ details: { ...mockFacility, hasBeenIssued: false } });
+    getFacilityMock.mockResolvedValue(MOCK_UNISSUED_FACILITY);
 
     // Act
     await getWhatNeedsToChange(req, res);

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
@@ -46,6 +46,7 @@ export const getWhatNeedsToChange = async (req: GetWhatNeedsToChangeRequest, res
 
     const viewModel: WhatNeedsToChangeViewModel = {
       exporterName: deal.exporter.companyName,
+      facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: `/gef/application-details/${dealId}`,
       amendmentFormEmail: STB_PIM_EMAIL,

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.test.ts
@@ -6,16 +6,9 @@ const updateAmendmentMock = jest.fn();
 
 import { createMocks } from 'node-mocks-http';
 import * as dtfsCommon from '@ukef/dtfs2-common';
-import {
-  aPortalSessionUser,
-  DEAL_STATUS,
-  DEAL_SUBMISSION_TYPE,
-  Facility,
-  PORTAL_LOGIN_STATUS,
-  PortalFacilityAmendmentWithUkefId,
-  ROLES,
-} from '@ukef/dtfs2-common';
+import { aPortalSessionUser, DEAL_STATUS, DEAL_SUBMISSION_TYPE, PORTAL_LOGIN_STATUS, PortalFacilityAmendmentWithUkefId, ROLES } from '@ukef/dtfs2-common';
 import { HttpStatusCode } from 'axios';
+import { MOCK_ISSUED_FACILITY } from '../../../utils/mocks/mock-facilities';
 import { PostWhatNeedsToChangeRequest, postWhatNeedsToChange } from './post-what-needs-to-change.ts';
 import { WhatNeedsToChangeViewModel } from '../../../types/view-models/amendments/what-needs-to-change-view-model.ts';
 import { STB_PIM_EMAIL } from '../../../constants/emails.ts';
@@ -63,10 +56,6 @@ const getHttpMocks = (amendmentOptions: string[] = ['changeCoverEndDate', 'chang
 
 const mockDeal = { exporter: { companyName }, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED } as Deal;
 
-const mockFacility = {
-  hasBeenIssued: true,
-} as Facility;
-
 describe('postWhatNeedsToChange', () => {
   let amendment: PortalFacilityAmendmentWithUkefId;
 
@@ -77,7 +66,7 @@ describe('postWhatNeedsToChange', () => {
     amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder().withDealId(dealId).withFacilityId(facilityId).withAmendmentId(amendmentId).build();
 
     getApplicationMock.mockResolvedValue(mockDeal);
-    getFacilityMock.mockResolvedValue({ details: mockFacility });
+    getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
     updateAmendmentMock.mockResolvedValue(amendment);
   });
 
@@ -137,6 +126,7 @@ describe('postWhatNeedsToChange', () => {
 
     const expectedRenderData: WhatNeedsToChangeViewModel = {
       exporterName: companyName,
+      facilityType: MOCK_ISSUED_FACILITY.details.type,
       previousPage: `/gef/application-details/${dealId}`,
       amendmentFormEmail: STB_PIM_EMAIL,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
@@ -41,6 +41,7 @@ export const postWhatNeedsToChange = async (req: PostWhatNeedsToChangeRequest, r
     if (validationError) {
       const viewModel: WhatNeedsToChangeViewModel = {
         exporterName: deal.exporter.companyName,
+        facilityType: facility.type,
         cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
         previousPage: `/gef/application-details/${dealId}`,
         amendmentFormEmail: STB_PIM_EMAIL,

--- a/gef-ui/server/types/view-models/amendments/bank-review-date-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/bank-review-date-view-model.ts
@@ -1,8 +1,9 @@
-import { DayMonthYearInput } from '@ukef/dtfs2-common';
+import { DayMonthYearInput, FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type BankReviewDateViewModel = {
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   errors?: ViewModelErrors | null;

--- a/gef-ui/server/types/view-models/amendments/cancel-amendment-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/cancel-amendment-view-model.ts
@@ -1,4 +1,7 @@
+import { FacilityType } from '@ukef/dtfs2-common';
+
 export type CancelAmendmentViewModel = {
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
 };

--- a/gef-ui/server/types/view-models/amendments/cover-end-date-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/cover-end-date-view-model.ts
@@ -1,8 +1,10 @@
+import { FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type CoverEndDateViewModel = {
   coverEndDate?: string | Date;
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   errors?: ViewModelErrors | null;

--- a/gef-ui/server/types/view-models/amendments/do-you-have-a-facility-end-date-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/do-you-have-a-facility-end-date-view-model.ts
@@ -1,7 +1,9 @@
+import { FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type DoYouHaveAFacilityEndDateViewModel = {
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   errors?: ViewModelErrors | null;

--- a/gef-ui/server/types/view-models/amendments/eligibility-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/eligibility-view-model.ts
@@ -1,3 +1,4 @@
+import { FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type EligibilityCriterion = {
@@ -9,6 +10,7 @@ export type EligibilityCriterion = {
 
 export type EligibilityViewModel = {
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   criteria?: EligibilityCriterion[]; // TODO 7765: Make required property when fetching this from database

--- a/gef-ui/server/types/view-models/amendments/facility-end-date-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/facility-end-date-view-model.ts
@@ -1,8 +1,9 @@
-import { DayMonthYearInput } from '@ukef/dtfs2-common';
+import { DayMonthYearInput, FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type FacilityEndDateViewModel = {
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   errors?: ViewModelErrors | null;

--- a/gef-ui/server/types/view-models/amendments/facility-value-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/facility-value-view-model.ts
@@ -1,9 +1,11 @@
+import { FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type FacilityValueViewModel = {
   facilityValue?: string;
   currencySymbol: string;
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   errors?: ViewModelErrors | null;

--- a/gef-ui/server/types/view-models/amendments/what-needs-to-change-view-model.ts
+++ b/gef-ui/server/types/view-models/amendments/what-needs-to-change-view-model.ts
@@ -1,9 +1,11 @@
+import { FacilityType } from '@ukef/dtfs2-common';
 import { ViewModelErrors } from '../view-model-errors';
 
 export type WhatNeedsToChangeViewModel = {
   changeFacilityValue?: boolean;
   changeCoverEndDate?: boolean;
   exporterName: string;
+  facilityType: FacilityType;
   previousPage: string;
   cancelUrl: string;
   amendmentFormEmail: string;

--- a/gef-ui/templates/partials/amendments/bank-review-date.njk
+++ b/gef-ui/templates/partials/amendments/bank-review-date.njk
@@ -13,7 +13,7 @@
 {% set headingHtml %}
 <header>
   <span class="govuk-caption-l" data-cy="heading-caption">
-    {{ exporterName }}
+    {{ exporterName }}, {{ facilityType }} facility
   </span>
 
   <h1 class="govuk-label-wrapper" data-cy="page-heading">

--- a/gef-ui/templates/partials/amendments/cancel.njk
+++ b/gef-ui/templates/partials/amendments/cancel.njk
@@ -7,7 +7,7 @@
 {%- endblock %}
 
 {% set headingHtml %}
-  
+
 {% endset %}
 
 {% block content %}
@@ -17,7 +17,7 @@
       attributes: {
         'data-cy': 'back-link'
       }
-    }) 
+    })
   }}
 
 
@@ -25,7 +25,7 @@
     <div class="govuk-grid-column-two-thirds">
       <header>
         <span class="govuk-caption-l" data-cy="heading-caption">
-          {{ exporterName }}
+          {{ exporterName }}, {{ facilityType }} facility
         </span>
         <h1 class="govuk-label-wrapper" data-cy="page-heading">
           <span class="govuk-heading-xl govuk-!-margin-bottom-1">Are you sure you want to cancel the request?</span>
@@ -37,8 +37,8 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <input type="hidden" name="previousPage" value="{{ previousPage }}">
 
-        <div 
-          class="govuk-button-group govuk-!-margin-top-4" 
+        <div
+          class="govuk-button-group govuk-!-margin-top-4"
         >
           {{ govukButton({
             text: "Yes, cancel",

--- a/gef-ui/templates/partials/amendments/cover-end-date.njk
+++ b/gef-ui/templates/partials/amendments/cover-end-date.njk
@@ -11,7 +11,7 @@
 {% set headingHtml %}
 <header>
   <span class="govuk-caption-l" data-cy="heading-caption">
-    {{ exporterName }}
+    {{ exporterName }}, {{ facilityType }} facility
   </span>
   <h1 class="govuk-label-wrapper" data-cy="page-heading">
     <label class="govuk-label govuk-label--xl govuk-!-padding-bottom-3" for="cover-end-date">
@@ -30,7 +30,7 @@
           'data-cy': 'error-summary'
         },
         classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-4"
-      }) 
+      })
     }}
   {% endif %}
 
@@ -40,7 +40,7 @@
       attributes: {
         'data-cy': 'back-link'
       }
-    }) 
+    })
   }}
 
   <div class="govuk-grid-row govuk-!-margin-bottom-3">
@@ -73,7 +73,7 @@
             attributes: {
             'data-cy': 'continue-button'
             }
-            }) 
+            })
           }}
 
           <a href={{cancelUrl}}  data-cy="cancel-link" class="govuk-link">Cancel</a>

--- a/gef-ui/templates/partials/amendments/do-you-have-a-facility-end-date.njk
+++ b/gef-ui/templates/partials/amendments/do-you-have-a-facility-end-date.njk
@@ -13,7 +13,7 @@
 
 {% set legendHtml %}
 <span class="govuk-caption-l" data-cy="heading-caption">
-  {{ exporterName }}
+  {{ exporterName }}, {{ facilityType }} facility
 </span>
 
 <h1 class="govuk-label-wrapper" data-cy="page-heading">

--- a/gef-ui/templates/partials/amendments/eligibility.njk
+++ b/gef-ui/templates/partials/amendments/eligibility.njk
@@ -38,7 +38,7 @@
 
         <header>
           <span class="govuk-caption-l" data-cy="heading-caption">
-            {{ exporterName }}
+            {{ exporterName }}, {{ facilityType }} facility
           </span>
 
           <h1 class="govuk-label-wrapper" data-cy="page-heading">

--- a/gef-ui/templates/partials/amendments/facility-end-date.njk
+++ b/gef-ui/templates/partials/amendments/facility-end-date.njk
@@ -13,7 +13,7 @@
 {% set headingHtml %}
 <header>
   <span class="govuk-caption-l" data-cy="heading-caption">
-    {{ exporterName }}
+    {{ exporterName }}, {{ facilityType }} facility
   </span>
 
   <h1 class="govuk-label-wrapper" data-cy="page-heading">
@@ -75,7 +75,7 @@
               value: facilityEndDate.day,
               attributes: {
                 'data-cy': 'facility-end-date-day'
-              }            
+              }
             },
             {
               classes: (errors.fieldErrors['facilityEndDate-month'] and "govuk-input--width-2 govuk-input--error") or "govuk-input--width-2",
@@ -83,7 +83,7 @@
               value: facilityEndDate.month,
               attributes: {
                 'data-cy': 'facility-end-date-month'
-              }   
+              }
             },
             {
               classes: (errors.fieldErrors['facilityEndDate-year'] and "govuk-input--width-4 govuk-input--error") or "govuk-input--width-4",
@@ -91,7 +91,7 @@
               value: facilityEndDate.year,
               attributes: {
                 'data-cy': 'facility-end-date-year'
-              }   
+              }
             }
           ]
         }) }}

--- a/gef-ui/templates/partials/amendments/facility-value.njk
+++ b/gef-ui/templates/partials/amendments/facility-value.njk
@@ -11,7 +11,7 @@
 {% set headingHtml %}
 <header>
   <span class="govuk-caption-l" data-cy="heading-caption">
-    {{ exporterName }}
+    {{ exporterName }}, {{ facilityType }} facility
   </span>
 
   <h1 class="govuk-label-wrapper" data-cy="page-heading">

--- a/gef-ui/templates/partials/amendments/what-needs-to-change.njk
+++ b/gef-ui/templates/partials/amendments/what-needs-to-change.njk
@@ -15,7 +15,7 @@
 {% set headingHtml %}
   <header>
     <span class="govuk-caption-l" data-cy="heading-caption">
-      {{ exporterName }}
+      {{ exporterName }}, {{ facilityType }} facility
     </span>
     <h1 class="govuk-label-wrapper" data-cy="page-heading">
       <label class="govuk-label govuk-label--xl" for="what-needs-to-change">


### PR DESCRIPTION
## Introduction :pencil2:
We've been accidentally missing one of the ACs on the amendments tickets - that the facility type should be displayed alongside the exporter name in the page caption as per the designs. 

This PR adds it to all pages. 

## Resolution :heavy_check_mark:
- Pass in facility type to each of the nunjucks files
- add to component tests
-
## Screenshots :heavy_plus_sign:
Now looks like:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/52f39045-165e-4794-a6fb-3075d9f045e2" />

(Highlighted with cursor to show the added part:)
<img width="700" alt="image" src="https://github.com/user-attachments/assets/ee5cffc7-e8c4-4848-8780-258b6fc53fdc" />

