### PR TITLE
fix(DTFS2-7771): added date helper functions

### DIFF
--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -76,6 +76,67 @@ describe('date helpers', () => {
       expect(result).toContain('T');
       expect(result).toContain('Z');
     });
+
+    it('should return the current date and time in ISO 8601 format', () => {
+      // Act
+      const result = getISO8601();
+      const year = now().getFullYear();
+      const month = (now().getMonth() + 1).toString().padStart(2, '0');
+      const date = now().getDate();
+
+      // Assert
+      expect(result).toContain(`${year}-${month}-${date}`);
+      expect(result).toContain('T');
+      expect(result).toContain('Z');
+    });
+
+    it('should return the provided date in ISO 8601 format', () => {
+      // Arrange
+      const date = new Date('2023-01-01T00:00:00Z');
+      const expected = date.toISOString();
+
+      // Act
+      const result = getISO8601(date);
+
+      // Assert
+      expect(result).toEqual(expected);
+    });
+
+    it('should handle leap year dates correctly', () => {
+      // Arrange
+      const date = new Date('2020-02-29T00:00:00Z');
+      const expected = date.toISOString();
+
+      // Act
+      const result = getISO8601(date);
+
+      // Assert
+      expect(result).toEqual(expected);
+    });
+
+    it('should handle dates before 1970 correctly', () => {
+      // Arrange
+      const date = new Date('1969-12-31T23:59:59Z');
+      const expected = date.toISOString();
+
+      // Act
+      const result = getISO8601(date);
+
+      // Assert
+      expect(result).toEqual(expected);
+    });
+
+    it('should handle future dates correctly', () => {
+      // Arrange
+      const date = new Date('2100-01-01T00:00:00Z');
+      const expected = date.toISOString();
+
+      // Act
+      const result = getISO8601(date);
+
+      // Assert
+      expect(result).toEqual(expected);
+    });
   });
 
   describe('getUnixTimestampSeconds', () => {
@@ -93,34 +154,65 @@ describe('date helpers', () => {
   });
 
   describe('addYear', () => {
-    it('should add one year provided date object', () => {
-      const year = 1;
-      const date = new Date('20-09-1989');
-      const oneYear = date.getFullYear() + year;
+    const yearsToAdd = [
+      {
+        year: 0,
+      },
+      {
+        year: 1,
+      },
+      {
+        year: 2,
+      },
+      {
+        year: 10,
+      },
+      {
+        year: 100,
+      },
+      {
+        year: 1000,
+      },
+      {
+        year: 3000,
+      },
+      {
+        year: 10000,
+      },
+    ];
 
-      const result = addYear(year, date);
+    it.each(yearsToAdd)('should add $year year(s) to the provided date object', ({ year }) => {
+      // Arrange
+      const pastDate = new Date('1989-09-20');
+      const expectedYear = pastDate.getFullYear() + year;
+      // JavaScript month are 0 indexed
+      const expectedMonth = 8;
+      const expectedDate = 20;
 
-      expect(result.getFullYear()).toBe(oneYear);
+      // Act
+      const result = addYear(year, pastDate);
+
+      // Assert
+      expect(result.getFullYear()).toBe(expectedYear);
+      expect(result.getMonth()).toBe(expectedMonth);
+      expect(result.getDate()).toBe(expectedDate);
     });
 
-    it('should add ten years provided date object', () => {
-      const year = 10;
-      const date = new Date();
-      const tenYears = date.getFullYear() + year;
+    it.each(yearsToAdd)('should add $year year(s) with no date argument', ({ year }) => {
+      // Arrange
+      const todayDate = now();
+      const expectedYear = todayDate.getFullYear() + year;
+      // JavaScript month are 0 indexed
+      const expectedMonth = todayDate.getMonth();
+      const expectedDate = todayDate.getDate();
 
-      const result = addYear(year, date);
+      // Act
+      const result = addYear(year, todayDate);
 
-      expect(result.getFullYear()).toBe(tenYears);
-    });
-
-    it('should add two years to now', () => {
-      const year = 2;
-      const date = now();
-      const twoYears = date.getFullYear() + year;
-
-      const result = addYear(year);
-
-      expect(result.getFullYear()).toBe(twoYears);
+      // Assert
+      expect(result.getFullYear()).toBe(expectedYear);
+      expect(result.getMonth()).toBe(expectedMonth);
+      expect(result.getDate()).toBe(expectedDate);
     });
   });
 
@@ -151,6 +243,41 @@ describe('date helpers', () => {
     it('should return EPOCH with milliseconds for 20/09/1989', () => {
       // Arrange
       const date = new Date('1989-09-20');
+      const epoch = date.valueOf();
+
+      // Act
+      const result = getEpochMs(date);
+
+      // Assert
+      expect(result).toBe(epoch);
+    });
+
+    it('should return EPOCH with milliseconds for 01/01/1970', () => {
+      // Arrange
+      const date = new Date('1970-01-01');
+
+      // Act
+      const result = getEpochMs(date);
+
+      // Assert
+      expect(result).toBe(0);
+    });
+
+    it('should return EPOCH with milliseconds for a future date', () => {
+      // Arrange
+      const date = new Date('2100-01-01');
+      const epoch = date.valueOf();
+
+      // Act
+      const result = getEpochMs(date);
+
+      // Assert
+      expect(result).toBe(epoch);
+    });
+
+    it('should return EPOCH with milliseconds for a leap year date', () => {
+      // Arrange
+      const date = new Date('2020-02-29');
       const epoch = date.valueOf();
 
       // Act

--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -1,5 +1,5 @@
 import { formatInTimeZone } from 'date-fns-tz';
-import { now, getNowAsUtcISOString, getMonthName, getISO8601, getUnixTimestampSeconds } from './date';
+import { now, getNowAsUtcISOString, getMonthName, getISO8601, getUnixTimestampSeconds, addYear, getEpochMs } from './date';
 
 describe('date helpers', () => {
   describe('getNowAsUtcISOString', () => {
@@ -89,6 +89,75 @@ describe('date helpers', () => {
 
       // Assert
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('addYear', () => {
+    it('should add one year provided date object', () => {
+      const year = 1;
+      const date = new Date('20-09-1989');
+      const oneYear = date.getFullYear() + year;
+
+      const result = addYear(year, date);
+
+      expect(result.getFullYear()).toBe(oneYear);
+    });
+
+    it('should add ten years provided date object', () => {
+      const year = 10;
+      const date = new Date();
+      const tenYears = date.getFullYear() + year;
+
+      const result = addYear(year, date);
+
+      expect(result.getFullYear()).toBe(tenYears);
+    });
+
+    it('should add two years to now', () => {
+      const year = 2;
+      const date = now();
+      const twoYears = date.getFullYear() + year;
+
+      const result = addYear(year);
+
+      expect(result.getFullYear()).toBe(twoYears);
+    });
+  });
+
+  describe('getEpochMs', () => {
+    it('should return EPOCH with milliseconds for now with an argument', () => {
+      // Arrange
+      const date = new Date();
+      const epoch = date.valueOf();
+
+      // Act
+      const result = getEpochMs(date);
+
+      // Assert
+      expect(result).toBe(epoch);
+    });
+
+    it('should return EPOCH with milliseconds for now with no argument', () => {
+      // Arrange
+      const epoch = new Date().valueOf();
+
+      // Act
+      const result = getEpochMs();
+
+      // Assert
+      expect(result).toBe(epoch);
+    });
+
+    it('should return EPOCH with milliseconds for 20/09/1989', () => {
+      // Arrange
+      const date = new Date('1989-09-20');
+      const epoch = date.valueOf();
+
+      // Act
+      const result = getEpochMs(date);
+
+      // Assert
+      expect(result).toBe(epoch);
     });
   });
 });

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -41,3 +41,20 @@ export const getUnixTimestampSeconds: (date: Date) => UnixTimestampSeconds = get
  * @returns {IsoDateTimeStamp} The current date and time as an ISO 8601 string.
  */
 export const getISO8601 = (): IsoDateTimeStamp => now().toISOString();
+
+/**
+ * Adds a specified number of years to a given date.
+ *
+ * @param year - The number of years to add.
+ * @param date - The date to which the years will be added. Defaults to the current date and time.
+ * @returns A new Date object with the specified number of years added.
+ */
+export const addYear = (year: number, date: Date = now()): Date => new Date(date.setFullYear(date.getFullYear() + year));
+
+/**
+ * Returns the epoch time in milliseconds for a given date.
+ *
+ * @param {Date} [date=now()] - The date for which to get the epoch time. Defaults to the current date and time if not provided.
+ * @returns {number} The epoch time in milliseconds.
+ */
+export const getEpochMs = (date: Date = now()): number => new Date(date).valueOf();

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -38,9 +38,10 @@ export const getUnixTimestampSeconds: (date: Date) => UnixTimestampSeconds = get
 /**
  * Returns the current date and time in ISO 8601 format.
  *
- * @returns {IsoDateTimeStamp} The current date and time as an ISO 8601 string.
+ * @param {Date} date JavaScript date object
+ * @returns {String} The current date and time as an ISO 8601 string.
  */
-export const getISO8601 = (): IsoDateTimeStamp => now().toISOString();
+export const getISO8601 = (date: Date = now()): string => date.toISOString();
 
 /**
  * Adds a specified number of years to a given date.

--- a/portal/api-tests/static-routes.api-test.js
+++ b/portal/api-tests/static-routes.api-test.js
@@ -40,8 +40,7 @@ describe('/.well-known/security.txt', () => {
       const response = await get('/.well-known/security.txt');
       // Only get the YYYY-MM-DD
       const addOneYear = addYear(1);
-      const expiry = getISO8601(addOneYear);
-      const oneYearFromToday = expiry.split('T')[0];
+      const oneYearFromToday = getISO8601(addOneYear);
 
       // Assert
       expect(response.text).toContain(`Expires: ${oneYearFromToday}`);

--- a/portal/api-tests/static-routes.api-test.js
+++ b/portal/api-tests/static-routes.api-test.js
@@ -41,9 +41,10 @@ describe('/.well-known/security.txt', () => {
       // Only get the YYYY-MM-DD
       const addOneYear = addYear(1);
       const oneYearFromToday = getISO8601(addOneYear);
+      const OneYearFromTodayDate = oneYearFromToday.split('T')[0];
 
       // Assert
-      expect(response.text).toContain(`Expires: ${oneYearFromToday}`);
+      expect(response.text).toContain(`Expires: ${OneYearFromTodayDate}`);
     });
 
     it('should contain acknowledgments information', async () => {

--- a/portal/api-tests/static-routes.api-test.js
+++ b/portal/api-tests/static-routes.api-test.js
@@ -10,7 +10,7 @@ jest.mock('../server/api', () => ({
   validateToken: () => true,
 }));
 
-const { ROLES, getISO8601 } = require('@ukef/dtfs2-common');
+const { ROLES, getISO8601, addYear } = require('@ukef/dtfs2-common');
 const { withRoleValidationApiTests } = require('./common-tests/role-validation-api-tests');
 const app = require('../server/createApp');
 const { get } = require('./create-api').createApi(app);
@@ -39,10 +39,12 @@ describe('/.well-known/security.txt', () => {
       // Act
       const response = await get('/.well-known/security.txt');
       // Only get the YYYY-MM-DD
-      const todayDate = getISO8601().split('T')[0];
+      const addOneYear = addYear(1);
+      const expiry = getISO8601(addOneYear);
+      const oneYearFromToday = expiry.split('T')[0];
 
       // Assert
-      expect(response.text).toContain(`Expires: ${todayDate}`);
+      expect(response.text).toContain(`Expires: ${oneYearFromToday}`);
     });
 
     it('should contain acknowledgments information', async () => {

--- a/portal/server/routes/static.js
+++ b/portal/server/routes/static.js
@@ -5,6 +5,17 @@ const router = express.Router();
 const oneYearInFutureDate = addYear(1);
 const IsoExpiryDate = getISO8601(oneYearInFutureDate);
 
+/**
+ * get
+ * Handles the GET request to serve the security.txt file.
+ *
+ * This controller returns a plain text response containing various security-related
+ * contact information, acknowledgments, preferred languages, canonical URL, policy,
+ * and hiring information.
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.send} security.txt file
+ */
 router.get('/.well-known/security.txt', (req, res) => {
   res.type('text/plain');
 
@@ -21,6 +32,17 @@ router.get('/.well-known/security.txt', (req, res) => {
   res.send();
 });
 
+/**
+ * get
+ *  Handles the GET request for the thank you page.
+ *
+ * This controller sets the response type to plain text and writes a thank you message
+ * with a placeholder for the date, name, and description.
+ *
+ * @param {Express.Request} Express request
+ * @param {Express.Response} Express response
+ * @returns {Express.Response.render} thanks.txt file
+ */
 router.get('/thanks.txt', (req, res) => {
   res.type('text/plain');
 

--- a/portal/server/routes/static.js
+++ b/portal/server/routes/static.js
@@ -1,7 +1,9 @@
 import express from 'express';
-import { getISO8601 } from '@ukef/dtfs2-common';
+import { addYear, getISO8601 } from '@ukef/dtfs2-common';
 
 const router = express.Router();
+const addOneYear = addYear(1);
+const expiry = getISO8601(addOneYear);
 
 router.get('/.well-known/security.txt', (req, res) => {
   res.type('text/plain');
@@ -9,7 +11,7 @@ router.get('/.well-known/security.txt', (req, res) => {
   res.write('Contact: https://www.gov.uk/contact/govuk\n');
   res.write('Contact: https://hackerone.com/7af14fd9-fe4e-4f39-bea1-8f8a364061b8/embedded_submissions/new\n');
   res.write('Contact: https://get-a-guarantee-for-export-finance.service.gov.uk/feedback\n');
-  res.write(`Expires: ${getISO8601()}\n`);
+  res.write(`Expires: ${expiry}\n`);
   res.write('Acknowledgments: https://get-a-guarantee-for-export-finance.service.gov.uk/thanks.txt\n');
   res.write('Preferred-Languages: en\n');
   res.write('Canonical: https://get-a-guarantee-for-export-finance.service.gov.uk/.well-known/security.txt\n');

--- a/portal/server/routes/static.js
+++ b/portal/server/routes/static.js
@@ -2,8 +2,8 @@ import express from 'express';
 import { addYear, getISO8601 } from '@ukef/dtfs2-common';
 
 const router = express.Router();
-const addOneYear = addYear(1);
-const expiry = getISO8601(addOneYear);
+const oneYearInFutureDate = addYear(1);
+const IsoExpiryDate = getISO8601(oneYearInFutureDate);
 
 router.get('/.well-known/security.txt', (req, res) => {
   res.type('text/plain');
@@ -11,7 +11,7 @@ router.get('/.well-known/security.txt', (req, res) => {
   res.write('Contact: https://www.gov.uk/contact/govuk\n');
   res.write('Contact: https://hackerone.com/7af14fd9-fe4e-4f39-bea1-8f8a364061b8/embedded_submissions/new\n');
   res.write('Contact: https://get-a-guarantee-for-export-finance.service.gov.uk/feedback\n');
-  res.write(`Expires: ${expiry}\n`);
+  res.write(`Expires: ${IsoExpiryDate}\n`);
   res.write('Acknowledgments: https://get-a-guarantee-for-export-finance.service.gov.uk/thanks.txt\n');
   res.write('Preferred-Languages: en\n');
   res.write('Canonical: https://get-a-guarantee-for-export-finance.service.gov.uk/.well-known/security.txt\n');


### PR DESCRIPTION
## Introduction :pencil2:
`security.txt` expiry date should be set to 1 year in future to conform with [RFC-9116](https://www.rfc-editor.org/rfc/rfc9116).

## Resolution :heavy_check_mark:
* Added `addYear` helper function.
* Updated API test case assertion.

## Miscellaneous :heavy_plus_sign:
* Added `getEpochMs` helper function to get EPOCH with ms.
* Added unit test cases.

