### PR TITLE
feat(FN-3664): add risk data to created customers

### DIFF
--- a/external-api/api-tests/v1/party-db.api-test.ts
+++ b/external-api/api-tests/v1/party-db.api-test.ts
@@ -17,8 +17,9 @@ import { app } from '../../src/createApp';
 import { api } from '../api';
 
 const { APIM_MDM_URL } = process.env;
-const { VALID, VALID_WITH_LETTERS } = MOCK_COMPANY_REGISTRATION_NUMBERS;
-const { get } = api(app);
+const { VALID, VALID_WITH_LETTERS, INVALID_TOO_SHORT, INVALID_TOO_LONG } = MOCK_COMPANY_REGISTRATION_NUMBERS;
+const { get, post } = api(app);
+const bodyValid = { companyRegNo: VALID, companyName: 'Some name', probabilityOfDefault: 3 };
 let axiosMock: MockAdapter;
 
 jest.mock('@ukef/dtfs2-common', () => ({
@@ -31,6 +32,7 @@ beforeEach(() => {
 
   axiosMock.onGet(`${APIM_MDM_URL}customers?companyReg=${VALID}`).reply(HttpStatusCode.Ok, {});
   axiosMock.onGet(`${APIM_MDM_URL}customers?companyReg=${VALID_WITH_LETTERS}`).reply(HttpStatusCode.Ok, {});
+  axiosMock.onPost(`${APIM_MDM_URL}customers`).reply(HttpStatusCode.Ok);
 });
 
 afterEach(() => {
@@ -50,7 +52,7 @@ describe('when automatic Salesforce customer creation feature flag is disabled',
         expect(status).toEqual(HttpStatusCode.Ok);
       });
 
-      it(`returns a ${HttpStatusCode.Ok} response with a valid companies house number`, async () => {
+      it(`returns a ${HttpStatusCode.Ok} response with a valid companies house number with letters`, async () => {
         const { status } = await get(`/party-db/${VALID_WITH_LETTERS}`);
 
         expect(status).toEqual(HttpStatusCode.Ok);
@@ -85,24 +87,48 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
       expect(status).toEqual(HttpStatusCode.Ok);
     });
 
-    it(`returns a ${HttpStatusCode.Ok} response with a valid companies house number`, async () => {
+    it(`returns a ${HttpStatusCode.Ok} response with a valid companies house number with letters`, async () => {
       const { status } = await get(`/party-db/${VALID_WITH_LETTERS}`);
 
       expect(status).toEqual(HttpStatusCode.Ok);
     });
+
+    const invalidCompaniesHouseNumberTestCases = [['ABC22'], ['127.0.0.1'], ['{}'], ['[]']];
+
+    describe('when company house number is invalid', () => {
+      test.each(invalidCompaniesHouseNumberTestCases)(
+        `returns a ${HttpStatusCode.BadRequest} if you provide an invalid company house number %s`,
+        async (companyHouseNumber) => {
+          const { status, body } = await get(`/party-db/${companyHouseNumber}`);
+
+          expect(status).toEqual(HttpStatusCode.BadRequest);
+          expect(body).toMatchObject({ data: 'Invalid company registration number', status: HttpStatusCode.BadRequest });
+        },
+      );
+    });
   });
 
-  const invalidCompaniesHouseNumberTestCases = [['ABC22'], ['127.0.0.1'], ['{}'], ['[]']];
+  describe('POST /party-db', () => {
+    it(`returns a ${HttpStatusCode.Ok} response with a valid body`, async () => {
+      const { status } = await post(bodyValid).to(`/party-db/`);
 
-  describe('when company house number is invalid', () => {
-    test.each(invalidCompaniesHouseNumberTestCases)(
-      `returns a ${HttpStatusCode.BadRequest} if you provide an invalid company house number %s`,
-      async (companyHouseNumber) => {
-        const { status, body } = await get(`/party-db/${companyHouseNumber}`);
+      expect(status).toEqual(HttpStatusCode.Ok);
+    });
+
+    const invalidBodies = [
+      { companyRegNo: null, companyName: 'Some name', probabilityOfDefault: 3 },
+      { companyRegNo: VALID, companyName: null, probabilityOfDefault: 3 },
+      { companyRegNo: VALID, companyName: 'Some name', probabilityOfDefault: null },
+      { companyRegNo: INVALID_TOO_SHORT, companyName: 'Some name', probabilityOfDefault: 3 },
+      { companyRegNo: INVALID_TOO_LONG, companyName: 'Some name', probabilityOfDefault: 3 },
+    ];
+
+    describe('when the body is invalid', () => {
+      test.each(invalidBodies)(`returns a ${HttpStatusCode.BadRequest} if you provide an invalid body %s`, async (invalidBody) => {
+        const { status } = await post(invalidBody).to(`/party-db/`);
 
         expect(status).toEqual(HttpStatusCode.BadRequest);
-        expect(body).toMatchObject({ data: 'Invalid company registration number', status: HttpStatusCode.BadRequest });
-      },
-    );
+      });
+    });
   });
 });

--- a/external-api/src/v1/controllers/party-db.controller.ts
+++ b/external-api/src/v1/controllers/party-db.controller.ts
@@ -57,9 +57,12 @@ export const lookup = async (req: Request, res: Response) => {
  * const res = { status: () => res, send: () => {} };
  * await getOrCreateParty(req, res);
  */
-export const getOrCreateParty = async (req: CustomExpressRequest<{ reqBody: { companyRegNo: string; companyName: string } }>, res: Response) => {
+export const getOrCreateParty = async (
+  req: CustomExpressRequest<{ reqBody: { companyRegNo: string; companyName: string; probabilityOfDefault: number } }>,
+  res: Response,
+) => {
   try {
-    const { companyRegNo: companyRegistrationNumber, companyName } = req.body;
+    const { companyRegNo: companyRegistrationNumber, companyName, probabilityOfDefault } = req.body;
 
     if (!isValidCompanyRegistrationNumber(companyRegistrationNumber)) {
       console.error('Invalid company registration number provided %s', companyRegistrationNumber);
@@ -71,6 +74,11 @@ export const getOrCreateParty = async (req: CustomExpressRequest<{ reqBody: { co
       return res.status(HttpStatusCode.BadRequest).send({ status: HttpStatusCode.BadRequest, data: 'Invalid company name' });
     }
 
+    if (!probabilityOfDefault) {
+      console.error('No probability of default provided');
+      return res.status(HttpStatusCode.BadRequest).send({ status: HttpStatusCode.BadRequest, data: 'Invalid probability of default' });
+    }
+
     const response: { status: number; data: unknown } = await axios({
       method: 'post',
       url: `${APIM_MDM_URL}customers`,
@@ -78,6 +86,7 @@ export const getOrCreateParty = async (req: CustomExpressRequest<{ reqBody: { co
       data: {
         companyRegistrationNumber,
         companyName,
+        probabilityOfDefault,
       },
     });
     const { status, data } = response;

--- a/external-api/src/v1/controllers/party-db.controller.ts
+++ b/external-api/src/v1/controllers/party-db.controller.ts
@@ -44,7 +44,7 @@ export const lookup = async (req: Request, res: Response) => {
  * to get or create the party. If validation fails or an error occurs, it returns the appropriate HTTP status and error message.
  *
  * @param {CustomExpressRequest<{ reqBody: { companyName: string } }>} req - The Express request object, which contains:
- *   - `req.body` - The company name (`companyName`) and companies house number (`companyReg`).
+ *   - `req.body` - The company name (`companyName`), companies house number (`companyReg`) and probability of default (`probabilityOfDefault`).
  * @param {Response} res - The Express response object used to send the HTTP response.
  *
  * @returns {Promise<Response>} A promise that resolves to an HTTP response. The response contains:
@@ -53,7 +53,7 @@ export const lookup = async (req: Request, res: Response) => {
  *
  * @example
  * // Example usage:
- * const req = { body: { companyReg: '12345678', companyName: 'Test Corp' } };
+ * const req = { body: { companyReg: '12345678', companyName: 'Test Corp', probabilityOfDefault: 14.1 } };
  * const res = { status: () => res, send: () => {} };
  * await getOrCreateParty(req, res);
  */

--- a/external-api/src/v1/routes/external-apis.route.ts
+++ b/external-api/src/v1/routes/external-apis.route.ts
@@ -379,10 +379,11 @@ apiRoutes.get('/party-db/:partyDbCompanyRegistrationNumber', partyDb.lookup);
  *       content:
  *         application/json:
  *           schema:
- *             name: companyName
- *              schema:
- *               type: string
- *               example: 'Some Name'
+ *             type: object
+ *             properties:
+ *               companyName:
+ *                 type: string
+ *                 example: 'Some Name'
  *     responses:
  *       200:
  *         description: OK

--- a/trade-finance-manager-api/api-tests/v1/deals/deals-party-db.api-test.js
+++ b/trade-finance-manager-api/api-tests/v1/deals/deals-party-db.api-test.js
@@ -4,7 +4,7 @@ const { addPartyUrns } = require('../../../src/v1/controllers/deal.party-db');
 const MOCK_DEAL = require('../../../src/v1/__mocks__/mock-deal');
 const api = require('../../../src/v1/api');
 const { MOCK_PORTAL_USERS } = require('../../../src/v1/__mocks__/mock-portal-users');
-const { COMPANY_REGISTRATION_NUMBER } = require('../../../src/constants/deals');
+const { COMPANY_REGISTRATION_NUMBER, PROBABILITY_OF_DEFAULT } = require('../../../src/constants/deals');
 
 describe('add partyUrn to deal', () => {
   beforeEach(() => {
@@ -27,6 +27,7 @@ describe('add partyUrn to deal', () => {
       exporter: {
         companiesHouseRegistrationNumber: '',
         companyName: 'some name',
+        probabilityOfDefault: PROBABILITY_OF_DEFAULT.DEFAULT_VALUE,
       },
     };
 
@@ -42,6 +43,7 @@ describe('add partyUrn to deal', () => {
       exporter: {
         companiesHouseRegistrationNumber: COMPANY_REGISTRATION_NUMBER.NO_MATCH,
         companyName: 'some name',
+        probabilityOfDefault: PROBABILITY_OF_DEFAULT.DEFAULT_VALUE,
       },
     };
 
@@ -57,6 +59,7 @@ describe('add partyUrn to deal', () => {
       exporter: {
         companiesHouseRegistrationNumber: COMPANY_REGISTRATION_NUMBER.MATCH,
         companyName: 'some name',
+        probabilityOfDefault: PROBABILITY_OF_DEFAULT.DEFAULT_VALUE,
       },
     };
 
@@ -72,6 +75,7 @@ describe('add partyUrn to deal', () => {
       exporter: {
         companiesHouseRegistrationNumber: COMPANY_REGISTRATION_NUMBER.MATCH,
         companyName: 'some name',
+        probabilityOfDefault: PROBABILITY_OF_DEFAULT.DEFAULT_VALUE,
       },
       tfm: {
         mockField: 'mock data',

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -829,11 +829,12 @@ const getPartyDbInfo = async ({ companyRegNo }) => {
 
 /**
  * Calls getOrCreatePartyDbInfo in external-api to get a customer in Salesforce, and create it if it doesn't exist
- * @param {number} companyRegNo Party URN
- * @param {number} companyName Company name
+ * @param {string} companyRegNo Party URN
+ * @param {string} companyName Company name
+ * @param {string} probabilityOfDefault Probability of default
  * @returns {Promise<Object>} Company information
  */
-const getOrCreatePartyDbInfo = async ({ companyRegNo, companyName }) => {
+const getOrCreatePartyDbInfo = async ({ companyRegNo, companyName, probabilityOfDefault }) => {
   try {
     const response = await axios({
       method: 'post',
@@ -842,6 +843,7 @@ const getOrCreatePartyDbInfo = async ({ companyRegNo, companyName }) => {
       data: {
         companyRegNo,
         companyName,
+        probabilityOfDefault,
       },
     });
 

--- a/trade-finance-manager-api/src/v1/controllers/deal.party-db.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.party-db.js
@@ -81,7 +81,7 @@ const addPartyUrns = async (deal, auditDetails) => {
   const { hasExporter, hasIndemnifier, hasAgent, hasBuyer } = identifyDealParties(deal);
   const companyRegNo = deal.exporter.companiesHouseRegistrationNumber;
   const { companyName } = deal.exporter;
-  const { probabilityOfDefault } = deal.exporter.probabilityOfDefault.toString();
+  const { probabilityOfDefault } = deal.exporter;
 
   const dealUpdate = {
     tfm: {

--- a/trade-finance-manager-api/src/v1/controllers/deal.party-db.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.party-db.js
@@ -34,9 +34,10 @@ const getCompany = async (req, res) => {
  * Gets a PartyURN
  * @param {string} companyRegNo The company registration number
  * @param {string} companyName The company name
+ * @param {string} probabilityOfDefault The probability of default
  * @returns {Promise<string>} PartyURN or '' if there is an error
  */
-const getPartyUrn = async ({ companyRegNo, companyName }) => {
+const getPartyUrn = async ({ companyRegNo, companyName, probabilityOfDefault }) => {
   if (!companyRegNo) {
     return '';
   }
@@ -48,7 +49,7 @@ const getPartyUrn = async ({ companyRegNo, companyName }) => {
       return '';
     }
 
-    partyDbInfo = await api.getOrCreatePartyDbInfo({ companyRegNo, companyName });
+    partyDbInfo = await api.getOrCreatePartyDbInfo({ companyRegNo, companyName, probabilityOfDefault });
   } else {
     partyDbInfo = await api.getPartyDbInfo({ companyRegNo });
   }
@@ -80,13 +81,14 @@ const addPartyUrns = async (deal, auditDetails) => {
   const { hasExporter, hasIndemnifier, hasAgent, hasBuyer } = identifyDealParties(deal);
   const companyRegNo = deal.exporter.companiesHouseRegistrationNumber;
   const { companyName } = deal.exporter;
+  const { probabilityOfDefault } = deal.exporter.probabilityOfDefault.toString();
 
   const dealUpdate = {
     tfm: {
       ...deal.tfm,
       parties: {
         exporter: {
-          partyUrn: await getPartyUrn({ companyRegNo, companyName }),
+          partyUrn: await getPartyUrn({ companyRegNo, companyName, probabilityOfDefault }),
           partyUrnRequired: hasExporter,
         },
         buyer: {

--- a/trade-finance-manager-api/src/v1/controllers/deal.party-db.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.party-db.js
@@ -49,6 +49,11 @@ const getPartyUrn = async ({ companyRegNo, companyName, probabilityOfDefault }) 
       return '';
     }
 
+    if (!probabilityOfDefault) {
+      console.error('No probability of default provided');
+      return '';
+    }
+
     partyDbInfo = await api.getOrCreatePartyDbInfo({ companyRegNo, companyName, probabilityOfDefault });
   } else {
     partyDbInfo = await api.getPartyDbInfo({ companyRegNo });

--- a/trade-finance-manager-api/src/v1/controllers/deal.party-db.test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.party-db.test.js
@@ -2,6 +2,7 @@ const { isSalesforceCustomerCreationEnabled } = require('@ukef/dtfs2-common');
 const { getPartyDbInfo, getOrCreatePartyDbInfo } = require('../api.js');
 
 const api = require('./deal.party-db');
+const { PROBABILITY_OF_DEFAULT } = require('../../constants/deals.js');
 
 const mockCompany = {
   partyUrn: '1234',
@@ -161,6 +162,19 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
     getOrCreatePartyDbInfo.mockResolvedValue([{ partyUrn: 'TEST_URN' }]);
 
     const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: 3 };
+
+    const result = await api.getPartyUrn(companyData);
+
+    expect(getOrCreatePartyDbInfo).toHaveBeenCalledWith(companyData);
+    expect(getOrCreatePartyDbInfo).toHaveBeenCalledTimes(1);
+
+    expect(result).toBe('TEST_URN');
+  });
+
+  it('should allow a probability of default set to its default value', async () => {
+    getOrCreatePartyDbInfo.mockResolvedValue([{ partyUrn: 'TEST_URN' }]);
+
+    const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: PROBABILITY_OF_DEFAULT.DEFAULT_VALUE };
 
     const result = await api.getPartyUrn(companyData);
 

--- a/trade-finance-manager-api/src/v1/controllers/deal.party-db.test.js
+++ b/trade-finance-manager-api/src/v1/controllers/deal.party-db.test.js
@@ -130,11 +130,19 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
     {
       query: {
         companyName: 'TEST NAME',
+        companyRegNo: '12345678',
       },
     },
     {
       query: {
         companyRegNo: '12345678',
+        probabilityOfDefault: 3,
+      },
+    },
+    {
+      query: {
+        companyName: 'TEST NAME',
+        probabilityOfDefault: 3,
       },
     },
     {
@@ -152,7 +160,7 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
   it('should call getOrCreatePartyDbInfo for a company that exists (or does not exist and is created with a new URN), and return URN', async () => {
     getOrCreatePartyDbInfo.mockResolvedValue([{ partyUrn: 'TEST_URN' }]);
 
-    const companyData = { companyRegNo: '12345678', companyName: 'name' };
+    const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: 3 };
 
     const result = await api.getPartyUrn(companyData);
 
@@ -165,7 +173,7 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
   it('should not call getPartyDbInfo', async () => {
     getOrCreatePartyDbInfo.mockResolvedValue([{ partyUrn: 'TEST_URN' }]);
 
-    const companyData = { companyRegNo: '12345678', companyName: 'name' };
+    const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: 3 };
 
     await api.getPartyUrn(companyData);
 
@@ -175,7 +183,7 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
   it('should return an empty string if getOrCreatePartyDbInfo returns false', async () => {
     getOrCreatePartyDbInfo.mockResolvedValue(false);
 
-    const companyData = { companyRegNo: '12345678', companyName: 'TEST NAME' };
+    const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: 3 };
 
     const result = await api.getPartyUrn(companyData);
 
@@ -187,7 +195,7 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
   it('should handle null partyUrn in creation response gracefully', async () => {
     getOrCreatePartyDbInfo.mockResolvedValue([{ partyUrn: null }]);
 
-    const companyData = { companyRegNo: '12345678', companyName: 'name' };
+    const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: 3 };
 
     const result = await api.getPartyUrn(companyData);
 
@@ -202,7 +210,7 @@ describe('when automatic Salesforce customer creation feature flag is enabled', 
   it('should handle null data in getOrCreatePartyDbInfo response gracefully', async () => {
     getOrCreatePartyDbInfo.mockResolvedValue({});
 
-    const companyData = { companyRegNo: '12345678', companyName: 'name' };
+    const companyData = { companyRegNo: '12345678', companyName: 'name', probabilityOfDefault: 3 };
 
     const result = await api.getPartyUrn(companyData);
 


### PR DESCRIPTION
## Introduction :pencil2:
In discussion with Risk teams, they wanted Risk data to be added to newly created customers in Salesforce.
The APIM side will default Risk rating at B+ and Loss given default at 50%, and the DTFS side will pass Probability of Default through to APIM to be set on the new record.

## Resolution :heavy_check_mark:
Adds probability of default (set to the exporter's value) to the data sent to the new APIM customer creation endpoint.

