### PR TITLE
feat(FN-3689): add back link to record correction review page

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/provide-correction.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/payment-report-officer/record-corrections/feature-flag-enabled/provide-correction.spec.js
@@ -130,6 +130,15 @@ context('Provide correction - Fee record correction feature flag enabled', () =>
             cy.clickContinueButton();
           });
 
+          it('should retain the values entered by the user when they return to the page via the review page back link', () => {
+            cy.clickBackLink();
+
+            provideCorrection.facilityIdInput().should('have.value', newFacilityId);
+            provideCorrection.reportedFeeInput().should('have.value', getFormattedMonetaryValue(newReportedFee));
+            provideCorrection.reportedCurrency.radioInput(newReportedCurrency).should('be.checked');
+            provideCorrection.additionalComments.input().should('have.value', additionalComments);
+          });
+
           it('should retain the values entered by the user when they return to the page via the review page change link', () => {
             reviewCorrection.changeNewValuesLink().click();
 

--- a/portal/templates/utilisation-report-service/record-correction/check-the-information.njk
+++ b/portal/templates/utilisation-report-service/record-correction/check-the-information.njk
@@ -4,6 +4,8 @@
 
 {% block pageTitle %}Check the information before submitting the record correction{% endblock %}
 
+{% set backLink = { href: backLinkHref } %}
+
 {% block content %}
   <h1 class="govuk-heading-l" data-cy="main-heading">Record correction</h1>
   <h2 class="govuk-heading-m" data-cy="check-the-information-heading">


### PR DESCRIPTION
## Introduction :pencil2:
The designs were updated to include a back link on the record correction review page.

## Resolution :heavy_check_mark:
- Add back link linking to previous page to record correction review page.
- Add e2e-test.

