### PR TITLE
feat(DTFS2-7498): add eligibility post controller

### DIFF
--- a/gef-ui/api-tests/amendments/eligibility.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/eligibility.post.api-test.ts
@@ -1,0 +1,261 @@
+import { Headers } from 'node-mocks-http';
+import { NextFunction, Request, Response } from 'express';
+import { HttpStatusCode } from 'axios';
+import { AnyObject, DEAL_STATUS, DEAL_SUBMISSION_TYPE, ROLES } from '@ukef/dtfs2-common';
+import { withRoleValidationApiTests } from '../common-tests/role-validation-api-tests';
+import app from '../../server/createApp';
+import { createApi } from '../create-api';
+import api from '../../server/services/api';
+import * as storage from '../test-helpers/storage/storage';
+import { MOCK_BASIC_DEAL } from '../../server/utils/mocks/mock-applications';
+import { MOCK_ISSUED_FACILITY } from '../../server/utils/mocks/mock-facilities';
+import { PortalFacilityAmendmentWithUkefIdMockBuilder } from '../../test-helpers/mock-amendment';
+import { PORTAL_AMENDMENT_PAGES } from '../../server/constants/amendments';
+
+const originalEnv = { ...process.env };
+
+const { post } = createApi(app);
+
+jest.mock('csurf', () => () => (_req: Request, _res: Response, next: NextFunction) => next());
+jest.mock('../../server/middleware/csrf', () => ({
+  csrfToken: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+const mockGetFacility = jest.fn();
+const mockGetApplication = jest.fn();
+const mockGetAmendment = jest.fn();
+const mockUpdateAmendment = jest.fn();
+
+const dealId = '123';
+const facilityId = '111';
+const amendmentId = '111';
+
+const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
+
+const validBody = {
+  '1': 'false',
+  '2': 'true',
+  '3': 'false',
+};
+
+const invalidBody = {
+  '1': 'false',
+  '3': 'false',
+};
+
+const url = `/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/${PORTAL_AMENDMENT_PAGES.ELIGIBILITY}`;
+
+describe(`POST ${url}`, () => {
+  let sessionCookie: string;
+
+  beforeEach(async () => {
+    await storage.flush();
+    jest.resetAllMocks();
+
+    ({ sessionCookie } = await storage.saveUserSession([ROLES.MAKER]));
+    jest.spyOn(api, 'getFacility').mockImplementation(mockGetFacility);
+    jest.spyOn(api, 'getAmendment').mockImplementation(mockGetAmendment);
+    jest.spyOn(api, 'getApplication').mockImplementation(mockGetApplication);
+    jest.spyOn(api, 'updateAmendment').mockImplementation(mockUpdateAmendment);
+
+    const criteria = [
+      {
+        id: 1,
+        text: 'Criterion 1',
+        answer: null,
+      },
+      {
+        id: 2,
+        text: 'Criterion 2',
+        textList: ['bullet 1', 'bullet 2'],
+        answer: null,
+      },
+      {
+        id: 3,
+        text: 'Criterion 3',
+        answer: null,
+      },
+    ];
+
+    const amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder()
+      .withDealId(dealId)
+      .withFacilityId(facilityId)
+      .withAmendmentId(amendmentId)
+      .withCriteria(criteria)
+      .build();
+
+    mockGetFacility.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    mockGetApplication.mockResolvedValue(mockDeal);
+    mockGetAmendment.mockResolvedValue(amendment);
+    mockUpdateAmendment.mockResolvedValue(amendment);
+  });
+
+  afterAll(async () => {
+    jest.resetAllMocks();
+    await storage.flush();
+    process.env = originalEnv;
+  });
+
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is disabled', () => {
+    beforeEach(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
+    });
+
+    it('should redirect to /not-found', async () => {
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+  });
+
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is not set', () => {
+    beforeEach(() => {
+      delete process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED;
+    });
+
+    it('should redirect to /not-found', async () => {
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+  });
+
+  describe('when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is enabled', () => {
+    beforeEach(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'true';
+    });
+
+    withRoleValidationApiTests({
+      makeRequestWithHeaders: (headers: Headers) => post(validBody, headers).to(url),
+      whitelistedRoles: [ROLES.MAKER],
+      successCode: HttpStatusCode.Found,
+    });
+
+    it('should redirect to /not-found when facility not found', async () => {
+      // Arrange
+      mockGetFacility.mockResolvedValue({ details: undefined });
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when deal not found', async () => {
+      // Arrange
+      mockGetApplication.mockResolvedValue(undefined);
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when amendment not found', async () => {
+      // Arrange
+      mockGetAmendment.mockResolvedValue(undefined);
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should render eligibility page with errors if some criteria are missing responses', async () => {
+      // Act
+      const response = await postWithSessionCookie(invalidBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Eligibility');
+      expect(response.text).toContain('Select if criterion 2');
+    });
+
+    it('should render eligibility page with errors if all criteria are missing responses', async () => {
+      // Act
+      const response = await postWithSessionCookie({}, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Eligibility');
+      expect(response.text).toContain('Select if criterion 1');
+      expect(response.text).toContain('Select if criterion 2');
+      expect(response.text).toContain('Select if criterion 3');
+    });
+
+    it('should redirect to the next page if the eligibility responses are valid', async () => {
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual(
+        `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/${PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE}`,
+      );
+    });
+
+    it('should render `problem with service` if getApplication throws an error', async () => {
+      // Arrange
+      mockGetApplication.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+
+    it('should render `problem with service` if getFacility throws an error', async () => {
+      // Arrange
+      mockGetFacility.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+
+    it('should render `problem with service` if getAmendment throws an error', async () => {
+      // Arrange
+      mockGetAmendment.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+
+    it('should render `problem with service` if updateAmendment throws an error', async () => {
+      // Arrange
+      mockUpdateAmendment.mockRejectedValue(new Error('test error'));
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Ok);
+      expect(response.text).toContain('Problem with the service');
+    });
+  });
+});
+
+function postWithSessionCookie(body: AnyObject, sessionCookie: string) {
+  return post(body, { Cookie: [`dtfs-session=${encodeURIComponent(sessionCookie)}`] }).to(url);
+}

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
@@ -14,7 +14,7 @@ import { MOCK_BASIC_DEAL } from '../../../utils/mocks/mock-applications';
 import { MOCK_UNISSUED_FACILITY, MOCK_ISSUED_FACILITY } from '../../../utils/mocks/mock-facilities';
 import { PortalFacilityAmendmentWithUkefIdMockBuilder } from '../../../../test-helpers/mock-amendment';
 import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
-import { getPreviousPage } from '../helpers/navigation.helper';
+import { getAmendmentsUrl, getPreviousPage } from '../helpers/navigation.helper';
 
 jest.mock('../../../services/api', () => ({
   getApplication: getApplicationMock,
@@ -117,7 +117,7 @@ describe('getEligibilityCriteria', () => {
     const expectedRenderData: EligibilityViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
-      cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
+      cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
       criteria,
     };

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import * as api from '../../../services/api';
 import { asLoggedInUserSession } from '../../../utils/express-session';
 import { userCanAmendFacility } from '../../../utils/facility-amendments.helper';
-import { getPreviousPage } from '../helpers/navigation.helper';
+import { getAmendmentsUrl, getPreviousPage } from '../helpers/navigation.helper';
 import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
 import { EligibilityViewModel } from '../../../types/view-models/amendments/eligibility-view-model.ts';
 
@@ -46,7 +46,7 @@ export const getEligibility = async (req: GetEligibilityRequest, res: Response) 
     const viewModel: EligibilityViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
-      cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
+      cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
       criteria,
     };

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
@@ -147,7 +147,7 @@ describe('postEligibility', () => {
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual('/not-found');
     expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', amendmentId, facilityId);
+    expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
   it('should redirect if the amendment is not found', async () => {
@@ -162,7 +162,7 @@ describe('postEligibility', () => {
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual('/not-found');
     expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found on facility %s', dealId, facilityId);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found on facility %s', amendmentId, facilityId);
   });
 
   it('should render `problem with service` if getApplication throws an error', async () => {

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
@@ -1,0 +1,320 @@
+// TODO: DTFS2-7724 - remove this eslint-disable
+/* eslint-disable import/first */
+const getApplicationMock = jest.fn();
+const getAmendmentMock = jest.fn();
+const getFacilityMock = jest.fn();
+const updateAmendmentMock = jest.fn();
+
+import * as dtfsCommon from '@ukef/dtfs2-common';
+import { aPortalSessionUser, DEAL_STATUS, DEAL_SUBMISSION_TYPE, PORTAL_LOGIN_STATUS, ROLES, PortalFacilityAmendmentWithUkefId } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { createMocks } from 'node-mocks-http';
+import { validateEligibilityResponse } from './validation.ts';
+import { EligibilityViewModel } from '../../../types/view-models/amendments/eligibility-view-model.ts';
+import { EligibilityReqBody, parseEligibilityResponse } from '../helpers/eligibility.helper.ts';
+import { MOCK_BASIC_DEAL } from '../../../utils/mocks/mock-applications';
+import { MOCK_ISSUED_FACILITY } from '../../../utils/mocks/mock-facilities';
+import { PortalFacilityAmendmentWithUkefIdMockBuilder } from '../../../../test-helpers/mock-amendment';
+import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
+import { getAmendmentsUrl, getNextPage } from '../helpers/navigation.helper';
+import { validationErrorHandler } from '../../../utils/helpers';
+import { ValidationError } from '../../../types/validation-error';
+import { postEligibility, PostEligibilityRequest } from './post-eligibility.ts';
+
+jest.mock('../../../services/api', () => ({
+  getApplication: getApplicationMock,
+  getAmendment: getAmendmentMock,
+  getFacility: getFacilityMock,
+  updateAmendment: updateAmendmentMock,
+}));
+
+const dealId = 'dealId';
+const facilityId = 'facilityId';
+const amendmentId = 'amendmentId';
+
+const criteria = [
+  {
+    id: 1,
+    text: 'Criterion 1',
+    answer: null,
+  },
+  {
+    id: 2,
+    text: 'Criterion 2',
+    textList: ['bullet 1', 'bullet 2'],
+    answer: null,
+  },
+  {
+    id: 3,
+    text: 'Criterion 3',
+    answer: null,
+  },
+];
+
+const previousPage = 'previousPage';
+
+const userToken = 'testToken';
+
+const aMockError = () => new Error();
+
+const getHttpMocks = (criteriaResponses: EligibilityReqBody = {}) =>
+  createMocks<PostEligibilityRequest>({
+    params: { dealId, facilityId, amendmentId },
+    session: {
+      user: { ...aPortalSessionUser(), roles: [ROLES.MAKER] },
+      userToken,
+      loginStatus: PORTAL_LOGIN_STATUS.VALID_2FA,
+    },
+    body: {
+      ...criteriaResponses,
+      previousPage,
+    },
+  });
+
+const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
+
+describe('postEligibility', () => {
+  let amendment: PortalFacilityAmendmentWithUkefId;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+
+    jest.spyOn(dtfsCommon, 'isPortalFacilityAmendmentsFeatureFlagEnabled').mockReturnValue(true);
+    jest.spyOn(console, 'error');
+
+    amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder()
+      .withDealId(dealId)
+      .withFacilityId(facilityId)
+      .withAmendmentId(amendmentId)
+      .withCriteria(criteria)
+      .build();
+
+    getApplicationMock.mockResolvedValue(mockDeal);
+    getAmendmentMock.mockResolvedValue(amendment);
+    getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    updateAmendmentMock.mockResolvedValue(amendment);
+  });
+
+  it('should call getApplication with the correct dealId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(getApplicationMock).toHaveBeenCalledTimes(1);
+    expect(getApplicationMock).toHaveBeenCalledWith({ dealId, userToken: req.session.userToken });
+  });
+
+  it('should call getFacility with the correct facilityId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(getFacilityMock).toHaveBeenCalledTimes(1);
+    expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should redirect if the facility is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getFacilityMock.mockResolvedValue({ details: undefined });
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual('/not-found');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
+  });
+
+  it('should redirect if the deal is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getApplicationMock.mockResolvedValue(undefined);
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual('/not-found');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', amendmentId, facilityId);
+  });
+
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual('/not-found');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found on facility %s', dealId, facilityId);
+  });
+
+  it('should render `problem with service` if getApplication throws an error', async () => {
+    // Arrange
+    const mockError = aMockError();
+    getApplicationMock.mockRejectedValue(mockError);
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Error posting amendments eligibility page %o', mockError);
+  });
+
+  it('should render `problem with service` if getFacility throws an error', async () => {
+    // Arrange
+    const mockError = aMockError();
+    getFacilityMock.mockRejectedValue(mockError);
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Error posting amendments eligibility page %o', mockError);
+  });
+
+  it('should render `problem with service` if getAmendment throws an error', async () => {
+    // Arrange
+    const mockError = aMockError();
+    getAmendmentMock.mockRejectedValue(mockError);
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Error posting amendments eligibility page %o', mockError);
+  });
+
+  describe('when there are missing criteria responses', () => {
+    const responseWithMissingAnswers = {
+      '1': 'true',
+      '3': 'false',
+    };
+
+    it('should not call updateAmendment', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks(responseWithMissingAnswers);
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      expect(updateAmendmentMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should render the page with validation errors', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks(responseWithMissingAnswers);
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      const parsedResponse = parseEligibilityResponse(responseWithMissingAnswers, criteria);
+
+      const expectedRenderData: EligibilityViewModel = {
+        exporterName: mockDeal.exporter.companyName,
+        facilityType: MOCK_ISSUED_FACILITY.details.type,
+        cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
+        previousPage,
+        errors: validationErrorHandler((validateEligibilityResponse(parsedResponse) as { errors: ValidationError[] }).errors),
+        criteria: parsedResponse,
+      };
+
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._getRenderView()).toEqual('partials/amendments/eligibility.njk');
+      expect(res._getRenderData()).toEqual(expectedRenderData);
+    });
+  });
+
+  describe('when answers to all criteria have been submitted', () => {
+    const responseWithAllAnswers = {
+      '1': 'true',
+      '2': 'true',
+      '3': 'false',
+    };
+
+    it('should call updateAmendment ', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks(responseWithAllAnswers);
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      const parsedResponse = parseEligibilityResponse(responseWithAllAnswers, criteria);
+
+      expect(updateAmendmentMock).toHaveBeenCalledTimes(1);
+      expect(updateAmendmentMock).toHaveBeenCalledWith({
+        facilityId,
+        amendmentId,
+        update: { eligibilityCriteria: { criteria: parsedResponse, version: amendment.eligibilityCriteria.version } },
+        userToken,
+      });
+      expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not call console.error', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks(responseWithAllAnswers);
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should redirect to the next page', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks(responseWithAllAnswers);
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+      expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment));
+    });
+
+    it('should render `problem with service` if updateAmendment throws an error', async () => {
+      // Arrange
+      const mockError = aMockError();
+      updateAmendmentMock.mockRejectedValue(mockError);
+      const { req, res } = getHttpMocks(responseWithAllAnswers);
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      expect(res._getRenderView()).toEqual('partials/problem-with-service.njk');
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith('Error posting amendments eligibility page %o', mockError);
+    });
+  });
+});

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
@@ -4,7 +4,7 @@ import * as api from '../../../services/api';
 import { asLoggedInUserSession } from '../../../utils/express-session';
 import { EligibilityReqBody, parseEligibilityResponse } from '../helpers/eligibility.helper.ts';
 import { EligibilityViewModel } from '../../../types/view-models/amendments/eligibility-view-model.ts';
-import { getNextPage } from '../helpers/navigation.helper.ts';
+import { getAmendmentsUrl, getNextPage } from '../helpers/navigation.helper.ts';
 import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments.ts';
 import { validationErrorHandler } from '../../../utils/helpers';
 import { validateEligibilityResponse } from './validation.ts';
@@ -56,7 +56,7 @@ export const postEligibility = async (req: PostEligibilityRequest, res: Response
       const viewModel: EligibilityViewModel = {
         exporterName: deal.exporter.companyName,
         facilityType: facility.type,
-        cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
+        cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
         previousPage,
         criteria: parsedResponse,
         errors: validationErrorHandler(errorsOrValidCriteria.errors),

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
@@ -1,0 +1,77 @@
+import { CustomExpressRequest } from '@ukef/dtfs2-common';
+import { Response } from 'express';
+import * as api from '../../../services/api';
+import { asLoggedInUserSession } from '../../../utils/express-session';
+import { EligibilityReqBody, parseEligibilityResponse } from '../helpers/eligibility.helper.ts';
+import { EligibilityViewModel } from '../../../types/view-models/amendments/eligibility-view-model.ts';
+import { getNextPage } from '../helpers/navigation.helper.ts';
+import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments.ts';
+import { validationErrorHandler } from '../../../utils/helpers';
+import { validateEligibilityResponse } from './validation.ts';
+
+export type PostEligibilityRequest = CustomExpressRequest<{
+  params: { dealId: string; facilityId: string; amendmentId: string };
+  reqBody: EligibilityReqBody & { previousPage: string };
+}>;
+
+/**
+ * Controller to post eligibility criteria responses
+ * @param req - The express request
+ * @param res - The express response
+ */
+export const postEligibility = async (req: PostEligibilityRequest, res: Response) => {
+  try {
+    const { dealId, facilityId, amendmentId } = req.params;
+    const { previousPage } = req.body;
+    const { userToken } = asLoggedInUserSession(req.session);
+
+    const deal = await api.getApplication({ dealId, userToken });
+    const { details: facility } = await api.getFacility({ facilityId, userToken });
+
+    if (!deal || !facility) {
+      console.error('Deal %s or Facility %s was not found', dealId, facilityId);
+      return res.redirect('/not-found');
+    }
+
+    const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
+    if (!amendment) {
+      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      return res.redirect('/not-found');
+    }
+
+    const {
+      eligibilityCriteria: { version, criteria },
+    } = amendment;
+
+    if (!criteria) {
+      console.error('Eligibility criteria was not found on amendment %s on facility %s', amendmentId, facilityId);
+      return res.redirect('/not-found');
+    }
+
+    const parsedResponse = parseEligibilityResponse(req.body, criteria);
+
+    const errorsOrValidCriteria = validateEligibilityResponse(parsedResponse);
+
+    if ('errors' in errorsOrValidCriteria) {
+      const viewModel: EligibilityViewModel = {
+        exporterName: deal.exporter.companyName,
+        facilityType: facility.type,
+        cancelUrl: `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/cancel`,
+        previousPage,
+        criteria: parsedResponse,
+        errors: validationErrorHandler(errorsOrValidCriteria.errors),
+      };
+
+      return res.render('partials/amendments/eligibility.njk', viewModel);
+    }
+
+    const update = { eligibilityCriteria: { version, criteria: errorsOrValidCriteria.value } };
+
+    const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
+
+    return res.redirect(getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, updatedAmendment));
+  } catch (error) {
+    console.error('Error posting amendments eligibility page %o', error);
+    return res.render('partials/problem-with-service.njk');
+  }
+};

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/validation.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/validation.test.ts
@@ -1,0 +1,80 @@
+import { validateEligibilityResponse } from './validation';
+
+const validCriterion1 = { id: 1, text: 'Criterion 1', answer: true };
+const invalidCriterion1 = { id: 1, text: 'Criterion 1', answer: null };
+
+const validCriterion2 = { id: 2, text: 'Criterion 2', answer: false };
+const invalidCriterion2 = { id: 2, text: 'Criterion 2', answer: null };
+
+const validCriterion3 = { id: 3, text: 'Criterion 3', textList: ['bullet point 1', 'bullet point 2'], answer: true };
+const invalidCriterion3 = { id: 3, text: 'Criterion 3', textList: ['bullet point 1', 'bullet point 2'], answer: null };
+
+describe('validateEligibilityResponse', () => {
+  const errorTestCases = [
+    {
+      description: 'one criterion is invalid',
+      value: [validCriterion1, invalidCriterion2, validCriterion3],
+      expectedErrors: [
+        {
+          errRef: '2',
+          errMsg: 'Select if criterion 2',
+        },
+      ],
+    },
+    {
+      description: 'two criteria are invalid',
+      value: [validCriterion1, invalidCriterion2, invalidCriterion3],
+      expectedErrors: [
+        {
+          errRef: '2',
+          errMsg: 'Select if criterion 2',
+        },
+        {
+          errRef: '3',
+          errMsg: 'Select if criterion 3',
+        },
+      ],
+    },
+    {
+      description: 'all criteria are invalid',
+      value: [invalidCriterion1, invalidCriterion2, invalidCriterion3],
+      expectedErrors: [
+        {
+          errRef: '1',
+          errMsg: 'Select if criterion 1',
+        },
+        {
+          errRef: '2',
+          errMsg: 'Select if criterion 2',
+        },
+        {
+          errRef: '3',
+          errMsg: 'Select if criterion 3',
+        },
+      ],
+    },
+  ];
+
+  it.each(errorTestCases)('should return the correct error when $description', ({ value, expectedErrors }) => {
+    // Act
+    const result = validateEligibilityResponse(value);
+
+    // Assert
+    expect(result).toEqual({ errors: expectedErrors });
+  });
+
+  const successTestCases = [
+    {
+      description: 'all criteria are valid',
+      value: [validCriterion1, validCriterion2, validCriterion3],
+    },
+  ];
+
+  it.each(successTestCases)('should return the value as the original passed in array when $description', ({ value }) => {
+    // Act
+    const result = validateEligibilityResponse(value);
+
+    // Assert
+    expect(result).toEqual({ value });
+  });
+});

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/validation.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/validation.ts
@@ -1,0 +1,29 @@
+import { AmendmentsEligibilityCriterion, AmendmentsEligibilityCriterionWithAnswer } from '@ukef/dtfs2-common';
+import { ValidationError } from '../../../types/validation-error.ts';
+import { ErrorsOrValue } from '../../../types/errors-or-value.ts';
+
+type criterionWithValidAnswer = AmendmentsEligibilityCriterion & {
+  answer: boolean;
+};
+
+/**
+ * Validates the eligibility response
+ * @param parsedResponse - the parsed response
+ * @returns the value or errors depending on the validation result
+ */
+export const validateEligibilityResponse = (parsedResponse: AmendmentsEligibilityCriterionWithAnswer[]): ErrorsOrValue<criterionWithValidAnswer[]> => {
+  const errors: ValidationError[] = [];
+
+  parsedResponse.forEach((item: AmendmentsEligibilityCriterionWithAnswer) => {
+    const { id, text, answer } = item;
+
+    if (answer === null) {
+      errors.push({
+        errRef: id.toString(),
+        errMsg: `Select if ${text.charAt(0).toLowerCase() + text.slice(1)}`,
+      });
+    }
+  });
+
+  return errors.length ? { errors } : { value: parsedResponse as criterionWithValidAnswer[] };
+};

--- a/gef-ui/server/controllers/amendments/helpers/eligibility.helper.parseEligibilityResponse.test.ts
+++ b/gef-ui/server/controllers/amendments/helpers/eligibility.helper.parseEligibilityResponse.test.ts
@@ -1,0 +1,160 @@
+import { parseEligibilityResponse } from './eligibility.helper.ts';
+
+const currentCriteriaBooleanResponses = [
+  {
+    id: 1,
+    text: 'Criterion 1',
+    answer: true,
+  },
+  {
+    id: 2,
+    text: 'Criterion 2',
+    textList: ['bullet 1', 'bullet 2'],
+    answer: false,
+  },
+  {
+    id: 3,
+    text: 'Criterion 3',
+    answer: false,
+  },
+];
+
+const currentCriteriaNullResponses = [
+  {
+    id: 1,
+    text: 'Criterion 1',
+    answer: null,
+  },
+  {
+    id: 2,
+    text: 'Criterion 2',
+    textList: ['bullet 1', 'bullet 2'],
+    answer: null,
+  },
+  {
+    id: 3,
+    text: 'Criterion 3',
+    answer: null,
+  },
+];
+
+describe('parseEligibilityResponse', () => {
+  describe('when the response body contains responses for all criteria', () => {
+    const responseBodyAllCriteria = {
+      '1': 'false',
+      '2': 'true',
+      '3': 'false',
+    };
+
+    it('should return the eligibility criteria with the new responses replacing boolean values', () => {
+      // Act
+      const result = parseEligibilityResponse(responseBodyAllCriteria, currentCriteriaBooleanResponses);
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: 1,
+          text: 'Criterion 1',
+          answer: false,
+        },
+        {
+          id: 2,
+          text: 'Criterion 2',
+          textList: ['bullet 1', 'bullet 2'],
+          answer: true,
+        },
+        {
+          id: 3,
+          text: 'Criterion 3',
+          answer: false,
+        },
+      ]);
+    });
+
+    it('should return the eligibility criteria with the new responses replacing null values', () => {
+      // Act
+      const result = parseEligibilityResponse(responseBodyAllCriteria, currentCriteriaNullResponses);
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: 1,
+          text: 'Criterion 1',
+          answer: false,
+        },
+        {
+          id: 2,
+          text: 'Criterion 2',
+          textList: ['bullet 1', 'bullet 2'],
+          answer: true,
+        },
+        {
+          id: 3,
+          text: 'Criterion 3',
+          answer: false,
+        },
+      ]);
+    });
+  });
+
+  describe('when the response body is missing responses for some criteria', () => {
+    const responseBodyMissingCriteria = {
+      '1': 'true',
+      '3': 'false',
+    };
+
+    it('should return the eligibility criteria with the missing answers as null', () => {
+      // Act
+      const result = parseEligibilityResponse(responseBodyMissingCriteria, currentCriteriaBooleanResponses);
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: 1,
+          text: 'Criterion 1',
+          answer: true,
+        },
+        {
+          id: 2,
+          text: 'Criterion 2',
+          textList: ['bullet 1', 'bullet 2'],
+          answer: null,
+        },
+        {
+          id: 3,
+          text: 'Criterion 3',
+          answer: false,
+        },
+      ]);
+    });
+  });
+
+  describe('when the response body is missing responses for all criteria', () => {
+    const responseBodyNoCriteria = {};
+
+    it('should return the eligibility criteria with all answers as null', () => {
+      // Act
+      const result = parseEligibilityResponse(responseBodyNoCriteria, currentCriteriaBooleanResponses);
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: 1,
+          text: 'Criterion 1',
+          answer: null,
+        },
+        {
+          id: 2,
+          text: 'Criterion 2',
+          textList: ['bullet 1', 'bullet 2'],
+          answer: null,
+        },
+        {
+          id: 3,
+          text: 'Criterion 3',
+          answer: null,
+        },
+      ]);
+    });
+  });
+});

--- a/gef-ui/server/controllers/amendments/helpers/eligibility.helper.parseStringAsBoolean.test.ts
+++ b/gef-ui/server/controllers/amendments/helpers/eligibility.helper.parseStringAsBoolean.test.ts
@@ -13,11 +13,6 @@ describe('parseStringAsBoolean', () => {
       expected: false,
     },
     {
-      description: 'should return null when the string is empty',
-      value: '',
-      expected: null,
-    },
-    {
       description: 'should return null when the string is "asdf"',
       value: 'asdf',
       expected: null,

--- a/gef-ui/server/controllers/amendments/helpers/eligibility.helper.parseStringAsBoolean.test.ts
+++ b/gef-ui/server/controllers/amendments/helpers/eligibility.helper.parseStringAsBoolean.test.ts
@@ -1,0 +1,49 @@
+import { parseStringAsBoolean } from './eligibility.helper.ts';
+
+describe('parseStringAsBoolean', () => {
+  const testCases = [
+    {
+      description: 'should return a true boolean when the string is "true"',
+      value: 'true',
+      expected: true,
+    },
+    {
+      description: 'should return a false boolean when the string is "false"',
+      value: 'false',
+      expected: false,
+    },
+    {
+      description: 'should return null when the string is empty',
+      value: '',
+      expected: null,
+    },
+    {
+      description: 'should return null when the string is "asdf"',
+      value: 'asdf',
+      expected: null,
+    },
+    {
+      description: 'should return null when the string is "True"',
+      value: 'True',
+      expected: null,
+    },
+    {
+      description: 'should return null when the string is "False"',
+      value: 'False',
+      expected: null,
+    },
+    {
+      description: 'should return null when the string is empty',
+      value: '',
+      expected: null,
+    },
+  ];
+
+  it.each(testCases)('$description', ({ value, expected }) => {
+    // Act
+    const result = parseStringAsBoolean(value);
+
+    // Assert
+    expect(result).toEqual(expected);
+  });
+});

--- a/gef-ui/server/controllers/amendments/helpers/eligibility.helper.ts
+++ b/gef-ui/server/controllers/amendments/helpers/eligibility.helper.ts
@@ -1,0 +1,50 @@
+import { AmendmentsEligibilityCriterionWithAnswer } from '@ukef/dtfs2-common';
+
+export type EligibilityReqBody = {
+  [key: string]: string;
+};
+
+/**
+ * Parses the result of the nunjucks radio boxes ('true' or 'false') as a boolean
+ * @param value - the string to parse as a boolean
+ * @returns the value as a boolean if it was 'true' or 'false', otherwise null
+ */
+export const parseStringAsBoolean = (value: string): boolean | null => {
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return null;
+};
+
+/**
+ * The nunjucks file returns the eligibility criteria responses as an object of the form e.g. { '1': 'true', '2': 'false', '3': 'true' }.
+ * This function returns the eligibility criteria responses in an array of objects more suitable for database storage: [{ id: 1, text: 'criteria 1 text', answer: true }, { id: 2, .... }, ... ]
+ * @param responseBody - the response received from the nunjucks file after user submission
+ * @param currentCriteriaResponses - the eligibility criteria existing on the amendment, these may have previous answers attached to them or all have null for the `answer` field
+ * @returns eligibility criteria responses in a format to validate and save to the amendment
+ */
+export const parseEligibilityResponse = (
+  responseBody: EligibilityReqBody,
+  currentCriteriaResponses: AmendmentsEligibilityCriterionWithAnswer[],
+): AmendmentsEligibilityCriterionWithAnswer[] => {
+  const criteriaWithNewResponses: AmendmentsEligibilityCriterionWithAnswer[] = [];
+
+  currentCriteriaResponses.forEach((item: AmendmentsEligibilityCriterionWithAnswer) => {
+    const { id, text, textList } = item;
+
+    const answer = responseBody[id.toString()] ? parseStringAsBoolean(responseBody[id.toString()]) : null;
+
+    if (textList?.length) {
+      criteriaWithNewResponses.push({ id, text, textList, answer });
+    } else {
+      criteriaWithNewResponses.push({ id, text, answer });
+    }
+  });
+
+  return criteriaWithNewResponses;
+};

--- a/gef-ui/server/controllers/amendments/helpers/eligibility.helper.ts
+++ b/gef-ui/server/controllers/amendments/helpers/eligibility.helper.ts
@@ -32,18 +32,10 @@ export const parseEligibilityResponse = (
   responseBody: EligibilityReqBody,
   currentCriteriaResponses: AmendmentsEligibilityCriterionWithAnswer[],
 ): AmendmentsEligibilityCriterionWithAnswer[] => {
-  const criteriaWithNewResponses: AmendmentsEligibilityCriterionWithAnswer[] = [];
+  const criteriaWithNewResponses = currentCriteriaResponses.map((criterion: AmendmentsEligibilityCriterionWithAnswer) => {
+    const newAnswer = responseBody[criterion.id.toString()] ? parseStringAsBoolean(responseBody[criterion.id.toString()]) : null;
 
-  currentCriteriaResponses.forEach((item: AmendmentsEligibilityCriterionWithAnswer) => {
-    const { id, text, textList } = item;
-
-    const answer = responseBody[id.toString()] ? parseStringAsBoolean(responseBody[id.toString()]) : null;
-
-    if (textList?.length) {
-      criteriaWithNewResponses.push({ id, text, textList, answer });
-    } else {
-      criteriaWithNewResponses.push({ id, text, answer });
-    }
+    return { ...criterion, answer: newAnswer };
   });
 
   return criteriaWithNewResponses;

--- a/gef-ui/server/routes/facilities/amendments/index.ts
+++ b/gef-ui/server/routes/facilities/amendments/index.ts
@@ -18,6 +18,7 @@ import { getFacilityEndDate } from '../../../controllers/amendments/facility-end
 import { postFacilityEndDate } from '../../../controllers/amendments/facility-end-date/post-facility-end-date';
 import { getBankReviewDate } from '../../../controllers/amendments/bank-review-date/get-bank-review-date.ts';
 import { getEligibility } from '../../../controllers/amendments/eligibility-criteria/get-eligibility.ts';
+import { postEligibility } from '../../../controllers/amendments/eligibility-criteria/post-eligibility.ts';
 
 const { WHAT_DO_YOU_NEED_TO_CHANGE, COVER_END_DATE, FACILITY_VALUE, DO_YOU_HAVE_A_FACILITY_END_DATE, FACILITY_END_DATE, BANK_REVIEW_DATE, ELIGIBILITY } =
   PORTAL_AMENDMENT_PAGES;
@@ -72,6 +73,7 @@ router
 router
   .route(`/application-details/:dealId/facilities/:facilityId/amendments/:amendmentId/${ELIGIBILITY}`)
   .all([validatePortalFacilityAmendmentsEnabled, validateToken, validateBank, validateRole({ role: [MAKER] })])
-  .get(getEligibility);
+  .get(getEligibility)
+  .post(postEligibility);
 
 export default router;


### PR DESCRIPTION
## Introduction :pencil2:
Handle a user presseing 'continue' on the eligibility page - either displaying validation errors or posting ot the amendment. 

**E2E tests will be added as a seperate PR**
## Resolution :heavy_check_mark:
- Parse the radio check box result from the nunjucks file
- Validate the response and display error messages if any missing criteria
- Update the amendment if a valid selection is submitted

## Screenshots 📷 :
<img width="682" alt="image" src="https://github.com/user-attachments/assets/b76dd5da-e238-4ab0-9a40-f337a69e3e9a" />


<img width="729" alt="image" src="https://github.com/user-attachments/assets/e7ead42f-da16-4b67-9ef4-5d8895902c2a" />
