### PR TITLE
feat(FN-3819): save bankTeamName, bankTeamEmails in fee record correction table

### DIFF
--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/correction-requested/correction-requested.event-handler.test.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/correction-requested/correction-requested.event-handler.test.ts
@@ -23,6 +23,9 @@ describe('handleFeeRecordCorrectionRequestedEvent', () => {
     lastName: 'User',
   };
 
+  const bankTeamName = 'Payment Officer Team';
+  const bankTeamEmails = 'test@ukexportfinance.gov.uk';
+
   const aCorrectionRequestedEventPayload = (): FeeRecordCorrectionRequestedEvent['payload'] => ({
     transactionEntityManager: mockEntityManager,
     reasons: [RECORD_CORRECTION_REASON.REPORTED_CURRENCY_INCORRECT],
@@ -31,6 +34,8 @@ describe('handleFeeRecordCorrectionRequestedEvent', () => {
       ...requestedByUser,
     },
     requestSource: aDbRequestSource(),
+    bankTeamName,
+    bankTeamEmails,
   });
 
   afterEach(() => {
@@ -104,6 +109,8 @@ describe('handleFeeRecordCorrectionRequestedEvent', () => {
       additionalInfo,
       requestedByUser,
       requestSource,
+      bankTeamName,
+      bankTeamEmails,
     });
 
     // Assert
@@ -113,6 +120,8 @@ describe('handleFeeRecordCorrectionRequestedEvent', () => {
       reasons,
       additionalInfo,
       requestSource,
+      bankTeamName,
+      bankTeamEmails,
     });
     expect(mockSave).toHaveBeenCalledWith(FeeRecordCorrectionEntity, newCorrection);
   });

--- a/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/correction-requested/correction-requested.event-handler.ts
+++ b/dtfs-central-api/src/services/state-machines/fee-record/event-handlers/correction-requested/correction-requested.event-handler.ts
@@ -8,6 +8,8 @@ type CorrectionRequestedEventPayload = {
   requestedByUser: RequestedByUser;
   reasons: RecordCorrectionReason[];
   additionalInfo: string;
+  bankTeamName: string;
+  bankTeamEmails: string;
 };
 
 export type FeeRecordCorrectionRequestedEvent = BaseFeeRecordEvent<'CORRECTION_REQUESTED', CorrectionRequestedEventPayload>;
@@ -25,7 +27,7 @@ export type FeeRecordCorrectionRequestedEvent = BaseFeeRecordEvent<'CORRECTION_R
  */
 export const handleFeeRecordCorrectionRequestedEvent = async (
   feeRecord: FeeRecordEntity,
-  { transactionEntityManager, requestSource, requestedByUser, reasons, additionalInfo }: CorrectionRequestedEventPayload,
+  { transactionEntityManager, requestSource, requestedByUser, reasons, additionalInfo, bankTeamName, bankTeamEmails }: CorrectionRequestedEventPayload,
 ): Promise<FeeRecordEntity> => {
   const correction = FeeRecordCorrectionEntity.createRequestedCorrection({
     feeRecord,
@@ -33,6 +35,8 @@ export const handleFeeRecordCorrectionRequestedEvent = async (
     reasons,
     additionalInfo,
     requestSource,
+    bankTeamName,
+    bankTeamEmails,
   });
 
   await transactionEntityManager.save(FeeRecordCorrectionEntity, correction);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/post-fee-record-correction.controller/helpers.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/post-fee-record-correction.controller/helpers.ts
@@ -2,8 +2,7 @@ import { getFormattedReportPeriodWithLongMonth, mapReasonToDisplayValue, RecordC
 import externalApi from '../../../../../external-api/api';
 import EMAIL_TEMPLATE_IDS from '../../../../../constants/email-template-ids';
 import { FeeRecordCorrectionRequestEmails, FeeRecordCorrectionRequestEmailAddresses } from '../../../../../types/utilisation-reports';
-import { getBankById } from '../../../../../repositories/banks-repo';
-import { NotFoundError } from '../../../../../errors';
+import { getBankPaymentOfficerTeamDetails } from '../../helpers/get-bank-payment-officer-team-details';
 
 /**
  * Formats the reasons for record correction into a bulleted list.
@@ -34,14 +33,7 @@ export const generateFeeRecordCorrectionRequestEmailParameters = async (
   bankId: string,
   requestedByUserEmail: string,
 ): Promise<FeeRecordCorrectionRequestEmails> => {
-  const bank = await getBankById(bankId);
-
-  if (!bank) {
-    console.error('Bank not found: %s', bankId);
-    throw new NotFoundError(`Bank not found: ${bankId}`);
-  }
-
-  const { teamName, emails } = bank.paymentOfficerTeam;
+  const { teamName, emails } = await getBankPaymentOfficerTeamDetails(bankId);
 
   const reportPeriodString = getFormattedReportPeriodWithLongMonth(reportPeriod);
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/post-fee-record-correction.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/post-fee-record-correction.controller/index.test.ts
@@ -19,12 +19,14 @@ import { FEE_RECORD_EVENT_TYPE } from '../../../../../services/state-machines/fe
 import { FeeRecordRepo } from '../../../../../repositories/fee-record-repo';
 import { sendFeeRecordCorrectionRequestEmails } from './helpers';
 import { FeeRecordCorrectionRequestEmailAddresses } from '../../../../../types/utilisation-reports';
+import { getBankPaymentOfficerTeamDetails } from '../../helpers/get-bank-payment-officer-team-details';
 
 jest.mock('../../../../../helpers');
 jest.mock('../../../../../services/state-machines/fee-record/fee-record.state-machine');
 jest.mock('../../../../../repositories/fee-record-correction-request-transient-form-data-repo');
 jest.mock('../../../../../repositories/fee-record-repo');
 jest.mock('./helpers');
+jest.mock('../../helpers/get-bank-payment-officer-team-details');
 
 console.error = jest.fn();
 
@@ -40,6 +42,14 @@ describe('post-fee-record-correction.controller', () => {
     const mockHandleEvent = jest.fn();
     const mockForFeeRecordStateMachineConstructor = jest.fn();
 
+    const mockTeamName = 'Mock team name';
+    const mockEmails = ['test1@ukexportfinance.gov.uk', 'test2@ukexportfinance.gov.uk'];
+
+    const getBankPaymentOfficerTeamDetailsResponse = {
+      teamName: mockTeamName,
+      emails: mockEmails,
+    };
+
     beforeEach(() => {
       jest.mocked(executeWithSqlTransaction).mockImplementation(async (functionToExecute) => {
         return await functionToExecute(mockEntityManager);
@@ -54,6 +64,7 @@ describe('post-fee-record-correction.controller', () => {
         deleteByUserIdAndFeeRecordId: mockDeleteTransientFormData,
       });
       jest.spyOn(FeeRecordRepo, 'withTransaction').mockReturnValue({ findOneByIdAndReportIdWithReport: mockFindFeeRecordWithReport });
+      jest.mocked(getBankPaymentOfficerTeamDetails).mockResolvedValue(getBankPaymentOfficerTeamDetailsResponse);
     });
 
     afterEach(() => {
@@ -171,6 +182,8 @@ describe('post-fee-record-correction.controller', () => {
             platform: REQUEST_PLATFORM_TYPE.TFM,
             userId,
           },
+          bankTeamName: mockTeamName,
+          bankTeamEmails: mockEmails.join(', '),
         };
 
         // Act

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/post-fee-record-correction.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/fee-record-correction/post-fee-record-correction.controller/index.ts
@@ -11,6 +11,7 @@ import { PostFeeRecordCorrectionPayload } from '../../../../routes/middleware/pa
 import { FeeRecordRepo } from '../../../../../repositories/fee-record-repo';
 import { sendFeeRecordCorrectionRequestEmails } from './helpers';
 import { FeeRecordCorrectionRequestEmailAddresses } from '../../../../../types/utilisation-reports';
+import { getBankPaymentOfficerTeamDetails } from '../../helpers/get-bank-payment-officer-team-details';
 
 export type PostFeeRecordCorrectionRequest = CustomExpressRequest<{
   params: {
@@ -64,6 +65,10 @@ export const postFeeRecordCorrection = async (req: PostFeeRecordCorrectionReques
         throw new NotFoundError(`Failed to find a fee record with id ${feeRecordId} and report id ${reportId}`);
       }
 
+      const { teamName, emails } = await getBankPaymentOfficerTeamDetails(feeRecord.report.bankId);
+
+      const bankTeamEmails = emails.join(', ');
+
       const stateMachine = FeeRecordStateMachine.forFeeRecord(feeRecord);
 
       await stateMachine.handleEvent({
@@ -81,6 +86,8 @@ export const postFeeRecordCorrection = async (req: PostFeeRecordCorrectionReques
             platform: REQUEST_PLATFORM_TYPE.TFM,
             userId,
           },
+          bankTeamName: teamName,
+          bankTeamEmails,
         },
       });
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-bank-payment-officer-team-details.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-bank-payment-officer-team-details.test.ts
@@ -1,0 +1,54 @@
+import { getBankPaymentOfficerTeamDetails } from './get-bank-payment-officer-team-details';
+import { aBank } from '../../../../../test-helpers';
+import { getBankById } from '../../../../repositories/banks-repo';
+import { NotFoundError } from '../../../../errors';
+
+jest.mock('../../../../repositories/banks-repo');
+
+console.error = jest.fn();
+
+describe('get-bank-payment-officer-team-details', () => {
+  const firstPaymentOfficerEmail = 'officer-1@example.com';
+  const secondPaymentOfficerEmail = 'officer-2@example.com';
+  const teamName = 'Payment Officer Team';
+
+  const bankId = '123';
+
+  const bank = {
+    ...aBank(),
+    paymentOfficerTeam: {
+      teamName,
+      emails: [firstPaymentOfficerEmail, secondPaymentOfficerEmail],
+    },
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when a bank is found', () => {
+    it('should return the bank payment officer team details', async () => {
+      jest.mocked(getBankById).mockResolvedValue(bank);
+
+      const result = await getBankPaymentOfficerTeamDetails(bankId);
+
+      const expected = {
+        emails: [firstPaymentOfficerEmail, secondPaymentOfficerEmail],
+        teamName,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a bank is not found', () => {
+    it('should throw a NotFoundError', async () => {
+      // Arrange
+      jest.mocked(getBankById).mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(getBankPaymentOfficerTeamDetails(bankId)).rejects.toThrow(new NotFoundError(`Bank not found: ${bankId}`));
+      expect(console.error).toHaveBeenCalledWith('Bank not found: %s', bankId);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-bank-payment-officer-team-details.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-bank-payment-officer-team-details.ts
@@ -1,0 +1,18 @@
+import { getBankById } from '../../../../repositories/banks-repo';
+import { NotFoundError } from '../../../../errors';
+
+export const getBankPaymentOfficerTeamDetails = async (bankId: string) => {
+  const bank = await getBankById(bankId);
+
+  if (!bank) {
+    console.error('Bank not found: %s', bankId);
+    throw new NotFoundError(`Bank not found: ${bankId}`);
+  }
+
+  const { teamName, emails } = bank.paymentOfficerTeam;
+
+  return {
+    emails,
+    teamName,
+  };
+};

--- a/libs/common/src/sql-db-connection/migrations/1732803141766-AddFeeRecordCorrectionTable.ts
+++ b/libs/common/src/sql-db-connection/migrations/1732803141766-AddFeeRecordCorrectionTable.ts
@@ -19,7 +19,9 @@ export class AddFeeRecordCorrectionTable1732803141766 implements MigrationInterf
                 "lastUpdatedByPortalUserId" nvarchar(255),
                 "lastUpdatedByTfmUserId" nvarchar(255),
                 "lastUpdatedByIsSystemUser" bit NOT NULL CONSTRAINT "DF_da9ebf56aea47e1ca26c5d38cff" DEFAULT 0,
-                CONSTRAINT "PK_b9f1a68a02c0d2bafcf977331e5" PRIMARY KEY ("id")
+                CONSTRAINT "PK_b9f1a68a02c0d2bafcf977331e5" PRIMARY KEY ("id"),
+                "bankTeamName" nvarchar(500),
+                "bankTeamEmails" nvarchar(1000)
             )
         `);
     await queryRunner.query(`

--- a/libs/common/src/sql-db-entities/fee-record-correction/fee-record-correction.entity.test.ts
+++ b/libs/common/src/sql-db-entities/fee-record-correction/fee-record-correction.entity.test.ts
@@ -21,14 +21,27 @@ describe('FeeRecordEntity', () => {
         platform: REQUEST_PLATFORM_TYPE.TFM,
       };
 
+      const bankTeamName = 'Payment Officer Team';
+      const bankTeamEmails = 'test@ukexportfinance.gov.uk';
+
       // Act
-      const correctionEntity = FeeRecordCorrectionEntity.createRequestedCorrection({ feeRecord, requestedByUser, reasons, additionalInfo, requestSource });
+      const correctionEntity = FeeRecordCorrectionEntity.createRequestedCorrection({
+        feeRecord,
+        requestedByUser,
+        reasons,
+        additionalInfo,
+        requestSource,
+        bankTeamName,
+        bankTeamEmails,
+      });
 
       // Assert
       expect(correctionEntity.reasons).toEqual(reasons);
       expect(correctionEntity.additionalInfo).toEqual(additionalInfo);
       expect(correctionEntity.requestedByUser).toEqual(requestedByUser);
       expect(correctionEntity.isCompleted).toEqual(false);
+      expect(correctionEntity.bankTeamName).toEqual(bankTeamName);
+      expect(correctionEntity.bankTeamEmails).toEqual(bankTeamEmails);
     });
   });
 

--- a/libs/common/src/sql-db-entities/fee-record-correction/fee-record-correction.entity.ts
+++ b/libs/common/src/sql-db-entities/fee-record-correction/fee-record-correction.entity.ts
@@ -62,6 +62,18 @@ export class FeeRecordCorrectionEntity extends AuditableBaseEntity {
   bankCommentary!: string | null;
 
   /**
+   * Bank team name
+   */
+  @Column({ type: 'nvarchar', length: '500' })
+  bankTeamName!: string;
+
+  /**
+   * Bank team emails
+   */
+  @Column({ type: 'nvarchar', length: '1000' })
+  bankTeamEmails!: string;
+
+  /**
    * The previous values of the fields of the fee record that the
    * correction is correcting
    */
@@ -105,6 +117,8 @@ export class FeeRecordCorrectionEntity extends AuditableBaseEntity {
     reasons,
     additionalInfo,
     requestSource,
+    bankTeamName,
+    bankTeamEmails,
   }: CreateFeeRecordCorrectionParams): FeeRecordCorrectionEntity {
     const recordCorrection = new FeeRecordCorrectionEntity();
     recordCorrection.feeRecord = feeRecord;
@@ -113,6 +127,8 @@ export class FeeRecordCorrectionEntity extends AuditableBaseEntity {
     recordCorrection.additionalInfo = additionalInfo;
     recordCorrection.isCompleted = false;
     recordCorrection.updateLastUpdatedBy(requestSource);
+    recordCorrection.bankTeamName = bankTeamName;
+    recordCorrection.bankTeamEmails = bankTeamEmails;
     return recordCorrection;
   }
 

--- a/libs/common/src/sql-db-entities/fee-record-correction/fee-record-correction.types.ts
+++ b/libs/common/src/sql-db-entities/fee-record-correction/fee-record-correction.types.ts
@@ -8,6 +8,8 @@ export type CreateFeeRecordCorrectionParams = {
   reasons: RecordCorrectionReason[];
   additionalInfo: string;
   requestSource: DbRequestSource;
+  bankTeamName: string;
+  bankTeamEmails: string;
 };
 
 export type CompleteCorrectionParams = {

--- a/libs/common/src/test-helpers/mock-data/fee-record-correction.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record-correction.entity.mock-builder.ts
@@ -31,6 +31,8 @@ export class FeeRecordCorrectionEntityMockBuilder {
     };
     data.additionalInfo = 'some info';
     data.reasons = [RECORD_CORRECTION_REASON.UTILISATION_INCORRECT];
+    data.bankTeamName = 'some team';
+    data.bankTeamEmails = 'test1@ukexportfinance.gov.uk, test2@ukexportfinance.gov.uk';
 
     if (isCompleted) {
       data.isCompleted = true;


### PR DESCRIPTION
## Introduction :pencil2:
This PR saves bankTeamName and bankTeamEmails in the fee record correction table

## Resolution :heavy_check_mark:
* Added bankTeamName and bankTeamEmails to FeeRecordCorrectionEntity
* Added to migration for FeeRecordCorrection
* Added helper to get bank payment officer team details

