### PR TITLE
fix(DTFS2-7798): remove duplicate createdBy in portal-amendments swagger definitions

### DIFF
--- a/dtfs-central-api/src/v1/swagger-definitions/portal/portal-amendments.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/portal/portal-amendments.js
@@ -32,18 +32,6 @@
  *           - IN_PROGRESS
  *           - COMPLETED
  *         description: The current status of the amendment.
- *       createdBy:
- *         type: object
- *         properties:
- *           username:
- *             type: string
- *             description: The username of the creator.
- *           name:
- *             type: string
- *             description: The name of the creator.
- *           email:
- *             type: string
- *             description: The email of the creator.
  *       eligibilityCriteria:
  *         type: object
  *         properties:

--- a/e2e-tests/e2e-fixtures/dateConstants.js
+++ b/e2e-tests/e2e-fixtures/dateConstants.js
@@ -59,6 +59,8 @@ export const twelveMonthsOneDayAgo = getFormattedValues(sub(todayDate, { months:
 export const oneYearAgo = getFormattedValues(sub(todayDate, { years: 1 }));
 export const twoYearsAgo = getFormattedValues(sub(todayDate, { years: 2 }));
 
+export const addDays = (days) => getFormattedValues(add(todayDate, { days }));
+
 // Dates calculated from other values
 /**
  * This constant is used for calculating the deadline for issuing a facility with submission date three days ago.

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -1,7 +1,7 @@
 import { PORTAL_ACTIVITY_LABEL } from '@ukef/dtfs2-common';
 import relative from '../../relativeURL';
 import CONSTANTS from '../../../fixtures/constants';
-import { threeDaysAgo, threeMonthsOneDay, twoMonths, threeMonths } from '../../../../../e2e-fixtures/dateConstants';
+import { threeDaysAgo, addDays, twoMonths, threeMonths } from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
 import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockGefFacilities } from '../../../../../e2e-fixtures/mock-gef-facilities';
@@ -205,7 +205,13 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
 
       coverStartDate.coverStartDateNo().click();
 
-      cy.completeDateFormFields({ idPrefix: 'ukef-cover-start-date', date: threeMonthsOneDay.date });
+      /**
+       * 3 months in the future in codebase is calculated as 90 days from today
+       * hence to get date over 3 months in the future to cause an error to be displayed
+       * add 91 days to today
+       */
+      const days = 91;
+      cy.completeDateFormFields({ idPrefix: 'ukef-cover-start-date', date: addDays(days).date });
 
       cy.clickContinueButton();
 

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -1,7 +1,7 @@
 import { PORTAL_ACTIVITY_LABEL } from '@ukef/dtfs2-common';
 import relative from '../../relativeURL';
 import CONSTANTS from '../../../fixtures/constants';
-import { tomorrow, threeDaysAgo, threeMonthsOneDay } from '../../../../../e2e-fixtures/dateConstants';
+import { tomorrow, threeDaysAgo, addDays } from '../../../../../e2e-fixtures/dateConstants';
 import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
 import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockGefFacilities } from '../../../../../e2e-fixtures/mock-gef-facilities';

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -190,7 +190,13 @@ context('Review UKEF decision MIA -> confirm coverStartDate without issuing faci
 
       coverStartDate.coverStartDateNo().click();
 
-      cy.completeDateFormFields({ idPrefix: 'ukef-cover-start-date', date: threeMonthsOneDay.date });
+      /**
+       * 3 months in the future in codebase is calculated as 90 days from today
+       * hence to get date over 3 months in the future to cause an error to be displayed
+       * add 91 days to today
+       */
+      const days = 91;
+      cy.completeDateFormFields({ idPrefix: 'ukef-cover-start-date', date: addDays(days).date });
 
       cy.clickContinueButton();
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes the YAMLSemanticError: Map keys must be unique; "createdBy" is repeated at line 5, column 7 error

## Resolution :heavy_check_mark:
* Remove duplicated createdBy definition

