### PR TITLE
feat(FN-3615): set up endpoints and template for record correction details

### DIFF
--- a/dtfs-central-api/api-tests/v1/utilisation-reports/get-record-correction-log-details.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/utilisation-reports/get-record-correction-log-details.api-test.ts
@@ -1,0 +1,133 @@
+import { Response } from 'supertest';
+import { format } from 'date-fns';
+import {
+  Bank,
+  FeeRecordEntityMockBuilder,
+  RECONCILIATION_IN_PROGRESS,
+  FeeRecordCorrectionEntityMockBuilder,
+  UtilisationReportEntityMockBuilder,
+  ReportPeriod,
+  GetRecordCorrectionLogDetailsResponseBody,
+  DATE_FORMATS,
+} from '@ukef/dtfs2-common';
+import { HttpStatusCode, getUri } from 'axios';
+import { withSqlIdPathParameterValidationTests } from '@ukef/dtfs2-common/test-cases-backend';
+import { testApi } from '../../test-api';
+import { SqlDbHelper } from '../../sql-db-helper';
+import { wipe } from '../../wipeDB';
+import { mongoDbClient } from '../../../src/drivers/db-client';
+import { aBank } from '../../../test-helpers';
+
+const BASE_URL = '/v1/utilisation-reports/record-correction-log-details/:correctionId';
+
+interface CustomResponse extends Response {
+  body: GetRecordCorrectionLogDetailsResponseBody;
+}
+
+console.error = jest.fn();
+
+describe(`GET ${BASE_URL}`, () => {
+  const getUrl = (correctionId: number | string) =>
+    getUri({
+      url: BASE_URL.replace(':correctionId', correctionId.toString()),
+    });
+
+  const today = new Date();
+
+  const bankId = '123';
+  const bankName = 'Test bank';
+  const bank: Bank = {
+    ...aBank(),
+    id: bankId,
+    name: bankName,
+  };
+
+  const reportPeriod: ReportPeriod = {
+    start: { month: 1, year: 2024 },
+    end: { month: 1, year: 2024 },
+  };
+
+  const reportId = 1;
+  const feeRecordId = 2;
+
+  const reconciliationInProgressReport = UtilisationReportEntityMockBuilder.forStatus(RECONCILIATION_IN_PROGRESS)
+    .withId(reportId)
+    .withBankId(bankId)
+    .withReportPeriod(reportPeriod)
+    .build();
+
+  const feeRecord = FeeRecordEntityMockBuilder.forReport(reconciliationInProgressReport).withId(feeRecordId).build();
+
+  const recordCorrection = FeeRecordCorrectionEntityMockBuilder.forFeeRecordAndIsCompleted(feeRecord, false).withDateRequested(today).build();
+
+  beforeAll(async () => {
+    await SqlDbHelper.initialize();
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrection');
+
+    await wipe(['banks']);
+
+    const banksCollection = await mongoDbClient.getCollection('banks');
+    await banksCollection.insertOne(bank);
+  });
+
+  beforeEach(async () => {
+    await SqlDbHelper.saveNewEntry('UtilisationReport', reconciliationInProgressReport);
+    await SqlDbHelper.saveNewEntry('FeeRecord', feeRecord);
+    await SqlDbHelper.saveNewEntry('FeeRecordCorrection', recordCorrection);
+  });
+
+  afterEach(async () => {
+    await SqlDbHelper.deleteAllEntries('FeeRecord');
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrection');
+  });
+
+  afterAll(async () => {
+    await SqlDbHelper.deleteAllEntries('FeeRecord');
+    await SqlDbHelper.deleteAllEntries('UtilisationReport');
+    await SqlDbHelper.deleteAllEntries('FeeRecordCorrection');
+  });
+
+  withSqlIdPathParameterValidationTests({
+    baseUrl: BASE_URL,
+    makeRequest: (url) => testApi.get(url),
+  });
+
+  it(`returns a ${HttpStatusCode.NotFound} when the record correction cannot be found by id`, async () => {
+    // Act
+    const response: CustomResponse = await testApi.get(getUrl(recordCorrection.id + 1));
+
+    // Assert
+    expect(response.status).toEqual(HttpStatusCode.NotFound);
+  });
+
+  it(`returns a ${HttpStatusCode.Ok} when a correction with the provided id is found`, async () => {
+    // Act
+    const response: CustomResponse = await testApi.get(getUrl(recordCorrection.id));
+
+    const expected = {
+      correctionDetails: {
+        facilityId: feeRecord.facilityId,
+        exporter: feeRecord.exporter,
+        formattedReasons: 'Utilisation is incorrect',
+        formattedDateSent: format(today, DATE_FORMATS.DD_MMM_YYYY),
+        formattedOldRecords: '100.00',
+        formattedCorrectRecords: '-',
+        isCompleted: false,
+        bankTeamName: recordCorrection.bankTeamName,
+        formattedBankTeamEmails: 'test1@ukexportfinance.gov.uk, test2@ukexportfinance.gov.uk',
+        additionalInfo: recordCorrection.additionalInfo,
+        formattedBankCommentary: '-',
+        formattedDateReceived: '-',
+        formattedRequestedByUser: `${recordCorrection.requestedByUser.firstName} ${recordCorrection.requestedByUser.lastName}`,
+      },
+      bankName,
+      reportPeriod,
+    };
+
+    // Assert
+    expect(response.status).toEqual(HttpStatusCode.Ok);
+    expect(response.body).toEqual(expected);
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-record-correction-log-details.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-record-correction-log-details.controller/index.test.ts
@@ -1,0 +1,169 @@
+import httpMocks from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { FeeRecordCorrectionEntityMockBuilder } from '@ukef/dtfs2-common';
+import { getRecordCorrectionLogDetails } from '.';
+import { FeeRecordCorrectionRepo } from '../../../../repositories/fee-record-correction-repo';
+import { getRecordCorrectionFields } from '../helpers/get-record-correction-fields';
+import { getBankNameById } from '../../../../repositories/banks-repo';
+
+console.error = jest.fn();
+
+jest.mock('../../../../repositories/banks-repo');
+jest.mock('../../../../repositories/fee-record-correction-repo');
+
+describe('get-record-correction-log-details.controller', () => {
+  const correctionId = 1;
+  const bankName = 'Test bank';
+  const today = new Date();
+
+  const getHttpMocks = () =>
+    httpMocks.createMocks({
+      params: { correctionId: correctionId.toString() },
+    });
+
+  const findRecordCorrectionSpy = jest.spyOn(FeeRecordCorrectionRepo, 'findOneByIdWithFeeRecordAndReport');
+  const feeRecordCorrectionEntity = FeeRecordCorrectionEntityMockBuilder.forIsCompleted(false).withDateRequested(today).build();
+
+  beforeEach(() => {
+    findRecordCorrectionSpy.mockResolvedValue(null);
+    jest.mocked(getBankNameById).mockResolvedValue(bankName);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when a record correction is not found', () => {
+    beforeEach(() => {
+      findRecordCorrectionSpy.mockResolvedValue(null);
+    });
+
+    it(`should respond with ${HttpStatusCode.NotFound}`, async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
+      expect(res._getData()).toEqual('Record correction not found');
+    });
+
+    it('should call FeeRecordCorrectionRepo.findOneByIdWithFeeRecordAndReport once with the correctionId', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(findRecordCorrectionSpy).toHaveBeenCalledTimes(1);
+      expect(findRecordCorrectionSpy).toHaveBeenCalledWith(correctionId);
+    });
+
+    it('should NOT call getBankNameById', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(getBankNameById).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('when a bank is not found', () => {
+    beforeEach(() => {
+      findRecordCorrectionSpy.mockResolvedValue(feeRecordCorrectionEntity);
+      jest.mocked(getBankNameById).mockResolvedValue('');
+    });
+
+    it(`should respond with ${HttpStatusCode.NotFound}`, async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
+      expect(res._getData()).toEqual('Bank not found');
+    });
+
+    it('should call FeeRecordCorrectionRepo.findOneByIdWithFeeRecordAndReport once with the correctionId', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(findRecordCorrectionSpy).toHaveBeenCalledTimes(1);
+      expect(findRecordCorrectionSpy).toHaveBeenCalledWith(correctionId);
+    });
+
+    it('should call getBankNameById once with the bankId', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(getBankNameById).toHaveBeenCalledTimes(1);
+      expect(getBankNameById).toHaveBeenCalledWith(feeRecordCorrectionEntity.feeRecord.report.bankId);
+    });
+  });
+
+  describe('when a record correction and bank are found', () => {
+    beforeEach(() => {
+      findRecordCorrectionSpy.mockResolvedValue(feeRecordCorrectionEntity);
+      jest.mocked(getBankNameById).mockResolvedValue(bankName);
+    });
+
+    it(`should respond with ${HttpStatusCode.Ok} and return the correct response object`, async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      const expected = {
+        fields: getRecordCorrectionFields(feeRecordCorrectionEntity.feeRecord, feeRecordCorrectionEntity),
+        bankName,
+        reportPeriod: feeRecordCorrectionEntity.feeRecord.report.reportPeriod,
+      };
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+
+      expect(res._getData()).toEqual(expected);
+    });
+
+    it('should call FeeRecordCorrectionRepo.findOneByIdWithFeeRecordAndReport once with the correctionId', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(findRecordCorrectionSpy).toHaveBeenCalledTimes(1);
+      expect(findRecordCorrectionSpy).toHaveBeenCalledWith(correctionId);
+    });
+
+    it('should call getBankNameById once with the bankId', async () => {
+      // Arrange
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(getBankNameById).toHaveBeenCalledTimes(1);
+      expect(getBankNameById).toHaveBeenCalledWith(feeRecordCorrectionEntity.feeRecord.report.bankId);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-record-correction-log-details.controller/index.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-record-correction-log-details.controller/index.test.ts
@@ -5,7 +5,6 @@ import { getRecordCorrectionLogDetails } from '.';
 import { FeeRecordCorrectionRepo } from '../../../../repositories/fee-record-correction-repo';
 import { getRecordCorrectionFields } from '../helpers/get-record-correction-fields';
 import { getBankNameById } from '../../../../repositories/banks-repo';
-import { NotFoundError } from '../../../../errors';
 
 console.error = jest.fn();
 
@@ -39,12 +38,17 @@ describe('get-record-correction-log-details.controller', () => {
       findRecordCorrectionSpy.mockResolvedValue(null);
     });
 
-    it('should throw a NotFoundError', async () => {
+    it(`should respond with a ${HttpStatusCode.NotFound}`, async () => {
       // Arrange
       const { req, res } = getHttpMocks();
 
       // Assert
-      await expect(getRecordCorrectionLogDetails(req, res)).rejects.toThrow(new NotFoundError('Record correction not found'));
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
+      const expectedErrorMessage = 'Record correction not found';
+      expect(res._getData()).toEqual(`Failed to get record correction log details: ${expectedErrorMessage}`);
     });
   });
 
@@ -54,12 +58,17 @@ describe('get-record-correction-log-details.controller', () => {
       jest.mocked(getBankNameById).mockResolvedValue(undefined);
     });
 
-    it('should throw a NotFoundError', async () => {
+    it(`should respond with a ${HttpStatusCode.NotFound}`, async () => {
       // Arrange
       const { req, res } = getHttpMocks();
 
       // Assert
-      await expect(getRecordCorrectionLogDetails(req, res)).rejects.toThrow(new NotFoundError('Bank not found'));
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.NotFound);
+      const expectedErrorMessage = 'Bank not found';
+      expect(res._getData()).toEqual(`Failed to get record correction log details: ${expectedErrorMessage}`);
     });
   });
 

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-record-correction-log-details.controller/index.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-record-correction-log-details.controller/index.ts
@@ -1,0 +1,42 @@
+import { Request } from 'express';
+import { HttpStatusCode } from 'axios';
+import { GetRecordCorrectionLogDetailsResponse } from '@ukef/dtfs2-common';
+import { FeeRecordCorrectionRepo } from '../../../../repositories/fee-record-correction-repo';
+import { getRecordCorrectionFields } from '../helpers/get-record-correction-fields';
+import { getBankNameById } from '../../../../repositories/banks-repo';
+
+/**
+ * gets record correction log details by id
+ * finds the correction and fee record and report by correction id
+ * returns the formatted fields for the record correction and fee record
+ * @param req - The request object
+ * @param res - The response object
+ * @returns formatted fields for the record correction and fee record
+ */
+export const getRecordCorrectionLogDetails = async (req: Request, res: GetRecordCorrectionLogDetailsResponse) => {
+  const { correctionId: correctionIdString } = req.params;
+
+  const correctionId = Number(correctionIdString);
+
+  const response = await FeeRecordCorrectionRepo.findOneByIdWithFeeRecordAndReport(correctionId);
+
+  if (!response || !response?.feeRecord || !response?.feeRecord?.report) {
+    return res.status(HttpStatusCode.NotFound).send('Record correction not found');
+  }
+
+  const bankName = await getBankNameById(response.feeRecord.report.bankId);
+
+  if (!bankName?.length) {
+    return res.status(HttpStatusCode.NotFound).send('Bank not found');
+  }
+
+  const fields = getRecordCorrectionFields(response.feeRecord, response);
+
+  const responseObject = {
+    fields,
+    bankName,
+    reportPeriod: response.feeRecord.report.reportPeriod,
+  };
+
+  return res.status(HttpStatusCode.Ok).send(responseObject);
+};

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-record-correction-details.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-record-correction-details.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@ukef/dtfs2-common';
 import { format } from 'date-fns';
 import { getRecordCorrectionDetails } from './get-record-correction-details';
-import { getFormattedOldAndCorrectValues } from './get-formatted-old-and-correct-values';
+import { getFormattedOldAndCorrectValues } from '../../helpers/get-formatted-old-and-correct-values';
 
 describe('get-record-correction-details', () => {
   const feeRecordId = 11;

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-record-correction-details.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/get-utilisation-report-reconciliation-details-by-id.controller/helpers/get-record-correction-details.ts
@@ -1,6 +1,5 @@
-import { format } from 'date-fns';
-import { FeeRecordEntity, FeeRecordCorrectionSummary, mapReasonsToDisplayValues, DATE_FORMATS } from '@ukef/dtfs2-common';
-import { getFormattedOldAndCorrectValues } from './get-formatted-old-and-correct-values';
+import { FeeRecordEntity, FeeRecordCorrectionSummary } from '@ukef/dtfs2-common';
+import { getRecordCorrectionFields } from '../../helpers/get-record-correction-fields';
 
 /**
  * Retrieves and constructs record correction data for the given fee records.
@@ -15,31 +14,16 @@ export const getRecordCorrectionDetails = (feeRecords: FeeRecordEntity[]): FeeRe
       return [];
     }
 
-    const { id: feeRecordId, exporter } = feeRecord;
-
     return feeRecord.corrections.map((correction) => {
-      const { id: correctionId, dateRequested, isCompleted } = correction;
-
-      /**
-       * return formatted old records and formatted correct records
-       * returns - if correction is not completed for formattedCorrectRecords
-       */
-      const { formattedOldRecords, formattedCorrectRecords } = getFormattedOldAndCorrectValues(correction, feeRecord);
-
-      /**
-       * maps the reasons as an array of strings to display values
-       * constructs a comma seperated string if there are more than one reason
-       * else constructs a string with the single reason
-       */
-      const reasonsArray = mapReasonsToDisplayValues(correction.reasons);
-      const formattedReasons = reasonsArray.join(', ');
+      const { correctionId, feeRecordId, exporter, formattedReasons, formattedDateSent, formattedCorrectRecords, formattedOldRecords, isCompleted } =
+        getRecordCorrectionFields(feeRecord, correction);
 
       return {
         correctionId,
         feeRecordId,
         exporter,
         formattedReasons,
-        formattedDateSent: format(dateRequested, DATE_FORMATS.DD_MMM_YYYY),
+        formattedDateSent,
         formattedOldRecords,
         formattedCorrectRecords,
         isCompleted,

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-date-received-and-bank-commentary.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-date-received-and-bank-commentary.test.ts
@@ -1,0 +1,60 @@
+import { format } from 'date-fns';
+import { DATE_FORMATS } from '@ukef/dtfs2-common';
+import { getDateReceivedAndBankCommentary } from './get-date-received-and-bank-commentary';
+
+describe('get-date-received-and-bank-commentary', () => {
+  const bankCommentary = 'abc';
+  const date = new Date();
+
+  describe('when isCompleted = false', () => {
+    it('should return an object with formattedDateReceived and formattedBankCommentary as "-"', () => {
+      const result = getDateReceivedAndBankCommentary(false, null, null);
+
+      const expected = {
+        formattedDateReceived: '-',
+        formattedBankCommentary: '-',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when isCompleted = true but dateReceived is undefined', () => {
+    it('should return an object with formattedDateReceived and formattedBankCommentary as "-"', () => {
+      const result = getDateReceivedAndBankCommentary(true, undefined, bankCommentary);
+
+      const expected = {
+        formattedDateReceived: '-',
+        formattedBankCommentary: '-',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when isCompleted = true but bankCommentary is undefined', () => {
+    it('should return an object with formattedDateReceived and formattedBankCommentary as "-"', () => {
+      const result = getDateReceivedAndBankCommentary(true, date);
+
+      const expected = {
+        formattedDateReceived: '-',
+        formattedBankCommentary: '-',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when isCompleted = true and all other values are provided', () => {
+    it('should return an object with formattedDateReceived and formattedBankCommentary as "-"', () => {
+      const result = getDateReceivedAndBankCommentary(true, date, bankCommentary);
+
+      const expected = {
+        formattedDateReceived: format(date, DATE_FORMATS.DD_MMM_YYYY),
+        formattedBankCommentary: bankCommentary,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-date-received-and-bank-commentary.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-date-received-and-bank-commentary.ts
@@ -1,0 +1,26 @@
+import { format } from 'date-fns';
+import { DATE_FORMATS } from '@ukef/dtfs2-common';
+
+/**
+ * returns formattedDateReceived and bankCommentary
+ * if correction is completed and date received and bank commentary are present
+ * sets their values in the correct format
+ * else they will be '-'
+ * @param isCompleted - if correction is completed
+ * @param dateReceived - date the correction was received
+ * @param bankCommentary - bank commentary on correction
+ * @returns formattedDateReceived and formattedBankCommentary with values or dashes
+ */
+export const getDateReceivedAndBankCommentary = (isCompleted: boolean, dateReceived?: Date | null, bankCommentary?: string | null) => {
+  if (isCompleted && dateReceived && bankCommentary) {
+    return {
+      formattedDateReceived: format(dateReceived, DATE_FORMATS.DD_MMM_YYYY),
+      formattedBankCommentary: bankCommentary,
+    };
+  }
+
+  return {
+    formattedDateReceived: '-',
+    formattedBankCommentary: '-',
+  };
+};

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-formatted-old-and-correct-values.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-formatted-old-and-correct-values.test.ts
@@ -1,7 +1,7 @@
 import { FeeRecordEntityMockBuilder, FeeRecordCorrectionEntityMockBuilder, RECORD_CORRECTION_REASON } from '@ukef/dtfs2-common';
 import { getFormattedOldAndCorrectValues } from './get-formatted-old-and-correct-values';
-import { mapCorrectionReasonsToFormattedOldFeeRecordValues } from '../../../../../helpers/map-correction-reasons-to-formatted-old-fee-record-values';
-import { mapCorrectionReasonsAndValuesToFormattedValues } from '../../../../../helpers/map-correction-reasons-and-values-to-formatted-values';
+import { mapCorrectionReasonsToFormattedOldFeeRecordValues } from '../../../../helpers/map-correction-reasons-to-formatted-old-fee-record-values';
+import { mapCorrectionReasonsAndValuesToFormattedValues } from '../../../../helpers/map-correction-reasons-and-values-to-formatted-values';
 
 describe('get-formatted-old-and-correct-values', () => {
   const feeRecordId = 11;

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-formatted-old-and-correct-values.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-formatted-old-and-correct-values.ts
@@ -1,6 +1,6 @@
 import { FeeRecordEntity, FeeRecordCorrectionEntity } from '@ukef/dtfs2-common';
-import { mapCorrectionReasonsToFormattedOldFeeRecordValues } from '../../../../../helpers/map-correction-reasons-to-formatted-old-fee-record-values';
-import { mapCorrectionReasonsAndValuesToFormattedValues } from '../../../../../helpers/map-correction-reasons-and-values-to-formatted-values';
+import { mapCorrectionReasonsToFormattedOldFeeRecordValues } from '../../../../helpers/map-correction-reasons-to-formatted-old-fee-record-values';
+import { mapCorrectionReasonsAndValuesToFormattedValues } from '../../../../helpers/map-correction-reasons-and-values-to-formatted-values';
 
 /**
  * generates formattedOldRecords and formattedCorrectRecords from correction and feeRecord

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-record-correction-fields.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-record-correction-fields.test.ts
@@ -10,6 +10,7 @@ describe('get-record-correction-fields', () => {
   describe('when a correction is not completed - isCompleted=false', () => {
     const feeRecordCorrectionEntity = FeeRecordCorrectionEntityMockBuilder.forIsCompleted(false)
       .withDateRequested(today)
+      .withDateReceived(today)
       .withBankTeamEmails(`${bankTeamEmails[0]},${bankTeamEmails[1]}`)
       .build();
 
@@ -30,10 +31,11 @@ describe('get-record-correction-fields', () => {
         formattedCorrectRecords: '-',
         isCompleted: false,
         bankTeamName: feeRecordCorrectionEntity.bankTeamName,
-        bankTeamEmails: `${bankTeamEmails[0]}, ${bankTeamEmails[1]}`,
+        formattedBankTeamEmails: `${bankTeamEmails[0]}, ${bankTeamEmails[1]}`,
         additionalInfo: feeRecordCorrectionEntity.additionalInfo,
         formattedBankCommentary: '-',
         formattedDateReceived: '-',
+        formattedRequestedByUser: `${feeRecordCorrectionEntity.requestedByUser.firstName} ${feeRecordCorrectionEntity.requestedByUser.lastName}`,
       };
 
       expect(result).toEqual(expected);
@@ -63,10 +65,11 @@ describe('get-record-correction-fields', () => {
         formattedCorrectRecords,
         isCompleted: true,
         bankTeamName: feeRecordCorrectionEntity.bankTeamName,
-        bankTeamEmails: `${bankTeamEmails[0]}, ${bankTeamEmails[1]}`,
+        formattedBankTeamEmails: `${bankTeamEmails[0]}, ${bankTeamEmails[1]}`,
         additionalInfo: feeRecordCorrectionEntity.additionalInfo,
         formattedBankCommentary: feeRecordCorrectionEntity.bankCommentary,
-        formattedDateReceived: format(feeRecordCorrectionEntity.dateReceived as Date, DATE_FORMATS.DD_MMM_YYYY),
+        formattedDateReceived: format(feeRecordCorrectionEntity.dateReceived!, DATE_FORMATS.DD_MMM_YYYY),
+        formattedRequestedByUser: `${feeRecordCorrectionEntity.requestedByUser.firstName} ${feeRecordCorrectionEntity.requestedByUser.lastName}`,
       };
 
       expect(result).toEqual(expected);

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-record-correction-fields.test.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-record-correction-fields.test.ts
@@ -1,0 +1,75 @@
+import { format } from 'date-fns';
+import { FeeRecordCorrectionEntityMockBuilder, DATE_FORMATS, mapReasonsToDisplayValues } from '@ukef/dtfs2-common';
+import { getRecordCorrectionFields } from './get-record-correction-fields';
+import { getFormattedOldAndCorrectValues } from './get-formatted-old-and-correct-values';
+
+describe('get-record-correction-fields', () => {
+  const today = new Date();
+  const bankTeamEmails = ['test1@ukexportfinance.gov.uk', 'test2@ukexportfinance.gpv.uk'];
+
+  describe('when a correction is not completed - isCompleted=false', () => {
+    const feeRecordCorrectionEntity = FeeRecordCorrectionEntityMockBuilder.forIsCompleted(false)
+      .withDateRequested(today)
+      .withBankTeamEmails(`${bankTeamEmails[0]},${bankTeamEmails[1]}`)
+      .build();
+
+    it('should return the fields with formattedDateReceived and formattedBankCommentary as "-"', () => {
+      const result = getRecordCorrectionFields(feeRecordCorrectionEntity.feeRecord, feeRecordCorrectionEntity);
+
+      const { formattedOldRecords } = getFormattedOldAndCorrectValues(feeRecordCorrectionEntity, feeRecordCorrectionEntity.feeRecord);
+      const reasonsArray = mapReasonsToDisplayValues(feeRecordCorrectionEntity.reasons);
+
+      const expected = {
+        facilityId: feeRecordCorrectionEntity.feeRecord.facilityId,
+        correctionId: feeRecordCorrectionEntity.id,
+        feeRecordId: feeRecordCorrectionEntity.feeRecord.id,
+        exporter: feeRecordCorrectionEntity.feeRecord.exporter,
+        formattedReasons: reasonsArray.join(', '),
+        formattedDateSent: format(today, DATE_FORMATS.DD_MMM_YYYY),
+        formattedOldRecords,
+        formattedCorrectRecords: '-',
+        isCompleted: false,
+        bankTeamName: feeRecordCorrectionEntity.bankTeamName,
+        bankTeamEmails: `${bankTeamEmails[0]}, ${bankTeamEmails[1]}`,
+        additionalInfo: feeRecordCorrectionEntity.additionalInfo,
+        formattedBankCommentary: '-',
+        formattedDateReceived: '-',
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when a correction is completed - isCompleted=true', () => {
+    const feeRecordCorrectionEntity = FeeRecordCorrectionEntityMockBuilder.forIsCompleted(true)
+      .withDateRequested(today)
+      .withBankTeamEmails(`${bankTeamEmails[0]},${bankTeamEmails[1]}`)
+      .build();
+
+    it('should return the fields with formattedDateReceived and formattedBankCommentary as the date and commentary', () => {
+      const result = getRecordCorrectionFields(feeRecordCorrectionEntity.feeRecord, feeRecordCorrectionEntity);
+
+      const { formattedOldRecords, formattedCorrectRecords } = getFormattedOldAndCorrectValues(feeRecordCorrectionEntity, feeRecordCorrectionEntity.feeRecord);
+      const reasonsArray = mapReasonsToDisplayValues(feeRecordCorrectionEntity.reasons);
+
+      const expected = {
+        facilityId: feeRecordCorrectionEntity.feeRecord.facilityId,
+        correctionId: feeRecordCorrectionEntity.id,
+        feeRecordId: feeRecordCorrectionEntity.feeRecord.id,
+        exporter: feeRecordCorrectionEntity.feeRecord.exporter,
+        formattedReasons: reasonsArray.join(', '),
+        formattedDateSent: format(today, DATE_FORMATS.DD_MMM_YYYY),
+        formattedOldRecords,
+        formattedCorrectRecords,
+        isCompleted: true,
+        bankTeamName: feeRecordCorrectionEntity.bankTeamName,
+        bankTeamEmails: `${bankTeamEmails[0]}, ${bankTeamEmails[1]}`,
+        additionalInfo: feeRecordCorrectionEntity.additionalInfo,
+        formattedBankCommentary: feeRecordCorrectionEntity.bankCommentary,
+        formattedDateReceived: format(feeRecordCorrectionEntity.dateReceived as Date, DATE_FORMATS.DD_MMM_YYYY),
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-record-correction-fields.ts
+++ b/dtfs-central-api/src/v1/controllers/utilisation-report-service/helpers/get-record-correction-fields.ts
@@ -1,0 +1,59 @@
+import { format } from 'date-fns';
+import { FeeRecordEntity, mapReasonsToDisplayValues, FeeRecordCorrectionEntity, DATE_FORMATS } from '@ukef/dtfs2-common';
+import { getFormattedOldAndCorrectValues } from './get-formatted-old-and-correct-values';
+
+/**
+ * gets all the fields from a record correction or fee record in the correct format for a number of pages
+ * returns certain values as '-' if the correction is not completed
+ * @param feeRecord - the fee record
+ * @param correction - the fee record correction
+ * @returns formatted fields for the record correction and fee record
+ */
+export const getRecordCorrectionFields = (feeRecord: FeeRecordEntity, correction: FeeRecordCorrectionEntity) => {
+  const { id: feeRecordId, exporter, facilityId } = feeRecord;
+  const { id: correctionId, dateRequested, isCompleted, bankTeamName, bankTeamEmails, additionalInfo, bankCommentary, dateReceived } = correction;
+
+  /**
+   * return formatted old records and formatted correct records
+   * returns - if correction is not completed for formattedCorrectRecords
+   */
+  const { formattedOldRecords, formattedCorrectRecords } = getFormattedOldAndCorrectValues(correction, feeRecord);
+
+  /**
+   * maps the reasons as an array of strings to display values
+   * constructs a comma seperated string if there are more than one reason
+   * else constructs a string with the single reason
+   */
+  const reasonsArray = mapReasonsToDisplayValues(correction.reasons);
+  const formattedReasons = reasonsArray.join(', ');
+
+  let formattedDateReceived = '-';
+  let formattedBankCommentary = '-';
+
+  /**
+   * if correction is completed and date received and bank commentary are present
+   * sets their value in the correct format
+   * else they will be '-'
+   */
+  if (isCompleted && dateReceived && bankCommentary) {
+    formattedDateReceived = format(dateReceived, DATE_FORMATS.DD_MMM_YYYY);
+    formattedBankCommentary = bankCommentary;
+  }
+
+  return {
+    facilityId,
+    correctionId,
+    feeRecordId,
+    exporter,
+    formattedReasons,
+    formattedDateSent: format(dateRequested, DATE_FORMATS.DD_MMM_YYYY),
+    formattedOldRecords,
+    formattedCorrectRecords,
+    isCompleted,
+    bankTeamName,
+    bankTeamEmails: bankTeamEmails.replace(/,/g, ', '),
+    additionalInfo,
+    formattedBankCommentary,
+    formattedDateReceived,
+  };
+};

--- a/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
+++ b/dtfs-central-api/src/v1/routes/utilisation-reports-routes.js
@@ -58,6 +58,8 @@ const {
 } = require('../controllers/utilisation-report-service/fee-record-correction/delete-fee-record-correction-transient-form-data.controller');
 const { getFeeRecordCorrection } = require('../controllers/utilisation-report-service/fee-record-correction/get-fee-record-correction.controller');
 
+const { getRecordCorrectionLogDetails } = require('../controllers/utilisation-report-service/get-record-correction-log-details.controller');
+
 const utilisationReportsRouter = express.Router();
 
 /**
@@ -1149,5 +1151,38 @@ utilisationReportsRouter
   .route('/fee-record-correction-review/:correctionId/user/:userId')
   .all(validation.sqlIdValidation('correctionId'), validation.mongoIdValidation('userId'), handleExpressValidatorResult)
   .get(getFeeRecordCorrectionReview);
+
+/**
+ * @openapi
+ * /utilisation-reports/record-correction-log-details/:correctionId:
+ *   get:
+ *     summary: Get the record correction log details for a record correction via correction id
+ *     tags: [Utilisation Report]
+ *     description: Gets the record correction log details for a record correction via correction id
+ *     parameters:
+ *       - in: path
+ *         name: correctionId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: the id for correction
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               $ref: '#/definitions/GetRecordCorrectionLogDetailsResponse'
+ *       400:
+ *         description: Bad request
+ *       404:
+ *         description: Not Found (if either the correction with matching id or bank with matching id cannot be found)
+ *       500:
+ *         description: Internal Server Error
+ */
+utilisationReportsRouter
+  .route('/record-correction-log-details/:correctionId')
+  .get(validation.sqlIdValidation('correctionId'), handleExpressValidatorResult, getRecordCorrectionLogDetails);
 
 module.exports = utilisationReportsRouter;

--- a/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/fee-record-correction-log-details.js
+++ b/dtfs-central-api/src/v1/swagger-definitions/utilisation-reports/fee-record-correction-log-details.js
@@ -1,0 +1,33 @@
+/**
+ * @openapi
+ * definitions:
+ *   GetRecordCorrectionLogDetailsResponse:
+ *     type: object
+ *     properties:
+ *       facilityId:
+ *         type: string
+ *       exporter:
+ *         type: string
+ *       formattedReasons:
+ *         type: string
+ *       formattedDateSent:
+ *         type: string
+ *       formattedOldRecords:
+ *         type: string
+ *       formattedCorrectRecords:
+ *         type: string
+ *       bankTeamName:
+ *         type: string
+ *       isCompleted:
+ *         type: boolean
+ *       formattedBankTeamEmails:
+ *         type: string
+ *       additionalInfo:
+ *         type: string
+ *       formattedBankCommentary:
+ *         type: string
+ *       formattedDateReceived:
+ *         type: string
+ *       formattedRequestedByUser:
+ *         type: string
+ */

--- a/libs/common/src/test-helpers/mock-data/fee-record-correction.entity.mock-builder.ts
+++ b/libs/common/src/test-helpers/mock-data/fee-record-correction.entity.mock-builder.ts
@@ -32,7 +32,7 @@ export class FeeRecordCorrectionEntityMockBuilder {
     data.additionalInfo = 'some info';
     data.reasons = [RECORD_CORRECTION_REASON.UTILISATION_INCORRECT];
     data.bankTeamName = 'some team';
-    data.bankTeamEmails = 'test1@ukexportfinance.gov.uk, test2@ukexportfinance.gov.uk';
+    data.bankTeamEmails = 'test1@ukexportfinance.gov.uk,test2@ukexportfinance.gov.uk';
 
     if (isCompleted) {
       data.isCompleted = true;
@@ -123,6 +123,11 @@ export class FeeRecordCorrectionEntityMockBuilder {
 
   public withBankCommentary(bankCommentary: string | null): FeeRecordCorrectionEntityMockBuilder {
     this.correction.bankCommentary = bankCommentary;
+    return this;
+  }
+
+  public withBankTeamEmails(bankTeamEmails: string): FeeRecordCorrectionEntityMockBuilder {
+    this.correction.bankTeamEmails = bankTeamEmails;
     return this;
   }
 

--- a/libs/common/src/test-helpers/mock-data/index.ts
+++ b/libs/common/src/test-helpers/mock-data/index.ts
@@ -18,3 +18,4 @@ export * from './get-auth-code-url-params';
 export * from './fee-record-correction-transient-form-data.entity.mock-builder';
 export * from './fee-record-correction-request-review-response-body-mock';
 export * from './record-correction-values';
+export * from './record-correction-log-details.mock';

--- a/libs/common/src/test-helpers/mock-data/record-correction-log-details.mock.ts
+++ b/libs/common/src/test-helpers/mock-data/record-correction-log-details.mock.ts
@@ -1,0 +1,23 @@
+export const recordCorrectionLogDetailsMock = {
+  fields: {
+    facilityId: '1',
+    correctionId: 2,
+    feeRecordId: 3,
+    exporter: 'Test exporter',
+    formattedReasons: 'Reason 1, Reason 2',
+    formattedDateSent: '01 Jan 2021',
+    formattedOldRecords: 'Old records',
+    formattedCorrectRecords: 'Correct records',
+    isCompleted: true,
+    bankTeamName: 'Test bank team',
+    bankTeamEmails: 'test@ukexportfinance.gov.uk',
+    additionalInfo: '123',
+    formattedBankCommentary: '-',
+    formattedDateReceived: '-',
+  },
+  bankName: 'test bank',
+  reportPeriod: {
+    start: { month: 1, year: 2023 },
+    end: { month: 1, year: 2023 },
+  },
+};

--- a/libs/common/src/test-helpers/mock-data/record-correction-log-details.mock.ts
+++ b/libs/common/src/test-helpers/mock-data/record-correction-log-details.mock.ts
@@ -1,8 +1,8 @@
-export const recordCorrectionLogDetailsMock = {
-  fields: {
+import { GetRecordCorrectionLogDetailsResponseBody } from '../../types';
+
+export const recordCorrectionLogDetailsMock: GetRecordCorrectionLogDetailsResponseBody = {
+  correctionDetails: {
     facilityId: '1',
-    correctionId: 2,
-    feeRecordId: 3,
     exporter: 'Test exporter',
     formattedReasons: 'Reason 1, Reason 2',
     formattedDateSent: '01 Jan 2021',
@@ -10,10 +10,11 @@ export const recordCorrectionLogDetailsMock = {
     formattedCorrectRecords: 'Correct records',
     isCompleted: true,
     bankTeamName: 'Test bank team',
-    bankTeamEmails: 'test@ukexportfinance.gov.uk',
+    formattedBankTeamEmails: 'test@ukexportfinance.gov.uk',
     additionalInfo: '123',
     formattedBankCommentary: '-',
     formattedDateReceived: '-',
+    formattedRequestedByUser: 'test name',
   },
   bankName: 'test bank',
   reportPeriod: {

--- a/libs/common/src/types/index.ts
+++ b/libs/common/src/types/index.ts
@@ -40,3 +40,4 @@ export * from './fee-record-correction-review-information';
 export * from './validation-error';
 export * from './record-correction-form-values';
 export * from './record-correction-form-value-validation-errors';
+export * from './record-correction-log';

--- a/libs/common/src/types/index.ts
+++ b/libs/common/src/types/index.ts
@@ -41,3 +41,4 @@ export * from './validation-error';
 export * from './record-correction-form-values';
 export * from './record-correction-form-value-validation-errors';
 export * from './record-correction-log';
+export * from './record-correction-fields';

--- a/libs/common/src/types/record-correction-fields.ts
+++ b/libs/common/src/types/record-correction-fields.ts
@@ -1,0 +1,17 @@
+export type RecordCorrectionFields = {
+  facilityId: string;
+  correctionId: number;
+  feeRecordId: number;
+  exporter: string;
+  formattedReasons: string;
+  formattedDateSent: string;
+  formattedOldRecords: string;
+  formattedCorrectRecords: string;
+  isCompleted: boolean;
+  bankTeamName: string;
+  formattedBankTeamEmails: string;
+  additionalInfo: string;
+  formattedBankCommentary: string;
+  formattedDateReceived: string;
+  formattedRequestedByUser: string;
+};

--- a/libs/common/src/types/record-correction-log.ts
+++ b/libs/common/src/types/record-correction-log.ts
@@ -3,8 +3,6 @@ import { ReportPeriodPartialEntity } from '../sql-db-entities';
 
 export type RecordCorrectionLogFields = {
   facilityId: string;
-  correctionId: number;
-  feeRecordId: number;
   exporter: string;
   formattedReasons: string;
   formattedDateSent: string;
@@ -12,14 +10,15 @@ export type RecordCorrectionLogFields = {
   formattedCorrectRecords: string;
   isCompleted: boolean;
   bankTeamName: string;
-  bankTeamEmails: string;
+  formattedBankTeamEmails: string;
   additionalInfo: string;
   formattedBankCommentary: string;
   formattedDateReceived: string;
+  formattedRequestedByUser: string;
 };
 
 export type GetRecordCorrectionLogDetailsResponseBody = {
-  fields: RecordCorrectionLogFields;
+  correctionDetails: RecordCorrectionLogFields;
   bankName: string;
   reportPeriod: ReportPeriodPartialEntity;
 };

--- a/libs/common/src/types/record-correction-log.ts
+++ b/libs/common/src/types/record-correction-log.ts
@@ -1,0 +1,27 @@
+import { Response } from 'express';
+import { ReportPeriodPartialEntity } from '../sql-db-entities';
+
+export type RecordCorrectionLogFields = {
+  facilityId: string;
+  correctionId: number;
+  feeRecordId: number;
+  exporter: string;
+  formattedReasons: string;
+  formattedDateSent: string;
+  formattedOldRecords: string;
+  formattedCorrectRecords: string;
+  isCompleted: boolean;
+  bankTeamName: string;
+  bankTeamEmails: string;
+  additionalInfo: string;
+  formattedBankCommentary: string;
+  formattedDateReceived: string;
+};
+
+export type GetRecordCorrectionLogDetailsResponseBody = {
+  fields: RecordCorrectionLogFields;
+  bankName: string;
+  reportPeriod: ReportPeriodPartialEntity;
+};
+
+export type GetRecordCorrectionLogDetailsResponse = Response<GetRecordCorrectionLogDetailsResponseBody | string>;

--- a/trade-finance-manager-api/src/v1/__mocks__/api.js
+++ b/trade-finance-manager-api/src/v1/__mocks__/api.js
@@ -276,4 +276,5 @@ module.exports = {
   createFeeRecordCorrection: jest.fn(),
   getFeeRecordCorrectionTransientFormData: jest.fn(),
   deleteFeeRecordCorrectionTransientFormData: jest.fn(),
+  getRecordCorrectionLogDetailsById: jest.fn(),
 };

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -1807,7 +1807,7 @@ const createFeeRecordCorrection = async (reportId, feeRecordId, user) => {
 
 /**
  * Gets the record correction log details by report id
- * @param {string} correctionId - The report id
+ * @param {string} correctionId - The correction id
  * @returns {Promise<import('@ukef/dtfs2-common').GetRecordCorrectionLogDetailsResponseBody>}
  */
 const getRecordCorrectionLogDetailsById = async (correctionId) => {

--- a/trade-finance-manager-api/src/v1/api.js
+++ b/trade-finance-manager-api/src/v1/api.js
@@ -1805,6 +1805,19 @@ const createFeeRecordCorrection = async (reportId, feeRecordId, user) => {
   return response.data;
 };
 
+/**
+ * Gets the record correction log details by report id
+ * @param {string} correctionId - The report id
+ * @returns {Promise<import('@ukef/dtfs2-common').GetRecordCorrectionLogDetailsResponseBody>}
+ */
+const getRecordCorrectionLogDetailsById = async (correctionId) => {
+  const response = await axios.get(`${DTFS_CENTRAL_API_URL}/v1/utilisation-reports/record-correction-log-details/${correctionId}`, {
+    headers: headers.central,
+  });
+
+  return response.data;
+};
+
 module.exports = {
   findOneDeal,
   findOnePortalDeal,
@@ -1889,4 +1902,5 @@ module.exports = {
   getFeeRecordCorrectionTransientFormData,
   deleteFeeRecordCorrectionTransientFormData,
   createFeeRecordCorrection,
+  getRecordCorrectionLogDetailsById,
 };

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/get-record-correction-log-details-by-id.controller.test.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/get-record-correction-log-details-by-id.controller.test.ts
@@ -1,0 +1,105 @@
+import httpMocks from 'node-mocks-http';
+import { AxiosResponse, HttpStatusCode, AxiosError } from 'axios';
+import { Request } from 'express';
+import { recordCorrectionLogDetailsMock, GetRecordCorrectionLogDetailsResponseBody } from '@ukef/dtfs2-common';
+import { getRecordCorrectionLogDetailsById } from './get-record-correction-log-details-by-id.controller';
+import api from '../../../api';
+
+console.error = jest.fn();
+
+jest.mock('../../../api');
+
+describe('get-record-correction-log-details-by-id.contoller', () => {
+  const correctionId = '1';
+
+  const getHttpMocks = () =>
+    httpMocks.createMocks<Request>({
+      params: { correctionId },
+    });
+
+  const aResponseBody = (): GetRecordCorrectionLogDetailsResponseBody => ({
+    ...recordCorrectionLogDetailsMock,
+  });
+
+  const getRecordCorrectionLogDetailsSpy = jest.spyOn(api, 'getRecordCorrectionLogDetailsById');
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when the api request is successful', () => {
+    const responseBody = aResponseBody();
+
+    beforeEach(() => {
+      getRecordCorrectionLogDetailsSpy.mockResolvedValue(responseBody);
+    });
+
+    it(`should return a ${HttpStatusCode.Ok} status code if the api request is successful`, async () => {
+      const { req, res } = getHttpMocks();
+
+      jest.mocked(api.getRecordCorrectionLogDetailsById).mockResolvedValue(responseBody);
+
+      // Act
+      await getRecordCorrectionLogDetailsById(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+      expect(res._getData()).toEqual(responseBody);
+    });
+
+    it('should call the "getRecordCorrectionLogDetailsById" api endpoint once', async () => {
+      const { req, res } = getHttpMocks();
+
+      // Act
+      await getRecordCorrectionLogDetailsById(req, res);
+
+      // Assert
+      expect(getRecordCorrectionLogDetailsSpy).toHaveBeenCalledTimes(1);
+      expect(getRecordCorrectionLogDetailsSpy).toHaveBeenCalledWith(correctionId);
+    });
+  });
+
+  it(`should return a ${HttpStatusCode.InternalServerError} status code if an unknown error occurs`, async () => {
+    // Arrange
+    jest.mocked(api.getRecordCorrectionLogDetailsById).mockRejectedValue(new Error('Some error'));
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await getRecordCorrectionLogDetailsById(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._isEndCalled()).toEqual(true);
+  });
+
+  it('should return a specific error code if an axios error is thrown', async () => {
+    const { req, res } = getHttpMocks();
+
+    // Arrange
+    const errorStatus = HttpStatusCode.BadRequest;
+    const axiosError = new AxiosError(undefined, undefined, undefined, undefined, { status: errorStatus } as AxiosResponse);
+
+    jest.mocked(api.getRecordCorrectionLogDetailsById).mockRejectedValue(axiosError);
+
+    // Act
+    await getRecordCorrectionLogDetailsById(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(errorStatus);
+    expect(res._isEndCalled()).toEqual(true);
+  });
+
+  it('should return an error message if an error occurs', async () => {
+    const { req, res } = getHttpMocks();
+
+    // Arrange
+    jest.mocked(api.getRecordCorrectionLogDetailsById).mockRejectedValue(new Error('Some error'));
+
+    // Act
+    await getRecordCorrectionLogDetailsById(req, res);
+
+    // Assert
+    expect(res._getData()).toEqual('Failed to get record correction log details');
+    expect(res._isEndCalled()).toEqual(true);
+  });
+});

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/get-record-correction-log-details-by-id.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/get-record-correction-log-details-by-id.controller.ts
@@ -1,0 +1,26 @@
+import { Request } from 'express';
+import { HttpStatusCode, isAxiosError } from 'axios';
+import { GetRecordCorrectionLogDetailsResponse } from '@ukef/dtfs2-common';
+import api from '../../../api';
+
+/**
+ * Get record correction log details by id
+ * @param req - the request
+ * @param res - the response
+ */
+export const getRecordCorrectionLogDetailsById = async (req: Request, res: GetRecordCorrectionLogDetailsResponse) => {
+  try {
+    const { correctionId } = req.params;
+
+    const utilisationReportReconciliationDetails = await api.getRecordCorrectionLogDetailsById(correctionId);
+
+    return res.status(HttpStatusCode.Ok).send(utilisationReportReconciliationDetails);
+  } catch (error) {
+    const errorMessage = 'Failed to get record correction log details';
+    const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;
+
+    console.error('%s %o', errorMessage, error);
+
+    return res.status(errorStatus).send(errorMessage);
+  }
+};

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/get-record-correction-log-details-by-id.controller.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/get-record-correction-log-details-by-id.controller.ts
@@ -12,9 +12,9 @@ export const getRecordCorrectionLogDetailsById = async (req: Request, res: GetRe
   try {
     const { correctionId } = req.params;
 
-    const utilisationReportReconciliationDetails = await api.getRecordCorrectionLogDetailsById(correctionId);
+    const recordCorrectionLogDetails = await api.getRecordCorrectionLogDetailsById(correctionId);
 
-    return res.status(HttpStatusCode.Ok).send(utilisationReportReconciliationDetails);
+    return res.status(HttpStatusCode.Ok).send(recordCorrectionLogDetails);
   } catch (error) {
     const errorMessage = 'Failed to get record correction log details';
     const errorStatus = (isAxiosError(error) && error.response?.status) || HttpStatusCode.InternalServerError;

--- a/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/index.ts
+++ b/trade-finance-manager-api/src/v1/controllers/utilisation-reports/fee-record-correction/index.ts
@@ -3,3 +3,4 @@ export { postFeeRecordCorrection } from './post-fee-record-correction.controller
 export { getFeeRecordCorrectionRequestReview } from './get-fee-record-correction-request-review.controller';
 export { getFeeRecordCorrectionTransientFormData } from './get-fee-record-correction-transient-form-data.controller';
 export { deleteFeeRecordCorrectionTransientFormData } from './delete-fee-record-correction-transient-form-data.controller';
+export { getRecordCorrectionLogDetailsById } from './get-record-correction-log-details-by-id.controller';

--- a/trade-finance-manager-api/src/v1/routes.js
+++ b/trade-finance-manager-api/src/v1/routes.js
@@ -232,4 +232,8 @@ authRouter
   .get(utilisationReportsController.getFeeRecordCorrectionTransientFormData)
   .delete(utilisationReportsController.deleteFeeRecordCorrectionTransientFormData);
 
+authRouter
+  .route('/utilisation-reports/record-correction-log-details/:correctionId')
+  .get(validation.sqlIdValidation('correctionId'), handleExpressValidatorResult, utilisationReportsController.getRecordCorrectionLogDetailsById);
+
 module.exports = { authRouter, openRouter };

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/record-correction-log-details.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/record-correction-log-details.component-test.ts
@@ -56,6 +56,14 @@ describe(page, () => {
     wrapper.expectText(definitionDescriptionSelector('Date sent')).toRead(correctionDetails.formattedDateSent);
   });
 
+  it('should render the contact name', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Contact name')).toRead(correctionDetails.bankTeamName);
+  });
+
   it('should render the contact email addresses', () => {
     // Act
     const wrapper = render(viewModel);

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/record-correction-log-details.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/record-correction-log-details.component-test.ts
@@ -1,0 +1,122 @@
+import { aCreateRecordCorrectionLogDetailsViewModel } from '../../../test-helpers/test-data/view-models';
+import { pageRenderer } from '../../pageRenderer';
+
+const page = '../templates/utilisation-reports/record-corrections/record-correction-log-details.njk';
+const render = pageRenderer(page);
+
+const definitionDescriptionSelector = (definitionTerm: string) => `[data-cy="summary-list"] dt:contains("${definitionTerm}") + dd`;
+const statusTagSelector = '[data-cy="record-correction-status"]';
+
+describe(page, () => {
+  const viewModel = aCreateRecordCorrectionLogDetailsViewModel();
+
+  const { correctionDetails } = viewModel;
+
+  it('should render the main heading', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText('h1[data-cy="main-heading"]').toRead('Record correction log');
+    wrapper.expectText('span[data-cy="heading-caption"]').toRead('test bank, January 2023');
+  });
+
+  it('should render a record correction status tag', () => {
+    // Act
+    const wrapper = render({
+      statusCode: viewModel.status,
+      displayStatus: viewModel.displayStatus,
+    });
+
+    // Assert
+    wrapper.expectText(statusTagSelector).toRead(viewModel.displayStatus);
+  });
+
+  it('should render the exporter', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Exporter')).toRead(correctionDetails.exporter);
+  });
+
+  it('should render the facility id', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Facility ID')).toRead(correctionDetails.facilityId);
+  });
+
+  it('should render the date sent', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Date sent')).toRead(correctionDetails.formattedDateSent);
+  });
+
+  it('should render the contact email addresses', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Contact email address(es)')).toRead(correctionDetails.formattedBankTeamEmails);
+  });
+
+  it('should render the requested by', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Requested by')).toRead(correctionDetails.formattedRequestedByUser);
+  });
+
+  it('should render the reasons for correction', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Reason(s) for correction')).toRead(correctionDetails.formattedReasons);
+  });
+
+  it('should render the additional information', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Additional information')).toRead(correctionDetails.additionalInfo);
+  });
+
+  it('should render the old records', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Old record(s)')).toRead(correctionDetails.formattedOldRecords);
+  });
+
+  it('should render the correct records', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('New record')).toRead(correctionDetails.formattedCorrectRecords);
+  });
+
+  it('should render the bank commentary', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Bank commentary')).toRead(correctionDetails.formattedBankCommentary);
+  });
+
+  it('should render the date correction received', () => {
+    // Act
+    const wrapper = render(viewModel);
+
+    // Assert
+    wrapper.expectText(definitionDescriptionSelector('Date correction received')).toRead(correctionDetails.formattedDateReceived);
+  });
+});

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1467,6 +1467,20 @@ const deleteFeeRecordCorrectionTransientFormData = async (reportId, feeRecordId,
   }
 };
 
+/**
+ * Gets the record correction log details by id
+ * @param {string} correctionId - The report id
+ * @param {string} userToken - The user token
+ * @returns {Promise<import('@ukef/dtfs2-common').GetRecordCorrectionLogDetailsResponseBody>}
+ */
+const getRecordCorrectionLogDetailsById = async (correctionId, userToken) => {
+  const response = await axios.get(`${TFM_API_URL}/v1/utilisation-reports/record-correction-log-details/${correctionId}`, {
+    headers: generateHeaders(userToken),
+  });
+
+  return response.data;
+};
+
 module.exports = {
   getDeal,
   getDeals,
@@ -1534,4 +1548,5 @@ module.exports = {
   updateFeeRecordCorrectionTransientFormData,
   getFeeRecordCorrectionTransientFormData,
   deleteFeeRecordCorrectionTransientFormData,
+  getRecordCorrectionLogDetailsById,
 };

--- a/trade-finance-manager-ui/server/api.js
+++ b/trade-finance-manager-ui/server/api.js
@@ -1469,7 +1469,7 @@ const deleteFeeRecordCorrectionTransientFormData = async (reportId, feeRecordId,
 
 /**
  * Gets the record correction log details by id
- * @param {string} correctionId - The report id
+ * @param {string} correctionId - The correction id
  * @param {string} userToken - The user token
  * @returns {Promise<import('@ukef/dtfs2-common').GetRecordCorrectionLogDetailsResponseBody>}
  */

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.test.ts
@@ -1,0 +1,75 @@
+import httpMocks from 'node-mocks-http';
+import { getFormattedReportPeriodWithLongMonth, recordCorrectionLogDetailsMock } from '@ukef/dtfs2-common';
+import { aTfmSessionUser } from '../../../../../test-helpers';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../../constants';
+import { getRecordCorrectionLogDetails } from '.';
+import api from '../../../../api';
+import { mapToRecordCorrectionStatus } from '../../helpers/map-record-correction-status';
+
+jest.mock('../../../../api');
+
+describe('controllers/utilisation-reports/record-corrections/record-correction-log-details', () => {
+  const correctionId = '123';
+
+  const userToken = 'user-token';
+  const user = aTfmSessionUser();
+  const requestSession = {
+    userToken,
+    user,
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('getRecordCorrectionLogDetails', () => {
+    const { req, res } = httpMocks.createMocks({
+      session: requestSession,
+      params: { correctionId },
+    });
+
+    beforeEach(() => {
+      jest.mocked(api.getRecordCorrectionLogDetailsById).mockResolvedValue(recordCorrectionLogDetailsMock);
+    });
+
+    it('should render check the information page', async () => {
+      // Act
+      await getRecordCorrectionLogDetails(req, res);
+
+      // Assert
+      const { status, displayStatus } = mapToRecordCorrectionStatus(recordCorrectionLogDetailsMock.fields.isCompleted);
+
+      const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(recordCorrectionLogDetailsMock.reportPeriod);
+
+      const expectedViewModel = {
+        user,
+        mappedCorrectionLog: recordCorrectionLogDetailsMock.fields,
+        status,
+        displayStatus,
+        formattedReportPeriod,
+        bankName: recordCorrectionLogDetailsMock.bankName,
+        activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+      };
+
+      expect(res._getRenderView()).toEqual('utilisation-reports/record-corrections/record-correction-log-details.njk');
+      expect(res._getRenderData()).toEqual(expectedViewModel);
+    });
+
+    describe('when there is an error', () => {
+      const error = new Error('error');
+
+      beforeEach(() => {
+        jest.mocked(api.getRecordCorrectionLogDetailsById).mockRejectedValue(error);
+      });
+
+      it('should render problem-with-service page', async () => {
+        // Act
+        await getRecordCorrectionLogDetails(req, res);
+
+        // Assert
+        expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');
+        expect(res._getRenderData()).toEqual({ user: req.session.user });
+      });
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.test.ts
@@ -43,7 +43,7 @@ describe('controllers/utilisation-reports/record-corrections/record-correction-l
 
       const expectedViewModel = {
         user,
-        mappedCorrectionLog: recordCorrectionLogDetailsMock.correctionDetails,
+        correctionDetails: recordCorrectionLogDetailsMock.correctionDetails,
         status,
         displayStatus,
         formattedReportPeriod,

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.test.ts
@@ -32,18 +32,18 @@ describe('controllers/utilisation-reports/record-corrections/record-correction-l
       jest.mocked(api.getRecordCorrectionLogDetailsById).mockResolvedValue(recordCorrectionLogDetailsMock);
     });
 
-    it('should render check the information page', async () => {
+    it('should render "record correction log details" page', async () => {
       // Act
       await getRecordCorrectionLogDetails(req, res);
 
       // Assert
-      const { status, displayStatus } = mapToRecordCorrectionStatus(recordCorrectionLogDetailsMock.fields.isCompleted);
+      const { status, displayStatus } = mapToRecordCorrectionStatus(recordCorrectionLogDetailsMock.correctionDetails.isCompleted);
 
       const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(recordCorrectionLogDetailsMock.reportPeriod);
 
       const expectedViewModel = {
         user,
-        mappedCorrectionLog: recordCorrectionLogDetailsMock.fields,
+        mappedCorrectionLog: recordCorrectionLogDetailsMock.correctionDetails,
         status,
         displayStatus,
         formattedReportPeriod,

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.ts
@@ -1,0 +1,41 @@
+import { Response, Request } from 'express';
+import { getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-common';
+import { asUserSession } from '../../../../helpers/express-session';
+import api from '../../../../api';
+import { mapToRecordCorrectionStatus } from '../../helpers/map-record-correction-status';
+import { RecordCorrectionLogDetailsViewModel } from '../../../../types/view-models';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../../constants';
+
+/**
+ * Renders the "get record correction log details" page for a record correction log entry
+ * @param req - the request
+ * @param res - the response
+ */
+export const getRecordCorrectionLogDetails = async (req: Request, res: Response) => {
+  try {
+    const { user, userToken } = asUserSession(req.session);
+    const { correctionId } = req.params;
+
+    const { fields, bankName, reportPeriod } = await api.getRecordCorrectionLogDetailsById(correctionId, userToken);
+
+    const { status, displayStatus } = mapToRecordCorrectionStatus(fields.isCompleted);
+
+    const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(reportPeriod);
+
+    const viewModel: RecordCorrectionLogDetailsViewModel = {
+      user,
+      mappedCorrectionLog: fields,
+      status,
+      displayStatus,
+      formattedReportPeriod,
+      bankName,
+      activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+    };
+
+    return res.render('utilisation-reports/record-corrections/record-correction-log-details.njk', viewModel);
+  } catch (error) {
+    console.error('Error getting record correction log details: %o', error);
+
+    return res.render('_partials/problem-with-service.njk', { user: req.session.user });
+  }
+};

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/record-correction-log-details/index.ts
@@ -16,15 +16,15 @@ export const getRecordCorrectionLogDetails = async (req: Request, res: Response)
     const { user, userToken } = asUserSession(req.session);
     const { correctionId } = req.params;
 
-    const { fields, bankName, reportPeriod } = await api.getRecordCorrectionLogDetailsById(correctionId, userToken);
+    const { correctionDetails, bankName, reportPeriod } = await api.getRecordCorrectionLogDetailsById(correctionId, userToken);
 
-    const { status, displayStatus } = mapToRecordCorrectionStatus(fields.isCompleted);
+    const { status, displayStatus } = mapToRecordCorrectionStatus(correctionDetails.isCompleted);
 
     const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(reportPeriod);
 
     const viewModel: RecordCorrectionLogDetailsViewModel = {
       user,
-      mappedCorrectionLog: fields,
+      correctionDetails,
       status,
       displayStatus,
       formattedReportPeriod,

--- a/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
+++ b/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
@@ -32,6 +32,7 @@ import {
 import { postInitiateRecordCorrectionRequest } from '../../controllers/utilisation-reports/record-corrections/initiate-record-correction-request';
 import { getRecordCorrectionRequestSent } from '../../controllers/utilisation-reports/record-corrections/request-sent';
 import { postCancelRecordCorrectionRequest } from '../../controllers/utilisation-reports/record-corrections/cancel-record-correction-request';
+import { getRecordCorrectionLogDetails } from '../../controllers/utilisation-reports/record-corrections/record-correction-log-details';
 
 export const utilisationReportsRoutes = express.Router();
 
@@ -213,4 +214,12 @@ utilisationReportsRoutes.post(
   validateSqlId('reportId'),
   validateSqlId('feeRecordId'),
   postCancelRecordCorrectionRequest,
+);
+
+utilisationReportsRoutes.get(
+  '/record-correction-log-details/:correctionId',
+  validateFeeRecordCorrectionFeatureFlagIsEnabled,
+  validateUserTeam(Object.values(PDC_TEAM_IDS)),
+  validateSqlId('correctionId'),
+  getRecordCorrectionLogDetails,
 );

--- a/trade-finance-manager-ui/server/types/view-models/record-correction/index.ts
+++ b/trade-finance-manager-ui/server/types/view-models/record-correction/index.ts
@@ -1,3 +1,4 @@
 export * from './create-record-correction-request-view-model';
 export * from './record-correction-request-information-view-model';
 export * from './record-correction-request-sent-view-model';
+export * from './record-correction-log-details-view-model';

--- a/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-log-details-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-log-details-view-model.ts
@@ -1,0 +1,10 @@
+import { RecordCorrectionLogFields } from '@ukef/dtfs2-common';
+import { BaseViewModel } from '../base-view-model';
+
+export type RecordCorrectionLogDetailsViewModel = BaseViewModel & {
+  mappedCorrectionLog: RecordCorrectionLogFields;
+  status: string;
+  displayStatus: string;
+  formattedReportPeriod: string;
+  bankName: string;
+};

--- a/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-log-details-view-model.ts
+++ b/trade-finance-manager-ui/server/types/view-models/record-correction/record-correction-log-details-view-model.ts
@@ -2,7 +2,7 @@ import { RecordCorrectionLogFields } from '@ukef/dtfs2-common';
 import { BaseViewModel } from '../base-view-model';
 
 export type RecordCorrectionLogDetailsViewModel = BaseViewModel & {
-  mappedCorrectionLog: RecordCorrectionLogFields;
+  correctionDetails: RecordCorrectionLogFields;
   status: string;
   displayStatus: string;
   formattedReportPeriod: string;

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/record-correction-status.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/record-correction-status.njk
@@ -5,15 +5,15 @@
   {% set displayStatus = params.displayStatus %}
 
   {% set tagColourClassForStatus = {
-    'RECORD_CORRECTION_RECEIVED': 'govuk-tag--green govuk-!-text-align-left',
-    'RECORD_CORRECTION_SENT': 'govuk-tag--pink govuk-!-text-align-left'
+    'RECORD_CORRECTION_RECEIVED': 'govuk-tag--green',
+    'RECORD_CORRECTION_SENT': 'govuk-tag--pink'
   } %}
 
   {% set tagColourClass = tagColourClassForStatus[status] %}
 
   {{ govukTag({
     text: displayStatus,
-    classes: tagColourClass,
+    classes: tagColourClass + " govuk-!-text-align-left",
     attributes: {
       'data-cy': 'record-correction-status'
     }

--- a/trade-finance-manager-ui/templates/utilisation-reports/_macros/record-correction-status.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/_macros/record-correction-status.njk
@@ -5,8 +5,8 @@
   {% set displayStatus = params.displayStatus %}
 
   {% set tagColourClassForStatus = {
-    'RECORD_CORRECTION_RECEIVED': 'govuk-tag--green',
-    'RECORD_CORRECTION_SENT': 'govuk-tag--pink'
+    'RECORD_CORRECTION_RECEIVED': 'govuk-tag--green govuk-!-text-align-left',
+    'RECORD_CORRECTION_SENT': 'govuk-tag--pink govuk-!-text-align-left'
   } %}
 
   {% set tagColourClass = tagColourClassForStatus[status] %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/record-correction-log-details.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/record-correction-log-details.njk
@@ -7,7 +7,7 @@
 {% block pageTitle %}Record correction log{% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row" data-cy="application-submit-page">
+  <div class="govuk-grid-row" data-cy="record-correction-log-details-page">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <div class="govuk-!-padding-top-7">
           <span class="govuk-caption-l" data-cy="heading-caption">{{ bankName }}, {{ formattedReportPeriod }}</span>
@@ -33,7 +33,7 @@
           text: "Exporter"
         },
         value: {
-          text: mappedCorrectionLog.exporter
+          text: correctionDetails.exporter
         }
       },
       {
@@ -41,7 +41,7 @@
           text: "Facility ID"
         },
         value: {
-          text: mappedCorrectionLog.facilityId
+          text: correctionDetails.facilityId
         }
       },
       {
@@ -49,7 +49,7 @@
           text: "Date sent"
         },
         value: {
-          text: mappedCorrectionLog.formattedDateSent
+          text: correctionDetails.formattedDateSent
         }
       },
       {
@@ -57,15 +57,15 @@
           text: "Contact name"
         },
         value: {
-          text: mappedCorrectionLog.bankTeamName
+          text: correctionDetails.bankTeamName
         }
       },
       {
         key: {
-          text: "Contact email address"
+          text: "Contact email address(es)"
         },
         value: {
-          text: mappedCorrectionLog.bankTeamEmails
+          text: correctionDetails.formattedBankTeamEmails
         }
       },
       {
@@ -73,7 +73,7 @@
           text: "Requested by"
         },
         value: {
-          text: 'todo'
+          text: correctionDetails.formattedRequestedByUser
         }
       },
       {
@@ -81,7 +81,7 @@
           text: "Reason(s) for correction"
         },
         value: {
-          text: mappedCorrectionLog.formattedReasons
+          text: correctionDetails.formattedReasons
         }
       },
       {
@@ -89,7 +89,7 @@
           text: "Additional information"
         },
         value: {
-          text: mappedCorrectionLog.additionalInfo
+          text: correctionDetails.additionalInfo
         }
       },
       {
@@ -97,7 +97,7 @@
           text: "Old record(s)"
         },
         value: {
-          text: mappedCorrectionLog.formattedOldRecords
+          text: correctionDetails.formattedOldRecords
         }
       },
       {
@@ -105,7 +105,7 @@
           text: "New record"
         },
         value: {
-          text: mappedCorrectionLog.formattedCorrectRecords
+          text: correctionDetails.formattedCorrectRecords
         }
       },
       {
@@ -113,7 +113,7 @@
           text: "Bank commentary"
         },
         value: {
-          text: mappedCorrectionLog.formattedBankCommentary
+          text: correctionDetails.formattedBankCommentary
         }
       },
       {
@@ -121,7 +121,7 @@
           text: "Date correction received"
         },
         value: {
-          text: mappedCorrectionLog.formattedDateReceived
+          text: correctionDetails.formattedDateReceived
         }
       }
     ],

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/record-correction-log-details.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/record-correction-log-details.njk
@@ -1,0 +1,134 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% import "../_macros/record-correction-status.njk" as recordCorrectionStatus %}
+{% extends "index.njk" %}
+
+{% set backLink = { "href": "/utilisation-reports/" + reportId + "#record-correction-log" } %}
+
+{% block pageTitle %}Record correction log{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row" data-cy="application-submit-page">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <div class="govuk-!-padding-top-7">
+          <span class="govuk-caption-l" data-cy="heading-caption">{{ bankName }}, {{ formattedReportPeriod }}</span>
+          <h1 class="govuk-heading-l" data-cy="main-heading">Record correction log</h1>
+      </div>
+    </div>
+    <div>
+      <div class="govuk-grid-column-one-third-from-desktop govuk-!-text-align-right">
+        <div class="govuk-!-padding-top-8">
+          {{ recordCorrectionStatus.render({
+            status: status,
+            displayStatus: displayStatus
+          }) }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Exporter"
+        },
+        value: {
+          text: mappedCorrectionLog.exporter
+        }
+      },
+      {
+        key: {
+          text: "Facility ID"
+        },
+        value: {
+          text: mappedCorrectionLog.facilityId
+        }
+      },
+      {
+        key: {
+          text: "Date sent"
+        },
+        value: {
+          text: mappedCorrectionLog.formattedDateSent
+        }
+      },
+      {
+        key: {
+          text: "Contact name"
+        },
+        value: {
+          text: mappedCorrectionLog.bankTeamName
+        }
+      },
+      {
+        key: {
+          text: "Contact email address"
+        },
+        value: {
+          text: mappedCorrectionLog.bankTeamEmails
+        }
+      },
+      {
+        key: {
+          text: "Requested by"
+        },
+        value: {
+          text: 'todo'
+        }
+      },
+      {
+        key: {
+          text: "Reason(s) for correction"
+        },
+        value: {
+          text: mappedCorrectionLog.formattedReasons
+        }
+      },
+      {
+        key: {
+          text: "Additional information"
+        },
+        value: {
+          text: mappedCorrectionLog.additionalInfo
+        }
+      },
+      {
+        key: {
+          text: "Old record(s)"
+        },
+        value: {
+          text: mappedCorrectionLog.formattedOldRecords
+        }
+      },
+      {
+        key: {
+          text: "New record"
+        },
+        value: {
+          text: mappedCorrectionLog.formattedCorrectRecords
+        }
+      },
+      {
+        key: {
+          text: "Bank commentary"
+        },
+        value: {
+          text: mappedCorrectionLog.formattedBankCommentary
+        }
+      },
+      {
+        key: {
+          text: "Date correction received"
+        },
+        value: {
+          text: mappedCorrectionLog.formattedDateReceived
+        }
+      }
+    ],
+    attributes: {
+      'data-cy': 'summary-list'
+    }
+  }) }}
+
+{% endblock %}
+{% block sub_content %}{% endblock %}

--- a/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/create-record-correction-log-details-view-model.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/create-record-correction-log-details-view-model.ts
@@ -1,0 +1,18 @@
+import { recordCorrectionLogDetailsMock, getFormattedReportPeriodWithLongMonth } from '@ukef/dtfs2-common';
+import { PRIMARY_NAVIGATION_KEYS } from '../../../../server/constants';
+import { RecordCorrectionLogDetailsViewModel } from '../../../../server/types/view-models';
+import { aTfmSessionUser } from '../../tfm-session-user';
+import { mapToRecordCorrectionStatus } from '../../../../server/controllers/utilisation-reports/helpers/map-record-correction-status';
+
+const { status, displayStatus } = mapToRecordCorrectionStatus(recordCorrectionLogDetailsMock.correctionDetails.isCompleted);
+
+const formattedReportPeriod = getFormattedReportPeriodWithLongMonth(recordCorrectionLogDetailsMock.reportPeriod);
+
+export const aCreateRecordCorrectionLogDetailsViewModel = (): RecordCorrectionLogDetailsViewModel => ({
+  user: aTfmSessionUser(),
+  activePrimaryNavigation: PRIMARY_NAVIGATION_KEYS.UTILISATION_REPORTS,
+  status,
+  displayStatus,
+  ...recordCorrectionLogDetailsMock,
+  formattedReportPeriod,
+});

--- a/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/index.ts
+++ b/trade-finance-manager-ui/test-helpers/test-data/view-models/record-corrections/index.ts
@@ -1,3 +1,4 @@
 export * from './create-record-correction-request-view-model';
 export * from './record-correction-request-information-view-model';
 export * from './record-correction-request-sent-view-model';
+export * from './create-record-correction-log-details-view-model';

--- a/utils/mock-data-loader/portal-users/index.js
+++ b/utils/mock-data-loader/portal-users/index.js
@@ -3,7 +3,6 @@ import MOCK_BANKS from '../banks';
 
 const UKEF_TEST_BANK_1 = MOCK_BANKS.find((bank) => bank.name === 'UKEF test bank (Delegated)');
 const UKEF_TEST_BANK_2 = MOCK_BANKS.find((bank) => bank.name === 'UKEF test bank (Delegated) 2');
-const Barclays = MOCK_BANKS.find((bank) => bank.name === 'Barclays Bank');
 const UKEF_GEF_ONLY_BANK = MOCK_BANKS.find((bank) => bank.name === 'GEF Only Bank');
 
 export const BANK1_MAKER1 = {
@@ -122,7 +121,7 @@ export const BANK1_PAYMENT_REPORT_OFFICER1 = {
   email: 'payment-officer1@ukexportfinance.gov.uk',
   timezone: 'Europe/London',
   roles: [ROLES.PAYMENT_REPORT_OFFICER],
-  bank: Barclays,
+  bank: UKEF_TEST_BANK_1,
   isTrusted: false,
 };
 

--- a/utils/mock-data-loader/portal-users/index.js
+++ b/utils/mock-data-loader/portal-users/index.js
@@ -3,6 +3,7 @@ import MOCK_BANKS from '../banks';
 
 const UKEF_TEST_BANK_1 = MOCK_BANKS.find((bank) => bank.name === 'UKEF test bank (Delegated)');
 const UKEF_TEST_BANK_2 = MOCK_BANKS.find((bank) => bank.name === 'UKEF test bank (Delegated) 2');
+const Barclays = MOCK_BANKS.find((bank) => bank.name === 'Barclays Bank');
 const UKEF_GEF_ONLY_BANK = MOCK_BANKS.find((bank) => bank.name === 'GEF Only Bank');
 
 export const BANK1_MAKER1 = {
@@ -121,7 +122,7 @@ export const BANK1_PAYMENT_REPORT_OFFICER1 = {
   email: 'payment-officer1@ukexportfinance.gov.uk',
   timezone: 'Europe/London',
   roles: [ROLES.PAYMENT_REPORT_OFFICER],
-  bank: UKEF_TEST_BANK_1,
+  bank: Barclays,
   isTrusted: false,
 };
 


### PR DESCRIPTION
## Introduction :pencil2:
This PR sets up the endpoints, routes and template for the record correction log details page.  E2E tests and linking to record correction log page will  be in the next PR

## Resolution :heavy_check_mark:
* Set up getRecordCorrectionLogDetails in central-api and calls from tfm-ui to tfm-api to central-api to get data
* Set up template
* Moved mapping record correction details to its own helper function
* Added unit tests


