### PR TITLE
fix(DTFS2-7804): updated property name to facility identifier

### DIFF
--- a/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/src/v1/controllers/acbs.controller.js
@@ -122,11 +122,11 @@ const updateDealAcbs = async (taskOutput) => {
   await tfmController.updateAcbs(taskOutput);
 
   const facilitiesUpdates = facilities
-    .filter((facility) => facility.facilityId)
+    .filter((facility) => facility.facilityIdentifier)
     .map((facility) => {
-      const { facilityId, ...acbsFacility } = facility;
+      const { facilityIdentifier, ...acbsFacility } = facility;
       // Add `acbs` object to tfm-facilities
-      return tfmController.updateFacilityAcbs(facilityId, acbsFacility);
+      return tfmController.updateFacilityAcbs(facilityIdentifier, acbsFacility);
     });
   await Promise.all(facilitiesUpdates);
 };


### PR DESCRIPTION
## Introduction :pencil2:
A facility issuance is being failed on production due to lack of facility.tfm.acbs object existence check. This happens due to failure to create the above objecte when a deal and its associated facilities have been created in ACBS and reconcilled with TFM.

## Resolution :heavy_check_mark:
* Updated property name to `facilityIdentifier`.

## Miscellaneous :heavy_plus_sign:
* Additional test cases and mocks have been pushed in this [commit](https://github.com/UK-Export-Finance/dtfs2/pull/4175/commits/9c542f26a504e6a980c994fef7c0ba3d353cb645).