### PR TITLE
feat(DTFS2-7494): add ui logic to show or hide make a change button

### DIFF
--- a/e2e-tests/e2e-fixtures/mock-gef-facilities.js
+++ b/e2e-tests/e2e-fixtures/mock-gef-facilities.js
@@ -232,6 +232,7 @@ const anIssuedContingentFacility = ({ facilityEndDateEnabled = false } = {}) => 
 });
 
 exports.anUnissuedCashFacility = anUnissuedCashFacility;
+exports.anUnissuedContingentFacility = anUnissuedContingentFacility;
 exports.anIssuedCashFacility = anIssuedCashFacility;
 exports.anIssuedCashFacilityWithCoverDateConfirmed = anIssuedCashFacilityWithCoverDateConfirmed;
 exports.anIssuedContingentFacility = anIssuedContingentFacility;

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-with-issued-and-unissued-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -2,7 +2,7 @@ import { PORTAL_ACTIVITY_LABEL } from '@ukef/dtfs2-common';
 import relative from '../../relativeURL';
 import CONSTANTS from '../../../fixtures/constants';
 import { threeDaysAgo, addDays, twoMonths, threeMonths } from '../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_SUBMITTED_TO_UKEF, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
 import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockGefFacilities } from '../../../../../e2e-fixtures/mock-gef-facilities';
 import { toTitleCase } from '../../../fixtures/helpers';
@@ -39,7 +39,7 @@ context('Review UKEF decision MIA -> confirm coverStartDate and issue unissued f
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT);
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_SUBMITTED_TO_UKEF);
           cy.submitDealAfterUkefIds(dealId, 'GEF', BANK1_CHECKER1_WITH_MOCK_ID);
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {

--- a/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/review-ukef-approval/review-ukef-approval-without-issuing-facilities-MIA-and-resubmit-to-ukef.spec.js
@@ -2,7 +2,7 @@ import { PORTAL_ACTIVITY_LABEL } from '@ukef/dtfs2-common';
 import relative from '../../relativeURL';
 import CONSTANTS from '../../../fixtures/constants';
 import { tomorrow, threeDaysAgo, addDays } from '../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_DRAFT, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA, MOCK_APPLICATION_MIA_SUBMITTED_TO_UKEF, UKEF_DECISION, underwriterManagersDecision } from '../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1, BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../../e2e-fixtures/portal-users.fixture';
 import { anIssuedCashFacilityWithCoverDateConfirmed, multipleMockGefFacilities } from '../../../../../e2e-fixtures/mock-gef-facilities';
 import { toTitleCase } from '../../../fixtures/helpers';
@@ -38,7 +38,7 @@ context('Review UKEF decision MIA -> confirm coverStartDate without issuing faci
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT);
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_SUBMITTED_TO_UKEF);
           cy.submitDealAfterUkefIds(dealId, 'GEF', BANK1_CHECKER1_WITH_MOCK_ID);
           cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
@@ -51,8 +51,7 @@ context('Unissued Facilities AIN - bank review date page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-bank-review-date-AIN.spec.js
@@ -2,7 +2,7 @@ import relative from '../../../relativeURL';
 import { errorSummary } from '../../../partials';
 import CONSTANTS from '../../../../fixtures/constants';
 import { threeDaysAgo, threeMonthsOneDay } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -28,7 +28,7 @@ context('Unissued Facilities AIN - bank review date page', () => {
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -52,6 +52,7 @@ context('Unissued Facilities AIN - bank review date page', () => {
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
@@ -12,7 +12,7 @@ import {
   twentyEightDays,
   threeDays,
 } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { continueButton, errorSummary, mainHeading } from '../../../partials';
@@ -42,7 +42,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -57,6 +57,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
             cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-all-AIN.spec.js
@@ -56,8 +56,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -42,7 +42,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-issued-to-unissued-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { backLink, cancelLink, continueButton, headingCaption, mainHeading, submitButton } from '../../../partials';
 import applicationPreview from '../../../pages/application-preview';
@@ -31,7 +31,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -42,7 +42,7 @@ context('Change issued facilities back to unissued AIN (changed to issued facili
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CONTINGENT, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedContingentFacility),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
@@ -1,4 +1,3 @@
-import { PORTAL_ACTIVITY_LABEL } from '@ukef/dtfs2-common';
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
@@ -51,7 +50,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
               unissuedCashFacilityWith20MonthsOfCover._id = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover);
             });
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });
@@ -553,12 +552,8 @@ context('Submit to UKEF with unissued to issued facilities', () => {
       cy.url().should('eq', relative(`/gef/application-details/${dealId}#${unissuedFacilitiesArray[2]._id}`));
     });
 
-    it('should not contain already issued facility or submission message', () => {
+    it('should not contain already issued facilities', () => {
       applicationActivities.subNavigationBarActivities().click();
-
-      applicationActivities.activityTimeline().should('not.contain', PORTAL_ACTIVITY_LABEL.MIN_SUBMISSION);
-      applicationActivities.activityTimeline().should('not.contain', PORTAL_ACTIVITY_LABEL.MIA_SUBMISSION);
-      applicationActivities.activityTimeline().should('not.contain', PORTAL_ACTIVITY_LABEL.AIN_SUBMISSION);
 
       // already issued facility should not appear in the activity list
       applicationActivities.facilityActivityChangedBy(issuedCashFacility.ukefFacilityId).should('not.exist');

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-change-submit-ukef-AIN.spec.js
@@ -1,7 +1,7 @@
 import { PORTAL_ACTIVITY_LABEL } from '@ukef/dtfs2-common';
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1, BANK1_CHECKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { threeDaysAgo, threeMonthsOneDay, twoMonths } from '../../../../../../e2e-fixtures/dateConstants';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -34,7 +34,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               unissuedCashFacility._id = facility.body.details._id;
@@ -51,7 +51,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
               unissuedCashFacilityWith20MonthsOfCover._id = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover);
             });
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
@@ -2,7 +2,7 @@ import relative from '../../../relativeURL';
 import { errorSummary } from '../../../partials';
 import CONSTANTS from '../../../../fixtures/constants';
 import { threeDaysAgo, threeMonthsOneDay, today } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import unissuedFacilityTable from '../../../pages/unissued-facilities';
@@ -28,7 +28,7 @@ context('Unissued Facilities AIN - facility end date page', () => {
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -51,7 +51,7 @@ context('Unissued Facilities AIN - facility end date page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facilities-facility-end-date-AIN.spec.js
@@ -51,7 +51,7 @@ context('Unissued Facilities AIN - facility end date page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
@@ -48,7 +48,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-change-from-preview-AIN.spec.js
@@ -1,6 +1,6 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { threeDaysAgo, threeMonthsOneDay, today, twoMonths } from '../../../../../../e2e-fixtures/dateConstants';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
@@ -34,7 +34,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
       .then(() => {
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -48,7 +48,7 @@ context('Unissued Facilities AIN - change to issued from preview page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -33,7 +33,7 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
-            cy.submitDealToTfm(dealId, token);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/AIN/unissued-facility-to-issued-cover-start-date-AIN.spec.js
@@ -1,7 +1,7 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { threeDaysAgoPlusThreeMonths, threeDaysAgo, threeMonthsOneDay } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_AIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { anUnissuedCashFacility } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { mainHeading } from '../../../partials';
@@ -28,12 +28,12 @@ context('Unissued Facilities AIN - change all to issued from unissued table', ()
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_AIN_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token);
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/about-unissued-facility.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/about-unissued-facility.spec.js
@@ -1,7 +1,7 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { fourDaysAgo, tomorrow, threeDaysAgo, threeMonths, threeMonthsOneDay, twoMonths, twentyEightDays } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA_DRAFT, MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { mainHeading, errorSummary } from '../../../partials';
@@ -27,7 +27,7 @@ context('Unissued Facilities MIN - about unissued facility page', () => {
       .then(() => {
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -41,7 +41,10 @@ context('Unissued Facilities MIN - about unissued facility page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF).then(() => {
+              cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
+              cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            });
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
@@ -1,7 +1,7 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { threeDaysAgo, threeMonths, threeMonthsOneDay, today, twoMonths } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA_DRAFT, MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { continueButton } from '../../../partials';
@@ -30,7 +30,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
         // creates application and inserts facilities and changes status
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               facilityOneId = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
@@ -44,7 +44,10 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token).then(() => {
+              cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
+              cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            });
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-all-MIN.spec.js
@@ -44,7 +44,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.submitDealToTfm(dealId, token).then(() => {
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF).then(() => {
               cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-submit-ukef-MIN.spec.js
@@ -50,7 +50,7 @@ context('Unissued Facilities MIN - change all to issued from unissued table', ()
               unissuedCashFacilityWith20MonthsOfCover._id = facility.body.details._id;
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover);
             });
-            cy.submitDealToTfm(dealId, token).then(() => {
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF).then(() => {
               cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
@@ -43,7 +43,7 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.submitDealToTfm(dealId, token).then(() => {
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF).then(() => {
               cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facilities-change-to-issued-3-months-after-MIN.spec.js
@@ -1,7 +1,7 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { sixYearsOneDay, threeYears, tomorrow, threeMonthsOneDay, oneYearAgo } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA_DRAFT, MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { errorSummary } from '../../../partials';
@@ -30,7 +30,7 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
           MOCK_APPLICATION_MIN.manualInclusionNoticeSubmissionDate = `${oneYearAgo.unixSecondsString}608`;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
@@ -43,7 +43,10 @@ context('Unissued Facilities MIN - change to issued more than 3 months after MIN
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token).then(() => {
+              cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
+              cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            });
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
@@ -45,7 +45,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.submitDealToTfm(dealId, token).then(() => {
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF).then(() => {
               cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-MIN.spec.js
@@ -1,7 +1,7 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { threeYears, threeDaysAgo, threeMonthsOneDay, today, twoMonths, twoYears } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA_DRAFT, MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { continueButton, errorSummary } from '../../../partials';
@@ -32,7 +32,7 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
       .then(() => {
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
@@ -45,7 +45,10 @@ context('Unissued Facilities MIN - change to issued from preview page', () => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token).then(() => {
+              cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
+              cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            });
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
@@ -1,7 +1,7 @@
 import relative from '../../../relativeURL';
 import CONSTANTS from '../../../../fixtures/constants';
 import { twoYears, threeYears, threeMonthsOneDay, today } from '../../../../../../e2e-fixtures/dateConstants';
-import { MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
+import { MOCK_APPLICATION_MIA_DRAFT, MOCK_APPLICATION_MIN } from '../../../../fixtures/mocks/mock-deals';
 import { BANK1_MAKER1 } from '../../../../../../e2e-fixtures/portal-users.fixture';
 import { multipleMockGefFacilities } from '../../../../../../e2e-fixtures/mock-gef-facilities';
 import { continueButton } from '../../../partials';
@@ -37,7 +37,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
       .then(() => {
         cy.apiCreateApplication(BANK1_MAKER1, token).then(({ body }) => {
           dealId = body._id;
-          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN).then(() => {
+          cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIA_DRAFT).then(() => {
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) => {
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacility);
             });
@@ -50,7 +50,10 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            cy.submitDealToTfm(dealId, token).then(() => {
+              cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
+              cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
+            });
           });
         });
       });

--- a/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
+++ b/e2e-tests/gef/cypress/e2e/facility/unissued-facilities/MIN/unissued-facility-change-from-preview-specialIssuedPermission-MIN.spec.js
@@ -50,7 +50,7 @@ context('Unissued Facilities MIN - change to issued from preview page - specialI
             cy.apiCreateFacility(dealId, CONSTANTS.FACILITY_TYPE.CASH, token).then((facility) =>
               cy.apiUpdateFacility(facility.body.details._id, token, unissuedCashFacilityWith20MonthsOfCover),
             );
-            cy.submitDealToTfm(dealId, token).then(() => {
+            cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.SUBMITTED_TO_UKEF).then(() => {
               cy.apiUpdateApplication(dealId, token, MOCK_APPLICATION_MIN);
               cy.apiSetApplicationStatus(dealId, token, CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED);
             });

--- a/e2e-tests/gef/cypress/fixtures/mocks/mock-deals.js
+++ b/e2e-tests/gef/cypress/fixtures/mocks/mock-deals.js
@@ -212,6 +212,21 @@ export const MOCK_APPLICATION_AIN = {
   ...commonApplicationDetails,
 };
 
+export const MOCK_APPLICATION_AIN_DRAFT = {
+  status: DEAL_STATUS.DRAFT,
+  submissionType: DEAL_SUBMISSION_TYPE.AIN,
+  submissionCount: 0,
+  eligibility: eligibilityCriteria(true),
+  supportingInformation: {
+    manualInclusion: [],
+    securityDetails: {},
+    status: 'IN_PROGRESS',
+    requiredFields: [],
+  },
+  ukefDecision: [],
+  ...commonApplicationDetails,
+};
+
 export const MOCK_APPLICATION_MIN = {
   status: DEAL_STATUS.UKEF_ACKNOWLEDGED,
   submissionType: DEAL_SUBMISSION_TYPE.MIN,
@@ -270,10 +285,10 @@ export const UKEF_DECISION = {
 };
 
 export const MOCK_APPLICATION_MIA_DRAFT = {
-  status: DEAL_STATUS.SUBMITTED_TO_UKEF,
+  status: DEAL_STATUS.DRAFT,
   submissionType: DEAL_SUBMISSION_TYPE.MIA,
   ukefDecisionAccepted: false,
-  submissionCount: 1,
+  submissionCount: 0,
   eligibility: eligibilityCriteria(false),
   supportingInformation: {
     manualInclusion: [

--- a/e2e-tests/gef/cypress/fixtures/mocks/mock-deals.js
+++ b/e2e-tests/gef/cypress/fixtures/mocks/mock-deals.js
@@ -309,6 +309,31 @@ export const MOCK_APPLICATION_MIA_DRAFT = {
   ...commonApplicationDetails,
 };
 
+export const MOCK_APPLICATION_MIA_SUBMITTED_TO_UKEF = {
+  status: DEAL_STATUS.SUBMITTED_TO_UKEF,
+  submissionType: DEAL_SUBMISSION_TYPE.MIA,
+  ukefDecisionAccepted: false,
+  submissionCount: 1,
+  eligibility: eligibilityCriteria(false),
+  supportingInformation: {
+    manualInclusion: [
+      {
+        _id: '61d71890a018210013a91c53',
+        parentId: '61d7185aa018210013a91c51',
+        filename: 'test.pdf',
+        mimetype: 'application/pdf',
+        encoding: '7bit',
+        size: 28583,
+        documentPath: 'manualInclusion',
+      },
+    ],
+    securityDetails: { exporter: '456465', application: '4564' },
+    status: 'In progress',
+    requiredFields: ['manualInclusion'],
+  },
+  ...commonApplicationDetails,
+};
+
 export const underwriterManagersDecision = {
   tfm: {
     underwriterManagersDecision: {

--- a/e2e-tests/gef/cypress/support/commands/api.js
+++ b/e2e-tests/gef/cypress/support/commands/api.js
@@ -1,5 +1,6 @@
-import { DEAL_STATUS, HEADERS } from '@ukef/dtfs2-common';
+import { HEADERS } from '@ukef/dtfs2-common';
 import { SIGN_IN_TOKENS } from '../../fixtures/constants';
+import { BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../e2e-fixtures/portal-users.fixture';
 import { UNDERWRITER_1_WITH_MOCK_ID } from '../../../../e2e-fixtures/tfm-users.fixture';
 
 const portalApi = 'http://localhost:5001/v1';
@@ -217,16 +218,13 @@ const tfmLogin = (username, password) =>
       return resp.body.token;
     });
 
-const submitDealToTfm = (dealId, token) =>
+const submitDealToTfm = (dealId, dealType) =>
   cy
     .request({
-      url: `${portalApi}/gef/application/status/${dealId}`,
+      url: `${centralApiUrl()}/v1/tfm/deals/submit`,
       method: 'PUT',
-      body: { status: DEAL_STATUS.SUBMITTED_TO_UKEF },
-      headers: {
-        [HEADERS.CONTENT_TYPE.KEY]: HEADERS.CONTENT_TYPE.VALUES.JSON,
-        Authorization: token,
-      },
+      body: { dealId, dealType, checker: BANK1_CHECKER1_WITH_MOCK_ID },
+      headers,
     })
     .then((resp) => {
       expect(resp.status).to.equal(200);

--- a/e2e-tests/gef/cypress/support/commands/api.js
+++ b/e2e-tests/gef/cypress/support/commands/api.js
@@ -1,6 +1,5 @@
-import { HEADERS } from '@ukef/dtfs2-common';
+import { DEAL_STATUS, HEADERS } from '@ukef/dtfs2-common';
 import { SIGN_IN_TOKENS } from '../../fixtures/constants';
-import { BANK1_CHECKER1_WITH_MOCK_ID } from '../../../../e2e-fixtures/portal-users.fixture';
 import { UNDERWRITER_1_WITH_MOCK_ID } from '../../../../e2e-fixtures/tfm-users.fixture';
 
 const portalApi = 'http://localhost:5001/v1';
@@ -218,13 +217,16 @@ const tfmLogin = (username, password) =>
       return resp.body.token;
     });
 
-const submitDealToTfm = (dealId, dealType) =>
+const submitDealToTfm = (dealId, token) =>
   cy
     .request({
-      url: `${centralApiUrl()}/v1/tfm/deals/submit`,
+      url: `${portalApi}/gef/application/status/${dealId}`,
       method: 'PUT',
-      body: { dealId, dealType, checker: BANK1_CHECKER1_WITH_MOCK_ID },
-      headers,
+      body: { status: DEAL_STATUS.SUBMITTED_TO_UKEF },
+      headers: {
+        [HEADERS.CONTENT_TYPE.KEY]: HEADERS.CONTENT_TYPE.VALUES.JSON,
+        Authorization: token,
+      },
     })
     .then((resp) => {
       expect(resp.status).to.equal(200);

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details.spec.js
@@ -1,0 +1,123 @@
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import {
+  anIssuedCashFacility,
+  anIssuedContingentFacility,
+  anUnissuedCashFacility,
+  anUnissuedContingentFacility,
+} from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+import whatDoYouNeedToChange from '../../../../../../../gef/cypress/e2e/pages/amendments/what-do-you-need-to-change';
+import facilityValue from '../../../../../../../gef/cypress/e2e/pages/amendments/facility-value';
+import eligibility from '../../../../../../../gef/cypress/e2e/pages/amendments/eligibility';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+context('Amendments - Application details - page tests', () => {
+  /**
+   * @type {string}
+   */
+  let dealId;
+
+  /**
+   * @type {string}
+   */
+  let issuedCashFacilityId;
+
+  /**
+   * @type {string}
+   */
+  let issuedContingentFacilityId;
+
+  /**
+   * @type {string}
+   */
+  let unissuedCashFacilityId;
+
+  /**
+   * @type {string}
+   */
+  let unissuedContingentFacilityId;
+
+  const issuedCashFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+  const issuedContingentFacility = anIssuedContingentFacility({ facilityEndDateEnabled: true });
+  const unissuedCashFacility = anUnissuedCashFacility({ facilityEndDateEnabled: true });
+  const unissuedContingentFacility = anUnissuedContingentFacility({ facilityEndDateEnabled: true });
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [issuedCashFacility], BANK1_MAKER1).then((createdFacility) => {
+        issuedCashFacilityId = createdFacility.details._id;
+      });
+
+      cy.createGefFacilities(dealId, [issuedContingentFacility], BANK1_MAKER1).then((createdFacility) => {
+        issuedContingentFacilityId = createdFacility.details._id;
+      });
+
+      cy.createGefFacilities(dealId, [unissuedCashFacility], BANK1_MAKER1).then((createdFacility) => {
+        unissuedCashFacilityId = createdFacility.details._id;
+      });
+
+      cy.createGefFacilities(dealId, [unissuedContingentFacility], BANK1_MAKER1).then((createdFacility) => {
+        unissuedContingentFacilityId = createdFacility.details._id;
+      });
+
+      cy.makerLoginSubmitGefDealForReview(insertedDeal);
+      cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+      cy.clearSessionCookies();
+      cy.login(BANK1_MAKER1);
+      cy.saveSession();
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(`/gef/application-details/${dealId}`));
+  });
+
+  describe('make a change button', () => {
+    it('should show the make a change button for issued facilities', () => {
+      applicationPreview.makeAChangeButton(issuedContingentFacilityId);
+      applicationPreview.makeAChangeButton(issuedCashFacilityId);
+    });
+
+    it('should not show the make a change button for unissued facilities', () => {
+      applicationPreview.makeAChangeButton(unissuedCashFacilityId).should('not.exist');
+      applicationPreview.makeAChangeButton(unissuedContingentFacilityId).should('not.exist');
+    });
+
+    it('should not show the make a change button for any facility after an amendment has been submitted to checker', () => {
+      cy.visit(relative(`/gef/application-details/${dealId}`));
+      applicationPreview.makeAChangeButton(issuedCashFacilityId).click();
+
+      whatDoYouNeedToChange.facilityValueCheckbox().click();
+      cy.clickContinueButton();
+      cy.keyboardInput(facilityValue.facilityValue(), '10000');
+      cy.clickContinueButton();
+      eligibility.allTrueRadioButtons().click({ multiple: true });
+      cy.clickContinueButton();
+      cy.completeDateFormFields({ idPrefix: 'effective-date' });
+      cy.clickContinueButton();
+      cy.clickSubmitButton();
+
+      cy.visit(relative(`/gef/application-details/${dealId}`));
+
+      applicationPreview.makeAChangeButton(issuedContingentFacilityId).should('not.exist');
+      applicationPreview.makeAChangeButton(issuedCashFacilityId).should('not.exist');
+      applicationPreview.makeAChangeButton(unissuedCashFacilityId).should('not.exist');
+      applicationPreview.makeAChangeButton(unissuedContingentFacilityId).should('not.exist');
+    });
+  });
+});

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -1,5 +1,5 @@
 const startCase = require('lodash/startCase');
-const { DEAL_TYPE, timeZoneConfig, DEAL_STATUS } = require('@ukef/dtfs2-common');
+const { DEAL_TYPE, timeZoneConfig, DEAL_STATUS, PORTAL_AMENDMENT_UNDERWAY_STATUSES } = require('@ukef/dtfs2-common');
 const api = require('../../services/api');
 const { canUpdateUnissuedFacilitiesCheck } = require('./canUpdateUnissuedFacilitiesCheck');
 const {
@@ -264,7 +264,10 @@ const applicationDetails = async (req, res, next) => {
       params.link += '/unissued-facilities';
     }
 
-    params.canIssuedFacilitiesBeAmended = canUserAmendIssuedFacilities(application.submissionType, application.status, userRoles);
+    const amendmentsUnderwayOnDeal = await api.getAmendmentsOnDeal({ dealId, statuses: PORTAL_AMENDMENT_UNDERWAY_STATUSES, userToken });
+
+    params.canIssuedFacilitiesBeAmended =
+      canUserAmendIssuedFacilities(application.submissionType, application.status, userRoles) && !amendmentsUnderwayOnDeal.length;
 
     return res.render(`partials/${partial}.njk`, params);
   } catch (error) {

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 import { DEAL_STATUS, DEAL_SUBMISSION_TYPE, DEAL_TYPE, FACILITY_TYPE, isPortalFacilityAmendmentsFeatureFlagEnabled, ROLES } from '@ukef/dtfs2-common';
+import { aPortalFacilityAmendment } from '@ukef/dtfs2-common/mock-data-backend';
 import { applicationDetails, postApplicationDetails } from '.';
 import api from '../../services/api';
 import { NON_MAKER_ROLES } from '../../../test-helpers/common-role-lists';
@@ -23,6 +24,7 @@ describe('controllers/application-details', () => {
   let mockFacilityResponse;
   let mockFacilitiesResponse;
   let mockUserResponse;
+  const mockGetAmendmentsOnDealResponse = [];
 
   beforeEach(() => {
     mockResponse = MOCKS.MockResponse();
@@ -35,6 +37,7 @@ describe('controllers/application-details', () => {
     api.getApplication.mockResolvedValue(mockApplicationResponse);
     api.getFacilities.mockResolvedValue(mockFacilitiesResponse);
     api.getUserDetails.mockResolvedValue(mockUserResponse);
+    api.getAmendmentsOnDeal.mockResolvedValue(mockGetAmendmentsOnDealResponse);
     mockRequest.flash = mockSuccessfulFlashResponse();
   });
 
@@ -334,7 +337,7 @@ describe('controllers/application-details', () => {
         );
       });
 
-      it(`renders 'application-preview' with canIssuedFacilitiesBeAmended=true when the deal status is ${DEAL_STATUS.UKEF_ACKNOWLEDGED} and the submission type is valid`, async () => {
+      it(`renders 'application-preview' with canIssuedFacilitiesBeAmended=true when the deal status is ${DEAL_STATUS.UKEF_ACKNOWLEDGED}, the submission type is valid and there are no amendments underway on the deal`, async () => {
         api.getFacilities.mockResolvedValue(MOCKS.MockFacilityResponseNotChangedIssued);
         jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(true);
 
@@ -414,6 +417,26 @@ describe('controllers/application-details', () => {
 
         api.getFacilities.mockResolvedValue(MOCKS.MockFacilityResponseNotChangedIssued);
         jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(true);
+
+        mockApplicationResponse.status = DEAL_STATUS.UKEF_ACKNOWLEDGED;
+        mockApplicationResponse.submissionType = DEAL_SUBMISSION_TYPE.AIN;
+        api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
+
+        await applicationDetails(mockRequest, mockResponse);
+
+        expect(mockResponse.render).toHaveBeenCalledWith(
+          'partials/application-preview.njk',
+          expect.objectContaining({
+            canIssuedFacilitiesBeAmended: false,
+          }),
+        );
+      });
+
+      it(`renders 'application-preview' with canIssuedFacilitiesBeAmended=false when there is an amendment already underway on the deal`, async () => {
+        api.getFacilities.mockResolvedValue(MOCKS.MockFacilityResponseNotChangedIssued);
+        jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(true);
+
+        api.getAmendmentsOnDeal.mockResolvedValueOnce([aPortalFacilityAmendment()]);
 
         mockApplicationResponse.status = DEAL_STATUS.UKEF_ACKNOWLEDGED;
         mockApplicationResponse.submissionType = DEAL_SUBMISSION_TYPE.AIN;


### PR DESCRIPTION
## Introduction :pencil2:
Show the make a change button only if there isn't an amendment already underway on the deal. 

## Resolution :heavy_check_mark:
- Added the UI change for this ticket (showing / hiding the amendment button based on if an amendment is underway currently or not). This change is in the one file: `gef-ui/server/controllers/application-details/index.js`. A unit test has been added for this as has an E2E test (the `application-details` E2E test file)

- Separately, due to reasons outlined on the 3 amigos channel, this small changed caused approx 10 existing GEF tests to fail as they weren't properly submitting the deal to TFM at the start of the tests causing dtfs-central-api to crash. I've fixed this in this PR (the status being updated in the `before` hooks was previously incorrect)



## Miscellaneous :heavy_plus_sign:
List any additional fixes or improvements.

