### PR TITLE
feat(DTFS2-7720): redirect to check answers page if change query is true

### DIFF
--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/journeys/cancel-amendment-journey.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/journeys/cancel-amendment-journey.spec.js
@@ -120,7 +120,7 @@ context('Amendments - Cancel amendment journey', () => {
 
             cy.getAmendmentIdFromUrl().then((amendmentId) => {
               amendmentUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}`;
-              pageActions(amendmentUrl);
+              pageActions();
             });
           });
         });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/journeys/check-your-answers-change-journey.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/journeys/check-your-answers-change-journey.spec.js
@@ -1,0 +1,248 @@
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+import whatDoYouNeedToChange from '../../../../../../../gef/cypress/e2e/pages/amendments/what-do-you-need-to-change';
+import coverEndDate from '../../../../../../../gef/cypress/e2e/pages/amendments/cover-end-date';
+import doYouHaveAFacilityEndDate from '../../../../../../../gef/cypress/e2e/pages/amendments/do-you-have-a-facility-end-date';
+import facilityEndDate from '../../../../../../../gef/cypress/e2e/pages/amendments/facility-end-date';
+import bankReviewDate from '../../../../../../../gef/cypress/e2e/pages/amendments/bank-review-date';
+import facilityValue from '../../../../../../../gef/cypress/e2e/pages/amendments/facility-value';
+import eligibility from '../../../../../../../gef/cypress/e2e/pages/amendments/eligibility';
+import effectiveDate from '../../../../../../../gef/cypress/e2e/pages/amendments/effective-date';
+import checkYourAnswers from '../../../../../../../gef/cypress/e2e/pages/amendments/check-your-answers';
+import manualApprovalNeeded from '../../../../../../../gef/cypress/e2e/pages/amendments/manual-approval-needed';
+import { tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+context('Amendments - Check your answers change journey', () => {
+  /**
+   * @type {string}
+   */
+  let dealId;
+  /**
+   * @type {string}
+   */
+  let facilityId;
+  /**
+   * @type {string}
+   */
+  let amendmentUrl;
+  /**
+   * @type {Date}
+   */
+  const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+  const eligibilityTestCases = Array.from({ length: 7 }, (_, index) => ({
+    description: 'eligibility',
+    page: 'eligibility',
+    nextPage: 'manual-approval-needed',
+    element: eligibility,
+    nextElement: manualApprovalNeeded,
+    checkYourAnswersChangeElement: () => checkYourAnswers.eligibilityCriteriaSummaryListTable().eligibilityCriterionChangeLink(index + 1),
+    fragment: `${index + 1}`,
+    nextPageHeading: 'This amendment cannot be automatically approved',
+    change: () => {
+      eligibility.allFalseRadioButtons().click({ multiple: true });
+      cy.clickContinueButton();
+    },
+  }));
+
+  const testCasesWithoutBRD = [
+    {
+      description: 'cover end date',
+      page: 'cover-end-date',
+      nextPage: 'do-you-have-a-facility-end-date',
+      element: coverEndDate,
+      nextElement: doYouHaveAFacilityEndDate,
+      checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().coverEndDateChangeLink(),
+      fragment: 'coverEndDate-day',
+      nextPageHeading: 'Do you have a facility end date?',
+      change: () => {
+        cy.completeDateFormFields({ idPrefix: 'cover-end-date', date: tomorrow.date });
+        cy.clickContinueButton();
+      },
+    },
+    {
+      description: 'facility end date',
+      page: 'facility-end-date',
+      nextPage: 'facility-value',
+      element: facilityEndDate,
+      nextElement: facilityValue,
+      checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().facilityEndDateChangeLink(),
+      fragment: 'facilityEndDate-day',
+      nextPageHeading: 'New facility value',
+      change: () => {
+        cy.completeDateFormFields({ idPrefix: 'facility-end-date', date: tomorrow.date });
+        cy.clickContinueButton();
+      },
+    },
+    {
+      description: 'facility value',
+      page: 'facility-value',
+      nextPage: 'eligibility',
+      element: facilityValue,
+      nextElement: eligibility,
+      checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().facilityValueChangeLink(),
+      fragment: 'facilityValue',
+      nextPageHeading: 'Eligibility',
+      change: () => {
+        cy.keyboardInput(facilityValue.facilityValue(), '20000');
+        cy.clickContinueButton();
+      },
+    },
+    {
+      description: 'effective date',
+      page: 'effective-date',
+      nextPage: 'check-your-answers',
+      element: effectiveDate,
+      nextElement: checkYourAnswers,
+      checkYourAnswersChangeElement: () => checkYourAnswers.effectiveDateSummaryListTable().effectiveDateChangeLink(),
+      fragment: 'effectiveDate-day',
+      nextPageHeading: 'Check your answers before submitting the amendment request',
+      change: () => {
+        cy.completeDateFormFields({ idPrefix: 'effective-date', date: tomorrow.date });
+        cy.clickContinueButton();
+      },
+    },
+    ...eligibilityTestCases,
+  ];
+
+  const testCasesWithBRD = [
+    {
+      description: 'what do you need to change',
+      page: 'what-do-you-need-to-change',
+      nextPage: 'cover-end-date',
+      element: whatDoYouNeedToChange,
+      nextElement: coverEndDate,
+      checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().amendmentOptionsChangeLink(),
+      fragment: 'amendmentOptions',
+      nextPageHeading: 'New cover end date',
+      change: () => {
+        whatDoYouNeedToChange.facilityValueCheckbox().click();
+        cy.clickContinueButton();
+      },
+    },
+    {
+      description: 'bank review date',
+      page: 'bank-review-date',
+      nextPage: 'eligibility',
+      element: bankReviewDate,
+      nextElement: eligibility,
+      checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().bankReviewDateChangeLink(),
+      fragment: 'bankReviewDate-day',
+      nextPageHeading: 'Eligibility',
+      change: () => {
+        cy.completeDateFormFields({ idPrefix: 'bank-review-date', date: tomorrow.date });
+        cy.clickContinueButton();
+      },
+    },
+  ];
+
+  const setupTest = async (testCases, pageActions, hasBankReviewDate) => {
+    before(() => {
+      cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+        dealId = insertedDeal._id;
+
+        cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+        cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+          facilityId = createdFacility.details._id;
+          cy.makerLoginSubmitGefDealForReview(insertedDeal);
+          cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+          cy.clearSessionCookies();
+          cy.login(BANK1_MAKER1);
+          cy.saveSession();
+          cy.visit(relative(`/gef/application-details/${dealId}`));
+
+          applicationPreview.makeAChangeButton(facilityId).click();
+
+          cy.getAmendmentIdFromUrl().then((amendmentId) => {
+            amendmentUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}`;
+            pageActions(hasBankReviewDate);
+          });
+        });
+      });
+    });
+
+    after(() => {
+      cy.clearCookies();
+      cy.clearSessionCookies();
+    });
+
+    beforeEach(() => {
+      cy.clearSessionCookies();
+      cy.login(BANK1_MAKER1);
+    });
+
+    testCases.forEach(({ description, page, nextPage, element, nextElement, checkYourAnswersChangeElement, fragment, nextPageHeading, change }) => {
+      it(`should navigate back to "Check your answers" page when no changes are made on the ${description} page`, () => {
+        cy.visit(relative(`${amendmentUrl}/check-your-answers`));
+        checkYourAnswersChangeElement().click();
+        cy.url().should('eq', relative(`${amendmentUrl}/${page}/?change=true#${fragment}`));
+        cy.clickContinueButton();
+        cy.url().should('eq', relative(`${amendmentUrl}/check-your-answers#${fragment}`));
+        checkYourAnswers.pageHeading().contains('Check your answers before submitting the amendment request');
+      });
+
+      it(`should navigate back to "Check your answers" page when the Back link is clicked on the ${description} page`, () => {
+        cy.visit(relative(`${amendmentUrl}/check-your-answers`));
+        checkYourAnswersChangeElement().click();
+        cy.url().should('eq', relative(`${amendmentUrl}/${page}/?change=true#${fragment}`));
+        element.backLink().click();
+        cy.url().should('eq', relative(`${amendmentUrl}/check-your-answers`));
+        checkYourAnswers.pageHeading().contains('Check your answers before submitting the amendment request');
+      });
+
+      it(`should navigate through the amendment journey when changes are made on the ${description} page`, () => {
+        cy.visit(relative(`${amendmentUrl}/check-your-answers`));
+        checkYourAnswersChangeElement().click();
+        cy.url().should('eq', relative(`${amendmentUrl}/${page}/?change=true#${fragment}`));
+        change();
+        if (nextPage !== 'manual-approval-needed') {
+          cy.url().should('eq', relative(`${amendmentUrl}/${nextPage}#${fragment}`));
+          nextElement.pageHeading().contains(nextPageHeading);
+        } else {
+          cy.url().should('eq', relative(`${amendmentUrl}/${nextPage}#${fragment}`));
+          nextElement.pageHeading().contains(nextPageHeading);
+          manualApprovalNeeded.backLink().click();
+          eligibility.allTrueRadioButtons().click({ multiple: true });
+          cy.clickContinueButton();
+        }
+      });
+    });
+  };
+
+  const pageActions = (hasBankReviewDate) => {
+    whatDoYouNeedToChange.coverEndDateCheckbox().click();
+    whatDoYouNeedToChange.facilityValueCheckbox().click();
+    cy.clickContinueButton();
+    cy.completeDateFormFields({ idPrefix: 'cover-end-date' });
+    cy.clickContinueButton();
+    if (hasBankReviewDate) {
+      doYouHaveAFacilityEndDate.noRadioButton().click();
+      cy.clickContinueButton();
+      cy.completeDateFormFields({ idPrefix: 'bank-review-date' });
+    } else {
+      doYouHaveAFacilityEndDate.yesRadioButton().click();
+      cy.clickContinueButton();
+      cy.completeDateFormFields({ idPrefix: 'facility-end-date' });
+    }
+    cy.clickContinueButton();
+    cy.keyboardInput(facilityValue.facilityValue(), '10000');
+    cy.clickContinueButton();
+    eligibility.allTrueRadioButtons().click({ multiple: true });
+    cy.clickContinueButton();
+    cy.completeDateFormFields({ idPrefix: 'effective-date' });
+    cy.clickContinueButton();
+  };
+
+  (async () => {
+    await setupTest(testCasesWithBRD, pageActions, true);
+    await setupTest(testCasesWithoutBRD, pageActions, false);
+  })();
+});

--- a/e2e-tests/ukef/cypress/fixtures/check-your-answers-change-journey.js
+++ b/e2e-tests/ukef/cypress/fixtures/check-your-answers-change-journey.js
@@ -1,0 +1,120 @@
+import coverEndDate from '../../../gef/cypress/e2e/pages/amendments/cover-end-date';
+import facilityEndDate from '../../../gef/cypress/e2e/pages/amendments/facility-end-date';
+import bankReviewDate from '../../../gef/cypress/e2e/pages/amendments/bank-review-date';
+import effectiveDate from '../../../gef/cypress/e2e/pages/amendments/effective-date';
+import whatDoYouNeedToChange from '../../../gef/cypress/e2e/pages/amendments/what-do-you-need-to-change';
+import doYouHaveAFacilityEndDate from '../../../gef/cypress/e2e/pages/amendments/do-you-have-a-facility-end-date';
+import facilityValue from '../../../gef/cypress/e2e/pages/amendments/facility-value';
+import eligibility from '../../../gef/cypress/e2e/pages/amendments/eligibility';
+import checkYourAnswers from '../../../gef/cypress/e2e/pages/amendments/check-your-answers';
+import manualApprovalNeeded from '../../../gef/cypress/e2e/pages/amendments/manual-approval-needed';
+import { tomorrow } from '../../../e2e-fixtures/dateConstants';
+
+const ELIGIBILITY_CRITERIA_COUNT = 7;
+const NEW_FACILITY_VALUE = '20000';
+
+const MOCK_ELIGIBILITY_TEST_CASES = Array.from({ length: ELIGIBILITY_CRITERIA_COUNT }, (_, index) => ({
+  description: 'eligibility',
+  page: 'eligibility',
+  nextPage: 'manual-approval-needed',
+  element: eligibility,
+  nextElement: manualApprovalNeeded,
+  checkYourAnswersChangeElement: () => checkYourAnswers.eligibilityCriteriaSummaryListTable().eligibilityCriterionChangeLink(index + 1),
+  fragment: `${index + 1}`,
+  nextPageHeading: 'This amendment cannot be automatically approved',
+  change: () => {
+    eligibility.allFalseRadioButtons().click({ multiple: true });
+    cy.clickContinueButton();
+  },
+}));
+
+export const MOCK_JOURNEYS_WITH_FED = [
+  {
+    description: 'cover end date',
+    page: 'cover-end-date',
+    nextPage: 'do-you-have-a-facility-end-date',
+    element: coverEndDate,
+    nextElement: doYouHaveAFacilityEndDate,
+    checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().coverEndDateChangeLink(),
+    fragment: 'coverEndDate-day',
+    nextPageHeading: 'Do you have a facility end date?',
+    change: () => {
+      cy.completeDateFormFields({ idPrefix: 'cover-end-date', date: tomorrow.date });
+      cy.clickContinueButton();
+    },
+  },
+  {
+    description: 'facility end date',
+    page: 'facility-end-date',
+    nextPage: 'facility-value',
+    element: facilityEndDate,
+    nextElement: facilityValue,
+    checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().facilityEndDateChangeLink(),
+    fragment: 'facilityEndDate-day',
+    nextPageHeading: 'New facility value',
+    change: () => {
+      cy.completeDateFormFields({ idPrefix: 'facility-end-date', date: tomorrow.date });
+      cy.clickContinueButton();
+    },
+  },
+  {
+    description: 'facility value',
+    page: 'facility-value',
+    nextPage: 'eligibility',
+    element: facilityValue,
+    nextElement: eligibility,
+    checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().facilityValueChangeLink(),
+    fragment: 'facilityValue',
+    nextPageHeading: 'Eligibility',
+    change: () => {
+      cy.keyboardInput(facilityValue.facilityValue(), NEW_FACILITY_VALUE);
+      cy.clickContinueButton();
+    },
+  },
+  {
+    description: 'effective date',
+    page: 'effective-date',
+    nextPage: 'check-your-answers',
+    element: effectiveDate,
+    nextElement: checkYourAnswers,
+    checkYourAnswersChangeElement: () => checkYourAnswers.effectiveDateSummaryListTable().effectiveDateChangeLink(),
+    fragment: 'effectiveDate-day',
+    nextPageHeading: 'Check your answers before submitting the amendment request',
+    change: () => {
+      cy.completeDateFormFields({ idPrefix: 'effective-date', date: tomorrow.date });
+      cy.clickContinueButton();
+    },
+  },
+  ...MOCK_ELIGIBILITY_TEST_CASES,
+];
+
+export const MOCK_JOURNEYS_WITH_BRD = [
+  {
+    description: 'what do you need to change',
+    page: 'what-do-you-need-to-change',
+    nextPage: 'cover-end-date',
+    element: whatDoYouNeedToChange,
+    nextElement: coverEndDate,
+    checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().amendmentOptionsChangeLink(),
+    fragment: 'amendmentOptions',
+    nextPageHeading: 'New cover end date',
+    change: () => {
+      whatDoYouNeedToChange.facilityValueCheckbox().click();
+      cy.clickContinueButton();
+    },
+  },
+  {
+    description: 'bank review date',
+    page: 'bank-review-date',
+    nextPage: 'eligibility',
+    element: bankReviewDate,
+    nextElement: eligibility,
+    checkYourAnswersChangeElement: () => checkYourAnswers.amendmentSummaryListTable().bankReviewDateChangeLink(),
+    fragment: 'bankReviewDate-day',
+    nextPageHeading: 'Eligibility',
+    change: () => {
+      cy.completeDateFormFields({ idPrefix: 'bank-review-date', date: tomorrow.date });
+      cy.clickContinueButton();
+    },
+  },
+];

--- a/gef-ui/api-tests/amendments/bank-review-date.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/bank-review-date.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/check-your-answers.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/check-your-answers.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/check-your-answers.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/check-your-answers.post.api-test.ts
@@ -21,9 +21,9 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockUpdateAmendmentStatus = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const url = `/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/${PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS}`;
 

--- a/gef-ui/api-tests/amendments/cover-end-date.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/cover-end-date.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/cover-end-date.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/cover-end-date.post.api-test.ts
@@ -24,11 +24,12 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
+const mockGetAmendment = jest.fn();
 const mockUpdateAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 
@@ -46,19 +47,20 @@ describe(`POST ${url}`, () => {
     ({ sessionCookie } = await storage.saveUserSession([ROLES.MAKER]));
     jest.spyOn(api, 'getFacility').mockImplementation(mockGetFacility);
     jest.spyOn(api, 'getApplication').mockImplementation(mockGetApplication);
+    jest.spyOn(api, 'getAmendment').mockImplementation(mockGetAmendment);
     jest.spyOn(api, 'updateAmendment').mockImplementation(mockUpdateAmendment);
     jest.spyOn(console, 'error');
 
+    const amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder()
+      .withDealId(dealId)
+      .withFacilityId(facilityId)
+      .withAmendmentId(amendmentId)
+      .withChangeCoverEndDate(true)
+      .build();
     mockGetFacility.mockResolvedValue(MOCK_ISSUED_FACILITY);
     mockGetApplication.mockResolvedValue(mockDeal);
-    mockUpdateAmendment.mockResolvedValue(
-      new PortalFacilityAmendmentWithUkefIdMockBuilder()
-        .withDealId(dealId)
-        .withFacilityId(facilityId)
-        .withAmendmentId(amendmentId)
-        .withChangeCoverEndDate(true)
-        .build(),
-    );
+    mockGetAmendment.mockResolvedValue(amendment);
+    mockUpdateAmendment.mockResolvedValue(amendment);
   });
 
   afterAll(async () => {
@@ -142,6 +144,25 @@ describe(`POST ${url}`, () => {
 
       // Act
       const response = await postWithSessionCookie(body, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when amendment not found', async () => {
+      // Arrange
+      mockGetAmendment.mockResolvedValue(undefined);
+
+      const body = {
+        'cover-end-date-day': format(todayPlusTwoYears, 'd'),
+        'cover-end-date-month': format(todayPlusTwoYears, 'M'),
+        'cover-end-date-year': format(todayPlusTwoYears, 'yyyy'),
+      };
+
+      // Act
+      const response = await postWithSessionCookie(body, sessionCookie);
+
       // Assert
       expect(response.status).toEqual(HttpStatusCode.Found);
       expect(response.headers.location).toEqual('/not-found');

--- a/gef-ui/api-tests/amendments/create-draft.api-test.ts
+++ b/gef-ui/api-tests/amendments/create-draft.api-test.ts
@@ -21,9 +21,9 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockUpsertFacility = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const url = `/application-details/${dealId}/facilities/${facilityId}/amendments/create-draft`;
 

--- a/gef-ui/api-tests/amendments/do-you-have-a-facility-end-date.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/do-you-have-a-facility-end-date.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/do-you-have-a-facility-end-date.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/do-you-have-a-facility-end-date.post.api-test.ts
@@ -27,9 +27,9 @@ const mockUpdateAmendment = jest.fn();
 
 const aMockError = () => new Error();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/effective-date.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/effective-date.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/eligibility.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/eligibility.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/eligibility.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/eligibility.post.api-test.ts
@@ -26,9 +26,9 @@ const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 const mockUpdateAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/facility-end-date.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/facility-end-date.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/facility-end-date.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/facility-end-date.post.api-test.ts
@@ -24,11 +24,12 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
+const mockGetAmendment = jest.fn();
 const mockUpdateAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 
@@ -46,18 +47,19 @@ describe(`POST ${url}`, () => {
     ({ sessionCookie } = await storage.saveUserSession([ROLES.MAKER]));
     jest.spyOn(api, 'getFacility').mockImplementation(mockGetFacility);
     jest.spyOn(api, 'getApplication').mockImplementation(mockGetApplication);
+    jest.spyOn(api, 'getAmendment').mockImplementation(mockGetAmendment);
     jest.spyOn(api, 'updateAmendment').mockImplementation(mockUpdateAmendment);
 
+    const amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder()
+      .withDealId(dealId)
+      .withFacilityId(facilityId)
+      .withAmendmentId(amendmentId)
+      .withFacilityEndDate(todayPlusTwoYears)
+      .build();
     mockGetFacility.mockResolvedValue(MOCK_ISSUED_FACILITY);
     mockGetApplication.mockResolvedValue(mockDeal);
-    mockUpdateAmendment.mockResolvedValue(
-      new PortalFacilityAmendmentWithUkefIdMockBuilder()
-        .withDealId(dealId)
-        .withFacilityId(facilityId)
-        .withAmendmentId(amendmentId)
-        .withFacilityEndDate(todayPlusTwoYears)
-        .build(),
-    );
+    mockGetAmendment.mockResolvedValue(amendment);
+    mockUpdateAmendment.mockResolvedValue(amendment);
   });
 
   afterAll(async () => {
@@ -141,6 +143,25 @@ describe(`POST ${url}`, () => {
 
       // Act
       const response = await postWithSessionCookie(body, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when amendment not found', async () => {
+      // Arrange
+      mockGetAmendment.mockResolvedValue(undefined);
+
+      const body = {
+        'facility-end-date-day': format(todayPlusTwoYears, 'd'),
+        'facility-end-date-month': format(todayPlusTwoYears, 'M'),
+        'facility-end-date-year': format(todayPlusTwoYears, 'yyyy'),
+      };
+
+      // Act
+      const response = await postWithSessionCookie(body, sessionCookie);
+
       // Assert
       expect(response.status).toEqual(HttpStatusCode.Found);
       expect(response.headers.location).toEqual('/not-found');

--- a/gef-ui/api-tests/amendments/facility-value.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/facility-value.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/facility-value.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/facility-value.post.api-test.ts
@@ -23,11 +23,12 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
+const mockGetAmendment = jest.fn();
 const mockUpdateAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 
@@ -43,18 +44,19 @@ describe(`POST ${url}`, () => {
     ({ sessionCookie } = await storage.saveUserSession([ROLES.MAKER]));
     jest.spyOn(api, 'getFacility').mockImplementation(mockGetFacility);
     jest.spyOn(api, 'getApplication').mockImplementation(mockGetApplication);
+    jest.spyOn(api, 'getAmendment').mockImplementation(mockGetAmendment);
     jest.spyOn(api, 'updateAmendment').mockImplementation(mockUpdateAmendment);
 
+    const amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder()
+      .withDealId(dealId)
+      .withFacilityId(facilityId)
+      .withAmendmentId(amendmentId)
+      .withChangeFacilityValue(true)
+      .build();
     mockGetFacility.mockResolvedValue(MOCK_ISSUED_FACILITY);
     mockGetApplication.mockResolvedValue(mockDeal);
-    mockUpdateAmendment.mockResolvedValue(
-      new PortalFacilityAmendmentWithUkefIdMockBuilder()
-        .withDealId(dealId)
-        .withFacilityId(facilityId)
-        .withAmendmentId(amendmentId)
-        .withChangeFacilityValue(true)
-        .build(),
-    );
+    mockGetAmendment.mockResolvedValue(amendment);
+    mockUpdateAmendment.mockResolvedValue(amendment);
   });
 
   afterAll(async () => {
@@ -107,6 +109,18 @@ describe(`POST ${url}`, () => {
     it('should redirect to /not-found when facility not found', async () => {
       // Arrange
       mockGetFacility.mockResolvedValue({ details: undefined });
+
+      // Act
+      const response = await postWithSessionCookie({ facilityValue: '100.00' }, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when amendment not found', async () => {
+      // Arrange
+      mockGetAmendment.mockResolvedValue(undefined);
 
       // Act
       const response = await postWithSessionCookie({ facilityValue: '100.00' }, sessionCookie);

--- a/gef-ui/api-tests/amendments/manual-approval-needed.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/manual-approval-needed.get.api-test.ts
@@ -27,9 +27,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 

--- a/gef-ui/api-tests/amendments/submitted-for-checking.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/submitted-for-checking.get.api-test.ts
@@ -21,9 +21,9 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = '111';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const url = `/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/${PORTAL_AMENDMENT_PAGES.SUBMITTED_FOR_CHECKING}`;
 

--- a/gef-ui/api-tests/amendments/what-needs-to-change.get.api-test.ts
+++ b/gef-ui/api-tests/amendments/what-needs-to-change.get.api-test.ts
@@ -26,9 +26,9 @@ const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
 const mockGetAmendment = jest.fn();
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = 'amendmentId';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 const mockFacility = MOCK_ISSUED_FACILITY.details;

--- a/gef-ui/api-tests/amendments/what-needs-to-change.post.api-test.ts
+++ b/gef-ui/api-tests/amendments/what-needs-to-change.post.api-test.ts
@@ -23,14 +23,15 @@ jest.mock('../../server/middleware/csrf', () => ({
 
 const mockGetFacility = jest.fn();
 const mockGetApplication = jest.fn();
+const mockGetAmendment = jest.fn();
 const mockUpdateAmendment = jest.fn();
 
 const validBody = { amendmentOptions: ['changeFacilityValue'] };
 const invalidBody = { amendmentOptions: [] };
 
-const dealId = '123';
-const facilityId = '111';
-const amendmentId = 'amendmentId';
+const dealId = '6597dffeb5ef5ff4267e5044';
+const facilityId = '6597dffeb5ef5ff4267e5045';
+const amendmentId = '6597dffeb5ef5ff4267e5046';
 
 const mockDeal = { ...MOCK_BASIC_DEAL, submissionType: DEAL_SUBMISSION_TYPE.AIN, status: DEAL_STATUS.UKEF_ACKNOWLEDGED };
 
@@ -46,19 +47,20 @@ describe(`POST ${url}`, () => {
     ({ sessionCookie } = await storage.saveUserSession([ROLES.MAKER]));
     jest.spyOn(api, 'getFacility').mockImplementation(mockGetFacility);
     jest.spyOn(api, 'getApplication').mockImplementation(mockGetApplication);
+    jest.spyOn(api, 'getAmendment').mockImplementation(mockGetAmendment);
     jest.spyOn(api, 'updateAmendment').mockImplementation(mockUpdateAmendment);
 
+    const amendment = new PortalFacilityAmendmentWithUkefIdMockBuilder()
+      .withDealId(dealId)
+      .withFacilityId(facilityId)
+      .withAmendmentId(amendmentId)
+      .withChangeCoverEndDate(false)
+      .withChangeFacilityValue(true)
+      .build();
     mockGetFacility.mockResolvedValue(MOCK_ISSUED_FACILITY);
     mockGetApplication.mockResolvedValue(mockDeal);
-    mockUpdateAmendment.mockResolvedValue(
-      new PortalFacilityAmendmentWithUkefIdMockBuilder()
-        .withDealId(dealId)
-        .withFacilityId(facilityId)
-        .withAmendmentId(amendmentId)
-        .withChangeCoverEndDate(false)
-        .withChangeFacilityValue(true)
-        .build(),
-    );
+    mockGetAmendment.mockResolvedValue(amendment);
+    mockUpdateAmendment.mockResolvedValue(amendment);
   });
 
   afterAll(async () => {
@@ -111,6 +113,18 @@ describe(`POST ${url}`, () => {
     it('should redirect to /not-found when facility not found', async () => {
       // Arrange
       mockGetFacility.mockResolvedValue({ details: undefined });
+
+      // Act
+      const response = await postWithSessionCookie(validBody, sessionCookie);
+
+      // Assert
+      expect(response.status).toEqual(HttpStatusCode.Found);
+      expect(response.headers.location).toEqual('/not-found');
+    });
+
+    it('should redirect to /not-found when amendment not found', async () => {
+      // Arrange
+      mockGetAmendment.mockResolvedValue(undefined);
 
       // Act
       const response = await postWithSessionCookie(validBody, sessionCookie);

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
@@ -89,7 +89,7 @@ describe('getBankReviewDate', () => {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true'),
       bankReviewDate: undefined,
     };
 

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
@@ -85,11 +85,12 @@ describe('getBankReviewDate', () => {
     await getBankReviewDate(req, res);
 
     // Assert
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true');
     const expectedRenderData: BankReviewDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true'),
+      previousPage,
       bankReviewDate: undefined,
     };
 

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.test.ts
@@ -85,7 +85,7 @@ describe('getBankReviewDate', () => {
     await getBankReviewDate(req, res);
 
     // Assert
-    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true');
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment);
     const expectedRenderData: BankReviewDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
@@ -10,7 +10,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetBankReviewDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -39,7 +39,7 @@ export const getBankReviewDate = async (req: GetBankReviewDateRequest, res: Resp
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
@@ -10,6 +10,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetBankReviewDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -67,7 +68,7 @@ export const getBankReviewDate = async (req: GetBankReviewDateRequest, res: Resp
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true'),
       bankReviewDate,
     };
 

--- a/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/get-bank-review-date.ts
@@ -10,7 +10,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetBankReviewDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -63,12 +63,13 @@ export const getBankReviewDate = async (req: GetBankReviewDateRequest, res: Resp
     }
 
     const bankReviewDate = amendment.bankReviewDate && convertDateToDayMonthYearInput(amendment.bankReviewDate);
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: BankReviewDateViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true'),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, changeQuery),
       bankReviewDate,
     };
 

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
@@ -243,6 +243,7 @@ describe('postBankReviewDate', () => {
     // Arrange
     const bankReviewDateDayMonthYear = { day: format(today, 'd'), month: format(today, 'M'), year: format(today, 'yyyy') };
     const { req, res } = getHttpMocks(bankReviewDateDayMonthYear);
+    req.query = { change: 'true' };
 
     // Act
     await postBankReviewDate(req, res);

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
@@ -268,7 +268,7 @@ describe('postBankReviewDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
@@ -267,6 +267,21 @@ describe('postBankReviewDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postBankReviewDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
+  });
+
   it('should redirect if the deal is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable import/first */
 const getFacilityMock = jest.fn();
 const getApplicationMock = jest.fn();
+const getAmendmentMock = jest.fn();
 const updateAmendmentMock = jest.fn();
 
 import httpMocks from 'node-mocks-http';
@@ -31,8 +32,11 @@ import { BankReviewDateViewModel } from '../../../types/view-models/amendments/b
 jest.mock('../../../services/api', () => ({
   getApplication: getApplicationMock,
   getFacility: getFacilityMock,
+  getAmendment: getAmendmentMock,
   updateAmendment: updateAmendmentMock,
 }));
+
+console.error = jest.fn();
 
 const dealId = 'dealId';
 const facilityId = 'facilityId';
@@ -89,6 +93,7 @@ describe('postBankReviewDate', () => {
 
     getApplicationMock.mockResolvedValue(mockDeal);
     getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    getAmendmentMock.mockResolvedValue(amendment);
     updateAmendmentMock.mockResolvedValue(amendment);
   });
 
@@ -114,6 +119,18 @@ describe('postBankReviewDate', () => {
     // Assert
     expect(getFacilityMock).toHaveBeenCalledTimes(1);
     expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should call getAmendment with the correct amendmentId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postBankReviewDate(req, res);
+
+    // Assert
+    expect(getAmendmentMock).toHaveBeenCalledTimes(1);
+    expect(getAmendmentMock).toHaveBeenCalledWith({ facilityId, amendmentId, userToken: req.session.userToken });
   });
 
   it('should call validateAndParseBankReviewDate', async () => {
@@ -220,6 +237,19 @@ describe('postBankReviewDate', () => {
     // Assert
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment));
+  });
+
+  it(`should redirect to the next page if bankReviewDate is valid and the change query parameter is true`, async () => {
+    // Arrange
+    const bankReviewDateDayMonthYear = { day: format(today, 'd'), month: format(today, 'M'), year: format(today, 'yyyy') };
+    const { req, res } = getHttpMocks(bankReviewDateDayMonthYear);
+
+    // Act
+    await postBankReviewDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, amendment, req.query.change === 'true'));
   });
 
   it('should redirect if the facility is not found', async () => {

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
@@ -78,9 +78,11 @@ export const postBankReviewDate = async (req: PostBankReviewDateRequest, res: Re
       !!amendment.bankReviewDate &&
       !!updatedAmendment.bankReviewDate &&
       new Date(amendment?.bankReviewDate).getTime() !== new Date(updatedAmendment?.bankReviewDate).getTime();
+
     const canMakeChange = req.query.change === 'true';
     const change = canMakeChange && !bankReviewDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments bank review date page %o', error);

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
@@ -75,8 +75,8 @@ export const postBankReviewDate = async (req: PostBankReviewDateRequest, res: Re
     // If the bank review date has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
     const bankReviewDateHasChanged =
-      amendment.bankReviewDate &&
-      updatedAmendment.bankReviewDate &&
+      !!amendment.bankReviewDate &&
+      !!updatedAmendment.bankReviewDate &&
       new Date(amendment?.bankReviewDate).getTime() !== new Date(updatedAmendment?.bankReviewDate).getTime();
     const canMakeChange = req.query.change === 'true';
     const change = canMakeChange && !bankReviewDateHasChanged;

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
@@ -70,10 +70,11 @@ export const postBankReviewDate = async (req: PostBankReviewDateRequest, res: Re
     const update = { bankReviewDate: validationErrorsOrValue.value };
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
-
-    // If change is true, then the previous page is "Check your answers"
-    // If the bank review date has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the bank review date has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const bankReviewDateHasChanged =
       !!amendment.bankReviewDate &&
       !!updatedAmendment.bankReviewDate &&

--- a/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
+++ b/gef-ui/server/controllers/amendments/bank-review-date/post-bank-review-date.ts
@@ -17,7 +17,7 @@ export type PostBankReviewDateRequest = CustomExpressRequest<{
     'bank-review-date-year': string;
     previousPage: string;
   };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -79,8 +79,8 @@ export const postBankReviewDate = async (req: PostBankReviewDateRequest, res: Re
       !!updatedAmendment.bankReviewDate &&
       new Date(amendment?.bankReviewDate).getTime() !== new Date(updatedAmendment?.bankReviewDate).getTime();
 
-    const canMakeChange = req.query.change === 'true';
-    const change = canMakeChange && !bankReviewDateHasChanged;
+    const changeQuery = req.query.change === 'true';
+    const change = changeQuery && !bankReviewDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE, updatedAmendment, change);
 
     return res.redirect(nextPage);

--- a/gef-ui/server/controllers/amendments/cancel-amendment/get-cancel-portal-facility-amendment.ts
+++ b/gef-ui/server/controllers/amendments/cancel-amendment/get-cancel-portal-facility-amendment.ts
@@ -37,7 +37,7 @@ export const getCancelPortalFacilityAmendment = async (req: GetCancelPortalFacil
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/check-your-answers/get-check-your-answers.ts
+++ b/gef-ui/server/controllers/amendments/check-your-answers/get-check-your-answers.ts
@@ -35,7 +35,7 @@ export const getCheckYourAnswers = async (req: GetCheckYourAnswersRequest, res: 
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
@@ -82,7 +82,7 @@ describe('getCoverEndDate', () => {
     await getCoverEndDate(req, res);
 
     // Assert
-    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true');
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment);
     const expectedRenderData: CoverEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
@@ -86,7 +86,7 @@ describe('getCoverEndDate', () => {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true'),
     };
 
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.test.ts
@@ -82,11 +82,12 @@ describe('getCoverEndDate', () => {
     await getCoverEndDate(req, res);
 
     // Assert
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true');
     const expectedRenderData: CoverEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true'),
+      previousPage,
     };
 
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
@@ -11,7 +11,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetCoverEndDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -40,7 +40,7 @@ export const getCoverEndDate = async (req: GetCoverEndDateRequest, res: Response
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
@@ -11,6 +11,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetCoverEndDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -61,7 +62,7 @@ export const getCoverEndDate = async (req: GetCoverEndDateRequest, res: Response
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true'),
       coverEndDate: coverEndDateDayMonthYear,
     };
 

--- a/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/get-cover-end-date.ts
@@ -11,7 +11,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetCoverEndDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -57,12 +57,13 @@ export const getCoverEndDate = async (req: GetCoverEndDateRequest, res: Response
     const currentCoverEndDate: Date | undefined = (amendment.coverEndDate && fromUnixTime(amendment.coverEndDate / 1000)) || undefined;
 
     const coverEndDateDayMonthYear: DayMonthYearInput | undefined = currentCoverEndDate && convertDateToDayMonthYearInput(currentCoverEndDate);
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: CoverEndDateViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true'),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, changeQuery),
       coverEndDate: coverEndDateDayMonthYear,
     };
 

--- a/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/first */
 const getFacilityMock = jest.fn();
 const getApplicationMock = jest.fn();
+const getAmendmentMock = jest.fn();
 const updateAmendmentMock = jest.fn();
 
 import httpMocks from 'node-mocks-http';
@@ -30,8 +31,11 @@ import { CoverEndDateViewModel } from '../../../types/view-models/amendments/cov
 jest.mock('../../../services/api', () => ({
   getApplication: getApplicationMock,
   getFacility: getFacilityMock,
+  getAmendment: getAmendmentMock,
   updateAmendment: updateAmendmentMock,
 }));
+
+console.error = jest.fn();
 
 const dealId = 'dealId';
 const facilityId = 'facilityId';
@@ -86,6 +90,7 @@ describe('postCoverEndDate', () => {
 
     getApplicationMock.mockResolvedValue(mockDeal);
     getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    getAmendmentMock.mockResolvedValue(amendment);
     updateAmendmentMock.mockResolvedValue(amendment);
   });
 
@@ -111,6 +116,18 @@ describe('postCoverEndDate', () => {
     // Assert
     expect(getFacilityMock).toHaveBeenCalledTimes(1);
     expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should call getAmendment with the correct amendmentId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postCoverEndDate(req, res);
+
+    // Assert
+    expect(getAmendmentMock).toHaveBeenCalledTimes(1);
+    expect(getAmendmentMock).toHaveBeenCalledWith({ facilityId, amendmentId, userToken: req.session.userToken });
   });
 
   it('should not call updateAmendment if the coverEndDate is invalid', async () => {
@@ -198,6 +215,20 @@ describe('postCoverEndDate', () => {
     // Assert
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment));
+  });
+
+  it(`should redirect to the next page if coverEndDate is valid and the change query parameter is true`, async () => {
+    // Arrange
+    const coverEndDateDayMonthYear = { day: format(today, 'd'), month: format(today, 'M'), year: format(today, 'yyyy') };
+    const { req, res } = getHttpMocks(coverEndDateDayMonthYear);
+    req.query = { change: 'true' };
+
+    // Act
+    await postCoverEndDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, amendment, req.query.change === 'true'));
   });
 
   it('should redirect if the facility is not found', async () => {

--- a/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.test.ts
@@ -246,6 +246,21 @@ describe('postCoverEndDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postCoverEndDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
+  });
+
   it('should redirect if the deal is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();

--- a/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.test.ts
@@ -246,7 +246,7 @@ describe('postCoverEndDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.ts
@@ -75,8 +75,10 @@ export const postCoverEndDate = async (req: PostCoverEndDateRequest, res: Respon
     // If the cover end date has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
     const coverEndDateHasChanged = amendment.coverEndDate !== updatedAmendment.coverEndDate;
+
     const change = req.query.change === 'true' && !coverEndDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments cover end date page %o', error);

--- a/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.ts
@@ -17,7 +17,7 @@ export type PostCoverEndDateRequest = CustomExpressRequest<{
     'cover-end-date-year': string;
     previousPage: string;
   };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -76,7 +76,8 @@ export const postCoverEndDate = async (req: PostCoverEndDateRequest, res: Respon
     // Otherwise, the next page should be the previous page "Check your answers".
     const coverEndDateHasChanged = amendment.coverEndDate !== updatedAmendment.coverEndDate;
 
-    const change = req.query.change === 'true' && !coverEndDateHasChanged;
+    const changeQuery = req.query?.change === 'true';
+    const change = changeQuery && !coverEndDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.COVER_END_DATE, updatedAmendment, change);
 
     return res.redirect(nextPage);

--- a/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.ts
+++ b/gef-ui/server/controllers/amendments/cover-end-date/post-cover-end-date.ts
@@ -70,10 +70,11 @@ export const postCoverEndDate = async (req: PostCoverEndDateRequest, res: Respon
     const update = { coverEndDate: validationErrorsOrValue.value };
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
-
-    // If change is true, then the previous page is "Check your answers"
-    // If the cover end date has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the cover end date has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const coverEndDateHasChanged = amendment.coverEndDate !== updatedAmendment.coverEndDate;
 
     const changeQuery = req.query?.change === 'true';

--- a/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/get-do-you-have-a-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/do-you-have-a-facility-end-date/get-do-you-have-a-facility-end-date.ts
@@ -37,7 +37,7 @@ export const getDoYouHaveAFacilityEndDate = async (req: GetDoYouHaveAFacilityEnd
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/effective-date/get-effective-date.test.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/get-effective-date.test.ts
@@ -79,11 +79,12 @@ describe('getEffectiveDate', () => {
     await getEffectiveDate(req, res);
 
     // Assert
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true');
     const expectedRenderData: EffectiveDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true'),
+      previousPage,
       effectiveDate: undefined,
     };
 

--- a/gef-ui/server/controllers/amendments/effective-date/get-effective-date.test.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/get-effective-date.test.ts
@@ -79,7 +79,7 @@ describe('getEffectiveDate', () => {
     await getEffectiveDate(req, res);
 
     // Assert
-    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true');
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment);
     const expectedRenderData: EffectiveDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/effective-date/get-effective-date.test.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/get-effective-date.test.ts
@@ -83,7 +83,7 @@ describe('getEffectiveDate', () => {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true'),
       effectiveDate: undefined,
     };
 

--- a/gef-ui/server/controllers/amendments/effective-date/get-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/get-effective-date.ts
@@ -11,7 +11,7 @@ import { EffectiveDateViewModel } from '../../../types/view-models/amendments/ef
 
 export type GetEffectiveDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -52,12 +52,13 @@ export const getEffectiveDate = async (req: GetEffectiveDateRequest, res: Respon
     const effectiveDate: DayMonthYearInput | undefined = amendment.effectiveDate
       ? convertDateToDayMonthYearInput(fromUnixTime(amendment.effectiveDate))
       : undefined;
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: EffectiveDateViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true'),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, changeQuery),
       effectiveDate,
     };
 

--- a/gef-ui/server/controllers/amendments/effective-date/get-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/get-effective-date.ts
@@ -11,7 +11,7 @@ import { EffectiveDateViewModel } from '../../../types/view-models/amendments/ef
 
 export type GetEffectiveDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -40,7 +40,7 @@ export const getEffectiveDate = async (req: GetEffectiveDateRequest, res: Respon
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/effective-date/get-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/get-effective-date.ts
@@ -11,6 +11,7 @@ import { EffectiveDateViewModel } from '../../../types/view-models/amendments/ef
 
 export type GetEffectiveDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -56,7 +57,7 @@ export const getEffectiveDate = async (req: GetEffectiveDateRequest, res: Respon
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true'),
       effectiveDate,
     };
 

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.test.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.test.ts
@@ -248,7 +248,7 @@ describe('postEffectiveDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.test.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.test.ts
@@ -248,6 +248,21 @@ describe('postEffectiveDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postEffectiveDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
+  });
+
   it('should redirect if the deal is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.test.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable import/first */
 const getFacilityMock = jest.fn();
 const getApplicationMock = jest.fn();
+const getAmendmentMock = jest.fn();
 const updateAmendmentMock = jest.fn();
 
 import httpMocks from 'node-mocks-http';
@@ -31,8 +32,11 @@ import { validateAndParseEffectiveDate } from './validation.ts';
 jest.mock('../../../services/api', () => ({
   getApplication: getApplicationMock,
   getFacility: getFacilityMock,
+  getAmendment: getAmendmentMock,
   updateAmendment: updateAmendmentMock,
 }));
+
+console.error = jest.fn();
 
 const dealId = 'dealId';
 const facilityId = 'facilityId';
@@ -88,6 +92,7 @@ describe('postEffectiveDate', () => {
 
     getApplicationMock.mockResolvedValue(mockDeal);
     getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    getAmendmentMock.mockResolvedValue(amendment);
     updateAmendmentMock.mockResolvedValue(amendment);
   });
 
@@ -113,6 +118,18 @@ describe('postEffectiveDate', () => {
     // Assert
     expect(getFacilityMock).toHaveBeenCalledTimes(1);
     expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should call getAmendment with the correct amendmentId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEffectiveDate(req, res);
+
+    // Assert
+    expect(getAmendmentMock).toHaveBeenCalledTimes(1);
+    expect(getAmendmentMock).toHaveBeenCalledWith({ facilityId, amendmentId, userToken: req.session.userToken });
   });
 
   it('should not call updateAmendment if the effectiveDate is invalid', async () => {
@@ -200,6 +217,20 @@ describe('postEffectiveDate', () => {
     // Assert
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment));
+  });
+
+  it(`should redirect to the next page if effectiveDate is valid and the change query parameter is true`, async () => {
+    // Arrange
+    const effectiveDateDayMonthYear = { day: format(today, 'd'), month: format(today, 'M'), year: format(today, 'yyyy') };
+    const { req, res } = getHttpMocks(effectiveDateDayMonthYear);
+    req.query = { change: 'true' };
+
+    // Act
+    await postEffectiveDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true'));
   });
 
   it('should redirect if the facility is not found', async () => {

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
@@ -71,9 +71,11 @@ export const postEffectiveDate = async (req: PostEffectiveDateRequest, res: Resp
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
 
-    // If change is true, then the previous page is "Check your answers"
-    // If the effective date has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the effective date has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const effectiveDateHasChanged = amendment.effectiveDate !== updatedAmendment.effectiveDate;
 
     const changeQuery = req.query?.change === 'true';

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
@@ -17,7 +17,7 @@ export type PostEffectiveDateRequest = CustomExpressRequest<{
     'effective-date-year': string;
     previousPage: string;
   };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -76,7 +76,8 @@ export const postEffectiveDate = async (req: PostEffectiveDateRequest, res: Resp
     // Otherwise, the next page should be the previous page "Check your answers".
     const effectiveDateHasChanged = amendment.effectiveDate !== updatedAmendment.effectiveDate;
 
-    const change = req.query.change === 'true' && !effectiveDateHasChanged;
+    const changeQuery = req.query?.change === 'true';
+    const change = changeQuery && !effectiveDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, updatedAmendment, change);
 
     return res.redirect(nextPage);

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
@@ -75,8 +75,10 @@ export const postEffectiveDate = async (req: PostEffectiveDateRequest, res: Resp
     // If the effective date has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
     const effectiveDateHasChanged = amendment.effectiveDate !== updatedAmendment.effectiveDate;
+
     const change = req.query.change === 'true' && !effectiveDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments effective date page %o', error);

--- a/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
+++ b/gef-ui/server/controllers/amendments/effective-date/post-effective-date.ts
@@ -17,7 +17,7 @@ export type PostEffectiveDateRequest = CustomExpressRequest<{
     'effective-date-year': string;
     previousPage: string;
   };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -48,7 +48,7 @@ export const postEffectiveDate = async (req: PostEffectiveDateRequest, res: Resp
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 
@@ -71,9 +71,13 @@ export const postEffectiveDate = async (req: PostEffectiveDateRequest, res: Resp
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
 
+    // If change is true, then the previous page is "Check your answers"
+    // If the effective date has changed, we need to go to the next page of the amendment journey.
+    // Otherwise, the next page should be the previous page "Check your answers".
     const effectiveDateHasChanged = amendment.effectiveDate !== updatedAmendment.effectiveDate;
-
-    return res.redirect(getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, updatedAmendment, req.query.change === 'true' && !effectiveDateHasChanged));
+    const change = req.query.change === 'true' && !effectiveDateHasChanged;
+    const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, updatedAmendment, change);
+    return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments effective date page %o', error);
     return res.render('partials/problem-with-service.njk');

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
@@ -88,11 +88,12 @@ describe('getEligibility', () => {
     await getEligibility(req, res);
 
     // Assert
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, req.query.change === 'true');
     const expectedRenderData: EligibilityViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, req.query.change === 'true'),
+      previousPage,
       criteria,
     };
 

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
@@ -88,7 +88,7 @@ describe('getEligibility', () => {
     await getEligibility(req, res);
 
     // Assert
-    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, req.query.change === 'true');
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment);
     const expectedRenderData: EligibilityViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.test.ts
@@ -92,7 +92,7 @@ describe('getEligibility', () => {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, req.query.change === 'true'),
       criteria,
     };
 

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
@@ -9,6 +9,7 @@ import { EligibilityViewModel } from '../../../types/view-models/amendments/elig
 
 export type GetEligibilityRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -52,7 +53,7 @@ export const getEligibility = async (req: GetEligibilityRequest, res: Response) 
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, req.query.change === 'true'),
       criteria,
     };
 

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
@@ -9,7 +9,7 @@ import { EligibilityViewModel } from '../../../types/view-models/amendments/elig
 
 export type GetEligibilityRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -48,12 +48,13 @@ export const getEligibility = async (req: GetEligibilityRequest, res: Response) 
     }
 
     const { criteria } = amendment.eligibilityCriteria;
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: EligibilityViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, req.query.change === 'true'),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment, changeQuery),
       criteria,
     };
 

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/get-eligibility.ts
@@ -9,7 +9,7 @@ import { EligibilityViewModel } from '../../../types/view-models/amendments/elig
 
 export type GetEligibilityRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -38,7 +38,7 @@ export const getEligibility = async (req: GetEligibilityRequest, res: Response) 
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
@@ -164,7 +164,7 @@ describe('postEligibility', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
@@ -176,7 +176,7 @@ describe('postEligibility', () => {
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual('/not-found');
     expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found on facility %s', amendmentId, facilityId);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
   });
 
   it('should render `problem with service` if getApplication throws an error', async () => {

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.test.ts
@@ -28,6 +28,8 @@ jest.mock('../../../services/api', () => ({
   updateAmendment: updateAmendmentMock,
 }));
 
+console.error = jest.fn();
+
 const dealId = 'dealId';
 const facilityId = 'facilityId';
 const amendmentId = 'amendmentId';
@@ -118,6 +120,18 @@ describe('postEligibility', () => {
     // Assert
     expect(getFacilityMock).toHaveBeenCalledTimes(1);
     expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should call getAmendment with the correct amendmentId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postEligibility(req, res);
+
+    // Assert
+    expect(getAmendmentMock).toHaveBeenCalledTimes(1);
+    expect(getAmendmentMock).toHaveBeenCalledWith({ facilityId, amendmentId, userToken: req.session.userToken });
   });
 
   it('should redirect if the facility is not found', async () => {
@@ -300,6 +314,19 @@ describe('postEligibility', () => {
       // Assert
       expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
       expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, amendment));
+    });
+
+    it(`should redirect to the next page if change query parameter is true`, async () => {
+      // Arrange
+      const { req, res } = getHttpMocks(responseWithAllAnswers);
+      req.query = { change: 'true' };
+
+      // Act
+      await postEligibility(req, res);
+
+      // Assert
+      expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+      expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE, amendment, req.query.change === 'true'));
     });
 
     it('should render `problem with service` if updateAmendment throws an error', async () => {

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
@@ -75,8 +75,10 @@ export const postEligibility = async (req: PostEligibilityRequest, res: Response
     // If the eligibility has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
     const eligibilityHasChanged = !isEqual(amendment.eligibilityCriteria, updatedAmendment.eligibilityCriteria);
+
     const change = req.query.change === 'true' && !eligibilityHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments eligibility page %o', error);

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
@@ -13,7 +13,7 @@ import { validateEligibilityResponse } from './validation.ts';
 export type PostEligibilityRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
   reqBody: EligibilityReqBody & { previousPage: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -76,7 +76,8 @@ export const postEligibility = async (req: PostEligibilityRequest, res: Response
     // Otherwise, the next page should be the previous page "Check your answers".
     const eligibilityHasChanged = !isEqual(amendment.eligibilityCriteria, updatedAmendment.eligibilityCriteria);
 
-    const change = req.query.change === 'true' && !eligibilityHasChanged;
+    const changeQuery = req.query?.change === 'true';
+    const change = changeQuery && !eligibilityHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, updatedAmendment, change);
 
     return res.redirect(nextPage);

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
@@ -12,6 +12,7 @@ import { validateEligibilityResponse } from './validation.ts';
 export type PostEligibilityRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
   reqBody: EligibilityReqBody & { previousPage: string };
+  query: { change: string };
 }>;
 
 /**
@@ -69,7 +70,9 @@ export const postEligibility = async (req: PostEligibilityRequest, res: Response
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
 
-    return res.redirect(getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, updatedAmendment));
+    const eligibilityHasChanged = JSON.stringify(amendment.eligibilityCriteria) !== JSON.stringify(updatedAmendment.eligibilityCriteria);
+
+    return res.redirect(getNextPage(PORTAL_AMENDMENT_PAGES.ELIGIBILITY, updatedAmendment, req.query.change === 'true' && !eligibilityHasChanged));
   } catch (error) {
     console.error('Error posting amendments eligibility page %o', error);
     return res.render('partials/problem-with-service.njk');

--- a/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
+++ b/gef-ui/server/controllers/amendments/eligibility-criteria/post-eligibility.ts
@@ -71,9 +71,11 @@ export const postEligibility = async (req: PostEligibilityRequest, res: Response
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
 
-    // If change is true, then the previous page is "Check your answers"
-    // If the eligibility has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the eligibility has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const eligibilityHasChanged = !isEqual(amendment.eligibilityCriteria, updatedAmendment.eligibilityCriteria);
 
     const changeQuery = req.query?.change === 'true';

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
@@ -84,11 +84,12 @@ describe('getFacilityEndDate', () => {
     await getFacilityEndDate(req, res);
 
     // Assert
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true');
     const expectedRenderData: FacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true'),
+      previousPage,
       facilityEndDate: undefined,
     };
 

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
@@ -88,7 +88,7 @@ describe('getFacilityEndDate', () => {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true'),
       facilityEndDate: undefined,
     };
 

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.test.ts
@@ -84,7 +84,7 @@ describe('getFacilityEndDate', () => {
     await getFacilityEndDate(req, res);
 
     // Assert
-    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true');
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment);
     const expectedRenderData: FacilityEndDateViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
@@ -10,6 +10,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetFacilityEndDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -63,7 +64,7 @@ export const getFacilityEndDate = async (req: GetFacilityEndDateRequest, res: Re
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true'),
       facilityEndDate,
     };
 

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
@@ -10,7 +10,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetFacilityEndDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -39,7 +39,7 @@ export const getFacilityEndDate = async (req: GetFacilityEndDateRequest, res: Re
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/get-facility-end-date.ts
@@ -10,7 +10,7 @@ import { convertDateToDayMonthYearInput } from '../helpers/dates.helper.ts';
 
 export type GetFacilityEndDateRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -59,12 +59,13 @@ export const getFacilityEndDate = async (req: GetFacilityEndDateRequest, res: Re
     }
 
     const facilityEndDate = amendment.facilityEndDate && convertDateToDayMonthYearInput(amendment.facilityEndDate);
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: FacilityEndDateViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true'),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, changeQuery),
       facilityEndDate,
     };
 

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable import/first */
 const getFacilityMock = jest.fn();
 const getApplicationMock = jest.fn();
+const getAmendmentMock = jest.fn();
 const updateAmendmentMock = jest.fn();
 
 import httpMocks from 'node-mocks-http';
@@ -31,8 +32,11 @@ import { getCoverStartDateOrToday } from '../../../utils/get-cover-start-date-or
 jest.mock('../../../services/api', () => ({
   getApplication: getApplicationMock,
   getFacility: getFacilityMock,
+  getAmendment: getAmendmentMock,
   updateAmendment: updateAmendmentMock,
 }));
+
+console.error = jest.fn();
 
 const dealId = 'dealId';
 const facilityId = 'facilityId';
@@ -89,6 +93,7 @@ describe('postFacilityEndDate', () => {
 
     getApplicationMock.mockResolvedValue(mockDeal);
     getFacilityMock.mockResolvedValue(MOCK_ISSUED_FACILITY);
+    getAmendmentMock.mockResolvedValue(amendment);
     updateAmendmentMock.mockResolvedValue(amendment);
   });
 
@@ -114,6 +119,18 @@ describe('postFacilityEndDate', () => {
     // Assert
     expect(getFacilityMock).toHaveBeenCalledTimes(1);
     expect(getFacilityMock).toHaveBeenCalledWith({ facilityId, userToken: req.session.userToken });
+  });
+
+  it('should call getAmendment with the correct amendmentId and userToken', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+
+    // Act
+    await postFacilityEndDate(req, res);
+
+    // Assert
+    expect(getAmendmentMock).toHaveBeenCalledTimes(1);
+    expect(getAmendmentMock).toHaveBeenCalledWith({ facilityId, amendmentId, userToken: req.session.userToken });
   });
 
   it('should call validateAndParseFacilityEndDate', async () => {
@@ -220,6 +237,20 @@ describe('postFacilityEndDate', () => {
     // Assert
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment));
+  });
+
+  it(`should redirect to the next page if facilityEndDate is valid and the change query parameter is true`, async () => {
+    // Arrange
+    const facilityEndDateDayMonthYear = { day: format(today, 'd'), month: format(today, 'M'), year: format(today, 'yyyy') };
+    const { req, res } = getHttpMocks(facilityEndDateDayMonthYear);
+    req.query = { change: 'true' };
+
+    // Act
+    await postFacilityEndDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, amendment, req.query.change === 'true'));
   });
 
   it('should redirect if the facility is not found', async () => {

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
@@ -268,6 +268,21 @@ describe('postFacilityEndDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postFacilityEndDate(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
+  });
+
   it('should redirect if the deal is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.test.ts
@@ -268,7 +268,7 @@ describe('postFacilityEndDate', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
@@ -71,10 +71,11 @@ export const postFacilityEndDate = async (req: PostFacilityEndDateRequest, res: 
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
 
-    // If change is true, then the previous page is "Check your answers"
-    // If the facility end date has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
-
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the facility end date has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const { facilityEndDate } = amendment;
     const updatedFacilityEndDate = updatedAmendment.facilityEndDate;
     const facilityEndDateHasChanged =

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
@@ -17,7 +17,7 @@ export type PostFacilityEndDateRequest = CustomExpressRequest<{
     'facility-end-date-year': string;
     previousPage: string;
   };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
@@ -74,10 +74,11 @@ export const postFacilityEndDate = async (req: PostFacilityEndDateRequest, res: 
     // If change is true, then the previous page is "Check your answers"
     // If the facility end date has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
+
+    const { facilityEndDate } = amendment;
+    const updatedFacilityEndDate = updatedAmendment.facilityEndDate;
     const facilityEndDateHasChanged =
-      !!amendment.facilityEndDate &&
-      !!updatedAmendment.facilityEndDate &&
-      new Date(amendment.facilityEndDate).getTime() !== new Date(updatedAmendment.facilityEndDate).getTime();
+      !!facilityEndDate && !!updatedFacilityEndDate && new Date(facilityEndDate).getTime() !== new Date(updatedFacilityEndDate).getTime();
 
     const change = req.query.change === 'true' && !facilityEndDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, updatedAmendment, change);

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
@@ -78,8 +78,10 @@ export const postFacilityEndDate = async (req: PostFacilityEndDateRequest, res: 
       !!amendment.facilityEndDate &&
       !!updatedAmendment.facilityEndDate &&
       new Date(amendment.facilityEndDate).getTime() !== new Date(updatedAmendment.facilityEndDate).getTime();
+
     const change = req.query.change === 'true' && !facilityEndDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments facility end date page %o', error);

--- a/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
+++ b/gef-ui/server/controllers/amendments/facility-end-date/post-facility-end-date.ts
@@ -75,8 +75,8 @@ export const postFacilityEndDate = async (req: PostFacilityEndDateRequest, res: 
     // If the facility end date has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
     const facilityEndDateHasChanged =
-      amendment.facilityEndDate &&
-      updatedAmendment.facilityEndDate &&
+      !!amendment.facilityEndDate &&
+      !!updatedAmendment.facilityEndDate &&
       new Date(amendment.facilityEndDate).getTime() !== new Date(updatedAmendment.facilityEndDate).getTime();
     const change = req.query.change === 'true' && !facilityEndDateHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE, updatedAmendment, change);

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
@@ -88,7 +88,7 @@ describe('getFacilityValue', () => {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, req.query.change === 'true'),
       currencySymbol: getCurrencySymbol(MOCK_ISSUED_FACILITY.details.currency!.id),
       facilityValue: '',
     };

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
@@ -84,11 +84,12 @@ describe('getFacilityValue', () => {
     await getFacilityValue(req, res);
 
     // Assert
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, req.query.change === 'true');
     const expectedRenderData: FacilityValueViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, req.query.change === 'true'),
+      previousPage,
       currencySymbol: getCurrencySymbol(MOCK_ISSUED_FACILITY.details.currency!.id),
       facilityValue: '',
     };

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.test.ts
@@ -84,7 +84,7 @@ describe('getFacilityValue', () => {
     await getFacilityValue(req, res);
 
     // Assert
-    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, req.query.change === 'true');
+    const previousPage = getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment);
     const expectedRenderData: FacilityValueViewModel = {
       exporterName: MOCK_BASIC_DEAL.exporter.companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
@@ -10,6 +10,7 @@ import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
 
 export type GetFacilityValueRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -61,7 +62,7 @@ export const getFacilityValue = async (req: GetFacilityValueRequest, res: Respon
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, req.query.change === 'true'),
       currencySymbol,
     };
 

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
@@ -10,7 +10,7 @@ import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
 
 export type GetFacilityValueRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -39,7 +39,7 @@ export const getFacilityValue = async (req: GetFacilityValueRequest, res: Respon
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/get-facility-value.ts
@@ -10,7 +10,7 @@ import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments';
 
 export type GetFacilityValueRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -56,13 +56,14 @@ export const getFacilityValue = async (req: GetFacilityValueRequest, res: Respon
     const currencySymbol = getCurrencySymbol(facility.currency?.id ?? CURRENCY.GBP);
 
     const facilityValue = amendment.value ? String(amendment.value) : '';
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: FacilityValueViewModel = {
       facilityValue,
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, req.query.change === 'true'),
+      previousPage: getPreviousPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, amendment, changeQuery),
       currencySymbol,
     };
 

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.test.ts
@@ -222,7 +222,7 @@ describe('postFacilityValue', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.test.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.test.ts
@@ -222,6 +222,21 @@ describe('postFacilityValue', () => {
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postFacilityValue(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
+  });
+
   it('should redirect if the deal is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
@@ -70,8 +70,10 @@ export const postFacilityValue = async (req: PostFacilityValueRequest, res: Resp
     // If the facility value has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
     const facilityValueHasChanged = amendment.value !== updatedAmendment.value;
+
     const change = req.query.change === 'true' && !facilityValueHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments facility value page %o', error);

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
@@ -15,7 +15,7 @@ export type PostFacilityValueRequest = CustomExpressRequest<{
     facilityValue: string;
     previousPage: string;
   };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -71,7 +71,8 @@ export const postFacilityValue = async (req: PostFacilityValueRequest, res: Resp
     // Otherwise, the next page should be the previous page "Check your answers".
     const facilityValueHasChanged = amendment.value !== updatedAmendment.value;
 
-    const change = req.query.change === 'true' && !facilityValueHasChanged;
+    const changeQuery = req.query?.change === 'true';
+    const change = changeQuery && !facilityValueHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.FACILITY_VALUE, updatedAmendment, change);
 
     return res.redirect(nextPage);

--- a/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
+++ b/gef-ui/server/controllers/amendments/facility-value/post-facility-value.ts
@@ -66,9 +66,11 @@ export const postFacilityValue = async (req: PostFacilityValueRequest, res: Resp
 
     const updatedAmendment = await api.updateAmendment({ facilityId, amendmentId, update, userToken });
 
-    // If change is true, then the previous page is "Check your answers"
-    // If the facility value has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the facility value has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const facilityValueHasChanged = amendment.value !== updatedAmendment.value;
 
     const changeQuery = req.query?.change === 'true';

--- a/gef-ui/server/controllers/amendments/helpers/amendment-summary-view-model.helper.test.ts
+++ b/gef-ui/server/controllers/amendments/helpers/amendment-summary-view-model.helper.test.ts
@@ -34,7 +34,12 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE })}/#amendmentOptions`,
+                href: `${getAmendmentsUrl({
+                  amendmentId,
+                  facilityId,
+                  dealId,
+                  page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE,
+                })}/?change=true#amendmentOptions`,
                 text: 'Change',
                 visuallyHiddenText: 'whether amending cover end date or facility value',
                 attributes: {
@@ -54,7 +59,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/#coverEndDate-day`,
+                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/?change=true#coverEndDate-day`,
                 text: 'Change',
                 visuallyHiddenText: 'cover end date',
                 attributes: {
@@ -74,7 +79,12 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE })}/#facilityEndDate-day`,
+                href: `${getAmendmentsUrl({
+                  amendmentId,
+                  facilityId,
+                  dealId,
+                  page: PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE,
+                })}/?change=true#facilityEndDate-day`,
                 text: 'Change',
                 visuallyHiddenText: 'facility end date',
                 attributes: {
@@ -117,7 +127,12 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE })}/#amendmentOptions`,
+                href: `${getAmendmentsUrl({
+                  amendmentId,
+                  facilityId,
+                  dealId,
+                  page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE,
+                })}/?change=true#amendmentOptions`,
                 text: 'Change',
                 visuallyHiddenText: 'whether amending cover end date or facility value',
                 attributes: {
@@ -137,7 +152,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/#coverEndDate-day`,
+                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/?change=true#coverEndDate-day`,
                 text: 'Change',
                 visuallyHiddenText: 'cover end date',
                 attributes: {
@@ -157,7 +172,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE })}/#bankReviewDate-day`,
+                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE })}/?change=true#bankReviewDate-day`,
                 text: 'Change',
                 visuallyHiddenText: 'bank review date',
                 attributes: {
@@ -199,7 +214,12 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE })}/#amendmentOptions`,
+                href: `${getAmendmentsUrl({
+                  amendmentId,
+                  facilityId,
+                  dealId,
+                  page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE,
+                })}/?change=true#amendmentOptions`,
                 text: 'Change',
                 visuallyHiddenText: 'whether amending cover end date or facility value',
                 attributes: {
@@ -219,7 +239,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.FACILITY_VALUE })}/#facilityValue`,
+                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.FACILITY_VALUE })}/?change=true#facilityValue`,
                 text: 'Change',
                 visuallyHiddenText: 'facility value',
                 attributes: {
@@ -265,7 +285,12 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE })}/#amendmentOptions`,
+                href: `${getAmendmentsUrl({
+                  amendmentId,
+                  facilityId,
+                  dealId,
+                  page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE,
+                })}/?change=true#amendmentOptions`,
                 text: 'Change',
                 visuallyHiddenText: 'whether amending cover end date or facility value',
                 attributes: {
@@ -285,7 +310,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/#coverEndDate-day`,
+                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/?change=true#coverEndDate-day`,
                 text: 'Change',
                 visuallyHiddenText: 'cover end date',
                 attributes: {
@@ -305,7 +330,12 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE })}/#facilityEndDate-day`,
+                href: `${getAmendmentsUrl({
+                  amendmentId,
+                  facilityId,
+                  dealId,
+                  page: PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE,
+                })}/?change=true#facilityEndDate-day`,
                 text: 'Change',
                 visuallyHiddenText: 'facility end date',
                 attributes: {
@@ -325,7 +355,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
           actions: {
             items: [
               {
-                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.FACILITY_VALUE })}/#facilityValue`,
+                href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.FACILITY_VALUE })}/?change=true#facilityValue`,
                 text: 'Change',
                 visuallyHiddenText: 'facility value',
                 attributes: {
@@ -369,7 +399,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
         actions: {
           items: [
             {
-              href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.ELIGIBILITY })}/#${criteria[0].id}`,
+              href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.ELIGIBILITY })}/?change=true#${criteria[0].id}`,
               text: 'Change',
               visuallyHiddenText: `response to eligibility criterion ${criteria[0].id}`,
               attributes: {
@@ -389,7 +419,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
         actions: {
           items: [
             {
-              href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.ELIGIBILITY })}/#${criteria[1].id}`,
+              href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.ELIGIBILITY })}/?change=true#${criteria[1].id}`,
               text: 'Change',
               visuallyHiddenText: `response to eligibility criterion ${criteria[1].id}`,
               attributes: {
@@ -429,7 +459,7 @@ describe('mapAmendmentToAmendmentSummaryListParams', () => {
         actions: {
           items: [
             {
-              href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE })}/#effectiveDate-day`,
+              href: `${getAmendmentsUrl({ amendmentId, facilityId, dealId, page: PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE })}/?change=true#effectiveDate-day`,
               text: 'Change',
               visuallyHiddenText: `date amendment effective from`,
               attributes: {

--- a/gef-ui/server/controllers/amendments/helpers/amendment-summary-view-model.helper.ts
+++ b/gef-ui/server/controllers/amendments/helpers/amendment-summary-view-model.helper.ts
@@ -20,7 +20,7 @@ const generateFacilityEndDateSummaryRows = (amendment: PortalFacilityAmendmentWi
         actions: {
           items: [
             {
-              href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE })}/#facilityEndDate-day`,
+              href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.FACILITY_END_DATE })}/?change=true#facilityEndDate-day`,
               text: 'Change',
               visuallyHiddenText: 'facility end date',
               attributes: {
@@ -44,7 +44,7 @@ const generateFacilityEndDateSummaryRows = (amendment: PortalFacilityAmendmentWi
       actions: {
         items: [
           {
-            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE })}/#bankReviewDate-day`,
+            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.BANK_REVIEW_DATE })}/?change=true#bankReviewDate-day`,
             text: 'Change',
             visuallyHiddenText: 'bank review date',
             attributes: {
@@ -77,7 +77,7 @@ const generateCoverEndDateSummaryRows = (amendment: PortalFacilityAmendmentWithU
       actions: {
         items: [
           {
-            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/#coverEndDate-day`,
+            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.COVER_END_DATE })}/?change=true#coverEndDate-day`,
             text: 'Change',
             visuallyHiddenText: 'cover end date',
             attributes: {
@@ -111,7 +111,7 @@ const generateFacilityValueSummaryRows = (amendment: PortalFacilityAmendmentWith
       actions: {
         items: [
           {
-            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.FACILITY_VALUE })}/#facilityValue`,
+            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.FACILITY_VALUE })}/?change=true#facilityValue`,
             text: 'Change',
             visuallyHiddenText: 'facility value',
             attributes: {
@@ -144,7 +144,7 @@ ${amendment.changeFacilityValue ? `<li>Facility value</li>` : ''}
       actions: {
         items: [
           {
-            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE })}/#amendmentOptions`,
+            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE })}/?change=true#amendmentOptions`,
             text: 'Change',
             visuallyHiddenText: 'whether amending cover end date or facility value',
             attributes: {
@@ -190,7 +190,7 @@ ${criterion.textList.map((item) => `<li>${item}</li>`).join('')}
       actions: {
         items: [
           {
-            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.ELIGIBILITY })}/#${criterion.id}`,
+            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.ELIGIBILITY })}/?change=true#${criterion.id}`,
             text: 'Change',
             visuallyHiddenText: `response to eligibility criterion ${criterion.id}`,
             attributes: {
@@ -219,7 +219,7 @@ const generateAmendmentSummaryEffectiveDateRows = (amendment: PortalFacilityAmen
       actions: {
         items: [
           {
-            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE })}/#effectiveDate-day`,
+            href: `${getAmendmentsUrl({ ...amendment, page: PORTAL_AMENDMENT_PAGES.EFFECTIVE_DATE })}/?change=true#effectiveDate-day`,
             text: 'Change',
             visuallyHiddenText: 'date amendment effective from',
             attributes: {

--- a/gef-ui/server/controllers/amendments/helpers/navigation.helper.getNextPage.test.ts
+++ b/gef-ui/server/controllers/amendments/helpers/navigation.helper.getNextPage.test.ts
@@ -29,8 +29,20 @@ describe('getNextPage', () => {
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).build(),
       },
       {
+        description: 'when changing the cover end date',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).build(),
+      },
+      {
         description: 'when changing the facility value but not the cover end date',
         expectedNextPage: FACILITY_VALUE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(false).withChangeFacilityValue(true).build(),
+      },
+      {
+        description: 'when changing the facility value but not the cover end date',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(false).withChangeFacilityValue(true).build(),
       },
     ],
@@ -42,6 +54,12 @@ describe('getNextPage', () => {
       {
         description: '',
         expectedNextPage: DO_YOU_HAVE_A_FACILITY_END_DATE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).build(),
+      },
+      {
+        description: '',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).build(),
       },
     ],
@@ -88,8 +106,28 @@ describe('getNextPage', () => {
           .build(),
       },
       {
+        description: 'when changing the facility value',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(true)
+          .withChangeFacilityValue(true)
+          .build(),
+      },
+      {
         description: 'when not changing the facility value',
         expectedNextPage: ELIGIBILITY,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(true)
+          .withChangeFacilityValue(false)
+          .build(),
+      },
+      {
+        description: 'when not changing the facility value',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
           .withChangeCoverEndDate(true)
           .withIsUsingFacilityEndDate(true)
@@ -122,8 +160,28 @@ describe('getNextPage', () => {
           .build(),
       },
       {
+        description: 'when changing the facility value',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(false)
+          .withChangeFacilityValue(true)
+          .build(),
+      },
+      {
         description: 'when not changing the facility value',
         expectedNextPage: ELIGIBILITY,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(false)
+          .withChangeFacilityValue(false)
+          .build(),
+      },
+      {
+        description: 'when not changing the facility value',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
           .withChangeCoverEndDate(true)
           .withIsUsingFacilityEndDate(false)
@@ -151,6 +209,12 @@ describe('getNextPage', () => {
         expectedNextPage: ELIGIBILITY,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(true).build(),
       },
+      {
+        description: '',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(true).build(),
+      },
     ],
     errorTestCases: [
       {
@@ -166,6 +230,18 @@ describe('getNextPage', () => {
       {
         description: 'when all eligibility criteria answers are "true"',
         expectedNextPage: EFFECTIVE_DATE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withCriteria([
+            { id: 1, text: 'Criterion 1', answer: true },
+            { id: 2, text: 'Criterion 2', answer: true },
+            { id: 3, text: 'Criterion 3', answer: true },
+          ])
+          .build(),
+      },
+      {
+        description: 'when all eligibility criteria answers are "true"',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
           .withCriteria([
             { id: 1, text: 'Criterion 1', answer: true },
@@ -227,6 +303,12 @@ describe('getNextPage', () => {
         expectedNextPage: CHECK_YOUR_ANSWERS,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().build(),
       },
+      {
+        description: '',
+        expectedNextPage: CHECK_YOUR_ANSWERS,
+        change: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().build(),
+      },
     ],
   });
 
@@ -276,6 +358,7 @@ function withNextPageTests({
   currentPage: PortalAmendmentPage;
   successTestCases?: {
     expectedNextPage: PortalAmendmentPage;
+    change?: boolean;
     amendment: PortalFacilityAmendmentWithUkefId;
     description: string;
   }[];
@@ -286,9 +369,9 @@ function withNextPageTests({
 }) {
   describe(`when current page is ${currentPage}`, () => {
     if (successTestCases) {
-      it.each(successTestCases)(`should return $expectedNextPage url $description`, ({ expectedNextPage, amendment }) => {
+      it.each(successTestCases)(`should return $expectedNextPage url $description`, ({ expectedNextPage, amendment, change }) => {
         // Act
-        const result = getNextPage(currentPage, amendment);
+        const result = getNextPage(currentPage, amendment, change);
 
         // Assert
         expect(result).toEqual(

--- a/gef-ui/server/controllers/amendments/helpers/navigation.helper.getPreviousPage.test.ts
+++ b/gef-ui/server/controllers/amendments/helpers/navigation.helper.getPreviousPage.test.ts
@@ -37,6 +37,12 @@ describe('getPreviousPage', () => {
         expectedPreviousPage: WHAT_DO_YOU_NEED_TO_CHANGE,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).build(),
       },
+      {
+        description: '',
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).build(),
+      },
     ],
     errorTestCases: [
       {
@@ -69,6 +75,12 @@ describe('getPreviousPage', () => {
       {
         description: '',
         expectedPreviousPage: DO_YOU_HAVE_A_FACILITY_END_DATE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).withIsUsingFacilityEndDate(true).build(),
+      },
+      {
+        description: '',
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeCoverEndDate(true).withIsUsingFacilityEndDate(true).build(),
       },
     ],
@@ -118,6 +130,16 @@ describe('getPreviousPage', () => {
           .build(),
       },
       {
+        description: `when amendment is changing the cover end date and amendment is using facility end date`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeFacilityValue(true)
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(true)
+          .build(),
+      },
+      {
         description: `when amendment changing the cover end date & amendment is not using facility end date`,
         expectedPreviousPage: BANK_REVIEW_DATE,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
@@ -127,8 +149,24 @@ describe('getPreviousPage', () => {
           .build(),
       },
       {
+        description: `when amendment changing the cover end date & amendment is not using facility end date`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeFacilityValue(true)
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(false)
+          .build(),
+      },
+      {
         description: `when amendment is not changing the cover end date`,
         expectedPreviousPage: WHAT_DO_YOU_NEED_TO_CHANGE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(true).withChangeCoverEndDate(false).build(),
+      },
+      {
+        description: `when amendment is not changing the cover end date`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(true).withChangeCoverEndDate(false).build(),
       },
     ],
@@ -149,8 +187,24 @@ describe('getPreviousPage', () => {
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(true).build(),
       },
       {
+        description: `when amendment is changing facility value`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(true).build(),
+      },
+      {
         description: `when amendment is not changing facility value, is changing the cover end date and is using facility end date`,
         expectedPreviousPage: FACILITY_END_DATE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeFacilityValue(false)
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(true)
+          .build(),
+      },
+      {
+        description: `when amendment is not changing facility value, is changing the cover end date and is using facility end date`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
           .withChangeFacilityValue(false)
           .withChangeCoverEndDate(true)
@@ -167,8 +221,24 @@ describe('getPreviousPage', () => {
           .build(),
       },
       {
+        description: `when amendment is not changing facility value, is changing the cover end date and is not using facility end date`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder()
+          .withChangeFacilityValue(false)
+          .withChangeCoverEndDate(true)
+          .withIsUsingFacilityEndDate(false)
+          .build(),
+      },
+      {
         description: `when amendment is not changing facility value or changing the cover end date`,
         expectedPreviousPage: WHAT_DO_YOU_NEED_TO_CHANGE,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(false).withChangeCoverEndDate(false).build(),
+      },
+      {
+        description: `when amendment is not changing facility value or changing the cover end date`,
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().withChangeFacilityValue(false).withChangeCoverEndDate(false).build(),
       },
     ],
@@ -211,6 +281,12 @@ describe('getPreviousPage', () => {
         expectedPreviousPage: ELIGIBILITY,
         amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().build(),
       },
+      {
+        description: '',
+        expectedPreviousPage: CHECK_YOUR_ANSWERS,
+        check: true,
+        amendment: new PortalFacilityAmendmentWithUkefIdMockBuilder().build(),
+      },
     ],
   });
 
@@ -244,6 +320,7 @@ function withPreviousPageTests({
   currentPage: PortalAmendmentPage;
   successTestCases?: {
     expectedPreviousPage: PortalAmendmentPage;
+    check?: boolean;
     amendment: PortalFacilityAmendmentWithUkefId;
     description: string;
   }[];
@@ -254,9 +331,9 @@ function withPreviousPageTests({
 }) {
   describe(`when current page is ${currentPage}`, () => {
     if (successTestCases) {
-      it.each(successTestCases)(`should return $expectedPreviousPage url $description`, ({ expectedPreviousPage, amendment }) => {
+      it.each(successTestCases)(`should return $expectedPreviousPage url $description`, ({ expectedPreviousPage, amendment, check }) => {
         // Act
-        const result = getPreviousPage(currentPage, amendment);
+        const result = getPreviousPage(currentPage, amendment, check);
 
         // Assert
         expect(result).toEqual(

--- a/gef-ui/server/controllers/amendments/helpers/navigation.helper.ts
+++ b/gef-ui/server/controllers/amendments/helpers/navigation.helper.ts
@@ -83,9 +83,10 @@ const getJourneyForAmendment = (amendment: PortalFacilityAmendmentWithUkefId): P
  *
  * @param currentPage - the current page
  * @param amendment - the amendment
+ * @param change - whether the user is changing the amendment journey
  * @returns the previous page in the journey for this amendment
  */
-export const getPreviousPage = (currentPage: PortalAmendmentPage, amendment: PortalFacilityAmendmentWithUkefId): string => {
+export const getPreviousPage = (currentPage: PortalAmendmentPage, amendment: PortalFacilityAmendmentWithUkefId, change?: boolean): string => {
   const journey = getJourneyForAmendment(amendment);
 
   const currentPageIndex = journey.indexOf(currentPage);
@@ -95,7 +96,7 @@ export const getPreviousPage = (currentPage: PortalAmendmentPage, amendment: Por
   }
 
   const { dealId, facilityId, amendmentId } = amendment;
-  const page = journey[currentPageIndex - 1];
+  const page = change ? CHECK_YOUR_ANSWERS : journey[currentPageIndex - 1];
 
   return getAmendmentsUrl({ dealId, facilityId, amendmentId, page });
 };
@@ -103,9 +104,10 @@ export const getPreviousPage = (currentPage: PortalAmendmentPage, amendment: Por
 /**
  * @param currentPage - the current page
  * @param amendment - the amendment
+ * @param change - whether the user is changing the amendment journey
  * @returns the next page in the journey for this amendment
  */
-export const getNextPage = (currentPage: PortalAmendmentPage, amendment: PortalFacilityAmendmentWithUkefId): string => {
+export const getNextPage = (currentPage: PortalAmendmentPage, amendment: PortalFacilityAmendmentWithUkefId, change?: boolean): string => {
   const journey = getJourneyForAmendment(amendment);
 
   const currentPageIndex = journey.indexOf(currentPage);
@@ -115,7 +117,7 @@ export const getNextPage = (currentPage: PortalAmendmentPage, amendment: PortalF
   }
 
   const { dealId, facilityId, amendmentId } = amendment;
-  const page = journey[currentPageIndex + 1];
+  const page = change ? CHECK_YOUR_ANSWERS : journey[currentPageIndex + 1];
 
   return getAmendmentsUrl({ dealId, facilityId, amendmentId, page });
 };

--- a/gef-ui/server/controllers/amendments/manual-approval-needed/get-manual-approval-needed.ts
+++ b/gef-ui/server/controllers/amendments/manual-approval-needed/get-manual-approval-needed.ts
@@ -39,7 +39,7 @@ export const getManualApprovalNeeded = async (req: GetManualApprovalNeededReques
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/submitted-for-checking/get-submitted-for-checking.test.ts
+++ b/gef-ui/server/controllers/amendments/submitted-for-checking/get-submitted-for-checking.test.ts
@@ -71,7 +71,7 @@ describe('getSubmittedForChecking', () => {
     expect(res._getRenderView()).toEqual('partials/amendments/submitted-for-checking.njk');
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
@@ -83,7 +83,7 @@ describe('getWhatNeedsToChange', () => {
     await getWhatNeedsToChange(req, res);
 
     // Assert
-    const previousPage = req.query.change === 'true' ? PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS : `/gef/application-details/${dealId}`;
+    const previousPage = `/gef/application-details/${dealId}`;
     const expectedRenderData: WhatNeedsToChangeViewModel = {
       exporterName: companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
@@ -83,10 +83,11 @@ describe('getWhatNeedsToChange', () => {
     await getWhatNeedsToChange(req, res);
 
     // Assert
+    const previousPage = req.query.change === 'true' ? PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS : `/gef/application-details/${dealId}`;
     const expectedRenderData: WhatNeedsToChangeViewModel = {
       exporterName: companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
-      previousPage: req.query.change === 'true' ? PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS : `/gef/application-details/${dealId}`,
+      previousPage,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       amendmentFormEmail: STB_PIM_EMAIL,
     };

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.test.ts
@@ -86,7 +86,7 @@ describe('getWhatNeedsToChange', () => {
     const expectedRenderData: WhatNeedsToChangeViewModel = {
       exporterName: companyName,
       facilityType: MOCK_ISSUED_FACILITY.details.type,
-      previousPage: `/gef/application-details/${dealId}`,
+      previousPage: req.query.change === 'true' ? PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS : `/gef/application-details/${dealId}`,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
       amendmentFormEmail: STB_PIM_EMAIL,
     };

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
@@ -54,7 +54,10 @@ export const getWhatNeedsToChange = async (req: GetWhatNeedsToChangeRequest, res
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: req.query.change === 'true' ? PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS : `/gef/application-details/${dealId}`,
+      previousPage:
+        req.query.change === 'true'
+          ? getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS })
+          : `/gef/application-details/${dealId}`,
       amendmentFormEmail: STB_PIM_EMAIL,
       changeCoverEndDate,
       changeFacilityValue,

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
@@ -10,7 +10,7 @@ import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments.ts';
 
 export type GetWhatNeedsToChangeRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change: string };
+  query: { change?: 'true' };
 }>;
 
 /**
@@ -39,7 +39,7 @@ export const getWhatNeedsToChange = async (req: GetWhatNeedsToChangeRequest, res
     const amendment = await api.getAmendment({ facilityId, amendmentId, userToken });
 
     if (!amendment) {
-      console.error('Amendment %s was not found on facility %s', amendmentId, facilityId);
+      console.error('Amendment %s was not found for the facility %s', amendmentId, facilityId);
       return res.redirect('/not-found');
     }
 

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
@@ -10,7 +10,7 @@ import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments.ts';
 
 export type GetWhatNeedsToChangeRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -49,15 +49,15 @@ export const getWhatNeedsToChange = async (req: GetWhatNeedsToChangeRequest, res
     }
 
     const { changeCoverEndDate, changeFacilityValue } = amendment;
+    const changeQuery = req.query?.change === 'true';
 
     const viewModel: WhatNeedsToChangeViewModel = {
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage:
-        req.query.change === 'true'
-          ? getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS })
-          : `/gef/application-details/${dealId}`,
+      previousPage: changeQuery
+        ? getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS })
+        : `/gef/application-details/${dealId}`,
       amendmentFormEmail: STB_PIM_EMAIL,
       changeCoverEndDate,
       changeFacilityValue,

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/get-what-needs-to-change.ts
@@ -10,6 +10,7 @@ import { PORTAL_AMENDMENT_PAGES } from '../../../constants/amendments.ts';
 
 export type GetWhatNeedsToChangeRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
+  query: { change: string };
 }>;
 
 /**
@@ -53,7 +54,7 @@ export const getWhatNeedsToChange = async (req: GetWhatNeedsToChangeRequest, res
       exporterName: deal.exporter.companyName,
       facilityType: facility.type,
       cancelUrl: getAmendmentsUrl({ dealId, facilityId, amendmentId, page: PORTAL_AMENDMENT_PAGES.CANCEL }),
-      previousPage: `/gef/application-details/${dealId}`,
+      previousPage: req.query.change === 'true' ? PORTAL_AMENDMENT_PAGES.CHECK_YOUR_ANSWERS : `/gef/application-details/${dealId}`,
       amendmentFormEmail: STB_PIM_EMAIL,
       changeCoverEndDate,
       changeFacilityValue,

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.test.ts
@@ -235,6 +235,21 @@ describe('postWhatNeedsToChange', () => {
     expect(console.error).toHaveBeenCalledWith(facilityOrDealNotFoundConsoleErrorText, dealId, facilityId);
   });
 
+  it('should redirect if the amendment is not found', async () => {
+    // Arrange
+    const { req, res } = getHttpMocks();
+    getAmendmentMock.mockResolvedValue(undefined);
+
+    // Act
+    await postWhatNeedsToChange(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
+    expect(res._getRedirectUrl()).toEqual(`/not-found`);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
+  });
+
   it('should render `problem with service` if getApplication throws an error', async () => {
     // Arrange
     getApplicationMock.mockRejectedValueOnce(mockError);

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.test.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.test.ts
@@ -235,7 +235,7 @@ describe('postWhatNeedsToChange', () => {
     expect(console.error).toHaveBeenCalledWith(facilityOrDealNotFoundConsoleErrorText, dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
@@ -70,9 +70,11 @@ export const postWhatNeedsToChange = async (req: PostWhatNeedsToChangeRequest, r
       userToken,
     });
 
-    // If change is true, then the previous page is "Check your answers"
-    // If the what needs to change has changed, we need to go to the next page of the amendment journey.
-    // Otherwise, the next page should be the previous page "Check your answers".
+    /*
+     * If change is true, then the previous page is "Check your answers"
+     * If the what needs to change has changed, we need to go to the next page of the amendment journey.
+     * Otherwise, the next page should be the previous page "Check your answers".
+     */
     const hasUserAmendedFacility =
       amendment.changeCoverEndDate !== updatedAmendment.changeCoverEndDate || amendment.changeFacilityValue !== updatedAmendment.changeFacilityValue;
 

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
@@ -75,8 +75,10 @@ export const postWhatNeedsToChange = async (req: PostWhatNeedsToChangeRequest, r
     // Otherwise, the next page should be the previous page "Check your answers".
     const whatNeedsToChangeHasChanged =
       amendment.changeCoverEndDate !== updatedAmendment.changeCoverEndDate || amendment.changeFacilityValue !== updatedAmendment.changeFacilityValue;
+
     const change = req.query.change === 'true' && !whatNeedsToChangeHasChanged;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE, updatedAmendment, change);
+
     return res.redirect(nextPage);
   } catch (error) {
     console.error('Error posting amendments what needs to change page %o', error);

--- a/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
+++ b/gef-ui/server/controllers/amendments/what-needs-to-change/post-what-needs-to-change.ts
@@ -12,7 +12,7 @@ import { validationErrorHandler } from '../../../utils/helpers';
 export type PostWhatNeedsToChangeRequest = CustomExpressRequest<{
   params: { dealId: string; facilityId: string; amendmentId: string };
   reqBody: { amendmentOptions: string[] };
-  query: { change?: 'true' };
+  query: { change?: string };
 }>;
 
 /**
@@ -73,10 +73,11 @@ export const postWhatNeedsToChange = async (req: PostWhatNeedsToChangeRequest, r
     // If change is true, then the previous page is "Check your answers"
     // If the what needs to change has changed, we need to go to the next page of the amendment journey.
     // Otherwise, the next page should be the previous page "Check your answers".
-    const whatNeedsToChangeHasChanged =
+    const hasUserAmendedFacility =
       amendment.changeCoverEndDate !== updatedAmendment.changeCoverEndDate || amendment.changeFacilityValue !== updatedAmendment.changeFacilityValue;
 
-    const change = req.query.change === 'true' && !whatNeedsToChangeHasChanged;
+    const changeQuery = req.query?.change === 'true';
+    const change = changeQuery && !hasUserAmendedFacility;
     const nextPage = getNextPage(PORTAL_AMENDMENT_PAGES.WHAT_DO_YOU_NEED_TO_CHANGE, updatedAmendment, change);
 
     return res.redirect(nextPage);

--- a/gef-ui/test-helpers/with-amendment-get-controller.tests.ts
+++ b/gef-ui/test-helpers/with-amendment-get-controller.tests.ts
@@ -104,7 +104,7 @@ export const withAmendmentGetControllerTests = <TRequest extends Request>({
     expect(console.error).toHaveBeenCalledWith('Deal %s or Facility %s was not found', dealId, facilityId);
   });
 
-  it('should redirect if the amendment is not found', async () => {
+  it('should redirect to "/not-found" if the amendment is not found', async () => {
     // Arrange
     const { req, res } = getHttpMocks();
     getAmendmentMock.mockResolvedValue(undefined);

--- a/gef-ui/test-helpers/with-amendment-get-controller.tests.ts
+++ b/gef-ui/test-helpers/with-amendment-get-controller.tests.ts
@@ -116,7 +116,7 @@ export const withAmendmentGetControllerTests = <TRequest extends Request>({
     expect(res._getStatusCode()).toEqual(HttpStatusCode.Found);
     expect(res._getRedirectUrl()).toEqual(`/not-found`);
     expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found on facility %s', amendmentId, facilityId);
+    expect(console.error).toHaveBeenCalledWith('Amendment %s was not found for the facility %s', amendmentId, facilityId);
   });
 
   it(`should redirect if the amendment has status ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL}`, async () => {


### PR DESCRIPTION
## Introduction :pencil2:
This is about the user being on ‘Check your answers before submitting the amendment request’ page, and deciding to change an attribute and being directed to that page. 
This page must be prepopulated, displaying the answer given.
The user must be redirected into the amendment journey if they make a change.
The user must be redirected to the ‘Check your answers before submitting the amendment request’ page if they **do not** make a change.
The user must be redirected back to the ‘Check your answers before submitting the amendment request’ page when they select the ‘back’ link on the page

## Resolution :heavy_check_mark:
add query parameter change='true' to the URL when the user clicks the change link on the ‘Check your answers before submitting the amendment request’ page
add a getAmendment request in all postControllers to check if the user made a change
add unit tests
add e2e tests 

## Screenshots:
![image](https://github.com/user-attachments/assets/55b73a8e-c427-403b-8a1f-20a9bc55c535)
![image](https://github.com/user-attachments/assets/2d1a7041-de21-4952-8d3a-a28e7c6adae9)


