### PR TITLE
fix(DTFS2-7820): cancel deal hide clone button

### DIFF
--- a/e2e-tests/portal/cypress/e2e/pages/cloneDeal.js
+++ b/e2e-tests/portal/cypress/e2e/pages/cloneDeal.js
@@ -3,6 +3,7 @@ const page = {
   bankInternalRefNameHint: () => cy.get('[data-cy="bank-supply-contract-id-hint"]'),
   additionalRefNameInput: () => cy.get('[data-cy="bank-supply-contract-name"]'),
   cloneTransactionsInput: () => cy.get('[data-cy="clone-transactions"]'),
+  cloneDealLink: () => cy.get('[data-cy="clone-deal-link"]'),
 };
 
 module.exports = page;

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/deal-cancellation-maker-unable-clone-deal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/BSS-EWCS/deal-cancellation-maker-unable-clone-deal.spec.js
@@ -1,0 +1,100 @@
+import { DEAL_STATUS, DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
+import portalPages from '../../../../../../../portal/cypress/e2e/pages';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { generateAinDealUnissuedFacilitiesWithDates } from '../../test-data/AIN-deal-unissued-facilities/dealReadyToSubmit';
+import generateMinDealUnissuedFacilitiesWithDates from '../../test-data/MIN-deal-unissued-facilities/dealReadyToSubmit';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+import { yesterday, tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+context('BSS/EWCS deals - When TFM submits a deal cancellation - Portal maker should not be able to clone the deal', () => {
+  /* creates 4 deals: 2 AIN deals (one cancelled and one scheduled for cancellation) 
+    and 2 MIN deals (one cancelled and one scheduled for cancellation). */
+  const ainDeal = Array(2).fill(generateAinDealUnissuedFacilitiesWithDates());
+  const minDeal = Array(2).fill(generateMinDealUnissuedFacilitiesWithDates());
+  const deals = [];
+
+  before(() => {
+    cy.insertManyDeals([...ainDeal, ...minDeal], BANK1_MAKER1).then((insertedDeals) => {
+      insertedDeals.forEach((insertedDeal, index) => {
+        const deal = { ...insertedDeal };
+        cy.createFacilities(insertedDeal._id, deal.mockFacilities, BANK1_MAKER1).then((createdFacilities) => {
+          deal.facilities = createdFacilities;
+
+          cy.makerSubmitDealForReview(deal);
+          cy.checkerSubmitDealToUkef(deal);
+
+          cy.clearCookie('dtfs-session');
+          cy.clearCookie('_csrf');
+          cy.getCookies().should('be.empty');
+
+          cy.visit(TFM_URL);
+          cy.tfmLogin(PIM_USER_1);
+          const effectiveDate = index % 2 === 0 ? tomorrow.date : yesterday.date;
+          cy.submitDealCancellation({ dealId: deal._id, effectiveDate });
+          // get deal with updated status for cancellation in past or in the future
+          cy.getOneDeal(deal._id, BANK1_MAKER1).then((response) => deals.push({ ...response.deal, facilities: createdFacilities }));
+        });
+      });
+    });
+  });
+
+  beforeEach(() => {
+    cy.clearCookie('dtfs-session');
+    cy.clearCookie('_csrf');
+    cy.getCookies().should('be.empty');
+    cy.login(BANK1_MAKER1);
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearCookie('dtfs-session');
+    cy.clearCookie('_csrf');
+    cy.getCookies().should('be.empty');
+  });
+
+  describe('when a deal submitted to UKEF and the deal has already been cancelled', () => {
+    describe('AIN deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const ainDealPast = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.AIN && deal.status === DEAL_STATUS.CANCELLED);
+
+        portalPages.contract.visit(ainDealPast);
+
+        portalPages.cloneDeal.cloneDealLink().should('not.exist');
+      });
+    });
+
+    describe('MIN deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const minDealPast = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.MIN && deal.status === DEAL_STATUS.CANCELLED);
+
+        portalPages.contract.visit(minDealPast);
+
+        portalPages.cloneDeal.cloneDealLink().should('not.exist');
+      });
+    });
+  });
+
+  describe('when a deal submitted to UKEF and the deal has been scheduled for cancellation', () => {
+    describe('AIN deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const ainDealFuture = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.AIN && deal.status === DEAL_STATUS.PENDING_CANCELLATION);
+
+        portalPages.contract.visit(ainDealFuture);
+
+        portalPages.cloneDeal.cloneDealLink().should('not.exist');
+      });
+    });
+
+    describe('MIN deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const minDealFuture = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.MIN && deal.status === DEAL_STATUS.PENDING_CANCELLATION);
+
+        portalPages.contract.visit(minDealFuture);
+
+        portalPages.cloneDeal.cloneDealLink().should('not.exist');
+      });
+    });
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/deal-cancellation-maker-unable-clone-deal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/deal-cancellation/gef/deal-cancellation-maker-unable-clone-deal.spec.js
@@ -1,0 +1,98 @@
+import { DEAL_STATUS, DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
+import relative from '../../../../relativeURL';
+import gefPages from '../../../../../../../gef/cypress/e2e/pages';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT, MOCK_APPLICATION_MIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { yesterday, tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+context('GEF deals - When TFM submits a deal cancellation - Portal maker should not be able to clone the deal', () => {
+  /* creates 4 deals: 2 AIN deals (one cancelled and one scheduled for cancellation) 
+    and 2 MIN deals (one cancelled and one scheduled for cancellation). */
+  const gefDeals = [MOCK_APPLICATION_AIN_DRAFT, MOCK_APPLICATION_AIN_DRAFT, MOCK_APPLICATION_MIN_DRAFT, MOCK_APPLICATION_MIN_DRAFT];
+  const deals = [];
+
+  before(() => {
+    cy.insertManyGefDeals(gefDeals, BANK1_MAKER1).then((insertedDeals) => {
+      insertedDeals.forEach((insertedDeal, index) => {
+        const gefDeal = { ...insertedDeal };
+
+        const mockDeal = index < 2 ? MOCK_APPLICATION_AIN_DRAFT : MOCK_APPLICATION_MIN_DRAFT;
+        cy.updateGefDeal(gefDeal._id, mockDeal, BANK1_MAKER1);
+
+        cy.createGefFacilities(gefDeal._id, [anIssuedCashFacility({ facilityEndDateEnabled: true })], BANK1_MAKER1).then((createdFacilities) => {
+          gefDeal.facilities = createdFacilities;
+          cy.makerLoginSubmitGefDealForReview(gefDeal);
+          cy.checkerLoginSubmitGefDealToUkef(gefDeal);
+          cy.clearSessionCookies();
+
+          cy.visit(TFM_URL);
+          cy.tfmLogin(PIM_USER_1);
+
+          /* effective date for cancellation and scheduled cancellation for AIN and MIN deals. */
+          const effectiveDate = index % 2 === 0 ? yesterday.date : tomorrow.date;
+          cy.submitDealCancellation({ dealId: gefDeal._id, effectiveDate });
+          // get deal with updated status for cancellation in past or in the future
+          cy.getOneGefDeal(gefDeal._id, BANK1_MAKER1).then((deal) => deals.push({ ...deal, facilities: createdFacilities }));
+        });
+      });
+    });
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  describe('when a deal has already been cancelled', () => {
+    describe('AIN Deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const ainDealPast = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.AIN && deal.status === DEAL_STATUS.CANCELLED);
+
+        cy.visit(relative(`/gef/application-details/${ainDealPast._id}`));
+
+        gefPages.cloneDeal.cloneGefDealLink().should('not.exist');
+      });
+    });
+
+    describe('MIN Deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const minDealPast = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.MIN && deal.status === DEAL_STATUS.CANCELLED);
+
+        cy.visit(relative(`/gef/application-details/${minDealPast._id}`));
+
+        gefPages.cloneDeal.cloneGefDealLink().should('not.exist');
+      });
+    });
+  });
+
+  describe('when a deal has been scheduled for cancellation', () => {
+    describe('AIN Deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const ainDealFuture = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.AIN && deal.status === DEAL_STATUS.PENDING_CANCELLATION);
+
+        cy.visit(relative(`/gef/application-details/${ainDealFuture._id}`));
+
+        gefPages.cloneDeal.cloneGefDealLink().should('not.exist');
+      });
+    });
+
+    describe('MIN Deal', () => {
+      it('should not allow a Maker to clone the deal', () => {
+        const minDealFuture = deals.find((deal) => deal.submissionType === DEAL_SUBMISSION_TYPE.MIN && deal.status === DEAL_STATUS.PENDING_CANCELLATION);
+
+        cy.visit(relative(`/gef/application-details/${minDealFuture._id}`));
+
+        gefPages.cloneDeal.cloneGefDealLink().should('not.exist');
+      });
+    });
+  });
+});

--- a/gef-ui/component-tests/includes/application-details/applicationReferenceAndActions.component-test.js
+++ b/gef-ui/component-tests/includes/application-details/applicationReferenceAndActions.component-test.js
@@ -1,3 +1,4 @@
+const { DEAL_STATUS } = require('@ukef/dtfs2-common');
 const pageRenderer = require('../../pageRenderer');
 const { NON_MAKER_ROLES } = require('../../../test-helpers/common-role-lists');
 const { MAKER } = require('../../../server/constants/roles');
@@ -9,6 +10,7 @@ describe(page, () => {
   let wrapper;
   const dealId = '61e54dd5b578247e14575882';
   const status = "Ready for Checker's approval";
+  const canCloneDeal = (dealStatus) => ![DEAL_STATUS.CANCELLED, DEAL_STATUS.PENDING_CANCELLATION].includes(dealStatus);
 
   describe("the 'Clone' button", () => {
     const cloneButtonSelector = '[data-cy="clone-gef-deal-link"]';
@@ -17,6 +19,7 @@ describe(page, () => {
       wrapper = render({
         dealId,
         status,
+        canCloneDeal: canCloneDeal(status),
       });
       wrapper.expectLink(cloneButtonSelector).notToExist();
     });
@@ -24,6 +27,27 @@ describe(page, () => {
     it('should not render when the page is rendered without the status param', () => {
       wrapper = render({
         dealId,
+        canCloneDeal: canCloneDeal(status),
+        userRoles: [MAKER],
+      });
+      wrapper.expectLink(cloneButtonSelector).notToExist();
+    });
+
+    it(`should not render when the page is rendered with status ${DEAL_STATUS.CANCELLED}`, () => {
+      wrapper = render({
+        dealId,
+        status: DEAL_STATUS.CANCELLED,
+        canCloneDeal: canCloneDeal(DEAL_STATUS.CANCELLED),
+        userRoles: [MAKER],
+      });
+      wrapper.expectLink(cloneButtonSelector).notToExist();
+    });
+
+    it(`should not render when the page is rendered with status ${DEAL_STATUS.PENDING_CANCELLATION}`, () => {
+      wrapper = render({
+        dealId,
+        status: DEAL_STATUS.PENDING_CANCELLATION,
+        canCloneDeal: canCloneDeal(DEAL_STATUS.PENDING_CANCELLATION),
         userRoles: [MAKER],
       });
       wrapper.expectLink(cloneButtonSelector).notToExist();
@@ -33,6 +57,7 @@ describe(page, () => {
       wrapper = render({
         dealId,
         status,
+        canCloneDeal: canCloneDeal(status),
         userRoles: [role],
       });
       wrapper.expectLink(cloneButtonSelector).notToExist();
@@ -42,6 +67,7 @@ describe(page, () => {
       wrapper = render({
         dealId,
         status,
+        canCloneDeal: canCloneDeal(status),
         userRoles: [MAKER],
       });
       wrapper.expectLink(cloneButtonSelector).toLinkTo(`${dealId}/clone`, 'Clone');

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -65,6 +65,7 @@ function buildBody(app, previewMode, user) {
   const unissuedFacilitiesPresent = areUnissuedFacilitiesPresent(app);
   const facilitiesChangedToIssued = facilitiesChangedToIssuedAsArray(app);
   const hasUkefDecisionAccepted = app.ukefDecisionAccepted ? app.ukefDecisionAccepted : false;
+  const dealCancelledStatus = [DEAL_STATUS.CANCELLED, DEAL_STATUS.PENDING_CANCELLATION];
 
   const mapSummaryParams = {
     app,
@@ -133,8 +134,7 @@ function buildBody(app, previewMode, user) {
     canUpdateUnissuedFacilities: canUpdateUnissuedFacilitiesCheck(app, unissuedFacilitiesPresent, facilitiesChangedToIssued, hasUkefDecisionAccepted),
     MIAReturnToMaker: isMIAWithoutChangedToIssuedFacilities(app),
     returnToMakerNoFacilitiesChanged: returnToMakerNoFacilitiesChanged(app, hasChangedFacilities),
-    dealStatusCancelled: app.status === DEAL_STATUS.CANCELLED,
-    dealStatusPendingCancellation: app.status === DEAL_STATUS.PENDING_CANCELLATION,
+    canCloneDeal: !dealCancelledStatus.includes(app.status),
   };
 
   return appBody;

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -133,6 +133,8 @@ function buildBody(app, previewMode, user) {
     canUpdateUnissuedFacilities: canUpdateUnissuedFacilitiesCheck(app, unissuedFacilitiesPresent, facilitiesChangedToIssued, hasUkefDecisionAccepted),
     MIAReturnToMaker: isMIAWithoutChangedToIssuedFacilities(app),
     returnToMakerNoFacilitiesChanged: returnToMakerNoFacilitiesChanged(app, hasChangedFacilities),
+    dealStatusCancelled: app.status === DEAL_STATUS.CANCELLED,
+    dealStatusPendingCancellation: app.status === DEAL_STATUS.PENDING_CANCELLATION,
   };
 
   return appBody;

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -155,8 +155,7 @@ describe('controllers/application-details', () => {
           canUpdateUnissuedFacilities: expect.any(Boolean),
           MIAReturnToMaker: expect.any(Boolean),
           returnToMakerNoFacilitiesChanged: expect.any(Boolean),
-          dealStatusCancelled: expect.any(Boolean),
-          dealStatusPendingCancellation: expect.any(Boolean),
+          canCloneDeal: expect.any(Boolean),
 
           // actions
           submit: expect.any(Boolean),

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -155,6 +155,8 @@ describe('controllers/application-details', () => {
           canUpdateUnissuedFacilities: expect.any(Boolean),
           MIAReturnToMaker: expect.any(Boolean),
           returnToMakerNoFacilitiesChanged: expect.any(Boolean),
+          dealStatusCancelled: expect.any(Boolean),
+          dealStatusPendingCancellation: expect.any(Boolean),
 
           // actions
           submit: expect.any(Boolean),

--- a/gef-ui/templates/includes/application-details/applicationReferenceAndActions.njk
+++ b/gef-ui/templates/includes/application-details/applicationReferenceAndActions.njk
@@ -5,7 +5,7 @@
 <div class="govuk-width-container" data-cy="application-banner">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full" id="application-reference-and-actions-actions">
-      {% if status and isMaker and not dealStatusCancelled and not dealStatusPendingCancellation %}
+      {% if status and isMaker and canCloneDeal %}
          {{ govukButton({
             text: "Clone",
             attributes: {

--- a/gef-ui/templates/includes/application-details/applicationReferenceAndActions.njk
+++ b/gef-ui/templates/includes/application-details/applicationReferenceAndActions.njk
@@ -5,7 +5,7 @@
 <div class="govuk-width-container" data-cy="application-banner">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full" id="application-reference-and-actions-actions">
-      {% if status and isMaker %}
+      {% if status and isMaker and not dealStatusCancelled and not dealStatusPendingCancellation %}
          {{ govukButton({
             text: "Clone",
             attributes: {

--- a/portal/component-tests/contract/components/clone-deal-link.component-test.js
+++ b/portal/component-tests/contract/components/clone-deal-link.component-test.js
@@ -1,5 +1,6 @@
 const {
   ROLES: { MAKER },
+  DEAL_STATUS,
 } = require('@ukef/dtfs2-common');
 const componentRenderer = require('../../componentRenderer');
 
@@ -20,6 +21,7 @@ describe(component, () => {
     { _id: '61f6fbaea2460c018a4189d8', status: DEAL.UKEF_APPROVED_WITH_CONDITIONS },
     { _id: '61f6fbaea2460c018a4189d9', status: DEAL.READY_FOR_APPROVAL },
   ];
+  const canCloneDeal = (status) => ![DEAL_STATUS.CANCELLED, DEAL_STATUS.PENDING_CANCELLATION].includes(status);
 
   describe('when viewed with the role maker', () => {
     const roles = [MAKER];
@@ -27,7 +29,7 @@ describe(component, () => {
 
     it('should be enabled', () => {
       for (const deal of deals) {
-        const wrapper = render({ user: mockUser, deal });
+        const wrapper = render({ user: mockUser, deal, canCloneDeal: canCloneDeal(deal.status) });
         wrapper.expectLink('[data-cy="clone-deal-link"]').toLinkTo(`/contract/${deal._id}/clone/before-you-start`, 'Clone');
       }
     });
@@ -38,7 +40,7 @@ describe(component, () => {
       const mockUser = { roles: [nonMakerRole] };
 
       for (const deal of deals) {
-        const wrapper = render({ user: mockUser, deal });
+        const wrapper = render({ user: mockUser, deal, canCloneDeal: canCloneDeal(deal.status) });
         wrapper.expectLink('[data-cy="clone-deal-link"]').notToExist();
       }
     });

--- a/portal/server/routes/contract/index.js
+++ b/portal/server/routes/contract/index.js
@@ -3,6 +3,7 @@ const {
   CURRENCY,
   ROLES: { CHECKER, MAKER },
   DEAL_STATUS,
+  DEAL_SUBMISSION_TYPE,
 } = require('@ukef/dtfs2-common');
 const api = require('../../api');
 const aboutRoutes = require('./about');
@@ -80,7 +81,7 @@ router.get('/contract/:_id', [provide([DEAL]), validateBank], async (req, res) =
     userCanSubmit: userCanSubmitDeal(deal, user),
     dealHasIssuedFacilitiesToSubmit: dealHasIssuedFacilitiesToSubmit(deal),
     confirmedRequestedCoverStartDates: confirmedRequestedCoverStartDates[dealId] || [],
-    allRequestedCoverStartDatesConfirmed: deal.submissionType === 'Automatic Inclusion Notice' || allRequestedCoverStartDatesConfirmed,
+    allRequestedCoverStartDatesConfirmed: deal.submissionType === DEAL_SUBMISSION_TYPE.AIN || allRequestedCoverStartDatesConfirmed,
     canCloneDeal: !dealCancelledStatus.includes(deal.status),
   });
 });

--- a/portal/server/routes/contract/index.js
+++ b/portal/server/routes/contract/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const {
   CURRENCY,
   ROLES: { CHECKER, MAKER },
+  DEAL_STATUS,
 } = require('@ukef/dtfs2-common');
 const api = require('../../api');
 const aboutRoutes = require('./about');
@@ -78,6 +79,8 @@ router.get('/contract/:_id', [provide([DEAL]), validateBank], async (req, res) =
     dealHasIssuedFacilitiesToSubmit: dealHasIssuedFacilitiesToSubmit(deal),
     confirmedRequestedCoverStartDates: confirmedRequestedCoverStartDates[dealId] || [],
     allRequestedCoverStartDatesConfirmed: deal.submissionType === 'Automatic Inclusion Notice' || allRequestedCoverStartDatesConfirmed,
+    dealStatusCancelled: deal.status === DEAL_STATUS.CANCELLED,
+    dealStatusPendingCancellation: deal.status === DEAL_STATUS.PENDING_CANCELLATION,
   });
 });
 

--- a/portal/server/routes/contract/index.js
+++ b/portal/server/routes/contract/index.js
@@ -68,6 +68,8 @@ router.get('/contract/:_id', [provide([DEAL]), validateBank], async (req, res) =
     issuedTotal === 0 ||
     (confirmedRequestedCoverStartDates && confirmedRequestedCoverStartDates[dealId] && confirmedRequestedCoverStartDates[dealId].length === issuedTotal);
 
+  const dealCancelledStatus = [DEAL_STATUS.CANCELLED, DEAL_STATUS.PENDING_CANCELLATION];
+
   return res.render('contract/contract-view.njk', {
     successMessage: getFlashSuccessMessage(req),
     deal: dealWithCanIssueOrEditIssueFacilityFlags(user.roles, deal),
@@ -79,8 +81,7 @@ router.get('/contract/:_id', [provide([DEAL]), validateBank], async (req, res) =
     dealHasIssuedFacilitiesToSubmit: dealHasIssuedFacilitiesToSubmit(deal),
     confirmedRequestedCoverStartDates: confirmedRequestedCoverStartDates[dealId] || [],
     allRequestedCoverStartDatesConfirmed: deal.submissionType === 'Automatic Inclusion Notice' || allRequestedCoverStartDatesConfirmed,
-    dealStatusCancelled: deal.status === DEAL_STATUS.CANCELLED,
-    dealStatusPendingCancellation: deal.status === DEAL_STATUS.PENDING_CANCELLATION,
+    canCloneDeal: !dealCancelledStatus.includes(deal.status),
   });
 });
 

--- a/portal/templates/contract/components/clone-deal-link.njk
+++ b/portal/templates/contract/components/clone-deal-link.njk
@@ -3,7 +3,7 @@
 {% macro render(params) %}
   {% if params.deal.status %}
 
-    {% if params.user.roles.includes('maker') and not params.dealStatusCancelled and not params.dealStatusPendingCancellation%}
+    {% if params.user.roles.includes('maker') and params.canCloneDeal%}
       <a
         href="/contract/{{ params.deal._id }}/clone/before-you-start"
         class="govuk-link govuk-!-font-size-14"

--- a/portal/templates/contract/components/clone-deal-link.njk
+++ b/portal/templates/contract/components/clone-deal-link.njk
@@ -3,7 +3,7 @@
 {% macro render(params) %}
   {% if params.deal.status %}
 
-    {% if params.user.roles.includes('maker') %}
+    {% if params.user.roles.includes('maker') and not params.dealStatusCancelled and not params.dealStatusPendingCancellation%}
       <a
         href="/contract/{{ params.deal._id }}/clone/before-you-start"
         class="govuk-link govuk-!-font-size-14"

--- a/portal/templates/contract/contract-view.njk
+++ b/portal/templates/contract/contract-view.njk
@@ -34,7 +34,9 @@
     userCanSubmit: userCanSubmit,
     dealHasIssuedFacilitiesToSubmit: dealHasIssuedFacilitiesToSubmit,
     confirmedRequestedCoverStartDates: confirmedRequestedCoverStartDates,
-    allRequestedCoverStartDatesConfirmed: allRequestedCoverStartDatesConfirmed
+    allRequestedCoverStartDatesConfirmed: allRequestedCoverStartDatesConfirmed,
+    dealStatusCancelled: dealStatusCancelled,
+    dealStatusPendingCancellation: dealStatusPendingCancellation
   } %}
 
   {% if successMessage %}

--- a/portal/templates/contract/contract-view.njk
+++ b/portal/templates/contract/contract-view.njk
@@ -35,8 +35,7 @@
     dealHasIssuedFacilitiesToSubmit: dealHasIssuedFacilitiesToSubmit,
     confirmedRequestedCoverStartDates: confirmedRequestedCoverStartDates,
     allRequestedCoverStartDatesConfirmed: allRequestedCoverStartDatesConfirmed,
-    dealStatusCancelled: dealStatusCancelled,
-    dealStatusPendingCancellation: dealStatusPendingCancellation
+    canCloneDeal: canCloneDeal
   } %}
 
   {% if successMessage %}


### PR DESCRIPTION
## Introduction :pencil2:
This PR  is about stopping the Maker from cloning a cancelled/pending cancellation deal. 

## Resolution :heavy_check_mark:
Gef deal : add flags to hide the clone button if the deal is either cancelled or pending cancellation
BSS or EWCS deal : add flags to hide the clone button if the deal is either cancelled or pending cancellation
add e2e test coverage

## Miscellaneous :heavy_plus_sign:

