### PR TITLE
fix(CVE-2025-27152): updated axios version to curcumvent CVE-2025-27152

### DIFF
--- a/azure-functions/acbs-function/package.json
+++ b/azure-functions/acbs-function/package.json
@@ -29,7 +29,7 @@
     "unit-test-ff": "jest --coverage --verbose --config=unit.ff.jest.config.js --passWithNoTests"
   },
   "dependencies": {
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "date-fns": "^2.30.0",
     "dotenv": "^16.4.5",
     "durable-functions": "^3.1.0"

--- a/dtfs-central-api/package.json
+++ b/dtfs-central-api/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@ukef/dtfs2-common": "1.0.0",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "big.js": "^6.2.2",
     "compression": "^1.8.0",
     "date-fns": "^2.30.0",

--- a/external-api/package.json
+++ b/external-api/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@types/lodash": "^4.17.16",
     "@ukef/dtfs2-common": "1.0.0",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "compression": "^1.8.0",
     "cors": "^2.8.5",
     "cron": "^3.5.0",

--- a/gef-ui/package.json
+++ b/gef-ui/package.json
@@ -37,7 +37,7 @@
     "@ministryofjustice/frontend": "3.0.2",
     "@ukef/dtfs2-common": "1.0.0",
     "ajv": "^8.17.1",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "chance": "^1.1.12",
     "cheerio": "1.0.0-rc.12",
     "clean-deep": "^3.4.0",

--- a/libs/common/package.json
+++ b/libs/common/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@azure/msal-node": "^2.16.2",
     "@types/lodash": "^4.17.16",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "big.js": "^6.2.2",
     "date-fns": "^3.3.1",
     "date-fns-tz": "^2.0.1",

--- a/libs/common/src/test-helpers/test-api-error.ts
+++ b/libs/common/src/test-helpers/test-api-error.ts
@@ -1,9 +1,9 @@
 import { HttpStatusCode } from 'axios';
 import { ApiError } from '../errors';
-import { ApiErrorCode } from '../types';
+import { HttpStatusCodes, ApiErrorCode } from '../types';
 
 type TestApiErrorParams = {
-  status?: HttpStatusCode;
+  status?: HttpStatusCodes;
   message?: string;
   code?: ApiErrorCode;
   cause?: unknown;

--- a/libs/common/src/types/http-status-codes.ts
+++ b/libs/common/src/types/http-status-codes.ts
@@ -1,0 +1,3 @@
+import { HttpStatusCode } from 'axios';
+
+export type HttpStatusCodes = (typeof HttpStatusCode)[keyof typeof HttpStatusCode];

--- a/libs/common/src/types/index.ts
+++ b/libs/common/src/types/index.ts
@@ -42,3 +42,4 @@ export * from './record-correction-form-value-validation-errors';
 export * from './record-correction-log';
 export * from './record-correction-fields';
 export * from './gov-uk';
+export * from './http-status-codes';

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "utils"
       ],
       "dependencies": {
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "express": "^4.21.2",
         "release-please": "^16.18.0"
       },
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "date-fns": "^2.30.0",
         "dotenv": "^16.4.5",
         "durable-functions": "^3.1.0"
@@ -116,7 +116,7 @@
       "license": "MIT",
       "dependencies": {
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "big.js": "^6.2.2",
         "compression": "^1.8.0",
         "date-fns": "^2.30.0",
@@ -299,7 +299,7 @@
       "dependencies": {
         "@types/lodash": "^4.17.16",
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "compression": "^1.8.0",
         "cors": "^2.8.5",
         "cron": "^3.5.0",
@@ -744,7 +744,7 @@
         "@ministryofjustice/frontend": "3.0.2",
         "@ukef/dtfs2-common": "1.0.0",
         "ajv": "^8.17.1",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "chance": "^1.1.12",
         "cheerio": "1.0.0-rc.12",
         "clean-deep": "^3.4.0",
@@ -889,7 +889,7 @@
       "dependencies": {
         "@azure/msal-node": "^2.16.2",
         "@types/lodash": "^4.17.16",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "big.js": "^6.2.2",
         "date-fns": "^3.3.1",
         "date-fns-tz": "^2.0.1",
@@ -9424,9 +9424,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
-      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -27593,7 +27593,7 @@
       "dependencies": {
         "@ministryofjustice/frontend": "3.0.2",
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "cheerio": "1.0.0-rc.12",
         "clamscan": "^2.4.0",
         "connect-flash": "0.1.1",
@@ -27679,7 +27679,7 @@
       "dependencies": {
         "@azure/storage-file-share": "12.14.0",
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "comma-number": "^2.1.0",
         "compression": "^1.8.0",
         "cors": "2.8.5",
@@ -27915,7 +27915,7 @@
         "@babel/plugin-transform-runtime": "7.23.6",
         "@babel/preset-env": "7.23.6",
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "bson": "^4.7.2",
         "comma-number": "^2.1.0",
         "compression": "^1.8.0",
@@ -28267,7 +28267,7 @@
         "@ministryofjustice/frontend": "3.0.2",
         "@ukef/dtfs2-common": "1.0.0",
         "ajv": "^8.17.1",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "chance": "^1.1.12",
         "cheerio": "1.0.0-rc.12",
         "chokidar": "^3.6.0",
@@ -28472,7 +28472,7 @@
       "dependencies": {
         "@faker-js/faker": "^8.4.1",
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "big.js": "^6.2.2",
         "bson": "^6.10.3",
         "chance": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "express": "^4.21.2",
     "release-please": "^16.18.0"
   },

--- a/portal-api/package.json
+++ b/portal-api/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@azure/storage-file-share": "12.14.0",
     "@ukef/dtfs2-common": "1.0.0",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "comma-number": "^2.1.0",
     "compression": "^1.8.0",
     "cors": "2.8.5",

--- a/portal/package.json
+++ b/portal/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ministryofjustice/frontend": "3.0.2",
     "@ukef/dtfs2-common": "1.0.0",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "cheerio": "1.0.0-rc.12",
     "clamscan": "^2.4.0",
     "connect-flash": "0.1.1",

--- a/trade-finance-manager-api/package.json
+++ b/trade-finance-manager-api/package.json
@@ -37,7 +37,7 @@
     "@babel/plugin-transform-runtime": "7.23.6",
     "@babel/preset-env": "7.23.6",
     "@ukef/dtfs2-common": "1.0.0",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "bson": "^4.7.2",
     "comma-number": "^2.1.0",
     "compression": "^1.8.0",

--- a/trade-finance-manager-ui/package.json
+++ b/trade-finance-manager-ui/package.json
@@ -39,7 +39,7 @@
     "@ministryofjustice/frontend": "3.0.2",
     "@ukef/dtfs2-common": "1.0.0",
     "ajv": "^8.17.1",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "chance": "^1.1.12",
     "cheerio": "1.0.0-rc.12",
     "chokidar": "^3.6.0",

--- a/utils/package.json
+++ b/utils/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@faker-js/faker": "^8.4.1",
         "@ukef/dtfs2-common": "1.0.0",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "big.js": "^6.2.2",
         "bson": "^6.10.3",
         "chance": "^1.1.12",


### PR DESCRIPTION
## Introduction :pencil2:
Include a summary of the changes and related feature(s) or issue(s).[CVE-2025-27152](https://www.mend.io/vulnerability-database/CVE-2025-27152).

## Resolution :heavy_check_mark:
* Updated `axios` to `1.8.2`
* Created a custom type `HttpStatusCodes` with a union type of all the values from `axios.HttpStatusCode` as number.
