### PR TITLE
chore(DTFS2-7431): replace insertonedeal with createbssewcs function

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
@@ -1,14 +1,22 @@
+import { DEAL_SUBMISSION_TYPE, FACILITY_STAGE } from '@ukef/dtfs2-common';
+
 const relative = require('../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const CONSTANTS = require('../../../../../fixtures/constants');
 const CONTENT_STRINGS = require('../../../../../fixtures/content-strings');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters } = require('../../../../partials');
-const { BSS_DEAL_READY_FOR_CHECK, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH_BY_STATUS = {
+  DRAFT: 1,
+  READY_FOR_APPROVAL: 1,
+  ALL_STATUSES: 2,
+};
 
 context('Dashboard Deals filters - filter by status', () => {
   const ALL_DEALS = [];
@@ -17,9 +25,8 @@ context('Dashboard Deals filters - filter by status', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_READY_FOR_CHECK, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
+    cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED });
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -41,7 +48,7 @@ context('Dashboard Deals filters - filter by status', () => {
       filters.showHideButton().click();
     });
 
-    it('submits the filter and redirects to the dashboard', () => {
+    it('should submit the filter and redirect to the dashboard', () => {
       // apply filter
       dashboardDeals.filters.panel.form.status.draft.checkbox().click();
       filters.panel.form.applyFiltersButton().click();
@@ -49,11 +56,11 @@ context('Dashboard Deals filters - filter by status', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
 
-    it('renders checked checkbox', () => {
+    it('should render checked checkbox', () => {
       dashboardDeals.filters.panel.form.status.draft.checkbox().should('be.checked');
     });
 
-    it('renders the applied filter in the `applied filters` section', () => {
+    it('should render the applied filter in the `applied filters` section', () => {
       filters.panel.selectedFilters.container().should('be.visible');
       filters.panel.selectedFilters.list().should('be.visible');
 
@@ -70,20 +77,17 @@ context('Dashboard Deals filters - filter by status', () => {
       firstAppliedFilter.should('have.text', expectedText);
     });
 
-    it('renders the applied filter in the `main container selected filters` section', () => {
+    it('should render the applied filter in the `main container selected filters` section', () => {
       dashboardDeals.filters.mainContainer.selectedFilters.statusDraft().should('be.visible');
 
       const expectedText = `Remove this filter ${CONSTANTS.DEALS.DEAL_STATUS.DRAFT}`;
       dashboardDeals.filters.mainContainer.selectedFilters.statusDraft().contains(expectedText);
     });
 
-    it('renders only draft deals', () => {
-      const ALL_DRAFT_DEALS = ALL_DEALS.filter(({ status }) => status === CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
-      dashboardDeals.rows().should('have.length', ALL_DRAFT_DEALS.length);
-
-      const firstDraftDeal = ALL_DRAFT_DEALS[0];
-
-      dashboardDeals.row.status(firstDraftDeal._id).should('have.text', CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
+    it('should render only draft deals', () => {
+      dashboardDeals.rows().each((row) => {
+        cy.wrap(row).contains(CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
+      });
     });
   });
 
@@ -102,7 +106,7 @@ context('Dashboard Deals filters - filter by status', () => {
       filters.showHideButton().click();
     });
 
-    it('submits the filter and redirects to the dashboard', () => {
+    it('should submit the filter and redirect to the dashboard', () => {
       // apply filter
       dashboardDeals.filters.panel.form.status.readyForChecker.checkbox().click();
       filters.panel.form.applyFiltersButton().click();
@@ -110,11 +114,11 @@ context('Dashboard Deals filters - filter by status', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
 
-    it('renders checked checkbox', () => {
+    it('should render checked checkbox', () => {
       dashboardDeals.filters.panel.form.status.readyForChecker.checkbox().should('be.checked');
     });
 
-    it('renders the applied filter in the `applied filters` section', () => {
+    it('should render the applied filter in the `applied filters` section', () => {
       filters.panel.selectedFilters.container().should('be.visible');
       filters.panel.selectedFilters.list().should('be.visible');
 
@@ -131,20 +135,19 @@ context('Dashboard Deals filters - filter by status', () => {
       firstAppliedFilter.should('have.text', expectedText);
     });
 
-    it('renders the applied filter in the `main container selected filters` section', () => {
+    it('should render the applied filter in the `main container selected filters` section', () => {
       dashboardDeals.filters.mainContainer.selectedFilters.statusReadyForChecker().should('be.visible');
 
       const expectedText = `Remove this filter ${CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL}`;
       dashboardDeals.filters.mainContainer.selectedFilters.statusReadyForChecker().contains(expectedText);
     });
 
-    it('renders only Ready for Check deals', () => {
-      const ALL_READY_FOR_CHECK_DEALS = ALL_DEALS.filter(({ status }) => status === CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL);
-      dashboardDeals.rows().should('have.length', ALL_READY_FOR_CHECK_DEALS.length);
+    it('should render only Ready for Check deals', () => {
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH_BY_STATUS.READY_FOR_APPROVAL);
 
-      const firstReadyToCheckDeal = ALL_READY_FOR_CHECK_DEALS[0];
-
-      dashboardDeals.row.status(firstReadyToCheckDeal._id).should('have.text', CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL);
+      dashboardDeals.rows().each((row) => {
+        cy.wrap(row).contains(CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL);
+      });
     });
   });
 
@@ -163,7 +166,7 @@ context('Dashboard Deals filters - filter by status', () => {
       filters.showHideButton().click();
     });
 
-    it('submits the filter and redirects to the dashboard', () => {
+    it('should submit the filter and redirect to the dashboard', () => {
       // apply filter
       dashboardDeals.filters.panel.form.status.all.checkbox().click();
       filters.panel.form.applyFiltersButton().click();
@@ -171,11 +174,11 @@ context('Dashboard Deals filters - filter by status', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
 
-    it('renders checked checkbox', () => {
+    it('should render checked checkbox', () => {
       dashboardDeals.filters.panel.form.status.all.checkbox().should('be.checked');
     });
 
-    it('renders the applied filter in the `applied filters` section', () => {
+    it('should render the applied filter in the `applied filters` section', () => {
       filters.panel.selectedFilters.container().should('be.visible');
       filters.panel.selectedFilters.list().should('be.visible');
 
@@ -192,15 +195,15 @@ context('Dashboard Deals filters - filter by status', () => {
       firstAppliedFilter.should('have.text', expectedText);
     });
 
-    it('renders the applied filter in the `main container selected filters` section', () => {
+    it('should render the applied filter in the `main container selected filters` section', () => {
       dashboardDeals.filters.mainContainer.selectedFilters.statusAll().should('be.visible');
 
       const expectedText = `Remove this filter ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.ALL_STATUSES}`;
       dashboardDeals.filters.mainContainer.selectedFilters.statusAll().contains(expectedText);
     });
 
-    it('renders all deals regardless of status', () => {
-      dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+    it('should render all deals regardless of status', () => {
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH_BY_STATUS.ALL_STATUSES);
     });
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-filters.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-filters.spec.js
@@ -2,11 +2,15 @@ const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const CONSTANTS = require('../../../../../fixtures/constants');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters, dashboardSubNavigation } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH = {
+  ALL_STATUSES: 2,
+};
 
 context('Dashboard Deals filters', () => {
   const ALL_DEALS = [];
@@ -15,9 +19,7 @@ context('Dashboard Deals filters', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -35,12 +37,12 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('by default', () => {
-    it('renders all deals', () => {
+    it('should render all deals', () => {
       dashboardDeals.rows().should('be.visible');
-      dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH.ALL_STATUSES);
     });
 
-    it('hides filters and renders `show filter` button', () => {
+    it('should hide filters and render `show filter` button', () => {
       // toggle to show filters (hidden by default)
       filters.showHideButton().click();
 
@@ -52,29 +54,29 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('clicking `show filter` button', () => {
-    it('renders all filters container', () => {
+    it('should render all filters container', () => {
       filters.panel.container().should('be.visible');
     });
 
-    it('changes show/hide button text', () => {
+    it('should change show/hide button text', () => {
       filters.showHideButton().should('be.visible');
       filters.showHideButton().should('have.text', 'Hide filter');
     });
 
-    it('renders `apply filters` button', () => {
+    it('should render `apply filters` button', () => {
       filters.panel.form.applyFiltersButton().should('be.visible');
       filters.panel.form.applyFiltersButton().contains('Apply filters');
     });
   });
 
   describe('renders all filters empty/unchecked by default', () => {
-    it('keyword', () => {
+    it('should render keyword filter', () => {
       filters.panel.form.keyword.label().contains('Keyword');
       filters.panel.form.keyword.input().should('be.visible');
       filters.panel.form.keyword.input().should('have.value', '');
     });
 
-    it('product/dealType', () => {
+    it('should render product/dealType', () => {
       dashboardDeals.filters.panel.form.dealType.bssEwcs.label().contains(CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS);
       dashboardDeals.filters.panel.form.dealType.bssEwcs.checkbox().should('exist');
       dashboardDeals.filters.panel.form.dealType.bssEwcs.checkbox().should('not.be.checked');
@@ -84,7 +86,7 @@ context('Dashboard Deals filters', () => {
       dashboardDeals.filters.panel.form.dealType.gef.checkbox().should('not.be.checked');
     });
 
-    it('submissionType/notice type', () => {
+    it('should render submissionType/notice type', () => {
       // AIN
       dashboardDeals.filters.panel.form.submissionType.AIN.label().contains(CONSTANTS.DEALS.SUBMISSION_TYPE.AIN);
       dashboardDeals.filters.panel.form.submissionType.AIN.checkbox().should('exist');
@@ -101,7 +103,7 @@ context('Dashboard Deals filters', () => {
       dashboardDeals.filters.panel.form.submissionType.MIN.checkbox().should('not.be.checked');
     });
 
-    it('status', () => {
+    it('should render status filter', () => {
       // all statuses
       dashboardDeals.filters.panel.form.status.all.label().contains('All statuses');
       dashboardDeals.filters.panel.form.status.all.checkbox().should('exist');
@@ -158,7 +160,7 @@ context('Dashboard Deals filters', () => {
       dashboardDeals.filters.panel.form.status.abandoned.checkbox().should('not.be.checked');
     });
 
-    it('contains the correct aria-label for no deal filters selected', () => {
+    it('should contain the correct aria-label for no deal filters selected', () => {
       dashboardSubNavigation
         .deals()
         .invoke('attr', 'aria-label')

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-main-container-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-main-container-filter-remove.spec.js
@@ -2,11 +2,13 @@ const relative = require('../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH = 2;
 
 context('Dashboard Deals - main container selected filters - remove a filter', () => {
   const ALL_DEALS = [];
@@ -15,9 +17,7 @@ context('Dashboard Deals - main container selected filters - remove a filter', (
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -28,7 +28,7 @@ context('Dashboard Deals - main container selected filters - remove a filter', (
     cy.url().should('eq', relative('/dashboard/deals/0'));
   });
 
-  it('applies and removes a filter', () => {
+  it('should apply and remove a filter', () => {
     // toggle to show filters (hidden by default)
     filters.showHideButton().click();
 
@@ -54,10 +54,10 @@ context('Dashboard Deals - main container selected filters - remove a filter', (
     dashboardDeals.filters.panel.form.submissionType.MIA.checkbox().should('not.be.checked');
 
     // should render all deals
-    dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+    dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH);
   });
 
-  it('retains other filters when one is removed', () => {
+  it('should retain other filters when one is removed', () => {
     cy.login(BANK1_MAKER1);
     dashboardDeals.visit();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-panel-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-panel-filter-remove.spec.js
@@ -2,11 +2,15 @@ const relative = require('../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH = {
+  ALL_STATUSES: 2,
+};
 
 context('Dashboard Deals - panel selected filters - remove a filter', () => {
   const ALL_DEALS = [];
@@ -15,9 +19,7 @@ context('Dashboard Deals - panel selected filters - remove a filter', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -28,7 +30,7 @@ context('Dashboard Deals - panel selected filters - remove a filter', () => {
     cy.url().should('eq', relative('/dashboard/deals/0'));
   });
 
-  it('applies and removes a filter', () => {
+  it('should apply and remove a filter', () => {
     // toggle to show filters (hidden by default)
     filters.showHideButton().click();
 
@@ -63,6 +65,6 @@ context('Dashboard Deals - panel selected filters - remove a filter', () => {
     dashboardDeals.filters.panel.form.submissionType.MIA.checkbox().should('not.be.checked');
 
     // should render all deals
-    dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+    dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH.ALL_STATUSES);
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/filters/dashboard-facilities-filters.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/filters/dashboard-facilities-filters.spec.js
@@ -2,7 +2,7 @@ const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const CONSTANTS = require('../../../../../fixtures/constants');
 const { dashboardFacilities } = require('../../../../pages');
 const { dashboardFilters, dashboardSubNavigation } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT, GEF_FACILITY_CASH, GEF_FACILITY_CONTINGENT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT, GEF_FACILITY_CASH, GEF_FACILITY_CONTINGENT } = require('../../fixtures');
 
 const { BANK1_MAKER1, BANK1_CHECKER1, ADMIN } = MOCK_USERS;
 
@@ -15,7 +15,7 @@ context('Dashboard Deals filters', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1);
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       const { _id: dealId } = deal;
@@ -34,7 +34,7 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('by default', () => {
-    it('renders all facilities (Checker)', () => {
+    it('should render all facilities (Checker)', () => {
       cy.login(BANK1_CHECKER1);
       dashboardFacilities.visit();
       dashboardFacilities.rows().should('be.visible');
@@ -43,7 +43,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
     });
 
-    it('renders all facilities (Maker)', () => {
+    it('should render all facilities (Maker)', () => {
       cy.login(BANK1_MAKER1);
       dashboardFacilities.visit();
       dashboardFacilities.rows().should('be.visible');
@@ -52,7 +52,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
     });
 
-    it('hides filters and renders `show filter` button', () => {
+    it('should hide filters and render `show filter` button', () => {
       cy.login(BANK1_MAKER1);
       dashboardFacilities.visit();
 
@@ -75,16 +75,16 @@ context('Dashboard Deals filters', () => {
       filters.showHideButton().click();
     });
 
-    it('renders all filters container', () => {
+    it('should render all filters container', () => {
       filters.panel.container().should('be.visible');
     });
 
-    it('changes show/hide button text', () => {
+    it('should change show/hide button text', () => {
       filters.showHideButton().should('be.visible');
       filters.showHideButton().should('have.text', 'Hide filter');
     });
 
-    it('renders `apply filters` button', () => {
+    it('should render `apply filters` button', () => {
       filters.panel.form.applyFiltersButton().should('be.visible');
       filters.panel.form.applyFiltersButton().contains('Apply filters');
     });
@@ -102,13 +102,13 @@ context('Dashboard Deals filters', () => {
       filters.showHideButton().click();
     });
 
-    it('keyword', () => {
+    it('should render keyword filter', () => {
       filters.panel.form.keyword.label().contains('Keyword');
       filters.panel.form.keyword.input().should('be.visible');
       filters.panel.form.keyword.input().should('have.value', '');
     });
 
-    it('product/facility type', () => {
+    it('should render product/facility type', () => {
       // Cash
       dashboardFacilities.filters.panel.form.type.cash.label().contains(CONSTANTS.FACILITY.FACILITY_TYPE.CASH);
       dashboardFacilities.filters.panel.form.type.cash.checkbox().should('exist');
@@ -130,7 +130,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.filters.panel.form.type.loan.checkbox().should('not.be.checked');
     });
 
-    it('submissionType/notice type', () => {
+    it('should render submissionType/notice type', () => {
       // AIN
       dashboardFacilities.filters.panel.form.submissionType.AIN.label().contains(CONSTANTS.DEALS.SUBMISSION_TYPE.AIN);
       dashboardFacilities.filters.panel.form.submissionType.AIN.checkbox().should('exist');
@@ -147,7 +147,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.filters.panel.form.submissionType.MIN.checkbox().should('not.be.checked');
     });
 
-    it('bank facility stage/hasBeenIssued', () => {
+    it('should render bank facility stage/hasBeenIssued', () => {
       // Issued
       dashboardFacilities.filters.panel.form.stage.issued.label().contains(CONSTANTS.FACILITY.FACILITY_STAGE.ISSUED);
       dashboardFacilities.filters.panel.form.stage.issued.checkbox().should('exist');
@@ -159,7 +159,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.filters.panel.form.stage.unissued.checkbox().should('not.be.checked');
     });
 
-    it('contains the correct aria-label for no facility filters selected', () => {
+    it('should contain the correct aria-label for no facility filters selected', () => {
       dashboardSubNavigation
         .facilities()
         .invoke('attr', 'aria-label')


### PR DESCRIPTION
## Introduction :pencil2:
BSS/EWCS E2E tests were creating deals by calling the API directly.
We want to prevent specific user roles (like maker, checker), from calling Portal API directly.
This PR updates all E2E tests that create individual BSS/EWCS deals, to be created via the UI, mimicking a true user journey.

## Resolution :heavy_check_mark:
Create createBssEwcsDeal cypress command.

## Miscellaneous :heavy_plus_sign:
Update E2E tests

