### PR TITLE
Chore/7431/create bss ewcs deal

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-keyword.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-keyword.spec.js
@@ -13,8 +13,6 @@ context('Dashboard Deals filters - filter by keyword', () => {
   let bssDealId;
   const MOCK_KEYWORD = 'Special exporter';
 
-  const ALL_DEALS = [];
-
   const EXPECTED_DEALS_LENGTH = {
     ALL_STATUSES: 2,
     FILTERED_BY_KEYWORD: 1,
@@ -29,9 +27,7 @@ context('Dashboard Deals filters - filter by keyword', () => {
     });
     cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED, exporterCompanyName: MOCK_KEYWORD });
 
-    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1);
   });
 
   beforeEach(() => {

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-notice-type.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-notice-type.spec.js
@@ -11,8 +11,6 @@ const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 const filters = dashboardFilters;
 
 context('Dashboard Deals filters - filter by submissionType/noticeType', () => {
-  const ALL_DEALS = [];
-
   before(() => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
@@ -20,9 +18,7 @@ context('Dashboard Deals filters - filter by submissionType/noticeType', () => {
     cy.createBssEwcsDeal();
     cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.MIA, facilityStage: FACILITY_STAGE.ISSUED });
 
-    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1);
   });
 
   describe('MIA', () => {

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
@@ -19,8 +19,6 @@ const EXPECTED_DEALS_LENGTH_BY_STATUS = {
 };
 
 context('Dashboard Deals filters - filter by status', () => {
-  const ALL_DEALS = [];
-
   before(() => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
@@ -28,9 +26,7 @@ context('Dashboard Deals filters - filter by status', () => {
     cy.createBssEwcsDeal();
     cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED });
 
-    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1);
   });
 
   describe('Draft', () => {

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
@@ -85,6 +85,8 @@ context('Dashboard Deals filters - filter by status', () => {
     });
 
     it('should render only draft deals', () => {
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH_BY_STATUS.DRAFT);
+
       dashboardDeals.rows().each((row) => {
         cy.wrap(row).contains(CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
       });

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filter-by/dashboard-deals-filter-by-status.spec.js
@@ -1,14 +1,22 @@
+import { DEAL_SUBMISSION_TYPE, FACILITY_STAGE } from '@ukef/dtfs2-common';
+
 const relative = require('../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const CONSTANTS = require('../../../../../fixtures/constants');
 const CONTENT_STRINGS = require('../../../../../fixtures/content-strings');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters } = require('../../../../partials');
-const { BSS_DEAL_READY_FOR_CHECK, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH_BY_STATUS = {
+  DRAFT: 1,
+  READY_FOR_APPROVAL: 1,
+  ALL_STATUSES: 2,
+};
 
 context('Dashboard Deals filters - filter by status', () => {
   const ALL_DEALS = [];
@@ -17,9 +25,8 @@ context('Dashboard Deals filters - filter by status', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_READY_FOR_CHECK, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
+    cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED });
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -41,7 +48,7 @@ context('Dashboard Deals filters - filter by status', () => {
       filters.showHideButton().click();
     });
 
-    it('submits the filter and redirects to the dashboard', () => {
+    it('should submit the filter and redirect to the dashboard', () => {
       // apply filter
       dashboardDeals.filters.panel.form.status.draft.checkbox().click();
       filters.panel.form.applyFiltersButton().click();
@@ -49,11 +56,11 @@ context('Dashboard Deals filters - filter by status', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
 
-    it('renders checked checkbox', () => {
+    it('should render checked checkbox', () => {
       dashboardDeals.filters.panel.form.status.draft.checkbox().should('be.checked');
     });
 
-    it('renders the applied filter in the `applied filters` section', () => {
+    it('should render the applied filter in the `applied filters` section', () => {
       filters.panel.selectedFilters.container().should('be.visible');
       filters.panel.selectedFilters.list().should('be.visible');
 
@@ -70,20 +77,17 @@ context('Dashboard Deals filters - filter by status', () => {
       firstAppliedFilter.should('have.text', expectedText);
     });
 
-    it('renders the applied filter in the `main container selected filters` section', () => {
+    it('should render the applied filter in the `main container selected filters` section', () => {
       dashboardDeals.filters.mainContainer.selectedFilters.statusDraft().should('be.visible');
 
       const expectedText = `Remove this filter ${CONSTANTS.DEALS.DEAL_STATUS.DRAFT}`;
       dashboardDeals.filters.mainContainer.selectedFilters.statusDraft().contains(expectedText);
     });
 
-    it('renders only draft deals', () => {
-      const ALL_DRAFT_DEALS = ALL_DEALS.filter(({ status }) => status === CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
-      dashboardDeals.rows().should('have.length', ALL_DRAFT_DEALS.length);
-
-      const firstDraftDeal = ALL_DRAFT_DEALS[0];
-
-      dashboardDeals.row.status(firstDraftDeal._id).should('have.text', CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
+    it('should render only draft deals', () => {
+      dashboardDeals.rows().each((row) => {
+        cy.wrap(row).contains(CONSTANTS.DEALS.DEAL_STATUS.DRAFT);
+      });
     });
   });
 
@@ -102,7 +106,7 @@ context('Dashboard Deals filters - filter by status', () => {
       filters.showHideButton().click();
     });
 
-    it('submits the filter and redirects to the dashboard', () => {
+    it('should submit the filter and redirect to the dashboard', () => {
       // apply filter
       dashboardDeals.filters.panel.form.status.readyForChecker.checkbox().click();
       filters.panel.form.applyFiltersButton().click();
@@ -110,11 +114,11 @@ context('Dashboard Deals filters - filter by status', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
 
-    it('renders checked checkbox', () => {
+    it('should render checked checkbox', () => {
       dashboardDeals.filters.panel.form.status.readyForChecker.checkbox().should('be.checked');
     });
 
-    it('renders the applied filter in the `applied filters` section', () => {
+    it('should render the applied filter in the `applied filters` section', () => {
       filters.panel.selectedFilters.container().should('be.visible');
       filters.panel.selectedFilters.list().should('be.visible');
 
@@ -131,20 +135,19 @@ context('Dashboard Deals filters - filter by status', () => {
       firstAppliedFilter.should('have.text', expectedText);
     });
 
-    it('renders the applied filter in the `main container selected filters` section', () => {
+    it('should render the applied filter in the `main container selected filters` section', () => {
       dashboardDeals.filters.mainContainer.selectedFilters.statusReadyForChecker().should('be.visible');
 
       const expectedText = `Remove this filter ${CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL}`;
       dashboardDeals.filters.mainContainer.selectedFilters.statusReadyForChecker().contains(expectedText);
     });
 
-    it('renders only Ready for Check deals', () => {
-      const ALL_READY_FOR_CHECK_DEALS = ALL_DEALS.filter(({ status }) => status === CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL);
-      dashboardDeals.rows().should('have.length', ALL_READY_FOR_CHECK_DEALS.length);
+    it('should render only Ready for Check deals', () => {
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH_BY_STATUS.READY_FOR_APPROVAL);
 
-      const firstReadyToCheckDeal = ALL_READY_FOR_CHECK_DEALS[0];
-
-      dashboardDeals.row.status(firstReadyToCheckDeal._id).should('have.text', CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL);
+      dashboardDeals.rows().each((row) => {
+        cy.wrap(row).contains(CONSTANTS.DEALS.DEAL_STATUS.READY_FOR_APPROVAL);
+      });
     });
   });
 
@@ -163,7 +166,7 @@ context('Dashboard Deals filters - filter by status', () => {
       filters.showHideButton().click();
     });
 
-    it('submits the filter and redirects to the dashboard', () => {
+    it('should submit the filter and redirect to the dashboard', () => {
       // apply filter
       dashboardDeals.filters.panel.form.status.all.checkbox().click();
       filters.panel.form.applyFiltersButton().click();
@@ -171,11 +174,11 @@ context('Dashboard Deals filters - filter by status', () => {
       cy.url().should('eq', relative('/dashboard/deals/0'));
     });
 
-    it('renders checked checkbox', () => {
+    it('should render checked checkbox', () => {
       dashboardDeals.filters.panel.form.status.all.checkbox().should('be.checked');
     });
 
-    it('renders the applied filter in the `applied filters` section', () => {
+    it('should render the applied filter in the `applied filters` section', () => {
       filters.panel.selectedFilters.container().should('be.visible');
       filters.panel.selectedFilters.list().should('be.visible');
 
@@ -192,15 +195,15 @@ context('Dashboard Deals filters - filter by status', () => {
       firstAppliedFilter.should('have.text', expectedText);
     });
 
-    it('renders the applied filter in the `main container selected filters` section', () => {
+    it('should render the applied filter in the `main container selected filters` section', () => {
       dashboardDeals.filters.mainContainer.selectedFilters.statusAll().should('be.visible');
 
       const expectedText = `Remove this filter ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.ALL_STATUSES}`;
       dashboardDeals.filters.mainContainer.selectedFilters.statusAll().contains(expectedText);
     });
 
-    it('renders all deals regardless of status', () => {
-      dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+    it('should render all deals regardless of status', () => {
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH_BY_STATUS.ALL_STATUSES);
     });
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-filters.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-filters.spec.js
@@ -13,17 +13,13 @@ const EXPECTED_DEALS_LENGTH = {
 };
 
 context('Dashboard Deals filters', () => {
-  const ALL_DEALS = [];
-
   before(() => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
     cy.createBssEwcsDeal();
 
-    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1);
 
     cy.login(BANK1_MAKER1);
   });

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-filters.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-filters.spec.js
@@ -2,11 +2,15 @@ const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const CONSTANTS = require('../../../../../fixtures/constants');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters, dashboardSubNavigation } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH = {
+  ALL_STATUSES: 2,
+};
 
 context('Dashboard Deals filters', () => {
   const ALL_DEALS = [];
@@ -15,9 +19,7 @@ context('Dashboard Deals filters', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -35,12 +37,12 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('by default', () => {
-    it('renders all deals', () => {
+    it('should render all deals', () => {
       dashboardDeals.rows().should('be.visible');
-      dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+      dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH.ALL_STATUSES);
     });
 
-    it('hides filters and renders `show filter` button', () => {
+    it('should hide filters and render `show filter` button', () => {
       // toggle to show filters (hidden by default)
       filters.showHideButton().click();
 
@@ -52,29 +54,29 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('clicking `show filter` button', () => {
-    it('renders all filters container', () => {
+    it('should render all filters container', () => {
       filters.panel.container().should('be.visible');
     });
 
-    it('changes show/hide button text', () => {
+    it('should change show/hide button text', () => {
       filters.showHideButton().should('be.visible');
       filters.showHideButton().should('have.text', 'Hide filter');
     });
 
-    it('renders `apply filters` button', () => {
+    it('should render `apply filters` button', () => {
       filters.panel.form.applyFiltersButton().should('be.visible');
       filters.panel.form.applyFiltersButton().contains('Apply filters');
     });
   });
 
   describe('renders all filters empty/unchecked by default', () => {
-    it('keyword', () => {
+    it('should render keyword filter', () => {
       filters.panel.form.keyword.label().contains('Keyword');
       filters.panel.form.keyword.input().should('be.visible');
       filters.panel.form.keyword.input().should('have.value', '');
     });
 
-    it('product/dealType', () => {
+    it('should render product/dealType', () => {
       dashboardDeals.filters.panel.form.dealType.bssEwcs.label().contains(CONSTANTS.DEALS.DEAL_TYPE.BSS_EWCS);
       dashboardDeals.filters.panel.form.dealType.bssEwcs.checkbox().should('exist');
       dashboardDeals.filters.panel.form.dealType.bssEwcs.checkbox().should('not.be.checked');
@@ -84,7 +86,7 @@ context('Dashboard Deals filters', () => {
       dashboardDeals.filters.panel.form.dealType.gef.checkbox().should('not.be.checked');
     });
 
-    it('submissionType/notice type', () => {
+    it('should render submissionType/notice type', () => {
       // AIN
       dashboardDeals.filters.panel.form.submissionType.AIN.label().contains(CONSTANTS.DEALS.SUBMISSION_TYPE.AIN);
       dashboardDeals.filters.panel.form.submissionType.AIN.checkbox().should('exist');
@@ -101,7 +103,7 @@ context('Dashboard Deals filters', () => {
       dashboardDeals.filters.panel.form.submissionType.MIN.checkbox().should('not.be.checked');
     });
 
-    it('status', () => {
+    it('should render status filter', () => {
       // all statuses
       dashboardDeals.filters.panel.form.status.all.label().contains('All statuses');
       dashboardDeals.filters.panel.form.status.all.checkbox().should('exist');
@@ -158,7 +160,7 @@ context('Dashboard Deals filters', () => {
       dashboardDeals.filters.panel.form.status.abandoned.checkbox().should('not.be.checked');
     });
 
-    it('contains the correct aria-label for no deal filters selected', () => {
+    it('should contain the correct aria-label for no deal filters selected', () => {
       dashboardSubNavigation
         .deals()
         .invoke('attr', 'aria-label')

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-main-container-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-main-container-filter-remove.spec.js
@@ -2,11 +2,13 @@ const relative = require('../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH = 2;
 
 context('Dashboard Deals - main container selected filters - remove a filter', () => {
   const ALL_DEALS = [];
@@ -15,9 +17,7 @@ context('Dashboard Deals - main container selected filters - remove a filter', (
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -28,7 +28,7 @@ context('Dashboard Deals - main container selected filters - remove a filter', (
     cy.url().should('eq', relative('/dashboard/deals/0'));
   });
 
-  it('applies and removes a filter', () => {
+  it('should apply and remove a filter', () => {
     // toggle to show filters (hidden by default)
     filters.showHideButton().click();
 
@@ -54,10 +54,10 @@ context('Dashboard Deals - main container selected filters - remove a filter', (
     dashboardDeals.filters.panel.form.submissionType.MIA.checkbox().should('not.be.checked');
 
     // should render all deals
-    dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+    dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH);
   });
 
-  it('retains other filters when one is removed', () => {
+  it('should retain other filters when one is removed', () => {
     cy.login(BANK1_MAKER1);
     dashboardDeals.visit();
 

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-main-container-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-main-container-filter-remove.spec.js
@@ -11,17 +11,13 @@ const filters = dashboardFilters;
 const EXPECTED_DEALS_LENGTH = 2;
 
 context('Dashboard Deals - main container selected filters - remove a filter', () => {
-  const ALL_DEALS = [];
-
   before(() => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
     cy.createBssEwcsDeal();
 
-    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1);
 
     cy.login(BANK1_MAKER1);
     dashboardDeals.visit();

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-panel-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-panel-filter-remove.spec.js
@@ -2,11 +2,15 @@ const relative = require('../../../../relativeURL');
 const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const { dashboardDeals } = require('../../../../pages');
 const { dashboardFilters } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT } = require('../../fixtures');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 const filters = dashboardFilters;
+
+const EXPECTED_DEALS_LENGTH = {
+  ALL_STATUSES: 2,
+};
 
 context('Dashboard Deals - panel selected filters - remove a filter', () => {
   const ALL_DEALS = [];
@@ -15,9 +19,7 @@ context('Dashboard Deals - panel selected filters - remove a filter', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       ALL_DEALS.push(deal);
@@ -28,7 +30,7 @@ context('Dashboard Deals - panel selected filters - remove a filter', () => {
     cy.url().should('eq', relative('/dashboard/deals/0'));
   });
 
-  it('applies and removes a filter', () => {
+  it('should apply and remove a filter', () => {
     // toggle to show filters (hidden by default)
     filters.showHideButton().click();
 
@@ -63,6 +65,6 @@ context('Dashboard Deals - panel selected filters - remove a filter', () => {
     dashboardDeals.filters.panel.form.submissionType.MIA.checkbox().should('not.be.checked');
 
     // should render all deals
-    dashboardDeals.rows().should('have.length', ALL_DEALS.length);
+    dashboardDeals.rows().should('have.length', EXPECTED_DEALS_LENGTH.ALL_STATUSES);
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-panel-filter-remove.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-deals/filters/dashboard-deals-panel-filter-remove.spec.js
@@ -13,17 +13,13 @@ const EXPECTED_DEALS_LENGTH = {
 };
 
 context('Dashboard Deals - panel selected filters - remove a filter', () => {
-  const ALL_DEALS = [];
-
   before(() => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
     cy.createBssEwcsDeal();
 
-    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
-      ALL_DEALS.push(deal);
-    });
+    cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1);
 
     cy.login(BANK1_MAKER1);
     dashboardDeals.visit();

--- a/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/filters/dashboard-facilities-filters.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/dashboard/dashboard-facilities/filters/dashboard-facilities-filters.spec.js
@@ -2,7 +2,7 @@ const MOCK_USERS = require('../../../../../../../e2e-fixtures');
 const CONSTANTS = require('../../../../../fixtures/constants');
 const { dashboardFacilities } = require('../../../../pages');
 const { dashboardFilters, dashboardSubNavigation } = require('../../../../partials');
-const { BSS_DEAL_DRAFT, GEF_DEAL_DRAFT, GEF_FACILITY_CASH, GEF_FACILITY_CONTINGENT } = require('../../fixtures');
+const { GEF_DEAL_DRAFT, GEF_FACILITY_CASH, GEF_FACILITY_CONTINGENT } = require('../../fixtures');
 
 const { BANK1_MAKER1, BANK1_CHECKER1, ADMIN } = MOCK_USERS;
 
@@ -15,7 +15,7 @@ context('Dashboard Deals filters', () => {
     cy.deleteGefApplications(ADMIN);
     cy.deleteDeals(ADMIN);
 
-    cy.insertOneDeal(BSS_DEAL_DRAFT, BANK1_MAKER1);
+    cy.createBssEwcsDeal();
 
     cy.insertOneGefApplication(GEF_DEAL_DRAFT, BANK1_MAKER1).then((deal) => {
       const { _id: dealId } = deal;
@@ -34,7 +34,7 @@ context('Dashboard Deals filters', () => {
   });
 
   describe('by default', () => {
-    it('renders all facilities (Checker)', () => {
+    it('should render all facilities (Checker)', () => {
       cy.login(BANK1_CHECKER1);
       dashboardFacilities.visit();
       dashboardFacilities.rows().should('be.visible');
@@ -43,7 +43,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
     });
 
-    it('renders all facilities (Maker)', () => {
+    it('should render all facilities (Maker)', () => {
       cy.login(BANK1_MAKER1);
       dashboardFacilities.visit();
       dashboardFacilities.rows().should('be.visible');
@@ -52,7 +52,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.rows().should('have.length', ALL_FACILITIES.length);
     });
 
-    it('hides filters and renders `show filter` button', () => {
+    it('should hide filters and render `show filter` button', () => {
       cy.login(BANK1_MAKER1);
       dashboardFacilities.visit();
 
@@ -75,16 +75,16 @@ context('Dashboard Deals filters', () => {
       filters.showHideButton().click();
     });
 
-    it('renders all filters container', () => {
+    it('should render all filters container', () => {
       filters.panel.container().should('be.visible');
     });
 
-    it('changes show/hide button text', () => {
+    it('should change show/hide button text', () => {
       filters.showHideButton().should('be.visible');
       filters.showHideButton().should('have.text', 'Hide filter');
     });
 
-    it('renders `apply filters` button', () => {
+    it('should render `apply filters` button', () => {
       filters.panel.form.applyFiltersButton().should('be.visible');
       filters.panel.form.applyFiltersButton().contains('Apply filters');
     });
@@ -102,13 +102,13 @@ context('Dashboard Deals filters', () => {
       filters.showHideButton().click();
     });
 
-    it('keyword', () => {
+    it('should render keyword filter', () => {
       filters.panel.form.keyword.label().contains('Keyword');
       filters.panel.form.keyword.input().should('be.visible');
       filters.panel.form.keyword.input().should('have.value', '');
     });
 
-    it('product/facility type', () => {
+    it('should render product/facility type', () => {
       // Cash
       dashboardFacilities.filters.panel.form.type.cash.label().contains(CONSTANTS.FACILITY.FACILITY_TYPE.CASH);
       dashboardFacilities.filters.panel.form.type.cash.checkbox().should('exist');
@@ -130,7 +130,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.filters.panel.form.type.loan.checkbox().should('not.be.checked');
     });
 
-    it('submissionType/notice type', () => {
+    it('should render submissionType/notice type', () => {
       // AIN
       dashboardFacilities.filters.panel.form.submissionType.AIN.label().contains(CONSTANTS.DEALS.SUBMISSION_TYPE.AIN);
       dashboardFacilities.filters.panel.form.submissionType.AIN.checkbox().should('exist');
@@ -147,7 +147,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.filters.panel.form.submissionType.MIN.checkbox().should('not.be.checked');
     });
 
-    it('bank facility stage/hasBeenIssued', () => {
+    it('should render bank facility stage/hasBeenIssued', () => {
       // Issued
       dashboardFacilities.filters.panel.form.stage.issued.label().contains(CONSTANTS.FACILITY.FACILITY_STAGE.ISSUED);
       dashboardFacilities.filters.panel.form.stage.issued.checkbox().should('exist');
@@ -159,7 +159,7 @@ context('Dashboard Deals filters', () => {
       dashboardFacilities.filters.panel.form.stage.unissued.checkbox().should('not.be.checked');
     });
 
-    it('contains the correct aria-label for no facility filters selected', () => {
+    it('should contain the correct aria-label for no facility filters selected', () => {
       dashboardSubNavigation
         .facilities()
         .invoke('attr', 'aria-label')

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/abandon-a-deal/abandon-a-deal.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/abandon-a-deal/abandon-a-deal.spec.js
@@ -2,56 +2,58 @@ const { contract, contractDelete, defaults } = require('../../../pages');
 const { successMessage } = require('../../../partials');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
-const twentyOneDeals = require('../../../../fixtures/deal-dashboard-data');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 context('A maker selects to abandon a contract from the view-contract page', () => {
-  let deal;
+  let bssDealId;
+
+  const dummyDeal = {
+    bankInternalRefName: '9',
+    additionalRefName: 'UKEF test bank (Delegated)',
+  };
 
   before(() => {
-    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.status)[0];
-
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(aDealInStatus('Draft'), BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
-  it('The cancel button returns the user to the view-contract page.', () => {
+  it('should cancel and return the user to the view-contract page.', () => {
     // log in, visit a deal, select abandon
     cy.login(BANK1_MAKER1);
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.abandonLink().contains('Abandon');
     contract
       .abandonLink()
       .invoke('attr', 'aria-label')
       .then((label) => {
-        expect(label).to.equal(`Abandon Deal ${deal.bankInternalRefName}`);
+        expect(label).to.equal(`Abandon Deal ${dummyDeal.bankInternalRefName}`);
       });
     contract.abandonButton().click();
 
     cy.title().should('eq', `Abandon Deal${defaults.pageTitleAppend}`);
 
-    cy.assertText(contractDelete.heading(), `Are you sure you want to abandon ${deal.additionalRefName}?`);
+    cy.assertText(contractDelete.heading(), `Are you sure you want to abandon ${dummyDeal.additionalRefName}?`);
 
     // cancel
     contractDelete.cancel().click();
 
     // check we've gone to the right page
-    cy.url().should('eq', relative(`/contract/${deal._id}`));
+    cy.url().should('eq', relative(`/contract/${bssDealId}`));
   });
 
-  it('The abandon button generates an error if no comment has been entered.', () => {
+  it('should generate an error if no comment has been entered when abandoning.', () => {
     // log in, visit a deal, select abandon
     cy.login(BANK1_MAKER1);
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.abandonLink().contains('Abandon');
     contract
       .abandonLink()
       .invoke('attr', 'aria-label')
       .then((label) => {
-        expect(label).to.equal(`Abandon Deal ${deal.bankInternalRefName}`);
+        expect(label).to.equal(`Abandon Deal ${dummyDeal.bankInternalRefName}`);
       });
     contract.abandonButton().click();
 
@@ -60,20 +62,20 @@ context('A maker selects to abandon a contract from the view-contract page', () 
     contractDelete.abandon().click();
 
     // expect to stay on the abandon page, and see an error
-    cy.url().should('eq', relative(`/contract/${deal._id}/delete`));
+    cy.url().should('eq', relative(`/contract/${bssDealId}/delete`));
     contractDelete.expectError('Comment is required when abandoning a deal.');
   });
 
-  it('If a comment has been entered, the Abandon button Abandons the deal and takes the user to /dashboard', () => {
+  it('should abandon the deal and take the user to /dashboard if a comment has been entered', () => {
     // log in, visit a deal, select abandon
     cy.login(BANK1_MAKER1);
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.abandonLink().contains('Abandon');
     contract
       .abandonLink()
       .invoke('attr', 'aria-label')
       .then((label) => {
-        expect(label).to.equal(`Abandon Deal ${deal.bankInternalRefName}`);
+        expect(label).to.equal(`Abandon Deal ${dummyDeal.bankInternalRefName}`);
       });
     contract.abandonButton().click();
 
@@ -92,7 +94,7 @@ context('A maker selects to abandon a contract from the view-contract page', () 
       });
 
     // visit the deal and confirm the updates have been made
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     cy.assertText(contract.status(), 'Abandoned');
 

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/bss-mandatory-criteria/bss-mandatory-criteria.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/bss-mandatory-criteria/bss-mandatory-criteria.spec.js
@@ -1,21 +1,33 @@
+import { DEAL_SUBMISSION_TYPE, FACILITY_STAGE } from '@ukef/dtfs2-common';
+
 const pages = require('../../../pages');
 const partials = require('../../../partials');
-const dealFullyCompleted = require('../fixtures/dealFullyCompleted');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
 
-const { BANK1_MAKER1 } = MOCK_USERS;
+const { ADMIN, BANK1_MAKER1 } = MOCK_USERS;
 
 context('BSS Mandatory criteria: Check deal details page', () => {
-  let deal;
-  beforeEach(() => {
-    cy.insertOneDeal(dealFullyCompleted, BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+  let bssDealId;
+
+  const dummyDeal = {
+    bankInternalRefName: '9',
+  };
+
+  before(() => {
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
+    cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED });
+  });
+
+  after(() => {
+    cy.deleteDeals(ADMIN);
   });
   it('should render the mandatory criteria checklist when a new deal is created', () => {
     cy.login(BANK1_MAKER1);
-    cy.visit(relative(`/contract/${deal._id}/submission-details`));
+    cy.visit(relative(`/contract/${bssDealId}/submission-details`));
+    pages.contract.checkDealDetailsTab().click();
     pages.contractSubmissionDetails.mandatoryCriteriaBox().should('exist');
     pages.contractSubmissionDetails.mandatoryCriteriaBox().find('ol > li[value="1"]').should('contain', 'Bank with a duly completed Supplier Declaration');
     pages.contractSubmissionDetails
@@ -36,13 +48,14 @@ context('BSS Mandatory criteria: Check deal details page', () => {
   });
 
   it('should render the mandatory criteria checklist when a deal is cloned', () => {
-    cy.loginGoToDealPage(BANK1_MAKER1, deal);
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(`/contract/${bssDealId}`));
     pages.contract.cloneDealLink().contains('Clone');
     pages.contract
       .cloneDealLink()
       .invoke('attr', 'aria-label')
       .then((label) => {
-        expect(label).to.equal(`Clone Deal ${deal.bankInternalRefName}`);
+        expect(label).to.equal(`Clone Deal ${dummyDeal.bankInternalRefName}`);
       });
     pages.contract.cloneDealLink().click();
     cy.url().should('include', '/clone/before-you-start');

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/edit-deal-name/edit-deal-name.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/edit-deal-name/edit-deal-name.spec.js
@@ -5,43 +5,43 @@ const MOCK_USERS = require('../../../../../../e2e-fixtures');
 const { ADMIN, BANK1_MAKER1 } = MOCK_USERS;
 
 context('Edit deal name', () => {
-  let deal;
+  let bssDealId;
 
   const dummyDeal = {
     bankInternalRefName: 'abc-1-def',
-    additionalRefName: 'Additional reference name example',
+    additionalRefName: 'UKEF test bank (Delegated)',
   };
 
   before(() => {
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(dummyDeal, BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
-  it('rejects an empty field', () => {
+  it('should reject an empty field', () => {
     cy.login(BANK1_MAKER1);
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.editDealName().contains('Edit deal name');
     contract.editDealName().click();
 
-    cy.title().should('eq', `Change name - ${deal.additionalRefName}${defaults.pageTitleAppend}`);
-    editDealName.additionalRefName().should('have.value', deal.additionalRefName);
-    cy.keyboardInput(editDealName.additionalRefName(), '{selectall}{backspace}');
+    cy.title().should('eq', `Change name - ${dummyDeal.additionalRefName}${defaults.pageTitleAppend}`);
+    editDealName.additionalRefName().should('have.value', dummyDeal.additionalRefName);
+    editDealName.additionalRefName().clear();
     cy.clickSubmitButton();
 
-    cy.url().should('eq', relative(`/contract/${deal._id}/edit-name`));
+    cy.url().should('eq', relative(`/contract/${bssDealId}/edit-name`));
 
     editDealName.expectError('A value is required.');
   });
 
-  it('updates deal.additionalRefName', () => {
+  it('should update deal.additionalRefName', () => {
     cy.login(BANK1_MAKER1);
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.editDealName().contains('Edit deal name');
     contract.editDealName().click();
 
-    cy.keyboardInput(editDealName.additionalRefName(), '{selectall}{backspace}mock');
+    cy.keyboardInput(editDealName.additionalRefName(), 'mock');
     cy.clickSubmitButton();
 
     cy.assertText(contract.additionalRefName(), 'mock');

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/proceed-to-review/proceed-to-review.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/proceed-to-review/proceed-to-review.spec.js
@@ -1,18 +1,20 @@
+import { DEAL_SUBMISSION_TYPE, FACILITY_STAGE } from '@ukef/dtfs2-common';
+
 const pages = require('../../../pages');
 const partials = require('../../../partials');
 const fillBondForm = require('../../maker-bond/fill-bond-forms');
 const fillLoanForm = require('../../maker-loan/fill-loan-forms');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
-const dealWithNoFacilities = require('../submit-issued-facilities-for-review/dealWithNoFacilities');
+const relative = require('../../../relativeURL');
 
 const { BANK1_MAKER1, ADMIN } = MOCK_USERS;
 
 context('Ensure proceed to review button is only visible once facilities are in eligible for submission', () => {
-  let deal;
+  let bssDealId;
 
   before(() => {
-    cy.insertOneDeal(dealWithNoFacilities, BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
@@ -25,7 +27,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.login(BANK1_MAKER1);
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Ensure proceed to review button does not exist
     pages.contract.proceedToReview().should('not.exist');
@@ -51,7 +53,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.login(BANK1_MAKER1);
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Add loan
     cy.clickAddLoanButton();
@@ -70,14 +72,8 @@ context('Ensure proceed to review button is only visible once facilities are in 
   });
 
   it('Ensure proceed to review button is visible', () => {
-    // Login as a `Maker`
-    cy.login(BANK1_MAKER1);
-
-    // Navigate to the deal in question
-    pages.contract.visit(deal);
-
-    // Proceed to review button
-    pages.contract.proceedToReview().should('exist');
+    cy.createBssEwcsDeal();
+    cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED });
   });
 
   it('Add an issued bond', () => {
@@ -85,7 +81,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.login(BANK1_MAKER1);
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Add bond
     cy.clickAddBondButton();
@@ -108,7 +104,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.login(BANK1_MAKER1);
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Add loan
     cy.clickAddLoanButton();
@@ -127,14 +123,8 @@ context('Ensure proceed to review button is only visible once facilities are in 
   });
 
   it('Ensure proceed to review button is visible', () => {
-    // Login as a `Maker`
-    cy.login(BANK1_MAKER1);
-
-    // Navigate to the deal in question
-    pages.contract.visit(deal);
-
-    // Proceed to review button
-    pages.contract.proceedToReview().should('exist');
+    cy.createBssEwcsDeal();
+    cy.completeBssEwcsDealFields({ dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, facilityStage: FACILITY_STAGE.UNISSUED });
   });
 
   it('Add a partial issued (unconditional) loan', () => {
@@ -142,7 +132,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.login(BANK1_MAKER1);
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Add loan
     cy.clickAddLoanButton();
@@ -161,7 +151,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.clickSubmitButton();
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Ensure facility stage is `Incomplete`
     pages.contract.loansTransactionsTableRows().each((row, index) => {
@@ -177,7 +167,7 @@ context('Ensure proceed to review button is only visible once facilities are in 
     cy.login(BANK1_MAKER1);
 
     // Navigate to the deal in question
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
     // Proceed to review button
     pages.contract.proceedToReview().should('not.exist');

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/xss/xss.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/xss/xss.spec.js
@@ -1,26 +1,23 @@
 const { contract, contractDelete, contractComments } = require('../../../pages');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
+const relative = require('../../../relativeURL');
 
 const { ADMIN, BANK1_MAKER1 } = MOCK_USERS;
 
-const twentyOneDeals = require('../../../../fixtures/deal-dashboard-data');
-
 context('Input is cleaned to avoid Cross Site Scripting', () => {
-  let deal;
+  let bssDealId;
 
   before(() => {
-    const aDealInStatus = (status) => twentyOneDeals.filter((aDeal) => status === aDeal.status)[0];
-
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(aDealInStatus('Draft'), BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
-  it('Does not allow <script> tag', () => {
+  it('should not allow <script> tag', () => {
     // log in, visit a deal, select abandon
     cy.login(BANK1_MAKER1);
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.abandonButton().click();
 
     // submit with a comment with script tag
@@ -31,7 +28,7 @@ context('Input is cleaned to avoid Cross Site Scripting', () => {
     cy.url().should('include', '/dashboard');
 
     // visit the deal and confirm the updates have been made
-    contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
     contract.commentsTab().click();
 
     contractComments

--- a/e2e-tests/portal/cypress/e2e/journeys/read-only/abandon-deal/cannot-abandon-a-deal.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/read-only/abandon-deal/cannot-abandon-a-deal.spec.js
@@ -1,27 +1,23 @@
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
 const relative = require('../../../relativeURL');
-const deals = require('../../../../fixtures/deal-dashboard-data');
-const { contract } = require('../../../pages');
 
-const { BANK1_READ_ONLY1, BANK1_MAKER1, ADMIN } = MOCK_USERS;
+const { BANK1_READ_ONLY1, ADMIN } = MOCK_USERS;
 
 context('Abandon a deal', () => {
-  let deal;
+  let bssDealId;
 
   before(() => {
-    const aDealInStatus = (status) => deals.filter((aDeal) => status === aDeal.status)[0];
-
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(aDealInStatus('Draft'), BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
   describe('when a read-only user views a draft deal', () => {
     it('should have no "abandon deal" link', () => {
-      cy.loginGoToDealPage(BANK1_READ_ONLY1, deal);
-      cy.url().should('eq', relative(`/contract/${deal._id}`));
-      contract.abandonLink().should('not.exist');
+      cy.login(BANK1_READ_ONLY1);
+      cy.visit(relative(`/contract/${bssDealId}`));
+      cy.url().should('eq', relative(`/contract/${bssDealId}`));
     });
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/read-only/deal/access-contract.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/read-only/deal/access-contract.spec.js
@@ -1,23 +1,21 @@
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
 const relative = require('../../../relativeURL');
-const deals = require('../../../../fixtures/deal-dashboard-data');
 
-const { READ_ONLY_ALL_BANKS, BANK1_MAKER1, ADMIN } = MOCK_USERS;
+const { READ_ONLY_ALL_BANKS, ADMIN } = MOCK_USERS;
 
 context('Access a deal', () => {
-  let deal;
+  let bssDealId;
 
   before(() => {
-    const aDealInStatus = (status) => deals.filter((aDeal) => status === aDeal.status)[0];
-
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(aDealInStatus('Draft'), BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
-  it('allows read only user with all bank access to view deal', () => {
-    cy.loginGoToDealPage(READ_ONLY_ALL_BANKS, deal);
-    cy.url().should('eq', relative(`/contract/${deal._id}`));
+  it('should allow read only user with all bank access to view deal', () => {
+    cy.login(READ_ONLY_ALL_BANKS);
+    cy.visit(relative(`/contract/${bssDealId}`));
+    cy.url().should('eq', relative(`/contract/${bssDealId}`));
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/read-only/deal/cannot-abandon-a-deal.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/read-only/deal/cannot-abandon-a-deal.spec.js
@@ -1,26 +1,24 @@
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
 const relative = require('../../../relativeURL');
-const deals = require('../../../../fixtures/deal-dashboard-data');
 const { contract } = require('../../../pages');
 
-const { BANK1_READ_ONLY1, BANK1_MAKER1, ADMIN } = MOCK_USERS;
+const { BANK1_READ_ONLY1, ADMIN } = MOCK_USERS;
 
 context('Abandon a deal', () => {
-  let deal;
+  let bssDealId;
 
   before(() => {
-    const aDealInStatus = (status) => deals.filter((aDeal) => status === aDeal.status)[0];
-
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(aDealInStatus('Draft'), BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
   describe('when a read-only user views a draft deal', () => {
     it('should have no "abandon deal" link', () => {
-      cy.loginGoToDealPage(BANK1_READ_ONLY1, deal);
-      cy.url().should('eq', relative(`/contract/${deal._id}`));
+      cy.login(BANK1_READ_ONLY1);
+      cy.visit(relative(`/contract/${bssDealId}`));
+      cy.url().should('eq', relative(`/contract/${bssDealId}`));
       contract.abandonLink().should('not.exist');
     });
   });

--- a/e2e-tests/portal/cypress/e2e/journeys/read-only/deal/cannot-modify-an-unissued-deal.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/read-only/deal/cannot-modify-an-unissued-deal.spec.js
@@ -1,20 +1,16 @@
 const pages = require('../../../pages');
 const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
-const deals = require('../../../../fixtures/deal-dashboard-data');
 
-const { BANK1_READ_ONLY1, BANK1_MAKER1, ADMIN } = MOCK_USERS;
-const { DEALS } = require('../../../../fixtures/constants');
+const { BANK1_READ_ONLY1, ADMIN } = MOCK_USERS;
 
 context('A read-only role viewing a bond that can be issued', () => {
-  let deal;
+  let bssDealId;
 
   before(() => {
-    const aDealInStatus = (status) => deals.filter((aDeal) => status === aDeal.status)[0];
-
     cy.deleteDeals(ADMIN);
-    cy.insertOneDeal(aDealInStatus(DEALS.DEAL_STATUS.READY_FOR_APPROVAL), BANK1_MAKER1).then((insertedDeal) => {
-      deal = insertedDeal;
+    cy.createBssEwcsDeal().then((dealId) => {
+      bssDealId = dealId;
     });
   });
 
@@ -24,9 +20,9 @@ context('A read-only role viewing a bond that can be issued', () => {
 
   it('should not allow for any publishing actions', () => {
     cy.login(BANK1_READ_ONLY1);
-    pages.contract.visit(deal);
+    cy.visit(relative(`/contract/${bssDealId}`));
 
-    cy.url().should('eq', relative(`/contract/${deal._id}`));
+    cy.url().should('eq', relative(`/contract/${bssDealId}`));
 
     pages.contract.proceedToSubmit().should('not.exist');
     pages.contract.proceedToReview().should('not.exist');


### PR DESCRIPTION
## Introduction :pencil2:
BSS/EWCS E2E tests were creating deals by calling the API directly.
We want to prevent specific user roles (like maker, checker), from calling Portal API directly.
This PR updates all E2E tests that create individual BSS/EWCS deals, to be created via the UI, mimicking a true user journey.

## Resolution :heavy_check_mark:
Create createBssEwcsDeal cypress command.

## Miscellaneous :heavy_plus_sign:
Update E2E tests

