### PR TITLE
fix(DTFS2-7917): record correction - cancel link

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/create-fee-record-correction-check-the-information.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/create-fee-record-correction-check-the-information.spec.js
@@ -10,7 +10,7 @@ import USERS from '../../../../../fixtures/users';
 import BANKS from '../../../../../fixtures/banks';
 import { NODE_TASKS } from '../../../../../../../e2e-fixtures';
 import relative from '../../../../relativeURL';
-import { summaryList, mainHeading } from '../../../../partials';
+import { summaryList, mainHeading, cancelLink } from '../../../../partials';
 import { getMatchingTfmFacilitiesForFeeRecords } from '../../../../../support/utils/getMatchingTfmFacilitiesForFeeRecords';
 
 context('When fee record correction feature flag is enabled', () => {
@@ -91,6 +91,12 @@ context('When fee record correction feature flag is enabled', () => {
       });
     });
 
+    it('should have a cancel link', () => {
+      cy.assertText(cancelLink(), 'Cancel record correction request');
+
+      cancelLink().should('have.attr', 'href', `/utilisation-reports/${reportId}/create-record-correction-request/${feeRecordAtToDoStatus.id}/cancel`);
+    });
+
     context('when the user clicks the "continue" button', () => {
       beforeEach(() => {
         cy.clickContinueButton();
@@ -167,9 +173,9 @@ context('When fee record correction feature flag is enabled', () => {
       });
     });
 
-    context('when user abandons their journey by clicking the cancel button', () => {
+    context('when user abandons their journey by clicking the cancel link', () => {
       beforeEach(() => {
-        cy.clickCancelButton();
+        cy.clickCancelLink();
       });
 
       it('should redirect to the utilisation report page with the fee record still checked', () => {

--- a/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/create-fee-record-correction-form.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/utilisation-reports/fee-record-correction/feature-flag-enabled/create-fee-record-correction-form.spec.js
@@ -10,7 +10,7 @@ import pages from '../../../../pages';
 import USERS from '../../../../../fixtures/users';
 import { NODE_TASKS } from '../../../../../../../e2e-fixtures';
 import relative from '../../../../relativeURL';
-import { feeRecordSummary, mainHeading } from '../../../../partials';
+import { feeRecordSummary, mainHeading, cancelLink } from '../../../../partials';
 import { getMatchingTfmFacilitiesForFeeRecords } from '../../../../../support/utils/getMatchingTfmFacilitiesForFeeRecords';
 
 context('When fee record correction feature flag is enabled', () => {
@@ -69,21 +69,27 @@ context('When fee record correction feature flag is enabled', () => {
       cy.login(USERS.PDC_RECONCILE);
 
       cy.visit(`utilisation-reports/${reportId}`);
-    });
 
-    it('should be able to initiate a record correction request', () => {
       premiumPaymentsContent.premiumPaymentsTable
         .checkbox([feeRecordAtToDoStatus.id], feeRecordAtToDoStatus.paymentCurrency, feeRecordAtToDoStatus.status)
         .click();
-
-      premiumPaymentsContent.createRecordCorrectionRequestButton().should('exist');
       premiumPaymentsContent.createRecordCorrectionRequestButton().click();
+    });
 
+    it('should be able to initiate a record correction request', () => {
       cy.assertText(mainHeading(), 'Record correction request');
+    });
+
+    it('should have a cancel link', () => {
+      cy.assertText(cancelLink(), 'Cancel record correction request');
+
+      cancelLink().should('have.attr', 'href', `/utilisation-reports/${reportId}/create-record-correction-request/${feeRecordAtToDoStatus.id}/cancel`);
     });
 
     context('when a user has initiated the correction request journey', () => {
       beforeEach(() => {
+        cy.visit(`utilisation-reports/${reportId}`);
+
         premiumPaymentsContent.premiumPaymentsTable
           .checkbox([feeRecordAtToDoStatus.id], feeRecordAtToDoStatus.paymentCurrency, feeRecordAtToDoStatus.status)
           .click();
@@ -112,12 +118,6 @@ context('When fee record correction feature flag is enabled', () => {
 
     context('when user clicks back on the create record correction request screen', () => {
       it('should return to premium payments tab with the checkbox selected', () => {
-        premiumPaymentsContent.premiumPaymentsTable
-          .checkbox([feeRecordAtToDoStatus.id], feeRecordAtToDoStatus.paymentCurrency, feeRecordAtToDoStatus.status)
-          .click();
-
-        premiumPaymentsContent.createRecordCorrectionRequestButton().click();
-
         cy.clickBackLink();
 
         cy.url().should('eq', relative(`/utilisation-reports/${reportId}?selectedFeeRecordIds=${feeRecordAtToDoStatus.id}`));
@@ -130,13 +130,15 @@ context('When fee record correction feature flag is enabled', () => {
 
     context('when user clicks cancel', () => {
       beforeEach(() => {
+        cy.visit(`utilisation-reports/${reportId}`);
+
         premiumPaymentsContent.premiumPaymentsTable
           .checkbox([feeRecordAtToDoStatus.id], feeRecordAtToDoStatus.paymentCurrency, feeRecordAtToDoStatus.status)
           .click();
 
         premiumPaymentsContent.createRecordCorrectionRequestButton().click();
 
-        cy.clickCancelButton();
+        cy.clickCancelLink();
       });
 
       it('should redirect to the utilisation report page with the fee record still checked', () => {
@@ -149,12 +151,6 @@ context('When fee record correction feature flag is enabled', () => {
     });
 
     it('should let the user enter additional info equal to the character limit containing special characters', () => {
-      premiumPaymentsContent.premiumPaymentsTable
-        .checkbox([feeRecordAtToDoStatus.id], feeRecordAtToDoStatus.paymentCurrency, feeRecordAtToDoStatus.status)
-        .click();
-
-      premiumPaymentsContent.createRecordCorrectionRequestButton().click();
-
       createFeeRecordCorrectionRequestPage.reasonCheckbox(RECORD_CORRECTION_REASON.OTHER).check();
 
       const specialCharactersToTest = '&!?$£¥€¢^*()_+=-%:;@~/><,.';

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/check-the-information.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/check-the-information.component-test.ts
@@ -194,11 +194,9 @@ describe('page', () => {
     const wrapper = render(viewModel);
 
     // Assert
-    const cancelButtonSelector = '[data-cy="cancel-button"]';
-    wrapper.expectElement(cancelButtonSelector).toExist();
-    wrapper.expectElement(cancelButtonSelector).toHaveAttribute('value', 'Cancel record correction request');
-    wrapper.expectElement(cancelButtonSelector).hasClass('govuk-button--warning');
-    wrapper.expectElement(cancelButtonSelector).toHaveAttribute('formaction', cancelLink);
+    const cancelLinkSelector = '[data-cy="cancel-link"]';
+    wrapper.expectElement(cancelLinkSelector).toExist();
+    wrapper.expectLink(cancelLinkSelector).toLinkTo(cancelLink, 'Cancel record correction request');
   });
 
   it('should render the back link', () => {

--- a/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/create-record-correction-request.component-test.ts
+++ b/trade-finance-manager-ui/component-tests/utilisation-reports/record-corrections/create-record-correction-request.component-test.ts
@@ -208,7 +208,7 @@ describe(page, () => {
     wrapper.expectText('[data-cy="continue-button"]').toRead('Continue');
   });
 
-  it('should render the cancel button', () => {
+  it('should render the cancel link', () => {
     // Arrange
     const cancelLink = '/utilisation-reports/123/create-record-correction-request/456/cancel';
     const viewModel: CreateRecordCorrectionRequestViewModel = {
@@ -220,11 +220,9 @@ describe(page, () => {
     const wrapper = render(viewModel);
 
     // Assert
-    const cancelButtonSelector = '[data-cy="cancel-button"]';
-    wrapper.expectElement(cancelButtonSelector).toExist();
-    wrapper.expectElement(cancelButtonSelector).toHaveAttribute('value', 'Cancel record correction request');
-    wrapper.expectElement(cancelButtonSelector).hasClass('govuk-button--warning');
-    wrapper.expectElement(cancelButtonSelector).toHaveAttribute('formaction', cancelLink);
+    const cancelLinkSelector = '[data-cy="cancel-link"]';
+    wrapper.expectElement(cancelLinkSelector).toExist();
+    wrapper.expectLink(cancelLinkSelector).toLinkTo(cancelLink, 'Cancel record correction request');
   });
 
   it('should render the main reasons hint', () => {

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/cancel-record-correction-request/index.test.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/cancel-record-correction-request/index.test.ts
@@ -1,7 +1,7 @@
 import httpMocks, { MockResponse } from 'node-mocks-http';
 import { Response } from 'express';
 import { aTfmSessionUser } from '../../../../../test-helpers';
-import { postCancelRecordCorrectionRequest, PostCancelRecordCorrectionRequestRequest } from '.';
+import { getCancelRecordCorrectionRequest, GetCancelRecordCorrectionRequest } from '.';
 import api from '../../../../api';
 import { getLinkToPremiumPaymentsTab } from '../../helpers';
 
@@ -22,8 +22,8 @@ describe('controllers/utilisation-reports/record-corrections/cancel-record-corre
     jest.resetAllMocks();
   });
 
-  describe('postCancelRecordCorrectionRequest', () => {
-    let req: PostCancelRecordCorrectionRequestRequest;
+  describe('getCancelRecordCorrectionRequest', () => {
+    let req: GetCancelRecordCorrectionRequest;
     let res: MockResponse<Response>;
 
     beforeEach(() => {
@@ -35,7 +35,7 @@ describe('controllers/utilisation-reports/record-corrections/cancel-record-corre
 
     it('should redirect to premium payments tab, with fee records selected, on success', async () => {
       // Act
-      await postCancelRecordCorrectionRequest(req, res);
+      await getCancelRecordCorrectionRequest(req, res);
 
       // Assert
       expect(res._getRedirectUrl()).toEqual(getLinkToPremiumPaymentsTab(reportId, [Number(feeRecordId)]));
@@ -43,7 +43,7 @@ describe('controllers/utilisation-reports/record-corrections/cancel-record-corre
 
     it('should clear transient form data', async () => {
       // Act
-      await postCancelRecordCorrectionRequest(req, res);
+      await getCancelRecordCorrectionRequest(req, res);
 
       // Assert
       expect(api.deleteFeeRecordCorrectionTransientFormData).toHaveBeenCalledTimes(1);
@@ -55,7 +55,7 @@ describe('controllers/utilisation-reports/record-corrections/cancel-record-corre
       jest.mocked(api.deleteFeeRecordCorrectionTransientFormData).mockRejectedValue(new Error('API Error'));
 
       // Act
-      await postCancelRecordCorrectionRequest(req, res);
+      await getCancelRecordCorrectionRequest(req, res);
 
       // Assert
       expect(res._getRenderView()).toEqual('_partials/problem-with-service.njk');

--- a/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/cancel-record-correction-request/index.ts
+++ b/trade-finance-manager-ui/server/controllers/utilisation-reports/record-corrections/cancel-record-correction-request/index.ts
@@ -4,7 +4,7 @@ import { getLinkToPremiumPaymentsTab } from '../../helpers';
 import { asUserSession } from '../../../../helpers/express-session';
 import api from '../../../../api';
 
-export type PostCancelRecordCorrectionRequestRequest = CustomExpressRequest<{
+export type GetCancelRecordCorrectionRequest = CustomExpressRequest<{
   params: {
     reportId: string;
     feeRecordId: string;
@@ -12,14 +12,15 @@ export type PostCancelRecordCorrectionRequestRequest = CustomExpressRequest<{
 }>;
 
 /**
- * Controller for the POST cancel record correction request route.
+ * Controller for the get cancel record correction request route.
+ * Get as a link is pressed to cancel the record correction request (instead of a button)
  * Deletes the transient form data for the given report id, fee record id, and
  * user, then redirects to the premium payments tab with the given fee record
  * id selected.
  * @param req - The request object
  * @param res - The response object
  */
-export const postCancelRecordCorrectionRequest = async (req: PostCancelRecordCorrectionRequestRequest, res: Response) => {
+export const getCancelRecordCorrectionRequest = async (req: GetCancelRecordCorrectionRequest, res: Response) => {
   try {
     const { reportId, feeRecordId } = req.params;
     const { user, userToken } = asUserSession(req.session);
@@ -28,7 +29,7 @@ export const postCancelRecordCorrectionRequest = async (req: PostCancelRecordCor
 
     return res.redirect(getLinkToPremiumPaymentsTab(reportId, [Number(feeRecordId)]));
   } catch (error) {
-    console.error('Failed to post cancel record correction request %o', error);
+    console.error('Failed to get cancel record correction request %o', error);
     return res.render('_partials/problem-with-service.njk', { user: req.session.user });
   }
 };

--- a/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
+++ b/trade-finance-manager-ui/server/routes/utilisation-reports/index.ts
@@ -23,7 +23,7 @@ import {
 } from '../../controllers/utilisation-reports/record-corrections/check-the-information';
 import { postInitiateRecordCorrectionRequest } from '../../controllers/utilisation-reports/record-corrections/initiate-record-correction-request';
 import { getRecordCorrectionRequestSent } from '../../controllers/utilisation-reports/record-corrections/request-sent';
-import { postCancelRecordCorrectionRequest } from '../../controllers/utilisation-reports/record-corrections/cancel-record-correction-request';
+import { getCancelRecordCorrectionRequest } from '../../controllers/utilisation-reports/record-corrections/cancel-record-correction-request';
 import { getRecordCorrectionLogDetails } from '../../controllers/utilisation-reports/record-corrections/record-correction-log-details';
 
 export const utilisationReportsRoutes = express.Router();
@@ -170,13 +170,13 @@ utilisationReportsRoutes.get(
   getRecordCorrectionRequestSent,
 );
 
-utilisationReportsRoutes.post(
+utilisationReportsRoutes.get(
   '/:reportId/create-record-correction-request/:feeRecordId/cancel',
   validateFeeRecordCorrectionFeatureFlagIsEnabled,
   validateUserTeam([PDC_TEAM_IDS.PDC_RECONCILE]),
   validateSqlId('reportId'),
   validateSqlId('feeRecordId'),
-  postCancelRecordCorrectionRequest,
+  getCancelRecordCorrectionRequest,
 );
 
 utilisationReportsRoutes.get(

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
@@ -103,16 +103,13 @@
         }
       }) }}
     </form>
-    <form method="post">
-      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-      <input
-        class="govuk-button govuk-button--warning"
-        formaction="{{ cancelLinkHref }}"
-        value="Cancel record correction request"
-        data-module="govuk-button"
-        type="submit"
-        data-cy="cancel-button"/>
-    </form>
+
+    <a
+      class="govuk-link govuk-link--no-visited-state"
+      href="{{ cancelLinkHref }}"
+      data-cy="cancel-link">
+      Cancel record correction request
+    </a>
   </div>
 
 {% endblock %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/check-the-information.njk
@@ -93,8 +93,8 @@
     }
   }) }}
 
-  <div class="govuk-button-group">
-    <form method="post">
+  <form method="post">
+    <div class="govuk-button-group">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
       {{ govukButton({
         text: "Send record correction request",
@@ -102,15 +102,16 @@
           'data-cy': 'continue-button'
         }
       }) }}
-    </form>
+    
+      <a
+        class="govuk-link govuk-link--no-visited-state"
+        href="{{ cancelLinkHref }}"
+        data-cy="cancel-link">
+        Cancel record correction request
+      </a>
+    </div>
+  </form>
 
-    <a
-      class="govuk-link govuk-link--no-visited-state"
-      href="{{ cancelLinkHref }}"
-      data-cy="cancel-link">
-      Cancel record correction request
-    </a>
-  </div>
 
 {% endblock %}
 {% block sub_content %}{% endblock %}

--- a/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/create-record-correction-request.njk
+++ b/trade-finance-manager-ui/templates/utilisation-reports/record-corrections/create-record-correction-request.njk
@@ -167,14 +167,13 @@
               "data-cy": "continue-button"
             }
           })}}
-
-          <input
-            class="govuk-button govuk-button--warning"
-            formaction="{{ cancelLinkHref }}"
-            value="Cancel record correction request"
-            data-module="govuk-button"
-            type="submit"
-            data-cy="cancel-button"/>
+    
+          <a
+            class="govuk-link govuk-link--no-visited-state"
+            href="{{ cancelLinkHref }}"
+            data-cy="cancel-link">
+            Cancel record correction request
+          </a>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Introduction :pencil2:
This PR fixes the record correction cancel link which was a button but should be a link

## Resolution :heavy_check_mark:
* Changed create-record-correction-request and check-the-information templates to have a link instead of a button
* Changed post cancel route to a get (as pressing a link triggers a get request)
* Updated tests
* Updated and added to e2e tests

## Screenshot :camera_flash:
![image](https://github.com/user-attachments/assets/fd331042-25c6-43bf-a4bd-a58100edd153)



