### PR TITLE
fix(DTFS2-7679): display task comments on application preview page

### DIFF
--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -16,7 +16,7 @@ const {
   getIssuedFacilitiesAsArray,
   getFacilityCoverStartDate,
   coverDatesConfirmed,
-  hasChangedToIssued,
+  isFacilityResubmissionAvailable,
 } = require('../../utils/facility-helpers');
 const { isUkefReviewAvailable, isUkefReviewPositive, makerCanReSubmit } = require('../../utils/deal-helpers');
 const { exporterItems, facilityItems } = require('../../utils/display-items');
@@ -64,7 +64,7 @@ function buildBody(app, previewMode, user) {
   const ukefReviewAvailable = isUkefReviewAvailable(app.status, app.ukefDecision);
   const ukefReviewPositive = isUkefReviewPositive(app.status, app.ukefDecision);
   const coverDates = coverDatesConfirmed(app.facilities);
-  const hasChangedFacilities = hasChangedToIssued(app);
+  const hasChangedFacilities = isFacilityResubmissionAvailable(app);
   const unissuedFacilitiesPresent = areUnissuedFacilitiesPresent(app);
   const facilitiesChangedToIssued = facilitiesChangedToIssuedAsArray(app);
   const hasUkefDecisionAccepted = app.ukefDecisionAccepted ? app.ukefDecisionAccepted : false;

--- a/gef-ui/server/utils/deal-helpers.js
+++ b/gef-ui/server/utils/deal-helpers.js
@@ -1,6 +1,6 @@
 const CONSTANTS = require('../constants');
 const { MAKER } = require('../constants/roles');
-const { hasChangedToIssued, coverDatesConfirmed, getIssuedFacilitiesAsArray } = require('./facility-helpers');
+const { isFacilityResubmissionAvailable, coverDatesConfirmed, getIssuedFacilitiesAsArray } = require('./facility-helpers');
 
 const status = {
   [CONSTANTS.DEAL_STATUS.NOT_STARTED]: {
@@ -52,7 +52,7 @@ const makerCanReSubmit = (maker, application) => {
 
   // only if AIN -> ensures a facility has changed to issued before resubmitting to bank
   if (application.status === CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED) {
-    facilitiesChangedToIssued = hasChangedToIssued(application);
+    facilitiesChangedToIssued = isFacilityResubmissionAvailable(application);
   }
   const coverDateConfirmed = getIssuedFacilitiesAsArray(application.facilities).length > 0 ? coverDatesConfirmed(application.facilities) : true;
   const ukefDecisionAccepted = application.submissionType === CONSTANTS.DEAL_SUBMISSION_TYPE.AIN ? true : application.ukefDecisionAccepted;

--- a/gef-ui/server/utils/helpers.js
+++ b/gef-ui/server/utils/helpers.js
@@ -16,7 +16,8 @@ const {
   summaryIssuedChangedToIssued,
   summaryIssuedUnchanged,
   areUnissuedFacilitiesPresent,
-  facilitiesChangedPresent,
+  isFacilityResubmissionAvailable,
+  isFacilityAmendmentInProgress,
 } = require('./facility-helpers');
 
 const { isUkefReviewAvailable } = require('./deal-helpers');
@@ -491,16 +492,22 @@ const commentsPresent = (app) => {
   return false;
 };
 
-/*
-  checks if taskComments should be shown on top of application
-  if any of the below conditions are present
-*/
+/**
+ * Determines whether task comments should be displayed based on various conditions.
+ *
+ * @param {Object} app - The application object containing relevant data.
+ * @param {string} app.status - The current status of the application.
+ * @param {string} app.ukefDecision - The UKEF decision associated with the application.
+ * @returns {boolean} - Returns `true` if any of the conditions for displaying task comments are met, otherwise `false`.
+ */
 const displayTaskComments = (app) => {
-  const ukefReviewAvailable = isUkefReviewAvailable(app.status, app.ukefDecision);
-  const unissuedFacilitiesPresent = areUnissuedFacilitiesPresent(app);
-  const facilitiesChanged = facilitiesChangedPresent(app);
-  const appCommentsPresent = commentsPresent(app);
-  return ukefReviewAvailable || unissuedFacilitiesPresent || facilitiesChanged || appCommentsPresent;
+  const comments = commentsPresent(app);
+  const ukefReview = isUkefReviewAvailable(app.status, app.ukefDecision);
+  const unissuedFacilities = areUnissuedFacilitiesPresent(app);
+  const facilityIssued = isFacilityResubmissionAvailable(app);
+  const facilityAmendment = isFacilityAmendmentInProgress(app);
+
+  return comments || ukefReview || unissuedFacilities || facilityIssued || facilityAmendment;
 };
 
 const pastDate = ({ day, month, year }) => {

--- a/gef-ui/server/utils/helpers.test.js
+++ b/gef-ui/server/utils/helpers.test.js
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { CURRENCY, DEAL_STATUS } from '@ukef/dtfs2-common';
+import { ROLES, CURRENCY, DEAL_STATUS, PORTAL_AMENDMENT_STATUS } from '@ukef/dtfs2-common';
 import {
   userToken,
   isObject,
@@ -30,7 +30,6 @@ import {
   MOCK_AIN_APPLICATION_RETURN_MAKER,
   MOCK_AIN_APPLICATION_CHECKER,
   MOCK_AIN_APPLICATION_ISSUED_ONLY,
-  MOCK_AIN_APPLICATION_FALSE_COMMENTS,
   MOCK_AIN_APPLICATION_SUPPORTING_INFO,
   MOCK_AIN_APPLICATION_UNISSUED_ONLY,
 } from './mocks/mock-applications';
@@ -1219,15 +1218,94 @@ describe('summaryItemsConditions()', () => {
 });
 
 describe('displayTaskComments()', () => {
-  it('should return true if any conditions are true', () => {
-    const result = displayTaskComments(MOCK_AIN_APPLICATION);
+  it('should return true if comments are present', () => {
+    // Arrange
+    const mockApplication = {
+      ...MOCK_AIN_APPLICATION,
+      comments: [
+        {
+          roles: [ROLES.MAKER],
+          userName: 'maker1@ukexportfinance.gov.uk',
+          firstname: 'First',
+          surname: 'Last',
+          email: 'maker1@ukexportfinance.gov.uk',
+          createdAt: 1744014786955,
+          comment: '123',
+        },
+      ],
+    };
 
+    // Act
+    const result = displayTaskComments(mockApplication);
+
+    // Assert
     expect(result).toEqual(true);
   });
 
-  it('should return false if all conditions are false', () => {
-    const result = displayTaskComments(MOCK_AIN_APPLICATION_FALSE_COMMENTS);
+  it('should return true if UKEF review is present', () => {
+    // Arrange
+    const mockApplication = {
+      ...MOCK_AIN_APPLICATION,
+      status: DEAL_STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS,
+      ukefDecision: [
+        {
+          decision: DEAL_STATUS.UKEF_APPROVED_WITHOUT_CONDITIONS,
+        },
+      ],
+    };
 
+    // Act
+    const result = displayTaskComments(mockApplication);
+
+    // Assert
+    expect(result).toEqual(true);
+  });
+
+  it('should return true if un-issued facilities are present', () => {
+    // Act
+    const result = displayTaskComments(MOCK_AIN_APPLICATION_UNISSUED_ONLY);
+
+    // Assert
+    expect(result).toEqual(true);
+  });
+
+  it('should return true if issued facilities are present', () => {
+    // Act
+    const result = displayTaskComments(MOCK_AIN_APPLICATION);
+
+    // Assert
+    expect(result).toEqual(true);
+  });
+
+  it('should return true if issued facility has an amendment in progress', () => {
+    // Arrange
+    const mockApplication = {
+      ...MOCK_AIN_APPLICATION,
+      isPortalAmendmentInProgress: true,
+      facilityIdWithAmendmentInProgress: '67f384b166041f835e52afe8',
+      portalAmendmentStatus: PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL,
+    };
+
+    // Act
+    const result = displayTaskComments(mockApplication);
+
+    // Assert
+    expect(result).toEqual(true);
+  });
+
+  it('should return false if all checks are false', () => {
+    // Arrange
+    const mockApplication = {
+      ...MOCK_AIN_APPLICATION_ISSUED_ONLY,
+      comments: [],
+      ukefDecision: [],
+      isPortalAmendmentInProgress: false,
+    };
+
+    // Act
+    const result = displayTaskComments(mockApplication);
+
+    // Assert
     expect(result).toEqual(false);
   });
 });

--- a/portal-api/src/v1/users/sign-in-link.service.js
+++ b/portal-api/src/v1/users/sign-in-link.service.js
@@ -164,8 +164,8 @@ class SignInLinkService {
    * @throws {Error} - If there is an issue sending the sign-in link email.
    */
   async #sendSignInLinkEmail({ userEmail, userFirstName, userLastName, signInLink }) {
-    if (isProduction()) {
-      console.info('Sending sign-in link %s', signInLink);
+    if (!isProduction()) {
+      console.info('🔑 Sending portal magic link %s', signInLink);
     }
 
     try {


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

Task comment section was not being displayed on `Maker's` application preview page, where an issued facility has an amendment which is with the `Checker` and has `Ready for Checker's approval` status.

## Resolution :heavy_check_mark:

* Add `isFacilityAmendmentInProgress` to `displayTaskComments`.
* Added test cases.

## Miscellaneous :heavy_plus_sign:

* Improved documentation.
* Improved test assertions for `displayTaskComments` function.
* Renamed variables and function name to improve readbility.
* Enable magic link for non-production environment.

## Screenshot :camera_flash:

![image](https://github.com/user-attachments/assets/d81de5c7-119b-46ca-8091-e5ddfcc7ee33)
