### PR TITLE
fix(DTFS2-7911): added html and plain text render argument to mc macro

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -165,40 +165,37 @@ jobs:
         uses: ./.github/actions/notify
         with:
           webhook: ${{ secrets.MSTEAMS_WEBHOOK }}
-          content: '{
-            "@type": "MessageCard",
-            "@context": "http://schema.org/extensions",
-            "themeColor": "00703c",
-            "title": "🚀 main : ${{ env.ENVIRONMENT }}",
-            "summary": "Deployed main branch to ${{ env.ENVIRONMENT }} DTFS environment",
-            "sections":
-            [
-            {
-            "activityTitle": "Branch deployment",
-            "activitySubtitle": "Deployed **main** branch to **${{ env.ENVIRONMENT }}** DTFS environment.",
-            "facts":
-            [
-            { "name": "Branch", "value": "main" },
-            { "name": "Environment", "value": "${{ env.ENVIRONMENT }}" },
-            { "name": "Commit", "value": "${{ github.sha }}" },
-            { "name": "Status", "value": "Successfull" },
-            ],
-            "markdown": true,
-            },
-            ],
-            "potentialAction":
-            [
-            {
-            "@type": "OpenUri",
-            "name": "Deployment",
-            "targets":
-            [
-            {
-            "os": "default",
-            "uri": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            },
-            ],
-            },
-            ],
+          content: '
+                      {
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "themeColor": "00703c",
+              "title": "🚀 main : ${{ env.ENVIRONMENT }}",
+              "summary": "Deployed main branch to ${{ env.ENVIRONMENT }} DTFS environment",
+              "sections": [
+                {
+                  "activityTitle": "Branch deployment",
+                  "activitySubtitle": "Deployed **main** branch to **${{ env.ENVIRONMENT }}** DTFS environment.",
+                  "facts": [
+                    { "name": "Branch", "value": "main" },
+                    { "name": "Environment", "value": "${{ env.ENVIRONMENT }}" },
+                    { "name": "Commit", "value": "${{ github.sha }}" },
+                    { "name": "Status", "value": "Successfull" }
+                  ],
+                  "markdown": true
+                }
+              ],
+              "potentialAction": [
+                {
+                  "@type": "OpenUri",
+                  "name": "Deployment",
+                  "targets": [
+                    {
+                      "os": "default",
+                      "uri": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
             }
             '

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -85,39 +85,36 @@ jobs:
         uses: ./.github/actions/notify
         with:
           webhook: ${{ secrets.MSTEAMS_WEBHOOK }}
-          content: '{
-            "@type": "MessageCard",
-            "@context": "http://schema.org/extensions",
-            "themeColor": "00703c",
-            "title": "🗑️ ${{ matrix.acr }} purge",
-            "summary": "Purged artefacts from ''${{ matrix.acr }}'' Azure container registry",
-            "sections":
-            [
-            {
-            "activityTitle": "ACR Purge",
-            "activitySubtitle": "Purged artefacts from **${{ matrix.acr }}** Azure container registry",
-            "facts":
-            [
-            { "name": "ACR", "value": "${{ matrix.acr }}" },
-            { "name": "Resource group", "value": "${{ env.RESOURCE_GROUP }}" },
-            { "name": "Commit", "value": "${{ github.sha }}" },
-            ],
-            "markdown": true,
-            },
-            ],
-            "potentialAction":
-            [
-            {
-            "@type": "OpenUri",
-            "name": "Workflow",
-            "targets":
-            [
-            {
-            "os": "default",
-            "uri": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            },
-            ],
-            },
-            ],
+          content: '
+                      {
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "themeColor": "00703c",
+              "title": "🗑️ ${{ matrix.acr }} purge",
+              "summary": "Purged artefacts from ''${{ matrix.acr }}'' Azure container registry",
+              "sections": [
+                {
+                  "activityTitle": "ACR Purge",
+                  "activitySubtitle": "Purged artefacts from **${{ matrix.acr }}** Azure container registry",
+                  "facts": [
+                    { "name": "ACR", "value": "${{ matrix.acr }}" },
+                    { "name": "Resource group", "value": "${{ env.RESOURCE_GROUP }}" },
+                    { "name": "Commit", "value": "${{ github.sha }}" }
+                  ],
+                  "markdown": true
+                }
+              ],
+              "potentialAction": [
+                {
+                  "@type": "OpenUri",
+                  "name": "Workflow",
+                  "targets": [
+                    {
+                      "os": "default",
+                      "uri": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
             }
             '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,43 +183,39 @@ jobs:
         with:
           webhook: ${{ secrets.MSTEAMS_WEBHOOK }}
           content: '
-            {
-            "@type": "MessageCard",
-            "@context": "http://schema.org/extensions",
-            "themeColor": "00703c",
-            "title": "🚀 ${{ github.event.workflow_run.head_branch }} : ${{ env.ENVIRONMENT }}",
-            "summary": "Deploying ${{ github.event.workflow_run.head_branch }} branch to ${{ env.ENVIRONMENT }} DTFS environment",
-            "sections":
-            [
-            {
-            "activityTitle": "Release deployment",
-            "activitySubtitle": "Deploying **${{ github.event.workflow_run.head_branch }}** release branch to **${{ env.ENVIRONMENT }}** DTFS environment.",
-            "facts":
-            [
-            {
-            "name": "Release",
-            "value": "${{ github.event.workflow_run.head_branch }}",
-            },
-            { "name": "Environment", "value": "${{ env.ENVIRONMENT }}" },
-            { "name": "Commit", "value": "${{ github.sha }}" },
-            { "name": "Status", "value": "Pending approval" },
-            ],
-            "markdown": true,
-            },
-            ],
-            "potentialAction":
-            [
-            {
-            "@type": "OpenUri",
-            "name": "Deployment",
-            "targets":
-            [
-            {
-            "os": "default",
-            "uri": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            },
-            ],
-            },
-            ],
+                      {
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "themeColor": "00703c",
+              "title": "🚀 ${{ github.event.workflow_run.head_branch }} : ${{ env.ENVIRONMENT }}",
+              "summary": "Deploying ${{ github.event.workflow_run.head_branch }} branch to ${{ env.ENVIRONMENT }} DTFS environment",
+              "sections": [
+                {
+                  "activityTitle": "Release deployment",
+                  "activitySubtitle": "Deploying **${{ github.event.workflow_run.head_branch }}** release branch to **${{ env.ENVIRONMENT }}** DTFS environment.",
+                  "facts": [
+                    {
+                      "name": "Release",
+                      "value": "${{ github.event.workflow_run.head_branch }}"
+                    },
+                    { "name": "Environment", "value": "${{ env.ENVIRONMENT }}" },
+                    { "name": "Commit", "value": "${{ github.sha }}" },
+                    { "name": "Status", "value": "Pending approval" }
+                  ],
+                  "markdown": true
+                }
+              ],
+              "potentialAction": [
+                {
+                  "@type": "OpenUri",
+                  "name": "Deployment",
+                  "targets": [
+                    {
+                      "os": "default",
+                      "uri": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
             }
             '

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/before-you-start/mandatory-criteria.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/before-you-start/mandatory-criteria.spec.js
@@ -1,0 +1,118 @@
+const pages = require('../../../pages');
+const relative = require('../../../relativeURL');
+const MOCK_USERS = require('../../../../../../e2e-fixtures');
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+context('Should render BSS/EWCS mandatory criteria', () => {
+  it('should render headings, introductory text, criteria and buttons', () => {
+    // Start a new BSS/EWCS submission
+    cy.createBSSSubmission(BANK1_MAKER1);
+    cy.url().should('eq', relative('/before-you-start'));
+
+    // Heading
+    pages.beforeYouStart.mandatoryCriteriaHeading().should('be.visible');
+    cy.assertText(pages.beforeYouStart.mandatoryCriteriaHeading(), 'Mandatory criteria');
+
+    // Sub-heading
+    pages.beforeYouStart.mandatoryCriteriaSubHeading().should('be.visible');
+    cy.assertText(pages.beforeYouStart.mandatoryCriteriaSubHeading(), "Does this deal meet all UKEF's mandatory criteria?");
+
+    // Introductory text
+    pages.beforeYouStart.mandatoryCriteriaIntro().should('be.visible');
+    cy.assertText(
+      pages.beforeYouStart.mandatoryCriteriaIntro(),
+      'To proceed with this submission, you need to be able to affirm that all the following mandatory criteria are or will be true for this deal on the date that cover starts.',
+    );
+
+    // Mandatory criteria
+
+    // Sub-headings
+    cy.assertText(pages.beforeYouStart.mandatoryCriterionOneTitle(), 'Supply contract/Transaction');
+    cy.assertText(pages.beforeYouStart.mandatoryCriterionTwoTitle(), 'Financial');
+    cy.assertText(pages.beforeYouStart.mandatoryCriterionThreeTitle(), 'Credit');
+    cy.assertText(pages.beforeYouStart.mandatoryCriterionFourTitle(), 'Bank Facility Letter');
+    cy.assertText(pages.beforeYouStart.mandatoryCriterionFiveTitle(), 'Legal');
+
+    // Criteria
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="1"]')
+      .should(
+        'contain',
+        'The Supplier has provided the Bank with a duly completed Supplier Declaration, and the Bank is not aware that any of the information contained within it is inaccurate.',
+      );
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="2"]')
+      .should('contain', 'The Bank has complied with its policies and procedures in relation to the Transaction.');
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="3"]')
+      .should(
+        'contain',
+        'Where the Supplier is a UK Supplier, the Supplier has provided the Bank with a duly completed UK Supplier Declaration, and the Bank is not aware that any of the information contained within it is inaccurate. (Conditional for UK Supplier)',
+      );
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="4"]')
+      .should('contain', 'Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an eligible person OR');
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="5"]')
+      .should('contain', 'Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an eligible person.');
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="6"]')
+      .should(
+        'contain',
+        'The Bank Customer (to include both the Supplier and any UK Parent Obligor) has a one-year probability of default of less than 14.1%.',
+      );
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="7"]')
+      .should('contain', 'The Bank Facility Letter is governed by the laws of England and Wales, Scotland or Northern Ireland.');
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="8"]')
+      .should('contain', 'The Bank is the sole and beneficial owner of, and has legal title to, the Transaction.');
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="9"]')
+      .should(
+        'contain',
+        'The Bank has not made a Disposal (other than a Permitted Disposal) or a Risk Transfer (other than a Permitted Risk Transfer) in relation to the Transaction.',
+      );
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="10"]')
+      .should(
+        'contain',
+        'The Bank’s right, title and interest in relation to the Transaction is clear of any Security and Quasi-Security (other than Permitted Security) and is freely assignable without the need to obtain consent of any Obligor or any other person.',
+      );
+
+    pages.beforeYouStart
+      .mandatoryCriterion()
+      .find('li[value="11"]')
+      .should(
+        'contain',
+        'The Bank is not restricted or prevented by any agreement with an Obligor from providing information and records relating to the Transaction.',
+      );
+
+    // Radio buttons
+    pages.beforeYouStart.true().should('exist');
+    pages.beforeYouStart.false().should('exist');
+
+    // Primary button
+    pages.beforeYouStart.submit().should('exist');
+  });
+});

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/before-you-start/mandatory-criteria.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/before-you-start/mandatory-criteria.spec.js
@@ -3,6 +3,7 @@ const relative = require('../../../relativeURL');
 const MOCK_USERS = require('../../../../../../e2e-fixtures');
 
 const { BANK1_MAKER1 } = MOCK_USERS;
+const { beforeYouStart } = pages;
 
 context('Should render BSS/EWCS mandatory criteria', () => {
   it('should render headings, introductory text, criteria and buttons', () => {
@@ -11,31 +12,31 @@ context('Should render BSS/EWCS mandatory criteria', () => {
     cy.url().should('eq', relative('/before-you-start'));
 
     // Heading
-    pages.beforeYouStart.mandatoryCriteriaHeading().should('be.visible');
-    cy.assertText(pages.beforeYouStart.mandatoryCriteriaHeading(), 'Mandatory criteria');
+    beforeYouStart.mandatoryCriteriaHeading().should('be.visible');
+    cy.assertText(beforeYouStart.mandatoryCriteriaHeading(), 'Mandatory criteria');
 
     // Sub-heading
-    pages.beforeYouStart.mandatoryCriteriaSubHeading().should('be.visible');
-    cy.assertText(pages.beforeYouStart.mandatoryCriteriaSubHeading(), "Does this deal meet all UKEF's mandatory criteria?");
+    beforeYouStart.mandatoryCriteriaSubHeading().should('be.visible');
+    cy.assertText(beforeYouStart.mandatoryCriteriaSubHeading(), "Does this deal meet all UKEF's mandatory criteria?");
 
     // Introductory text
-    pages.beforeYouStart.mandatoryCriteriaIntro().should('be.visible');
+    beforeYouStart.mandatoryCriteriaIntro().should('be.visible');
     cy.assertText(
-      pages.beforeYouStart.mandatoryCriteriaIntro(),
+      beforeYouStart.mandatoryCriteriaIntro(),
       'To proceed with this submission, you need to be able to affirm that all the following mandatory criteria are or will be true for this deal on the date that cover starts.',
     );
 
     // Mandatory criteria
 
     // Sub-headings
-    cy.assertText(pages.beforeYouStart.mandatoryCriterionOneTitle(), 'Supply contract/Transaction');
-    cy.assertText(pages.beforeYouStart.mandatoryCriterionTwoTitle(), 'Financial');
-    cy.assertText(pages.beforeYouStart.mandatoryCriterionThreeTitle(), 'Credit');
-    cy.assertText(pages.beforeYouStart.mandatoryCriterionFourTitle(), 'Bank Facility Letter');
-    cy.assertText(pages.beforeYouStart.mandatoryCriterionFiveTitle(), 'Legal');
+    cy.assertText(beforeYouStart.mandatoryCriterionOneTitle(), 'Supply contract/Transaction');
+    cy.assertText(beforeYouStart.mandatoryCriterionTwoTitle(), 'Financial');
+    cy.assertText(beforeYouStart.mandatoryCriterionThreeTitle(), 'Credit');
+    cy.assertText(beforeYouStart.mandatoryCriterionFourTitle(), 'Bank Facility Letter');
+    cy.assertText(beforeYouStart.mandatoryCriterionFiveTitle(), 'Legal');
 
     // Criteria
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="1"]')
       .should(
@@ -43,12 +44,12 @@ context('Should render BSS/EWCS mandatory criteria', () => {
         'The Supplier has provided the Bank with a duly completed Supplier Declaration, and the Bank is not aware that any of the information contained within it is inaccurate.',
       );
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="2"]')
       .should('contain', 'The Bank has complied with its policies and procedures in relation to the Transaction.');
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="3"]')
       .should(
@@ -56,17 +57,17 @@ context('Should render BSS/EWCS mandatory criteria', () => {
         'Where the Supplier is a UK Supplier, the Supplier has provided the Bank with a duly completed UK Supplier Declaration, and the Bank is not aware that any of the information contained within it is inaccurate. (Conditional for UK Supplier)',
       );
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="4"]')
       .should('contain', 'Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an eligible person OR');
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="5"]')
       .should('contain', 'Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an eligible person.');
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="6"]')
       .should(
@@ -74,17 +75,17 @@ context('Should render BSS/EWCS mandatory criteria', () => {
         'The Bank Customer (to include both the Supplier and any UK Parent Obligor) has a one-year probability of default of less than 14.1%.',
       );
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="7"]')
       .should('contain', 'The Bank Facility Letter is governed by the laws of England and Wales, Scotland or Northern Ireland.');
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="8"]')
       .should('contain', 'The Bank is the sole and beneficial owner of, and has legal title to, the Transaction.');
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="9"]')
       .should(
@@ -92,7 +93,7 @@ context('Should render BSS/EWCS mandatory criteria', () => {
         'The Bank has not made a Disposal (other than a Permitted Disposal) or a Risk Transfer (other than a Permitted Risk Transfer) in relation to the Transaction.',
       );
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="10"]')
       .should(
@@ -100,7 +101,7 @@ context('Should render BSS/EWCS mandatory criteria', () => {
         'The Bank’s right, title and interest in relation to the Transaction is clear of any Security and Quasi-Security (other than Permitted Security) and is freely assignable without the need to obtain consent of any Obligor or any other person.',
       );
 
-    pages.beforeYouStart
+    beforeYouStart
       .mandatoryCriterion()
       .find('li[value="11"]')
       .should(
@@ -109,10 +110,10 @@ context('Should render BSS/EWCS mandatory criteria', () => {
       );
 
     // Radio buttons
-    pages.beforeYouStart.true().should('exist');
-    pages.beforeYouStart.false().should('exist');
+    beforeYouStart.true().should('exist');
+    beforeYouStart.false().should('exist');
 
     // Primary button
-    pages.beforeYouStart.submit().should('exist');
+    beforeYouStart.submit().should('exist');
   });
 });

--- a/e2e-tests/portal/cypress/e2e/journeys/maker/bss-mandatory-criteria/bss-mandatory-criteria.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/maker/bss-mandatory-criteria/bss-mandatory-criteria.spec.js
@@ -77,8 +77,11 @@ context('BSS Mandatory criteria: Check deal details page', () => {
     partials.successMessage.successMessageLink().click();
     cy.url().should('include', '/contract/');
 
+    // Deal details tab
     pages.contract.checkDealDetailsTab().click();
     pages.contractSubmissionDetails.mandatoryCriteriaBox().should('exist');
+
+    // Assert all BSS/EWCS latest mandatory criteria with HTML stripped out
     pages.contractSubmissionDetails
       .mandatoryCriteriaBox()
       .find('ol > li[value="1"]')
@@ -86,10 +89,12 @@ context('BSS Mandatory criteria: Check deal details page', () => {
         'contain',
         'The Supplier has provided the Bank with a duly completed Supplier Declaration, and the Bank is not aware that any of the information contained within it is inaccurate.',
       );
+
     pages.contractSubmissionDetails
       .mandatoryCriteriaBox()
       .find('ol > li[value="2"]')
       .should('contain', 'The Bank has complied with its policies and procedures in relation to the Transaction.');
+
     pages.contractSubmissionDetails
       .mandatoryCriteriaBox()
       .find('ol > li[value="3"]')
@@ -97,12 +102,57 @@ context('BSS Mandatory criteria: Check deal details page', () => {
         'contain',
         'Where the Supplier is a UK Supplier, the Supplier has provided the Bank with a duly completed UK Supplier Declaration, and the Bank is not aware that any of the information contained within it is inaccurate. (Conditional for UK Supplier)',
       );
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="4"]')
+      .should('contain', 'Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an eligible person OR');
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="5"]')
+      .should('contain', 'Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an eligible person.');
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="6"]')
+      .should(
+        'contain',
+        'The Bank Customer (to include both the Supplier and any UK Parent Obligor) has a one-year probability of default of less than 14.1%.',
+      );
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="7"]')
+      .should('contain', 'The Bank Facility Letter is governed by the laws of England and Wales, Scotland or Northern Ireland.');
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="8"]')
+      .should('contain', 'The Bank is the sole and beneficial owner of, and has legal title to, the Transaction.');
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="9"]')
+      .should(
+        'contain',
+        'The Bank has not made a Disposal (other than a Permitted Disposal) or a Risk Transfer (other than a Permitted Risk Transfer) in relation to the Transaction.',
+      );
+
     pages.contractSubmissionDetails
       .mandatoryCriteriaBox()
       .find('ol > li[value="10"]')
       .should(
         'contain',
         'The Bank’s right, title and interest in relation to the Transaction is clear of any Security and Quasi-Security (other than Permitted Security) and is freely assignable without the need to obtain consent of any Obligor or any other person.',
+      );
+
+    pages.contractSubmissionDetails
+      .mandatoryCriteriaBox()
+      .find('ol > li[value="11"]')
+      .should(
+        'contain',
+        'The Bank is not restricted or prevented by any agreement with an Obligor from providing information and records relating to the Transaction.',
       );
   });
 });

--- a/e2e-tests/portal/cypress/e2e/pages/beforeYouStart.js
+++ b/e2e-tests/portal/cypress/e2e/pages/beforeYouStart.js
@@ -1,12 +1,20 @@
 const page = {
   visit: () => cy.visit('/before-you-start'),
-  true: () => cy.get('[data-cy="criteriaMet-true"]'),
-  false: () => cy.get('[data-cy="criteriaMet-false"]'),
 
   mandatoryCriteriaHeading: () => cy.get('[data-cy="mandatory-criteria-heading"]'),
   mandatoryCriteriaSubHeading: () => cy.get('[data-cy="mandatory-criteria-sub-heading"]'),
   mandatoryCriteriaIntro: () => cy.get('[data-cy="mandatory-criteria-intro"]'),
   mandatoryCriterion: () => cy.get('[data-cy="mandatory-criteria-criterion"]'),
+
+  mandatoryCriterionOneTitle: () => cy.get('[data-cy="mandatory-criteria-criterion-1-title"]'),
+  mandatoryCriterionTwoTitle: () => cy.get('[data-cy="mandatory-criteria-criterion-2-title"]'),
+  mandatoryCriterionThreeTitle: () => cy.get('[data-cy="mandatory-criteria-criterion-3-title"]'),
+  mandatoryCriterionFourTitle: () => cy.get('[data-cy="mandatory-criteria-criterion-4-title"]'),
+  mandatoryCriterionFiveTitle: () => cy.get('[data-cy="mandatory-criteria-criterion-5-title"]'),
+
+  true: () => cy.get('[data-cy="criteriaMet-true"]'),
+  false: () => cy.get('[data-cy="criteriaMet-false"]'),
+  submit: () => cy.get('[data-cy="submit-button"]'),
 };
 
 module.exports = page;

--- a/libs/common/src/helpers/generate-mandatory-criteria.test.ts
+++ b/libs/common/src/helpers/generate-mandatory-criteria.test.ts
@@ -1,0 +1,90 @@
+import { generateMandatoryCriteria } from './generate-mandatory-criteria';
+import { GEF_CRITERION } from '../types';
+
+describe('generateMandatoryCriteria', () => {
+  it('should return single test criterion', () => {
+    // Arrange
+    const criteria: GEF_CRITERION[] = [
+      {
+        id: '1',
+        body: 'test',
+      },
+    ];
+
+    // Act
+    const result = generateMandatoryCriteria(criteria);
+
+    // Assert
+    expect(result).toEqual('1 test\n\n^True\n\n');
+  });
+
+  it('should return multiple criteria with HTML stripped out', () => {
+    // Arrange
+    const criteria: GEF_CRITERION[] = [
+      {
+        id: '1',
+        body: 'test one',
+      },
+      {
+        id: '2',
+        body: 'test two',
+      },
+      {
+        id: '3.a',
+        body: 'test three',
+      },
+      {
+        id: '4',
+        body: 'test four',
+        childList: [
+          "child list one with link to the <a href = '/asset/file.docx'>file</a>.",
+          'child list two with <b>bold text</b>.',
+          'child list three no html.',
+        ],
+      },
+    ];
+
+    // Act
+    const result = generateMandatoryCriteria(criteria);
+
+    // Assert
+    expect(result).toEqual(
+      '1 test one\n\n2 test two\n\n3a test three\n\n4 test four\n\n*child list one with link to the file.\n\n*child list two with bold text.\n\n*child list three no html.\n\n^True\n\n',
+    );
+  });
+
+  it('should return multiple criteria without HTML stripped out', () => {
+    // Arrange
+    const criteria: GEF_CRITERION[] = [
+      {
+        id: '1',
+        body: 'test one',
+      },
+      {
+        id: '2',
+        body: 'test two',
+      },
+      {
+        id: '3.a',
+        body: 'test three',
+      },
+      {
+        id: '4',
+        body: 'test four',
+        childList: [
+          "child list one with link to the <a href = '/asset/file.docx'>file</a>.",
+          'child list two with <b>bold text</b>.',
+          'child list three no html.',
+        ],
+      },
+    ];
+
+    // Act
+    const result = generateMandatoryCriteria(criteria, true);
+
+    // Assert
+    expect(result).toEqual(
+      "1 test one\n\n2 test two\n\n3a test three\n\n4 test four\n\n*child list one with link to the <a href = '/asset/file.docx'>file</a>.\n\n*child list two with <b>bold text</b>.\n\n*child list three no html.\n\n^True\n\n",
+    );
+  });
+});

--- a/libs/common/src/helpers/generate-mandatory-criteria.ts
+++ b/libs/common/src/helpers/generate-mandatory-criteria.ts
@@ -1,0 +1,56 @@
+import { GEF_CRITERION } from '../types';
+import { stripHtml } from './strip-html';
+
+/**
+ * Generates a formatted string of mandatory criteria for GovNotify email template based on the provided criteria array.
+ *
+ * @param {Array<GEF_CRITERION>} criteria - An array of criteria objects, each containing an `id`, `body`, and optionally a `childList`.
+ * @param {boolean} [html=false] - A flag indicating whether the content should include HTML or be stripped of HTML tags.
+ * @returns {string} A formatted string of mandatory criteria, including sub-items if present.
+ *                   If no criteria are provided, an empty string is returned.
+ *
+ * Each criterion is formatted as:
+ * - `<id> <content>` followed by sub-items (if any) prefixed with `*`.
+ * - Ends with `^True` if there are any criteria.
+ *
+ * Example output:
+ * ```
+ * 1 Criterion content
+ *
+ * *Sub-item content
+ *
+ * ^True
+ * ```
+ */
+export const generateMandatoryCriteria = (criteria: Array<GEF_CRITERION>, html = false): string => {
+  if (criteria?.length) {
+    let mandatoryCriteria = '';
+
+    criteria.forEach((criterion) => {
+      if (criterion.id && criterion.body) {
+        const { id, body, childList } = criterion;
+
+        const number = id.toString().replaceAll('.', '');
+        const content = html ? body : stripHtml(body);
+
+        mandatoryCriteria += `${number} ${content}\n\n`;
+
+        if (childList?.length) {
+          childList.forEach((item) => {
+            const subContent = html ? item : stripHtml(item);
+            mandatoryCriteria += `*${subContent}\n\n`;
+          });
+        }
+      }
+    });
+
+    if (mandatoryCriteria !== '') {
+      // Below adds True as a text to GovNotify after all criteria
+      mandatoryCriteria += '^True\n\n';
+    }
+
+    return mandatoryCriteria;
+  }
+
+  return '';
+};

--- a/libs/common/src/helpers/index.ts
+++ b/libs/common/src/helpers/index.ts
@@ -25,3 +25,5 @@ export * from './table-data-sort';
 export * from './utilisation-report-emails';
 export * from './fee-record-status';
 export * from './is-production';
+export * from './generate-mandatory-criteria';
+export * from './strip-html';

--- a/libs/common/src/helpers/strip-html.test.ts
+++ b/libs/common/src/helpers/strip-html.test.ts
@@ -1,0 +1,58 @@
+import { stripHtml } from './strip-html';
+
+describe('stripHtml', () => {
+  it('should return text without HTML markups.', () => {
+    // Arrange
+    const input = "This is a <b>test</b> <a href = '/asset/file.xlsx'>file</a>.";
+
+    // Act
+    const result = stripHtml(input);
+
+    // Assert
+    expect(result).toBe('This is a test file.');
+  });
+
+  it('should return input string with no replacement', () => {
+    // Arrange
+    const input = 'This is a test.';
+
+    // Act
+    const result = stripHtml(input);
+
+    // Assert
+    expect(result).toBe('This is a test.');
+  });
+
+  it('should return input blank string', () => {
+    // Arrange
+    const input = '';
+
+    // Act
+    const result = stripHtml(input);
+
+    // Assert
+    expect(result).toBe('');
+  });
+
+  it('should return input string with nested markup tags', () => {
+    // Arrange
+    const input = 'These are my <u>points</u><ol><li>Point one</li><li>Point two<li></ol>';
+
+    // Act
+    const result = stripHtml(input, ' ');
+
+    // Assert
+    expect(result).toBe('These are my  points   Point one  Point two  ');
+  });
+
+  it('should return input string with no replacement', () => {
+    // Arrange
+    const input = 'This is a test.';
+
+    // Act
+    const result = stripHtml(input, '-');
+
+    // Assert
+    expect(result).toBe('This is a test.');
+  });
+});

--- a/libs/common/src/helpers/strip-html.ts
+++ b/libs/common/src/helpers/strip-html.ts
@@ -1,0 +1,8 @@
+/**
+ * Removes all HTML tags from a given string.
+ *
+ * @param string - The input string that may contain HTML tags.
+ * @param replace - The replace string, defaults to ''.
+ * @returns A new string with all HTML tags stripped out.
+ */
+export const stripHtml = (string: string, replace: string = ''): string => string.replace(/<[^>]*>/g, replace);

--- a/libs/common/src/types/index.ts
+++ b/libs/common/src/types/index.ts
@@ -44,3 +44,4 @@ export * from './record-correction-fields';
 export * from './gov-uk';
 export * from './http-status-codes';
 export * from './status-tag-colours';
+export * from './mandatory-criteria';

--- a/libs/common/src/types/mandatory-criteria.ts
+++ b/libs/common/src/types/mandatory-criteria.ts
@@ -1,0 +1,29 @@
+export type GEF_CRITERION = {
+  id: string;
+  body: string;
+  childList?: Array<string>;
+};
+
+export type GEF_MANDATORY_CRITERIA = {
+  version: number;
+  createdAt: number;
+  updatedAt: number;
+  isInDraft: boolean;
+  title: string;
+  introText: string;
+  criteria: Array<GEF_CRITERION>;
+};
+
+export type BSS_EWCS_CRITERION = {
+  id: number;
+  title: string;
+  items: Array<{
+    id: number;
+    copy: string;
+  }>;
+};
+
+export type BSS_EWCS_MANDATORY_CRITERIA = {
+  version: number;
+  criteria: Array<BSS_EWCS_CRITERION>;
+};

--- a/portal/component-tests/_macros/mandatory-criteria-box.test.js
+++ b/portal/component-tests/_macros/mandatory-criteria-box.test.js
@@ -1,0 +1,93 @@
+const componentRenderer = require('../componentRenderer');
+
+const component = '_macros/mandatory-criteria-box.njk';
+const render = componentRenderer(component);
+const deal = require('../fixtures/deal-fully-completed');
+
+const { mandatoryCriteria } = deal;
+
+describe(component, () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = render({ mandatoryCriteria });
+  });
+
+  it('should render all the headings', () => {
+    wrapper.expectElement('[data-cy="mandatory-criteria-box"]').toExist();
+    wrapper.expectText('h4').toRead('Mandatory criteria');
+    wrapper.expectText('h5').toRead('This deal meets all UKEF’s mandatory criteria.');
+  });
+
+  it('should render introductory paragraph', () => {
+    wrapper
+      .expectText('p')
+      .toRead('You have affirmed that all the following mandatory criteria are or will be true for this deal on the date that cover starts.');
+  });
+
+  it('should render criteria as HTML', () => {
+    // Arrange
+    wrapper = render({ mandatoryCriteria });
+
+    // Assert
+    wrapper
+      .expectElement('li[value=4]')
+      .toHaveHtmlContent(
+        'Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an <a href="/assets/files/financial_difficulty_model_1.1.0.xlsx" class="govuk-link">eligible person</a> OR',
+      );
+
+    wrapper
+      .expectElement('li[value=5]')
+      .toHaveHtmlContent(
+        'Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an <a href="/assets/files/financial_difficulty_model_1.1.0.xlsx" class="govuk-link">eligible person</a>.',
+      );
+  });
+
+  it('should render criteria as HTML with explicity parameter as false', () => {
+    // Arrange
+    wrapper = render({ mandatoryCriteria, text: false });
+
+    // Assert
+    wrapper
+      .expectElement('li[value=4]')
+      .toHaveHtmlContent(
+        'Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an <a href="/assets/files/financial_difficulty_model_1.1.0.xlsx" class="govuk-link">eligible person</a> OR',
+      );
+
+    wrapper
+      .expectElement('li[value=5]')
+      .toHaveHtmlContent(
+        'Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an <a href="/assets/files/financial_difficulty_model_1.1.0.xlsx" class="govuk-link">eligible person</a>.',
+      );
+  });
+
+  it('should render criteria as plain text', () => {
+    // Arrange
+    wrapper = render({ mandatoryCriteria, text: true });
+
+    // Assert
+    wrapper.expectElement('li[value=4]').toContain('Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an eligible person OR');
+
+    wrapper
+      .expectElement('li[value=5]')
+      .toContain('Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an eligible person.');
+  });
+
+  it('should not render mandatory criteria macro if no criterion exist', () => {
+    // Arrange
+    wrapper = render({});
+
+    // Assert
+    wrapper.expectElement('[data-cy="mandatory-criteria-box"]').notToExist();
+  });
+
+  it('should not render mandatory criteria macro if no criterion exist', () => {
+    // Arrange
+    wrapper = render({
+      mandatoryCriteria: [],
+    });
+
+    // Assert
+    wrapper.expectElement('[data-cy="mandatory-criteria-box"]').notToExist();
+  });
+});

--- a/portal/component-tests/assertions.js
+++ b/portal/component-tests/assertions.js
@@ -71,6 +71,9 @@ const assertions = (wrapper, html) => ({
     notToExist: () => {
       expect(wrapper(selector).html()).toBeNull();
     },
+    toContain: (text) => {
+      expect(wrapper(selector).text().trim()).toContain(text);
+    },
     toHaveHtmlContent: (value) => {
       expect(wrapper(selector).html()?.trim()).toBe(value);
     },

--- a/portal/component-tests/contract/contract-submission-details.component-test.js
+++ b/portal/component-tests/contract/contract-submission-details.component-test.js
@@ -72,8 +72,18 @@ describe(page, () => {
       wrapper.expectElement(selector).toExist();
     });
 
-    it('should render Mandatory criteria component', () => {
+    it('should render mandatory criteria component', () => {
       wrapper.expectElement('[data-cy="mandatory-criteria-box"]').toExist();
+    });
+
+    it('should render mandatory criteria criterion without HTML tags', () => {
+      wrapper
+        .expectText('[data-cy="mandatory-criteria-box"]')
+        .toContain('Where the supplier is not a “Person Within Scope of Windsor Framework”, it is an eligible person OR');
+
+      wrapper
+        .expectText('[data-cy="mandatory-criteria-box"]')
+        .toContain('Where the supplier is a “Person Within Scope of Windsor Framework”, both it and its parent obligor (if any) is an eligible person.');
     });
 
     describe('v1 migrated data', () => {

--- a/portal/templates/_macros/mandatory-criteria-box.njk
+++ b/portal/templates/_macros/mandatory-criteria-box.njk
@@ -1,6 +1,6 @@
 {% macro render(params) %}
 
-  {% if params.mandatoryCriteria | length %}
+  {% if params.mandatoryCriteria and params.mandatoryCriteria.criteria | length %}
     <div class="govuk-grid-row govuk-!-margin-0 govuk-!-padding-top-4 govuk-!-margin-bottom-6 box" data-cy="mandatory-criteria-box">
 
       <div class="govuk-grid-column-full">
@@ -15,7 +15,13 @@
 
           <ol class="govuk-list govuk-list--number">
             {% for item in group.items %}
-              <li value="{{ item.id }}" class="govuk-body-s">{{ item.copy | safe}}</li>
+              <li value="{{ item.id }}" class="govuk-body-s">
+                {% if params.text %}
+                  {{ item.copy | striptags }}
+                {% else %}
+                  {{ item.copy | safe }}
+                {% endif %}
+              </li>
             {% endfor %}
           </ol>
 

--- a/portal/templates/contract/contract-submission-details.njk
+++ b/portal/templates/contract/contract-submission-details.njk
@@ -51,7 +51,7 @@
   </h3>
 
   {% if deal.mandatoryCriteria %}
-    {{ mandatoryCriteriaBox.render({ mandatoryCriteria: deal.mandatoryCriteria }) }}
+    {{ mandatoryCriteriaBox.render({ mandatoryCriteria: deal.mandatoryCriteria, text: true }) }}
   {% endif %}
 
   {% if deal.eligibility.criteria %}

--- a/trade-finance-manager-api/src/v1/helpers/generate-mandatory-criteria-string.js
+++ b/trade-finance-manager-api/src/v1/helpers/generate-mandatory-criteria-string.js
@@ -1,24 +1,17 @@
-/* eslint-disable no-restricted-syntax */
+const { generateMandatoryCriteria } = require('@ukef/dtfs2-common');
 const api = require('../api');
 
+/**
+ * Generates a mandatory criteria string based on the provided mandatory version ID.
+ *
+ * @param {string} mandatoryVersionId - The ID of the mandatory criteria version to fetch.
+ * @returns {Promise<string>} A promise that resolves to the generated mandatory criteria string.
+ */
 const generateMandatoryCriteriaString = async (mandatoryVersionId) => {
+  // Fetch criteria by version ID
   const { criteria } = await api.getGefMandatoryCriteriaByVersion(mandatoryVersionId);
-  let output = '';
-  if (criteria) {
-    for (const criterion of criteria) {
-      output += ` ${criterion.id.replaceAll('.', ' ')} ${criterion.body}\n\n`;
-      if (criterion?.childList) {
-        for (const text of criterion.childList) {
-          output += `*${text}\n\n`;
-          output += '\n\n';
-        }
-      }
-    }
-    output += '^True\n\n';
-    output += '\n\n';
-  }
-
-  return output;
+  // Generate mandatory criteria as text
+  return generateMandatoryCriteria(criteria);
 };
 
 module.exports = { generateMandatoryCriteriaString };


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

Mandatory criteria is being displayed as a HTML on check details page for `BSS/EWCS` and in an email.

## Resolution :heavy_check_mark:

* Added a second argument `text` to the macro to ascertain HTML render.
* Added component test cases.
* Added additional Cypress E2E tests cases.
* Introduced a new helper function `generateMandatoryCriteria` to render MC for an email, with an additional support to strip out HTML.
* 

## Miscellaneous :heavy_plus_sign:
* Improved test assertions.
* Added `toContain` to component test assertion.
* Minor typo fix.
* Minor lint fixes on GHA workflows.


## Screenshot :camera_flash:

**BSS/EWCS**

![image](https://github.com/user-attachments/assets/56356da1-1e5b-4b34-96e5-2b90941f85c1)


![image](https://github.com/user-attachments/assets/8ff17109-eaba-4d00-baf7-d702f1453c07)

**GEF**

![image](https://github.com/user-attachments/assets/b78eee89-ddf0-4d79-bcf3-11ec2a4c8887)

![image](https://github.com/user-attachments/assets/5a3123df-de26-4bc0-a6db-1eb6e0bf4229)


