### PR TITLE
fix(DTFS2-7852): fix checker can call getCheckersApprovalAmendmentDeal when feature flag is enabled

### DIFF
--- a/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
@@ -1,0 +1,40 @@
+import { PORTAL_AMENDMENT_STATUS, ROLES, CHECKERS_AMENDMENTS_DEAL_ID } from '@ukef/dtfs2-common';
+import { dashboardDealsFiltersQuery } from './deals-filters-query';
+import { STATUS } from '../../../constants';
+import getCheckersApprovalAmendmentDealIds from '../../../helpers/getCheckersApprovalAmendmentDealIds';
+
+jest.mock('../../../helpers/getCheckersApprovalAmendmentDealIds');
+
+const { MAKER, CHECKER } = ROLES;
+
+describe('controllers/dashboard/deals - filters query', () => {
+  const mockUser = {
+    _id: '123',
+    roles: [MAKER],
+    bank: { id: '9' },
+  };
+
+  describe('when user is a checker', () => {
+    it(`should return ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL} filter when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is enabled`, async () => {
+      // Arrange
+      const mockFilters = [];
+      mockUser.roles = [CHECKER];
+      const mockDealIds = ['deal1', 'deal2'];
+      getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
+      const expected = {
+        AND: [
+          { 'bank.id': mockUser.bank.id },
+          {
+            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }, { [CHECKERS_AMENDMENTS_DEAL_ID]: ['deal1', 'deal2'] }],
+          },
+        ],
+      };
+
+      // Act
+      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+      // Assert
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
@@ -18,9 +18,7 @@ describe('controllers/dashboard/deals - filters query', () => {
     it(`should return ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL} filter when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is enabled`, async () => {
       // Arrange
       const mockFilters = [];
-      mockUser.roles = [CHECKER];
       const mockDealIds = ['deal1', 'deal2'];
-      getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
       const expected = {
         AND: [
           { 'bank.id': mockUser.bank.id },
@@ -29,6 +27,9 @@ describe('controllers/dashboard/deals - filters query', () => {
           },
         ],
       };
+
+      mockUser.roles = [CHECKER];
+      getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
 
       // Act
       const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
@@ -23,7 +23,7 @@ describe('controllers/dashboard/deals - filters query', () => {
         AND: [
           { 'bank.id': mockUser.bank.id },
           {
-            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }, { [CHECKERS_AMENDMENTS_DEAL_ID]: ['deal1', 'deal2'] }],
+            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }, { [CHECKERS_AMENDMENTS_DEAL_ID]: mockDealIds }],
           },
         ],
       };

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.js
@@ -27,8 +27,14 @@ const dashboardDealsFiltersQuery = async (filters, user, userToken) => {
     const isFeatureFlagEnabled = isPortalFacilityAmendmentsFeatureFlagEnabled();
     const orQuery = { OR: [{ [CONSTANTS.FIELD_NAMES.DEAL.STATUS]: CONSTANTS.STATUS.DEAL.READY_FOR_APPROVAL }] };
 
+    /**
+     * Feature flag validation for Checker's portal screen.
+     * Portal amendment endpoint will be invoked upon checker login and therefore,
+     * it should only be invoked if Portal amendment feature flag is truthy.
+     */
     if (isFeatureFlagEnabled) {
       const checkersApprovalAmendmentDealIds = await getCheckersApprovalAmendmentDealIds(userToken);
+
       if (checkersApprovalAmendmentDealIds?.length) {
         orQuery.OR.push({ [CHECKERS_AMENDMENTS_DEAL_ID]: checkersApprovalAmendmentDealIds });
       }

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.js
@@ -1,4 +1,4 @@
-const { CHECKERS_AMENDMENTS_DEAL_ID } = require('@ukef/dtfs2-common');
+const { CHECKERS_AMENDMENTS_DEAL_ID, isPortalFacilityAmendmentsFeatureFlagEnabled } = require('@ukef/dtfs2-common');
 const CONSTANTS = require('../../../constants');
 const CONTENT_STRINGS = require('../../../content-strings');
 const { getUserRoles, isSuperUser, getCheckersApprovalAmendmentDealIds } = require('../../../helpers');
@@ -24,12 +24,15 @@ const dashboardDealsFiltersQuery = async (filters, user, userToken) => {
   }
 
   if (isChecker && !isMaker) {
-    const checkersApprovalAmendmentDealIds = await getCheckersApprovalAmendmentDealIds(userToken);
-    const dealIdsQuery = checkersApprovalAmendmentDealIds?.length ? [{ [CHECKERS_AMENDMENTS_DEAL_ID]: checkersApprovalAmendmentDealIds }] : [];
+    const isFeatureFlagEnabled = isPortalFacilityAmendmentsFeatureFlagEnabled();
+    const orQuery = { OR: [{ [CONSTANTS.FIELD_NAMES.DEAL.STATUS]: CONSTANTS.STATUS.DEAL.READY_FOR_APPROVAL }] };
 
-    const orQuery = {
-      OR: [{ [CONSTANTS.FIELD_NAMES.DEAL.STATUS]: CONSTANTS.STATUS.DEAL.READY_FOR_APPROVAL }, ...dealIdsQuery],
-    };
+    if (isFeatureFlagEnabled) {
+      const checkersApprovalAmendmentDealIds = await getCheckersApprovalAmendmentDealIds(userToken);
+      if (checkersApprovalAmendmentDealIds?.length) {
+        orQuery.OR.push({ [CHECKERS_AMENDMENTS_DEAL_ID]: checkersApprovalAmendmentDealIds });
+      }
+    }
 
     query.AND.push(orQuery);
   }

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.test.js
@@ -1,4 +1,4 @@
-import { PORTAL_AMENDMENT_STATUS, ROLES, CHECKERS_AMENDMENTS_DEAL_ID, isPortalFacilityAmendmentsFeatureFlagEnabled } from '@ukef/dtfs2-common';
+import { PORTAL_AMENDMENT_STATUS, ROLES, isPortalFacilityAmendmentsFeatureFlagEnabled } from '@ukef/dtfs2-common';
 import { dashboardDealsFiltersQuery } from './deals-filters-query';
 import { STATUS, SUBMISSION_TYPE, FIELD_NAMES, ALL_BANKS_ID } from '../../../constants';
 import CONTENT_STRINGS from '../../../content-strings';
@@ -22,38 +22,41 @@ describe('controllers/dashboard/deals - filters query', () => {
   };
 
   it('should return bank.id filter', async () => {
+    // Arrange
     const mockFilters = [];
-
-    const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
     const expected = {
       AND: [{ 'bank.id': mockUser.bank.id }],
     };
 
+    // Act
+    const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+    // Assert
     expect(result).toEqual(expected);
   });
 
   describe('when createdByYou is true', () => {
     it('should return maker._id filter', async () => {
+      // Arrange
       const mockFilters = [{ [FIELD_NAMES.DEAL.CREATED_BY]: ['Created by you'] }];
-
-      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
       const expected = {
         AND: [{ 'bank.id': mockUser.bank.id }, { 'maker._id': mockUser._id }],
       };
 
+      // Act
+      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+      // Assert
       expect(result).toEqual(expected);
     });
 
     it('should return maker._id filter and other filters if many selected', async () => {
+      // Arrange
       const mockFilters = [
         { [FIELD_NAMES.DEAL.DEAL_TYPE]: ['BSS', 'EWCS'] },
         { [FIELD_NAMES.DEAL.SUBMISSION_TYPE]: [SUBMISSION_TYPE.AIN] },
         { [FIELD_NAMES.DEAL.CREATED_BY]: ['Created by you'] },
       ];
-
-      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
 
       const expected = {
         AND: [
@@ -68,19 +71,20 @@ describe('controllers/dashboard/deals - filters query', () => {
         ],
       };
 
+      // Act
+      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+      // Assert
       expect(result).toEqual(expected);
     });
   });
 
   describe('when user is a checker', () => {
     it(`should return ${STATUS.DEAL.READY_FOR_APPROVAL} filter`, async () => {
+      // Arrange
       const mockFilters = [];
       mockUser.roles = [CHECKER];
       const mockDealIds = [];
-      getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
-
-      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
       const expected = {
         AND: [
           { 'bank.id': mockUser.bank.id },
@@ -90,67 +94,58 @@ describe('controllers/dashboard/deals - filters query', () => {
         ],
       };
 
+      getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
+
+      // Act
+      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+      // Assert
       expect(result).toEqual(expected);
     });
 
-    it(`should return ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL} filter when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is disabled`, async () => {
+    it(`should only return deals with status ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL} filter when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is disabled`, async () => {
+      // Arrange
       const mockFilters = [];
       mockUser.roles = [CHECKER];
       const mockDealIds = ['deal1', 'deal2'];
+      const expected = {
+        AND: [
+          { 'bank.id': mockUser.bank.id },
+          {
+            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }],
+          },
+        ],
+      };
+
       getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
       jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(false);
 
+      // Act
       const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
 
-      const expected = {
-        AND: [
-          { 'bank.id': mockUser.bank.id },
-          {
-            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }],
-          },
-        ],
-      };
-
-      expect(result).toEqual(expected);
-    });
-
-    it(`should return ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL} filter when FF_PORTAL_FACILITY_AMENDMENTS_ENABLED is enabled`, async () => {
-      const mockFilters = [];
-      mockUser.roles = [CHECKER];
-      const mockDealIds = ['deal1', 'deal2'];
-      getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
-      jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(true);
-
-      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
-      const expected = {
-        AND: [
-          { 'bank.id': mockUser.bank.id },
-          {
-            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }, { [CHECKERS_AMENDMENTS_DEAL_ID]: ['deal1', 'deal2'] }],
-          },
-        ],
-      };
-
+      // Assert
       expect(result).toEqual(expected);
     });
   });
 
   describe('when user is a super user', () => {
     it('should not return any filters', async () => {
+      // Arrange
       const mockFilters = [];
       mockUser.bank.id = ALL_BANKS_ID;
       mockUser.roles = [];
-
-      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
       const expected = {};
 
+      // Act
+      const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+      // Assert
       expect(result).toEqual(expected);
     });
   });
 
   it('should add multiple custom filters to the query', async () => {
+    // Arrange
     const mockKeyword = 'test';
     const mockFilters = [
       { [FIELD_NAMES.DEAL.DEAL_TYPE]: ['BSS', 'EWCS'] },
@@ -159,11 +154,6 @@ describe('controllers/dashboard/deals - filters query', () => {
         [CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FIELD_NAMES.KEYWORD]: [mockKeyword],
       },
     ];
-    mockUser.bank.id = ALL_BANKS_ID;
-    mockUser.roles = [];
-
-    const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
     const expected = {
       AND: [
         {
@@ -177,19 +167,27 @@ describe('controllers/dashboard/deals - filters query', () => {
         },
       ],
     };
+    mockUser.bank.id = ALL_BANKS_ID;
+    mockUser.roles = [];
 
+    // Act
+    const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+    // Assert
     expect(result).toEqual(expected);
   });
 
   it(`should NOT add a filter to the query when the field value is ${CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.DEALS.ALL_STATUSES}`, async () => {
+    // Arrange
     const mockFilters = [{ status: [CONTENT_STRINGS.DASHBOARD_FILTERS.BESPOKE_FILTER_VALUES.DEALS.ALL_STATUSES] }];
     mockUser.bank.id = ALL_BANKS_ID;
     mockUser.roles = [];
-
-    const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
-
     const expected = {};
 
+    // Act
+    const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+    // Assert
     expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

This PR is about to fix when `FF_PORTAL_FACILITY_AMENDMENTS_ENABLED` is disable then  checker cannot call `getCheckersApprovalAmendmentDeal` function on application-details page.

## Resolution :heavy_check_mark:
- add isPortalFacilityAmendmentsFeatureFlagEnabled() from `libs/common` to `deals-filters-query.js`
- add feature flag on unit test

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot :camera_flash:
