### PR TITLE
fix(FN-3923): added hyperlink check for a cell value

### DIFF
--- a/portal/server/utils/csv-utils.js
+++ b/portal/server/utils/csv-utils.js
@@ -74,6 +74,15 @@ const handleFloatingPointRoundingErrors = (number) => {
 const isRichTextValue = (cellValue) => Boolean(cellValue && Array.isArray(cellValue.richText));
 
 /**
+ * Determines if a cell value represents a hyperlinked cell.
+ *
+ * @param {object} cellValue - The value of the cell to check.
+ * @param {string} [cellValue.hyperlink] - The hyperlink property of the cell value.
+ * @returns {boolean} True if the cell value contains a hyperlink, otherwise false.
+ */
+const isHyperlinkedCell = (cellValue) => Boolean(cellValue && cellValue?.hyperlink);
+
+/**
  * Extracts the value in the cell of an excel cell and removes any new lines or commas so that it doesn't affect parsing as a csv.
  * @param {Object} cell - excel cell.
  * @returns {string | number} - cell value.
@@ -88,6 +97,13 @@ const extractCellValue = (cell) => {
 
   // sets the value to the cellValue - replaced if it is a richText value
   let value = cellValue;
+
+  /**
+   * If cell is hyperlinked
+   */
+  if (isHyperlinkedCell(cellValue)) {
+    value = cellValue?.text;
+  }
 
   /**
    * if cellValue is a richText value
@@ -333,6 +349,7 @@ module.exports = {
   excelColumnToColumnIndex,
   parseXlsxToCsvArrays,
   isRichTextValue,
+  isHyperlinkedCell,
   xlsxBasedCsvToJsonPromise,
   csvBasedCsvToJsonPromise,
   removeCellAddressesFromArray,

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -15,13 +15,13 @@ const {
 
 describe('csv-utils', () => {
   describe('columnIndexToExcelColumn', () => {
-    it('should returns the correct column for an index below 26', async () => {
+    it('should return the correct column for an index below 26', async () => {
       const excelColumnIndex = columnIndexToExcelColumn(2);
 
       expect(excelColumnIndex).toEqual('C');
     });
 
-    it('should returns the correct column for an index above 26', async () => {
+    it('should return the correct column for an index above 26', async () => {
       const excelColumnIndex = columnIndexToExcelColumn(30);
 
       expect(excelColumnIndex).toEqual('AE');
@@ -29,13 +29,13 @@ describe('csv-utils', () => {
   });
 
   describe('excelColumnToColumnIndex', () => {
-    it('should returns the correct index for a column below 26', async () => {
+    it('should return the correct index for a column below 26', async () => {
       const columnIndex = excelColumnToColumnIndex('C');
 
       expect(columnIndex).toEqual(2);
     });
 
-    it('should returns the correct index for a column above 26', async () => {
+    it('should return the correct index for a column above 26', async () => {
       const columnIndex = excelColumnToColumnIndex('AE');
 
       expect(columnIndex).toEqual(30);
@@ -210,7 +210,7 @@ describe('csv-utils', () => {
   });
 
   describe('isRichTextValue', () => {
-    it('should returns true for a rich text value', () => {
+    it('should return true for a rich text value', () => {
       const cellValue = { richText: [{ text: 'test' }, { text: 'string' }] };
 
       const result = isRichTextValue(cellValue);
@@ -218,7 +218,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(true);
     });
 
-    it('should returns false for a non-rich text value', () => {
+    it('should return false for a non-rich text value', () => {
       const cellValue = 'test string';
 
       const result = isRichTextValue(cellValue);
@@ -226,7 +226,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('should returns false for a null value', () => {
+    it('should return false for a null value', () => {
       const cellValue = null;
 
       const result = isRichTextValue(cellValue);
@@ -234,7 +234,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('should returns false for an empty string', () => {
+    it('should return false for an empty string', () => {
       const cellValue = '';
 
       const result = isRichTextValue(cellValue);
@@ -242,7 +242,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('should returns false for an object without richText property', () => {
+    it('should return false for an object without richText property', () => {
       const cellValue = { text: 'test string' };
 
       const result = isRichTextValue(cellValue);
@@ -250,7 +250,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('should returns false for an array', () => {
+    it('should return false for an array', () => {
       const cellValue = ['test', 'string'];
 
       const result = isRichTextValue(cellValue);
@@ -300,7 +300,7 @@ describe('csv-utils', () => {
   });
 
   describe('extractCellValue', () => {
-    it('should returns the cell value', async () => {
+    it('should return the cell value', async () => {
       const cellValue = { value: CURRENCY.GBP };
 
       const extractedValue = extractCellValue(cellValue);
@@ -308,7 +308,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(CURRENCY.GBP);
     });
 
-    it('should returns the cell value without new lines', async () => {
+    it('should return the cell value without new lines', async () => {
       const cellValue = { value: 'GBP\na' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -316,7 +316,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
-    it('should returns the cell value without any new line characters', async () => {
+    it('should return the cell value without any new line characters', async () => {
       const cellValue = { value: 'GBP\ra' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -324,7 +324,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
-    it('should returns the cell value without new lines without whitespace at start or end', async () => {
+    it('should return the cell value without new lines without whitespace at start or end', async () => {
       const cellValue = { value: '\r\nGBP\na' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -332,7 +332,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
-    it('should returns the cell value without commas', async () => {
+    it('should return the cell value without commas', async () => {
       const cellValue = { value: 'GBP,' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -340,7 +340,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(CURRENCY.GBP);
     });
 
-    it('should returns the cell value without commas or new lines', async () => {
+    it('should return the cell value without commas or new lines', async () => {
       const cellValue = { value: '\n100,000' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -348,7 +348,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('100000');
     });
 
-    it('should returns the cell value if the value is a number', async () => {
+    it('should return the cell value if the value is a number', async () => {
       const cellValue = { value: 123 };
 
       const extractedValue = extractCellValue(cellValue);
@@ -356,7 +356,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(123);
     });
 
-    it('should returns the cell value as a string if it is a rich string value', () => {
+    it('should return the cell value as a string if it is a rich string value', () => {
       const cellValue = {
         value: {
           richText: [
@@ -374,7 +374,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('test string');
     });
 
-    it('should returns the cell value as a string if it is a rich string value with multiple rich text values', () => {
+    it('should return the cell value as a string if it is a rich string value with multiple rich text values', () => {
       const cellValue = {
         value: {
           richText: [
@@ -393,7 +393,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('test string');
     });
 
-    it('should returns the cell value as an empty string if passed as richText with an empty string', () => {
+    it('should return the cell value as an empty string if passed as richText with an empty string', () => {
       const cellValue = {
         value: {
           richText: [
@@ -411,7 +411,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('');
     });
 
-    it('should returns the cell value if the cell is using a formula to calculate the value', async () => {
+    it('should return the cell value if the cell is using a formula to calculate the value', async () => {
       const cellValue = { value: { result: 123, formula: 'SUM(A1:A2)' } };
 
       const extractedValue = extractCellValue(cellValue);
@@ -419,7 +419,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(123);
     });
 
-    it('should returns the cell value if the cell is using a formula to calculate the value and the result is missing in the value key', async () => {
+    it('should return the cell value if the cell is using a formula to calculate the value and the result is missing in the value key', async () => {
       const cellValue = { _value: { result: 123, formula: 'SUM(A1:A2)' } };
 
       const extractedValue = extractCellValue(cellValue);

--- a/portal/server/utils/csv-utils.test.js
+++ b/portal/server/utils/csv-utils.test.js
@@ -8,19 +8,20 @@ const {
   removeCellAddressesFromArray,
   extractCellValue,
   isRichTextValue,
+  isHyperlinkedCell,
   parseXlsxToCsvArrays,
   handleFloatingPointRoundingErrors,
 } = require('./csv-utils');
 
 describe('csv-utils', () => {
   describe('columnIndexToExcelColumn', () => {
-    it('returns the correct column for an index below 26', async () => {
+    it('should returns the correct column for an index below 26', async () => {
       const excelColumnIndex = columnIndexToExcelColumn(2);
 
       expect(excelColumnIndex).toEqual('C');
     });
 
-    it('returns the correct column for an index above 26', async () => {
+    it('should returns the correct column for an index above 26', async () => {
       const excelColumnIndex = columnIndexToExcelColumn(30);
 
       expect(excelColumnIndex).toEqual('AE');
@@ -28,13 +29,13 @@ describe('csv-utils', () => {
   });
 
   describe('excelColumnToColumnIndex', () => {
-    it('returns the correct index for a column below 26', async () => {
+    it('should returns the correct index for a column below 26', async () => {
       const columnIndex = excelColumnToColumnIndex('C');
 
       expect(columnIndex).toEqual(2);
     });
 
-    it('returns the correct index for a column above 26', async () => {
+    it('should returns the correct index for a column above 26', async () => {
       const columnIndex = excelColumnToColumnIndex('AE');
 
       expect(columnIndex).toEqual(30);
@@ -209,7 +210,7 @@ describe('csv-utils', () => {
   });
 
   describe('isRichTextValue', () => {
-    it('returns true for a rich text value', () => {
+    it('should returns true for a rich text value', () => {
       const cellValue = { richText: [{ text: 'test' }, { text: 'string' }] };
 
       const result = isRichTextValue(cellValue);
@@ -217,7 +218,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(true);
     });
 
-    it('returns false for a non-rich text value', () => {
+    it('should returns false for a non-rich text value', () => {
       const cellValue = 'test string';
 
       const result = isRichTextValue(cellValue);
@@ -225,7 +226,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('returns false for a null value', () => {
+    it('should returns false for a null value', () => {
       const cellValue = null;
 
       const result = isRichTextValue(cellValue);
@@ -233,7 +234,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('returns false for an empty string', () => {
+    it('should returns false for an empty string', () => {
       const cellValue = '';
 
       const result = isRichTextValue(cellValue);
@@ -241,7 +242,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('returns false for an object without richText property', () => {
+    it('should returns false for an object without richText property', () => {
       const cellValue = { text: 'test string' };
 
       const result = isRichTextValue(cellValue);
@@ -249,7 +250,7 @@ describe('csv-utils', () => {
       expect(result).toEqual(false);
     });
 
-    it('returns false for an array', () => {
+    it('should returns false for an array', () => {
       const cellValue = ['test', 'string'];
 
       const result = isRichTextValue(cellValue);
@@ -258,8 +259,48 @@ describe('csv-utils', () => {
     });
   });
 
+  describe('isHyperlinkedCell', () => {
+    it('should return true for a hyperlinked cell', () => {
+      // Arrange
+      const cellValue = {
+        hyperlink: 'https://example',
+        value: '123',
+      };
+
+      // Assert
+      const result = isHyperlinkedCell(cellValue);
+
+      // Act
+      expect(result).toEqual(true);
+    });
+
+    it('should return false for a non-hyperlinked cell', () => {
+      // Arrange
+      const cellValue = {
+        value: '123',
+      };
+
+      // Assert
+      const result = isHyperlinkedCell(cellValue);
+
+      // Act
+      expect(result).toEqual(false);
+    });
+
+    it('should return false for an empty cell', () => {
+      // Arrange
+      const cellValue = {};
+
+      // Assert
+      const result = isHyperlinkedCell(cellValue);
+
+      // Act
+      expect(result).toEqual(false);
+    });
+  });
+
   describe('extractCellValue', () => {
-    it('returns the cell value', async () => {
+    it('should returns the cell value', async () => {
       const cellValue = { value: CURRENCY.GBP };
 
       const extractedValue = extractCellValue(cellValue);
@@ -267,7 +308,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(CURRENCY.GBP);
     });
 
-    it('returns the cell value without new lines', async () => {
+    it('should returns the cell value without new lines', async () => {
       const cellValue = { value: 'GBP\na' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -275,7 +316,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
-    it('returns the cell value without any new line characters', async () => {
+    it('should returns the cell value without any new line characters', async () => {
       const cellValue = { value: 'GBP\ra' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -283,7 +324,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
-    it('returns the cell value without new lines without whitespace at start or end', async () => {
+    it('should returns the cell value without new lines without whitespace at start or end', async () => {
       const cellValue = { value: '\r\nGBP\na' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -291,7 +332,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('GBP a');
     });
 
-    it('returns the cell value without commas', async () => {
+    it('should returns the cell value without commas', async () => {
       const cellValue = { value: 'GBP,' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -299,7 +340,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(CURRENCY.GBP);
     });
 
-    it('returns the cell value without commas or new lines', async () => {
+    it('should returns the cell value without commas or new lines', async () => {
       const cellValue = { value: '\n100,000' };
 
       const extractedValue = extractCellValue(cellValue);
@@ -307,7 +348,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('100000');
     });
 
-    it('returns the cell value if the value is a number', async () => {
+    it('should returns the cell value if the value is a number', async () => {
       const cellValue = { value: 123 };
 
       const extractedValue = extractCellValue(cellValue);
@@ -315,7 +356,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(123);
     });
 
-    it('returns the cell value as a string if it is a rich string value', () => {
+    it('should returns the cell value as a string if it is a rich string value', () => {
       const cellValue = {
         value: {
           richText: [
@@ -333,7 +374,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('test string');
     });
 
-    it('returns the cell value as a string if it is a rich string value with multiple rich text values', () => {
+    it('should returns the cell value as a string if it is a rich string value with multiple rich text values', () => {
       const cellValue = {
         value: {
           richText: [
@@ -352,7 +393,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('test string');
     });
 
-    it('returns the cell value as an empty string if passed as richText with an empty string', () => {
+    it('should returns the cell value as an empty string if passed as richText with an empty string', () => {
       const cellValue = {
         value: {
           richText: [
@@ -370,7 +411,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual('');
     });
 
-    it('returns the cell value if the cell is using a formula to calculate the value', async () => {
+    it('should returns the cell value if the cell is using a formula to calculate the value', async () => {
       const cellValue = { value: { result: 123, formula: 'SUM(A1:A2)' } };
 
       const extractedValue = extractCellValue(cellValue);
@@ -378,7 +419,7 @@ describe('csv-utils', () => {
       expect(extractedValue).toEqual(123);
     });
 
-    it('returns the cell value if the cell is using a formula to calculate the value and the result is missing in the value key', async () => {
+    it('should returns the cell value if the cell is using a formula to calculate the value and the result is missing in the value key', async () => {
       const cellValue = { _value: { result: 123, formula: 'SUM(A1:A2)' } };
 
       const extractedValue = extractCellValue(cellValue);


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

When uploading a spreadsheet under `GEF utilisation and fees` and if any of the cell is hyperlinked, the uploaded report's cell value is presented with an `[Object Object]` value to the user. This is due to the following object being rendered by the XLSX renderer.

```js
{
  hyper: 'http://',
  value: 'test',
}
```

instead of a plain value `test`.

## Resolution :heavy_check_mark:

* Have added `isHyperlinkedCell` CSV utility helper for evaluation, if true then refer to the `value` property.
* Added test cases.

## Miscellaneous :heavy_plus_sign:

* Minor typo fixes.

## Screenshot :camera_flash:

![image](https://github.com/user-attachments/assets/a1cd0d02-308a-4e47-b08b-3c39fad4bbc3)

