### PR TITLE
fix(DTFS2): fix date e2e tests

### DIFF
--- a/e2e-tests/tfm/cypress/e2e/journeys/facility/facility-ain-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/facility/facility-ain-details.spec.js
@@ -44,7 +44,7 @@ context('Facility page - Automatic Inclusion Notice', () => {
       .invoke('text')
       .then((text) => {
         const trimmedText = text.trim();
-        expect(trimmedText).to.equal(today.dd_MMMM_yyyy);
+        expect(trimmedText).to.equal(today.d_MMMM_yyyy);
       });
   });
 });

--- a/e2e-tests/tfm/cypress/e2e/journeys/facility/facility-min-details.spec.js
+++ b/e2e-tests/tfm/cypress/e2e/journeys/facility/facility-min-details.spec.js
@@ -46,7 +46,7 @@ context('Facility page - Manual Inclusion Notice', () => {
       .invoke('text')
       .then((text) => {
         const trimmedText = text.trim();
-        expect(trimmedText).to.equal(today.dd_MMMM_yyyy);
+        expect(trimmedText).to.equal(today.d_MMMM_yyyy);
       });
   });
 });


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

This PR is about to fix e2e tests which fail because the date format dd_MMMM_yyyy do not much the actual output format. Example : Date expected to be in form '2 May 2025' but we get '02 May 2025' 
## Resolution :heavy_check_mark:

 - today.dd_MMMM_yyyy changed to today.d_MMMM_yyyy

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot :camera_flash:
