### PR TITLE
feat(DTFS2-7799): display latest amendment values on application details page

### DIFF
--- a/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-get-acknowledged.api-test.ts
+++ b/dtfs-central-api/api-tests/v1/portal-facility-amendments/amendment-get-acknowledged.api-test.ts
@@ -1,0 +1,178 @@
+import { Response } from 'supertest';
+import { ObjectId } from 'mongodb';
+import { HttpStatusCode } from 'axios';
+import {
+  AMENDMENT_TYPES,
+  AnyObject,
+  API_ERROR_CODE,
+  DEAL_SUBMISSION_TYPE,
+  DEAL_TYPE,
+  FACILITY_TYPE,
+  MONGO_DB_COLLECTIONS,
+  PortalFacilityAmendment,
+  PORTAL_AMENDMENT_STATUS,
+} from '@ukef/dtfs2-common';
+import { aPortalFacilityAmendmentUserValues } from '@ukef/dtfs2-common/mock-data-backend';
+import { generatePortalAuditDetails } from '@ukef/dtfs2-common/change-stream';
+
+import wipeDB from '../../wipeDB';
+import { testApi } from '../../test-api';
+import { createDeal, submitDealToTfm } from '../../helpers/create-deal';
+import aDeal from '../deal-builder';
+import { aPortalUser } from '../../mocks/test-users/portal-user';
+import { createPortalUser } from '../../helpers/create-portal-user';
+import { createPortalFacilityAmendment } from '../../helpers/create-portal-facility-amendment';
+import { mongoDbClient as db } from '../../../src/drivers/db-client';
+import { amendmentsEligibilityCriteria } from '../../../test-helpers/test-data/eligibility-criteria-amendments';
+
+const originalEnv = { ...process.env };
+
+interface FacilityAmendmentResponse extends Response {
+  body: PortalFacilityAmendment;
+}
+
+const generateUrl = (facilityId: string): string => {
+  return `/v1/portal/facilities/${facilityId}/amendments/acknowledged`;
+};
+
+const generateSubmitAmendmentUrl = (facilityId: string, amendmentId: string): string => {
+  return `/v1/portal/facilities/${facilityId}/amendments/${amendmentId}/submit-amendment`;
+};
+
+const newDeal = aDeal({
+  dealType: DEAL_TYPE.GEF,
+  submissionType: DEAL_SUBMISSION_TYPE.AIN,
+}) as AnyObject;
+
+describe('GET /v1/portal/facilities/:facilityId/amendments/acknowledged', () => {
+  let dealId: string;
+  let facilityId: string;
+  let portalUserId: string;
+  let referenceNumber: string;
+
+  beforeAll(async () => {
+    await wipeDB.wipe([MONGO_DB_COLLECTIONS.FACILITIES, MONGO_DB_COLLECTIONS.TFM_FACILITIES, MONGO_DB_COLLECTIONS.ELIGIBILITY_CRITERIA_AMENDMENTS]);
+    await db
+      .getCollection(MONGO_DB_COLLECTIONS.ELIGIBILITY_CRITERIA_AMENDMENTS)
+      .then((collection) => collection.insertOne(amendmentsEligibilityCriteria(1, [FACILITY_TYPE.CASH, FACILITY_TYPE.CONTINGENT])));
+
+    portalUserId = (await createPortalUser())._id;
+  });
+
+  beforeEach(async () => {
+    const createDealResponse: { body: { _id: string } } = await createDeal({ deal: newDeal, user: aPortalUser() });
+    dealId = createDealResponse.body._id;
+
+    const createFacilityResponse: { body: { _id: string } } = await testApi
+      .post({ dealId, type: FACILITY_TYPE.CASH, hasBeenIssued: false })
+      .to('/v1/portal/gef/facilities');
+
+    facilityId = createFacilityResponse.body._id;
+    referenceNumber = `${facilityId}-23`;
+
+    await submitDealToTfm({ dealId, dealSubmissionType: DEAL_SUBMISSION_TYPE.AIN, dealType: DEAL_TYPE.GEF });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('with FF_PORTAL_FACILITY_AMENDMENTS_ENABLED set to `false`', () => {
+    beforeAll(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'false';
+    });
+
+    it(`should return ${HttpStatusCode.NotFound}`, async () => {
+      const { status } = (await testApi.get(generateUrl(facilityId))) as FacilityAmendmentResponse;
+
+      expect(status).toEqual(HttpStatusCode.NotFound);
+    });
+  });
+
+  describe('with FF_PORTAL_FACILITY_AMENDMENTS_ENABLED set to `true`', () => {
+    let amendmentId: string;
+
+    beforeEach(async () => {
+      const existingAmendment = await createPortalFacilityAmendment({
+        facilityId,
+        dealId,
+        userId: portalUserId,
+        amendment: {
+          ...aPortalFacilityAmendmentUserValues(),
+          eligibilityCriteria: {
+            criteria: [{ id: 1, text: 'item 1', answer: true }],
+            version: 1,
+          },
+        },
+        status: PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL,
+      });
+
+      // create second amendment with status which is not acknowledged
+      await createPortalFacilityAmendment({
+        facilityId,
+        dealId,
+        userId: portalUserId,
+        amendment: {
+          ...aPortalFacilityAmendmentUserValues(),
+          eligibilityCriteria: {
+            criteria: [{ id: 1, text: 'item 1', answer: true }],
+            version: 1,
+          },
+        },
+        status: PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL,
+      });
+
+      amendmentId = existingAmendment.amendmentId.toString();
+
+      const newStatus = PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED;
+
+      // submit amendment to make it acknowledged
+      await testApi
+        .patch({ auditDetails: generatePortalAuditDetails(portalUserId), newStatus, referenceNumber })
+        .to(generateSubmitAmendmentUrl(facilityId, amendmentId));
+    });
+
+    beforeAll(() => {
+      process.env.FF_PORTAL_FACILITY_AMENDMENTS_ENABLED = 'true';
+    });
+
+    it(`should return ${HttpStatusCode.BadRequest} when the facility id is invalid`, async () => {
+      const anInvalidFacilityId = 'InvalidId';
+
+      const { status, body } = (await testApi.get(generateUrl(anInvalidFacilityId))) as FacilityAmendmentResponse;
+
+      expect(status).toEqual(HttpStatusCode.BadRequest);
+
+      expect(body).toEqual({
+        message: "Expected path parameter 'facilityId' to be a valid mongo id",
+        code: API_ERROR_CODE.INVALID_MONGO_ID_PATH_PARAMETER,
+      });
+    });
+
+    it(`should an empty array when the facility does not exist`, async () => {
+      const aValidButNonExistentFacilityId = new ObjectId().toString();
+
+      const { status, body } = (await testApi.get(generateUrl(aValidButNonExistentFacilityId))) as FacilityAmendmentResponse;
+
+      expect(status).toEqual(HttpStatusCode.Ok);
+      expect(body).toEqual([]);
+    });
+
+    it(`should return one amendment only which has status ${PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED}`, async () => {
+      const { status, body } = (await testApi.get(generateUrl(facilityId))) as FacilityAmendmentResponse;
+
+      expect(status).toEqual(HttpStatusCode.Ok);
+
+      expect(body).toHaveLength(1);
+
+      expect(body).toEqual([
+        expect.objectContaining({
+          amendmentId,
+          dealId,
+          facilityId,
+          type: AMENDMENT_TYPES.PORTAL,
+        } as AnyObject),
+      ]);
+    });
+  });
+});

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/acknowledged-portal-amendments-by-facility-id.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/acknowledged-portal-amendments-by-facility-id.ts
@@ -1,0 +1,15 @@
+import { ObjectId, Document } from 'mongodb';
+import { PORTAL_AMENDMENT_STATUS, AMENDMENT_TYPES } from '@ukef/dtfs2-common';
+
+/**
+ * Generate aggregate pipeline to get acknowledged portal amendments by facility id
+ * @param facilityId - the facility id
+ * @returns aggregate pipeline to get acknowledged portal amendments by facility id
+ */
+export const acknowledgedPortalAmendmentsByFacilityId = (facilityId: string | ObjectId): Document[] => [
+  { $match: { _id: { $eq: new ObjectId(facilityId) } } },
+  { $unwind: '$amendments' },
+  { $match: { 'amendments.status': { $eq: PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED }, 'amendments.type': { $eq: AMENDMENT_TYPES.PORTAL } } },
+  { $sort: { 'amendments.updatedAt': -1, 'amendments.version': -1 } },
+  { $project: { _id: false, amendments: true } },
+];

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/index.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/aggregate-pipelines/index.ts
@@ -6,6 +6,7 @@ import { tfmAmendmentsByDealIdAndStatus } from './tfm-amendments-by-deal-id-and-
 import { latestCompletedTfmAmendmentByFacilityId } from './latest-completed-amendment-by-facility-id';
 import { latestCompletedAmendmentByDealId } from './lastest-completed-amendment-by-deal-id';
 import { allFacilitiesAndFacilityCount } from './all-facilities-and-facility-count';
+import { acknowledgedPortalAmendmentsByFacilityId } from './acknowledged-portal-amendments-by-facility-id';
 
 export { AllFacilitiesAndFacilityCountAggregatePipelineOptions } from './all-facilities-and-facility-count';
 
@@ -18,4 +19,5 @@ export const aggregatePipelines = {
   latestCompletedTfmAmendmentByFacilityId,
   latestCompletedAmendmentByDealId,
   allFacilitiesAndFacilityCount,
+  acknowledgedPortalAmendmentsByFacilityId,
 };

--- a/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
+++ b/dtfs-central-api/src/repositories/tfm-facilities-repo/tfm-facilities.repo.ts
@@ -313,6 +313,21 @@ export class TfmFacilitiesRepo {
   }
 
   /**
+   * Finds acknowledged portal amendments by facility id
+   * @param facilityId - The facility id
+   * @returns The latest completed amendment
+   */
+  public static async findAcknowledgedPortalAmendmentsByFacilityId(facilityId: string | ObjectId): Promise<FacilityAmendment[] | null> {
+    const collection = await this.getCollection();
+    const amendments = await collection
+      .aggregate(aggregatePipelines.acknowledgedPortalAmendmentsByFacilityId(facilityId))
+      .map<FacilityAmendment>((doc) => doc.amendments as FacilityAmendment)
+      .toArray();
+
+    return amendments ?? null;
+  }
+
+  /**
    * Finds the latest completed amendment by deal id
    * @param dealId - The deal id
    * @returns The latest completed amendment

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-acknowledged-amendments-by-facility-id.controller.test.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-acknowledged-amendments-by-facility-id.controller.test.ts
@@ -1,0 +1,85 @@
+import { createMocks } from 'node-mocks-http';
+import { HttpStatusCode } from 'axios';
+import { PORTAL_AMENDMENT_STATUS, PortalAmendmentStatus, TestApiError } from '@ukef/dtfs2-common';
+import { aPortalFacilityAmendment } from '@ukef/dtfs2-common/mock-data-backend';
+import { getAcknowledgedAmendmentsByFacilityId, GetAcknowledgedAmendmentsByFacilityIdRequest } from './get-acknowledged-amendments-by-facility-id.controller';
+import { TfmFacilitiesRepo } from '../../../../repositories/tfm-facilities-repo';
+
+const { ACKNOWLEDGED } = PORTAL_AMENDMENT_STATUS;
+
+const anAcknowledgedPortalAmendment = aPortalFacilityAmendment({ status: ACKNOWLEDGED });
+const mockReturnedPortalAmendments = [anAcknowledgedPortalAmendment];
+
+const mockGetAcknowledgedAmendmentsByFacilityId = jest.fn();
+
+const generateHttpMocks = ({ statuses }: { statuses?: PortalAmendmentStatus[] } = {}) =>
+  createMocks<GetAcknowledgedAmendmentsByFacilityIdRequest>({ query: { statuses } });
+
+describe('getAcknowledgedAmendmentsByFacilityId', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    jest.spyOn(TfmFacilitiesRepo, 'findAcknowledgedPortalAmendmentsByFacilityId').mockImplementation(mockGetAcknowledgedAmendmentsByFacilityId);
+    mockGetAcknowledgedAmendmentsByFacilityId.mockResolvedValue(mockReturnedPortalAmendments);
+  });
+
+  it('should call TfmFacilitiesRepo.findAcknowledgedPortalAmendmentsByFacilityId with the correct params', async () => {
+    // Arrange
+    const { req, res } = generateHttpMocks();
+
+    // Act
+    await getAcknowledgedAmendmentsByFacilityId(req, res);
+
+    // Assert
+    expect(mockGetAcknowledgedAmendmentsByFacilityId).toHaveBeenCalledTimes(1);
+  });
+
+  it(`should return ${HttpStatusCode.Ok} and all the amendments for all facilities`, async () => {
+    // Arrange
+    const { req, res } = generateHttpMocks();
+
+    // Act
+    await getAcknowledgedAmendmentsByFacilityId(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.Ok);
+    expect(res._getData()).toEqual(mockReturnedPortalAmendments);
+  });
+
+  it('should return the correct status and body if TfmFacilitiesRepo.findAcknowledgedPortalAmendmentsByFacilityId throws an api error', async () => {
+    // Arrange
+    const status = HttpStatusCode.Forbidden;
+    const message = 'Test error message';
+    mockGetAcknowledgedAmendmentsByFacilityId.mockRejectedValue(new TestApiError({ status, message }));
+
+    const { req, res } = generateHttpMocks();
+
+    // Act
+    await getAcknowledgedAmendmentsByFacilityId(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(status);
+    expect(res._getData()).toEqual({
+      status,
+      message,
+    });
+  });
+
+  it(`should return ${HttpStatusCode.InternalServerError} if TfmFacilitiesRepo.findAcknowledgedPortalAmendmentsByFacilityId throws an unknown error`, async () => {
+    // Arrange
+    const message = 'Test error message';
+    mockGetAcknowledgedAmendmentsByFacilityId.mockRejectedValue(new Error(message));
+
+    const { req, res } = generateHttpMocks();
+
+    // Act
+    await getAcknowledgedAmendmentsByFacilityId(req, res);
+
+    // Assert
+    expect(res._getStatusCode()).toEqual(HttpStatusCode.InternalServerError);
+    expect(res._getData()).toEqual({
+      status: HttpStatusCode.InternalServerError,
+      message: 'Unknown error occurred when getting acknowledged amendments by facilityId',
+    });
+  });
+});

--- a/dtfs-central-api/src/v1/controllers/portal/facility/get-acknowledged-amendments-by-facility-id.controller.ts
+++ b/dtfs-central-api/src/v1/controllers/portal/facility/get-acknowledged-amendments-by-facility-id.controller.ts
@@ -1,0 +1,34 @@
+import { ApiError, CustomExpressRequest } from '@ukef/dtfs2-common';
+import { HttpStatusCode } from 'axios';
+import { Response } from 'express';
+import { TfmFacilitiesRepo } from '../../../../repositories/tfm-facilities-repo';
+
+type GetAcknowledgedAmendmentsByFacilityIdRequestParams = { facilityId: string };
+export type GetAcknowledgedAmendmentsByFacilityIdRequest = CustomExpressRequest<{ params: GetAcknowledgedAmendmentsByFacilityIdRequestParams }>;
+
+/**
+ * get acknowledged amendments by facilityId
+ * @param req - request
+ * @param res - response
+ */
+export const getAcknowledgedAmendmentsByFacilityId = async (req: GetAcknowledgedAmendmentsByFacilityIdRequest, res: Response) => {
+  const { facilityId } = req.params;
+
+  try {
+    const amendments = await TfmFacilitiesRepo.findAcknowledgedPortalAmendmentsByFacilityId(facilityId);
+
+    return res.status(HttpStatusCode.Ok).send(amendments);
+  } catch (error) {
+    console.error(`Error getting acknowledged amendments by facilityId: %o`, error);
+
+    if (error instanceof ApiError) {
+      const { status, message, code } = error;
+      return res.status(status).send({ status, message, code });
+    }
+
+    return res.status(HttpStatusCode.InternalServerError).send({
+      status: HttpStatusCode.InternalServerError,
+      message: 'Unknown error occurred when getting acknowledged amendments by facilityId',
+    });
+  }
+};

--- a/dtfs-central-api/src/v1/routes/portal-routes.js
+++ b/dtfs-central-api/src/v1/routes/portal-routes.js
@@ -44,6 +44,7 @@ const patchFacilityAmendmentController = require('../controllers/portal/facility
 const deleteFacilityAmendmentController = require('../controllers/portal/facility/delete-amendment.controller');
 const patchAmendmentStatusController = require('../controllers/portal/facility/patch-amendment-status.controller');
 const patchSubmitAmendmentController = require('../controllers/portal/facility/patch-submit-amendment.controller');
+const getAcknowledgedAmendmentsByFacilityIdController = require('../controllers/portal/facility/get-acknowledged-amendments-by-facility-id.controller');
 
 const getAllFacilityAmendmentController = require('../controllers/portal/facility/get-all-amendments.controller');
 const getFacilityAmendmentsForDealController = require('../controllers/portal/facility/get-amendments-on-deal.controller');
@@ -557,6 +558,35 @@ portalRouter.route('/facilities/:id').delete(deleteFacilityController.deleteFaci
  *         description: Not found
  */
 portalRouter.route('/facilities/:id/status').put(updateFacilityStatusController.updateFacilityStatusPut);
+
+/**
+ * @openapi
+ * /facilities/:facilityId/amendments/acknowledged:
+ *   get:
+ *     summary: Get all acknowledged amendments for a facility
+ *     tags: [Portal - Amendments]
+ *     description:  Get all acknowledged amendments for a facility
+ *     parameters:
+ *       - in: path
+ *         name: facilityId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: Facility ID amendment exists on
+ *     responses:
+ *       200:
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *                $ref: '#/definitions/PortalAmendment'
+ *       404:
+ *         description: Not found
+ */
+portalRouter
+  .route('/facilities/:facilityId/amendments/acknowledged')
+  .all(validatePortalFacilityAmendmentsEnabled, validation.mongoIdValidation('facilityId'))
+  .get(getAcknowledgedAmendmentsByFacilityIdController.getAcknowledgedAmendmentsByFacilityId);
 
 /**
  * @openapi

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-multiple-cover-end-date-amendment.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-multiple-cover-end-date-amendment.spec.js
@@ -1,0 +1,73 @@
+import { getFormattedMonetaryValueWithoutDecimals } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { D_MMMM_YYYY_FORMAT, twoDays } from '../../../../../../../e2e-fixtures/dateConstants';
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+context('Amendments - Multiple cover end date amendments - Application details displays amendment values on facility summary list', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+  let facilityValue;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+        facilityValue = createdFacility.details.value;
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+
+        // first amendment request with cover end date
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          facilityValueExists: false,
+          coverEndDateExists: true,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+
+        // second amendment request with different cover end date
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          facilityValueExists: false,
+          coverEndDateExists: true,
+          changedCoverEndDate: twoDays.date,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(applicationDetailsUrl));
+  });
+
+  it('should display the latest updated amendment cover end date on facility summary list', () => {
+    applicationPreview.facilitySummaryList().contains(getFormattedMonetaryValueWithoutDecimals(facilityValue));
+    applicationPreview.facilitySummaryList().contains(format(twoDays.date, D_MMMM_YYYY_FORMAT));
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-multiple-value-amendment.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-multiple-value-amendment.spec.js
@@ -1,0 +1,72 @@
+import { getFormattedMonetaryValueWithoutDecimals } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { D_MMMM_YYYY_FORMAT } from '../../../../../../../e2e-fixtures/dateConstants';
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+const CHANGED_FACILITY_VALUE_1 = '20000';
+const CHANGED_FACILITY_VALUE_2 = '30000';
+
+context('Amendments - Multiple value amendments - Application details displays amendment values on facility summary list', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+  let coverEndDate;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+        coverEndDate = new Date(createdFacility.details.coverEndDate);
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE_1,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE_2,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(applicationDetailsUrl));
+  });
+
+  it('should display the latest updated amendment value on facility summary list', () => {
+    applicationPreview.facilitySummaryList().contains(getFormattedMonetaryValueWithoutDecimals(CHANGED_FACILITY_VALUE_2));
+    applicationPreview.facilitySummaryList().contains(format(coverEndDate, D_MMMM_YYYY_FORMAT));
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-multiple-value-and-date-amendment.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-multiple-value-and-date-amendment.spec.js
@@ -1,0 +1,76 @@
+import { getFormattedMonetaryValueWithoutDecimals } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { D_MMMM_YYYY_FORMAT, twoDays } from '../../../../../../../e2e-fixtures/dateConstants';
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+const CHANGED_FACILITY_VALUE_1 = '20000';
+const CHANGED_FACILITY_VALUE_2 = '30000';
+
+context('Amendments - Multiple cover end date AND value amendments - Application details displays amendment values on facility summary list', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+
+        // first amendment request with facility value and cover end date
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          coverEndDateExists: true,
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE_1,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+
+        // second amendment request with different facility value and cover end date
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          coverEndDateExists: true,
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE_2,
+          changedCoverEndDate: twoDays.date,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(applicationDetailsUrl));
+  });
+
+  it('should display the latest updated amendment value AND cover end date on facility summary list', () => {
+    applicationPreview.facilitySummaryList().contains(getFormattedMonetaryValueWithoutDecimals(CHANGED_FACILITY_VALUE_2));
+    applicationPreview.facilitySummaryList().contains(format(twoDays.date, D_MMMM_YYYY_FORMAT));
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-single-cover-end-date-amendment.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-single-cover-end-date-amendment.spec.js
@@ -1,0 +1,62 @@
+import { getFormattedMonetaryValueWithoutDecimals } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { D_MMMM_YYYY_FORMAT } from '../../../../../../../e2e-fixtures/dateConstants';
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+context('Amendments - Single cover end date amendment - Application details displays amendment values on facility summary list', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+  let facilityValue;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+        facilityValue = createdFacility.details.value;
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          facilityValueExists: false,
+          coverEndDateExists: true,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(applicationDetailsUrl));
+  });
+
+  it('should display the updated amendment cover end date on facility summary list', () => {
+    applicationPreview.facilitySummaryList().contains(getFormattedMonetaryValueWithoutDecimals(facilityValue));
+    applicationPreview.facilitySummaryList().contains(format(new Date(), D_MMMM_YYYY_FORMAT));
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-single-value-amendment.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-single-value-amendment.spec.js
@@ -1,0 +1,63 @@
+import { getFormattedMonetaryValueWithoutDecimals } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { D_MMMM_YYYY_FORMAT } from '../../../../../../../e2e-fixtures/dateConstants';
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+const CHANGED_FACILITY_VALUE = '20000';
+
+context('Amendments - Single value amendment - Application details displays amendment values on facility summary list', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+  let coverEndDate;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+        coverEndDate = new Date(createdFacility.details.coverEndDate);
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(applicationDetailsUrl));
+  });
+
+  it('should display the updated amendment value on facility summary list', () => {
+    applicationPreview.facilitySummaryList().contains(getFormattedMonetaryValueWithoutDecimals(CHANGED_FACILITY_VALUE));
+    applicationPreview.facilitySummaryList().contains(format(coverEndDate, D_MMMM_YYYY_FORMAT));
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-single-value-and-date-amendment.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-values-single-value-and-date-amendment.spec.js
@@ -1,0 +1,63 @@
+import { getFormattedMonetaryValueWithoutDecimals } from '@ukef/dtfs2-common';
+import { format } from 'date-fns';
+import { D_MMMM_YYYY_FORMAT } from '../../../../../../../e2e-fixtures/dateConstants';
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+const CHANGED_FACILITY_VALUE = '20000';
+
+context('Amendments - Single cover end date AND value amendment - Application details displays amendment values on facility summary list', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+
+        cy.loginAndSubmitPortalAmendmentRequestToUkef({
+          coverEndDateExists: true,
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE,
+          applicationDetailsUrl,
+          facilityId,
+          dealId,
+        });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+    cy.login(BANK1_MAKER1);
+    cy.visit(relative(applicationDetailsUrl));
+  });
+
+  it('should display the updated amendment value AND cover end date on facility summary list', () => {
+    applicationPreview.facilitySummaryList().contains(getFormattedMonetaryValueWithoutDecimals(CHANGED_FACILITY_VALUE));
+    applicationPreview.facilitySummaryList().contains(format(new Date(), D_MMMM_YYYY_FORMAT));
+  });
+});

--- a/e2e-tests/ukef/cypress/support/commands.js
+++ b/e2e-tests/ukef/cypress/support/commands.js
@@ -10,6 +10,7 @@ import { getOneGefDeal } from './portal-api/getOneGefDeal';
 import { clearSessionCookies } from './utils/clearSessionCookies';
 import { getAmendmentIdFromUrl } from './utils/getAmendmentIdFromUrl';
 import { makerSubmitPortalAmendmentForReview } from './gef/makerSubmitPortalAmendmentForReview';
+import { loginAndSubmitPortalAmendmentRequestToUkef } from './gef/loginAndSubmitPortalAmendmentRequestToUkef';
 import { makerMakesPortalAmendmentRequest } from './gef/makerMakesPortalAmendmentRequest';
 import { makerAndCheckerSubmitPortalAmendmentRequest } from './gef/makerAndCheckerSubmitPortalAmendmentRequest';
 import { checkerSubmitsPortalAmendmentRequest } from './gef/checkerSubmitsPortalAmendmentRequest';
@@ -60,6 +61,7 @@ Cypress.Commands.add('makerSubmitPortalAmendmentForReview', makerSubmitPortalAme
 Cypress.Commands.add('makerMakesPortalAmendmentRequest', makerMakesPortalAmendmentRequest);
 Cypress.Commands.add('makerAndCheckerSubmitPortalAmendmentRequest', makerAndCheckerSubmitPortalAmendmentRequest);
 Cypress.Commands.add('checkerSubmitsPortalAmendmentRequest', checkerSubmitsPortalAmendmentRequest);
+Cypress.Commands.add('loginAndSubmitPortalAmendmentRequestToUkef', loginAndSubmitPortalAmendmentRequestToUkef);
 
 Cypress.Commands.add('submitDealCancellation', submitDealCancellation);
 

--- a/e2e-tests/ukef/cypress/support/gef/loginAndSubmitPortalAmendmentRequestToUkef.js
+++ b/e2e-tests/ukef/cypress/support/gef/loginAndSubmitPortalAmendmentRequestToUkef.js
@@ -1,0 +1,52 @@
+import relative from '../../e2e/relativeURL';
+import MOCK_USERS from '../../../../e2e-fixtures/portal-users.fixture';
+
+import { applicationPreview } from '../../../../gef/cypress/e2e/pages';
+
+const { BANK1_MAKER1 } = MOCK_USERS;
+
+/**
+ * Log in and submit a portal amendment to UKEF
+ * @param {Boolean} param.coverEndDateExists - if cover end date is changed
+ * @param {Boolean} param.facilityValueExists - if facility value is changed
+ * @param {Boolean} param.facilityEndDateExists - if facility end date is changed
+ * @param {String} param.changedFacilityValue - the new value for the facility
+ * @param {String} param.changedCoverEndDate - the new cover end date
+ * @param {String} param.applicationDetailsUrl - the URL to the application details page
+ * @param {String} param.facilityId - the ID of the facility
+ * @param {String} param.dealId - the ID of the deal
+ */
+export const loginAndSubmitPortalAmendmentRequestToUkef = ({
+  coverEndDateExists = false,
+  facilityValueExists = false,
+  facilityEndDateExists = false,
+  changedFacilityValue,
+  changedCoverEndDate,
+  applicationDetailsUrl,
+  facilityId,
+  dealId,
+}) => {
+  cy.login(BANK1_MAKER1);
+  cy.saveSession();
+
+  cy.visit(relative(applicationDetailsUrl));
+  applicationPreview.makeAChangeButton(facilityId).click();
+
+  cy.getAmendmentIdFromUrl().then((amendmentId) => {
+    const confirmSubmissionToUkefUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/submit-amendment-to-ukef`;
+    const submittedUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}`;
+    const approvedByUkefUrl = `${submittedUrl}/approved-by-ukef`;
+    const amendmentDetailsUrl = `/gef/application-details/${dealId}/amendment-details`;
+
+    cy.makerAndCheckerSubmitPortalAmendmentRequest({
+      facilityValueExists,
+      coverEndDateExists,
+      facilityEndDateExists,
+      changedFacilityValue,
+      changedCoverEndDate,
+      amendmentDetailsUrl,
+      submittedUrl: approvedByUkefUrl,
+      confirmSubmissionToUkefUrl,
+    });
+  });
+};

--- a/e2e-tests/ukef/cypress/support/gef/makerAndCheckerSubmitPortalAmendmentRequest.js
+++ b/e2e-tests/ukef/cypress/support/gef/makerAndCheckerSubmitPortalAmendmentRequest.js
@@ -6,6 +6,7 @@ import relative from '../../e2e/relativeURL';
  * @param {Boolean} param.facilityValueExists - if facility value is changed
  * @param {Boolean} param.facilityEndDateExists - if facility end date is changed
  * @param {String} param.changedFacilityValue - the new value for the facility
+ * @param {String} param.changedCoverEndDate - the new cover end date
  * @param {String} param.amendmentDetailsUrl - the URL to the amendment details page
  * @param {String} param.submitToUkefUrl - the URL to the confirm amendment submission page
  * @param {String} param.submittedUrl - the URL to the approved by ukef page
@@ -15,6 +16,7 @@ export const makerAndCheckerSubmitPortalAmendmentRequest = ({
   facilityValueExists = false,
   facilityEndDateExists = false,
   changedFacilityValue,
+  changedCoverEndDate,
   amendmentDetailsUrl,
   confirmSubmissionToUkefUrl,
   submittedUrl,
@@ -25,6 +27,7 @@ export const makerAndCheckerSubmitPortalAmendmentRequest = ({
     facilityValueExists,
     facilityEndDateExists,
     changedFacilityValue,
+    changedCoverEndDate,
   });
 
   // submits checker part of journey

--- a/e2e-tests/ukef/cypress/support/gef/makerMakesPortalAmendmentRequest.js
+++ b/e2e-tests/ukef/cypress/support/gef/makerMakesPortalAmendmentRequest.js
@@ -9,12 +9,14 @@ import facilityValue from '../../../../gef/cypress/e2e/pages/amendments/facility
  * @param {Boolean} param.facilityValueExists - if facility value is changed
  * @param {Boolean} param.facilityEndDateExists - if facility end date is changed
  * @param {String} param.changedFacilityValue - the new value for the facility
+ * @param {String} param.changedCoverEndDate - the new cover end date
  */
 export const makerMakesPortalAmendmentRequest = ({
   coverEndDateExists = false,
   facilityValueExists = false,
   facilityEndDateExists = false,
   changedFacilityValue,
+  changedCoverEndDate,
 }) => {
   if (coverEndDateExists) {
     whatDoYouNeedToChange.coverEndDateCheckbox().click();
@@ -27,7 +29,7 @@ export const makerMakesPortalAmendmentRequest = ({
   cy.clickContinueButton();
 
   if (coverEndDateExists) {
-    cy.completeDateFormFields({ idPrefix: 'cover-end-date' });
+    cy.completeDateFormFields({ idPrefix: 'cover-end-date', date: changedCoverEndDate });
     cy.clickContinueButton();
 
     if (facilityEndDateExists) {

--- a/e2e-tests/ukef/cypress/support/gef/makerSubmitPortalAmendmentForReview.js
+++ b/e2e-tests/ukef/cypress/support/gef/makerSubmitPortalAmendmentForReview.js
@@ -6,18 +6,21 @@ import amendmentPage from '../../../../gef/cypress/e2e/pages/amendments/amendmen
  * @param {Boolean} param.facilityValueExists - if facility value is changed
  * @param {Boolean} param.facilityEndDateExists - if facility end date is changed
  * @param {String} param.changedFacilityValue - the new value for the facility
+ * @param {String} param.changedCoverEndDate - the new cover end date
  */
 export const makerSubmitPortalAmendmentForReview = ({
   coverEndDateExists = false,
   facilityValueExists = false,
   facilityEndDateExists = false,
   changedFacilityValue,
+  changedCoverEndDate,
 }) => {
   cy.makerMakesPortalAmendmentRequest({
     coverEndDateExists,
     facilityValueExists,
     facilityEndDateExists,
     changedFacilityValue,
+    changedCoverEndDate,
   });
 
   cy.clickSubmitButton();

--- a/libs/common/src/helpers/index.ts
+++ b/libs/common/src/helpers/index.ts
@@ -28,3 +28,4 @@ export * from './is-production';
 export * from './generate-mandatory-criteria';
 export * from './strip-html';
 export * from './is-gov-notify-mocked';
+export * from './map-facility-to-amendment-values';

--- a/libs/common/src/helpers/map-facility-to-amendment-values.test.ts
+++ b/libs/common/src/helpers/map-facility-to-amendment-values.test.ts
@@ -1,0 +1,66 @@
+import { mapAmendmentToFacilityValues } from './map-facility-to-amendment-values';
+import { aPortalFacilityAmendment } from '../test-helpers/mock-data-backend/portal-facility-amendment';
+import { PORTAL_AMENDMENT_STATUS } from '../constants';
+
+describe('map-amendment-to-facility-values helper', () => {
+  const anAcknowledgedPortalAmendment = aPortalFacilityAmendment({ status: PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED });
+  const valueAmendment1 = {
+    ...anAcknowledgedPortalAmendment,
+    value: 5000,
+    coverEndDate: null,
+  };
+
+  const valueAmendment2 = {
+    ...anAcknowledgedPortalAmendment,
+    value: 10000,
+    coverEndDate: null,
+  };
+
+  const coverEndDateAmendment1 = {
+    ...anAcknowledgedPortalAmendment,
+    coverEndDate: new Date('2023-01-01').valueOf(),
+    value: null,
+  };
+
+  const coverEndDateAmendment2 = {
+    ...anAcknowledgedPortalAmendment,
+    coverEndDate: new Date('2023-02-01').valueOf(),
+    value: null,
+  };
+
+  describe('when there is one value amendment', () => {
+    it('should return the value from the amendment', () => {
+      const result = mapAmendmentToFacilityValues([valueAmendment1]);
+
+      expect(result.value).toEqual(valueAmendment1.value);
+      expect(result.coverEndDate).toBeNull();
+    });
+  });
+
+  describe('when there is one coverEndDate amendment', () => {
+    it('should return the coverEndDate from the amendment', () => {
+      const result = mapAmendmentToFacilityValues([coverEndDateAmendment1]);
+
+      expect(result.value).toBeNull();
+      expect(result.coverEndDate).toEqual(coverEndDateAmendment1.coverEndDate);
+    });
+  });
+
+  describe('when there are multiple value amendments', () => {
+    it('should return the value from the latest amendment', () => {
+      const result = mapAmendmentToFacilityValues([valueAmendment1, valueAmendment2]);
+
+      expect(result.value).toEqual(valueAmendment1.value);
+      expect(result.coverEndDate).toBeNull();
+    });
+  });
+
+  describe('when there are multiple coverEndDate amendments', () => {
+    it('should return the coverEndDate from the latest amendment', () => {
+      const result = mapAmendmentToFacilityValues([coverEndDateAmendment1, coverEndDateAmendment2]);
+
+      expect(result.value).toBeNull();
+      expect(result.coverEndDate).toEqual(coverEndDateAmendment1.coverEndDate);
+    });
+  });
+});

--- a/libs/common/src/helpers/map-facility-to-amendment-values.ts
+++ b/libs/common/src/helpers/map-facility-to-amendment-values.ts
@@ -1,0 +1,27 @@
+import { FacilityAmendment } from '../types';
+
+/**
+ * Finds the first amendment in the amendments array for coverEndDate and value
+ * if the updatedValue for either field is not already set, then it will be set to the amended value from the amendment
+ * @param amendments - amendments array
+ * @returns object with amended coverEndDate and value
+ */
+export const mapAmendmentToFacilityValues = (amendments: FacilityAmendment[]) => {
+  return amendments.reduce((updatedFields, amendment) => {
+    const amendedValues = updatedFields;
+
+    /**
+     * if updatedFields does not have a coverEndDate or value,
+     * then set it to the amended value from the amendment
+     * hence ensuring that the latest amendment for each field is used
+     */
+    if (!updatedFields.coverEndDate && amendment.coverEndDate) {
+      amendedValues.coverEndDate = amendment.coverEndDate;
+    }
+    if (!updatedFields.value && amendment.value) {
+      amendedValues.value = amendment.value;
+    }
+
+    return amendedValues;
+  });
+};

--- a/libs/common/src/helpers/monetary-value.test.ts
+++ b/libs/common/src/helpers/monetary-value.test.ts
@@ -1,4 +1,4 @@
-import { getFormattedMonetaryValue, getMonetaryValueAsNumber } from './monetary-value';
+import { getFormattedMonetaryValue, getFormattedMonetaryValueWithoutDecimals, getMonetaryValueAsNumber } from './monetary-value';
 
 describe('monetary value helpers', () => {
   describe('getFormattedMonetaryValue', () => {
@@ -57,6 +57,68 @@ describe('monetary value helpers', () => {
 
       // Act
       const formattedValue = getFormattedMonetaryValue(value);
+
+      // Assert
+      expect(formattedValue).toEqual(expectedFormattedValue);
+    });
+  });
+
+  describe('getFormattedMonetaryValueWithoutDecimals', () => {
+    it('should format the given value as a string with thousands separated by comma', () => {
+      // Arrange
+      const value = 1234567;
+      const expectedFormattedValue = '1,234,567';
+
+      // Act
+      const formattedValue = getFormattedMonetaryValueWithoutDecimals(value);
+
+      // Assert
+      expect(formattedValue).toEqual(expectedFormattedValue);
+    });
+
+    it('should format the given value as a string with thousands separated by comma rounded up when has decimal places', () => {
+      // Arrange
+      const value = 1234567.85;
+      const expectedFormattedValue = '1,234,568';
+
+      // Act
+      const formattedValue = getFormattedMonetaryValueWithoutDecimals(value);
+
+      // Assert
+      expect(formattedValue).toEqual(expectedFormattedValue);
+    });
+
+    it('should format the given value as a string with thousands separated by comma rounded down when has decimal places under 0.5', () => {
+      // Arrange
+      const value = 1234567.41;
+      const expectedFormattedValue = '1,234,567';
+
+      // Act
+      const formattedValue = getFormattedMonetaryValueWithoutDecimals(value);
+
+      // Assert
+      expect(formattedValue).toEqual(expectedFormattedValue);
+    });
+
+    it('should format the given value as a string without thousand seperators when under 1000', () => {
+      // Arrange
+      const value = 250;
+      const expectedFormattedValue = '250';
+
+      // Act
+      const formattedValue = getFormattedMonetaryValueWithoutDecimals(value);
+
+      // Assert
+      expect(formattedValue).toEqual(expectedFormattedValue);
+    });
+
+    it('should format the given value as a string without thousand seperators when 0', () => {
+      // Arrange
+      const value = 0;
+      const expectedFormattedValue = '0';
+
+      // Act
+      const formattedValue = getFormattedMonetaryValueWithoutDecimals(value);
 
       // Assert
       expect(formattedValue).toEqual(expectedFormattedValue);

--- a/libs/common/src/helpers/monetary-value.ts
+++ b/libs/common/src/helpers/monetary-value.ts
@@ -12,6 +12,18 @@ export const getFormattedMonetaryValue = (monetaryValue: number): string => {
 };
 
 /**
+ * Formats the value without decimals and with thousands separators
+ * @param monetaryValue the value to format
+ * @returns the formatted value
+ */
+export const getFormattedMonetaryValueWithoutDecimals = (monetaryValue: number): string => {
+  const formatter = new Intl.NumberFormat('en-GB', {
+    maximumFractionDigits: 0,
+  });
+  return formatter.format(monetaryValue);
+};
+
+/**
  * Converts a monetary value string with commas to a number
  * @param monetaryValue the string value to convert (e.g. "1,234.56")
  * @returns the numeric value without commas (e.g. 1234.56)

--- a/portal-api/api-tests/fixtures/gef/facility-update.js
+++ b/portal-api/api-tests/fixtures/gef/facility-update.js
@@ -1,0 +1,24 @@
+import { CURRENCY } from '@ukef/dtfs2-common';
+
+import { FACILITY_PAYMENT_TYPE } from '../../../src/v1/gef/enums';
+
+export const facilityUpdate = {
+  hasBeenIssued: true,
+  name: 'test',
+  shouldCoverStartOnSubmission: true,
+  coverStartDate: null,
+  coverEndDate: '2015-01-01T00:00:00.000Z',
+  monthsOfCover: 12,
+  details: ['test'],
+  detailsOther: null,
+  currency: { id: CURRENCY.GBP },
+  value: '10000000',
+  coverPercentage: 80,
+  interestPercentage: 40,
+  paymentType: 'Monthly',
+  feeType: FACILITY_PAYMENT_TYPE.IN_ADVANCE,
+  feeFrequency: 'Monthly',
+  dayCountBasis: 365,
+  coverDateConfirmed: true,
+  ukefFacilityId: 1234,
+};

--- a/portal-api/api-tests/v1/gef/facilities/facilities.put.api-test.js
+++ b/portal-api/api-tests/v1/gef/facilities/facilities.put.api-test.js
@@ -19,6 +19,7 @@ const { calculateUkefExposure, calculateGuaranteeFee } = require('../../../../sr
 const { DB_COLLECTIONS } = require('../../../fixtures/constants');
 const { generateANewFacility } = require('./helpers/generate-a-new-facility.tests');
 const { generateACompleteFacilityUpdate } = require('./helpers/generate-a-facility-update.tests');
+const { facilityUpdate } = require('../../../fixtures/gef/facility-update');
 
 jest.mock('@ukef/dtfs2-common', () => ({
   ...jest.requireActual('@ukef/dtfs2-common'),
@@ -172,36 +173,21 @@ describe(baseUrl, () => {
 
       it('name is required if hasBeenIssued', async () => {
         const { details } = newFacility;
-        const update = {
-          hasBeenIssued: true,
-          name: null,
-          shouldCoverStartOnSubmission: true,
-          coverStartDate: null,
-          coverEndDate: '2015-01-01T00:00:00.000Z',
-          monthsOfCover: 12,
-          details: ['test'],
-          detailsOther: null,
-          currency: { id: CURRENCY.GBP },
-          value: '10000000',
-          coverPercentage: 80,
-          interestPercentage: 40,
-          paymentType: 'Monthly',
-          feeType: FACILITY_PAYMENT_TYPE.IN_ADVANCE,
-          feeFrequency: 'Monthly',
-          dayCountBasis: 365,
-        };
+
         const item = await as(aMaker).post({ dealId: mockApplication.body._id, type: FACILITY_TYPE.CASH, hasBeenIssued: false }).to(baseUrl);
-        const { status, body } = await as(aMaker).put(update).to(`${baseUrl}/${item.body.details._id}`);
+
+        const { status, body } = await as(aMaker).put(facilityUpdate).to(`${baseUrl}/${item.body.details._id}`);
+
         const expected = {
           status: CONSTANTS.DEAL.DEAL_STATUS.IN_PROGRESS,
           details: {
             ...details,
-            ...update,
+            ...facilityUpdate,
             updatedAt: expect.any(Number),
             value: expect.any(Number),
             monthsOfCover: null, // this is nullified if `hasBeenIssued` is true
-            ukefExposure: calculateUkefExposure(update, {}),
-            guaranteeFee: calculateGuaranteeFee(update, {}),
+            ukefExposure: calculateUkefExposure(facilityUpdate, {}),
+            guaranteeFee: calculateGuaranteeFee(facilityUpdate, {}),
           },
           validation: {
             required: addFacilityEndDateToValidation(['name'], dealVersion),


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

This PR displays the latest amendment values for cover end date and facility value on the application details/preview page (for each facility)

## Resolution :heavy_check_mark:

* Added new portal-api and central-api route to get acknowledged amendment
* Updated portal-api getAllFacilities controller to return latest amendment values for value or coverEndDate
* Added new TfmFacilitiesRepo call to get acknowledged portal amendments
* Updated and added tests
* Added e2e tests

## Screenshot :camera_flash:

![image](https://github.com/user-attachments/assets/63cacf14-23be-4dbc-8429-8166d497a2e4)

![image](https://github.com/user-attachments/assets/d41e963f-1fa8-4d65-a1ac-7bead9207390)

