### PR TITLE
fix(DTFS2-7969): updated cookie to 0.7.0 for csurf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13167,9 +13167,9 @@
       }
     },
     "node_modules/csurf/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+      "integrity": "sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -89,5 +89,10 @@
     "node": ">=23.4.0",
     "npm": ">=10.8.2"
   },
-  "engineStrict": true
+  "engineStrict": true,
+  "overrides": {
+    "csurf": {
+      "cookie": "0.7.0"
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

[CVE-2024-47764](https://www.mend.io/vulnerability-database/CVE-2024-47764) was raised against `cookie` NPM package for version `0.4.0` being used by `csurf` (depreciated package).

## Resolution :heavy_check_mark:

* Forceful override of dependency to cookie `0.7.0` using NPM overrides.
