### PR TITLE
fix(DTFS2-7986): getTfmDeal conditional check on portal

### DIFF
--- a/azure-functions/acbs-function/tsconfig.json
+++ b/azure-functions/acbs-function/tsconfig.json
@@ -50,7 +50,7 @@
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
     "importHelpers": true /* Allow importing helper functions from tslib once per project, instead of including them per-file. */,
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */

--- a/gef-ui/server/controllers/application-details/canIssueUnissuedFacilities.test.js
+++ b/gef-ui/server/controllers/application-details/canIssueUnissuedFacilities.test.js
@@ -261,5 +261,26 @@ describe('canIssueUnissuedFacilities', () => {
       // Assert
       expect(response).toBe(false);
     });
+
+    it('should return false if deal has not yet been submitted to the TFM', () => {
+      // Arrange
+      const tfmDeal = null;
+      const portalDeal = mockPortalDeal;
+      const unissuedFacilitiesPresent = true;
+      const canResubmitIssueFacilities = [];
+      const hasUkefDecisionAccepted = false;
+
+      // Act
+      const response = canIssueUnissuedFacilities({
+        portalDeal,
+        tfmDeal,
+        unissuedFacilitiesPresent,
+        canResubmitIssueFacilities,
+        hasUkefDecisionAccepted,
+      });
+
+      // Assert
+      expect(response).toBe(false);
+    });
   });
 });

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -88,7 +88,7 @@ const buildBody = async (app, previewMode, user) => {
     const canResubmitIssueFacilities = canResubmitIssuedFacilities(app);
     const hasUkefDecisionAccepted = app.ukefDecisionAccepted ? app.ukefDecisionAccepted : false;
     const dealCancelledStatus = [DEAL_STATUS.CANCELLED, DEAL_STATUS.PENDING_CANCELLATION];
-    let tfmDeal = null;
+    let tfmDeal;
 
     if (hasBeenSubmittedToTfm(app)) {
       tfmDeal = await getTfmDeal({ dealId: app._id, userToken: apiToken });

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -1,5 +1,12 @@
 const startCase = require('lodash/startCase');
-const { DEAL_TYPE, timeZoneConfig, DEAL_STATUS, PORTAL_AMENDMENT_INPROGRESS_STATUSES, PORTAL_AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
+const {
+  DEAL_TYPE,
+  timeZoneConfig,
+  DEAL_STATUS,
+  PORTAL_AMENDMENT_INPROGRESS_STATUSES,
+  PORTAL_AMENDMENT_STATUS,
+  hasBeenSubmittedToTfm,
+} = require('@ukef/dtfs2-common');
 const { getTfmDeal, getPortalAmendmentsOnDeal, getFacilities, getFacility } = require('../../services/api');
 const { canIssueUnissuedFacilities } = require('./canIssueUnissuedFacilities');
 const {
@@ -81,7 +88,11 @@ const buildBody = async (app, previewMode, user) => {
     const canResubmitIssueFacilities = canResubmitIssuedFacilities(app);
     const hasUkefDecisionAccepted = app.ukefDecisionAccepted ? app.ukefDecisionAccepted : false;
     const dealCancelledStatus = [DEAL_STATUS.CANCELLED, DEAL_STATUS.PENDING_CANCELLATION];
-    const tfmDeal = await getTfmDeal({ dealId: app._id, userToken: apiToken });
+    let tfmDeal = null;
+
+    if (hasBeenSubmittedToTfm(app)) {
+      tfmDeal = await getTfmDeal({ dealId: app._id, userToken: apiToken });
+    }
 
     const mapSummaryParams = {
       app,

--- a/gef-ui/server/helpers/map-facility-application-details.ts
+++ b/gef-ui/server/helpers/map-facility-application-details.ts
@@ -2,9 +2,9 @@ import { Role, PORTAL_AMENDMENT_INPROGRESS_STATUSES, DEAL_STATUS } from '@ukef/d
 import { STAGE } from '../constants';
 import { addAmendmentParamsToFacility } from './add-amendment-params-to-facility';
 import { canUserAmendIssuedFacilities } from '../utils/facility-amendments.helper';
-import { Deal } from '../types/deal';
 import { Facility, FacilityParams } from '../types/facility';
 import { AmendmentDetailsUrlAndText, AmendmentInProgressParams } from '../types/portal-amendments';
+import { Deal } from '../types/deal';
 
 export type AmendmentDetailsFacilityParams = {
   readyForCheckerAmendmentDetailsUrlAndText: AmendmentDetailsUrlAndText[];

--- a/gef-ui/tsconfig.json
+++ b/gef-ui/tsconfig.json
@@ -50,7 +50,7 @@
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
     "importHelpers": true /* Allow importing helper functions from tslib once per project, instead of including them per-file. */,
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */

--- a/libs/common/src/helpers/has-been-submitted-to-tfm.test.ts
+++ b/libs/common/src/helpers/has-been-submitted-to-tfm.test.ts
@@ -1,0 +1,205 @@
+import { ObjectId } from 'mongodb';
+import { hasBeenSubmittedToTfm } from './has-been-submitted-to-tfm';
+import { Deal } from '../types';
+import { DEAL_SUBMISSION_TYPE, DEAL_TYPE } from '../constants';
+
+describe('hasBeenSubmittedToTfm', () => {
+  describe('BSS/EWCS', () => {
+    it('should return true if the submission count is greater than zero for an AIN', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.AIN,
+        dealType: DEAL_TYPE.BSS_EWCS,
+        details: {
+          ukefDealId: '0030113304',
+          submissionCount: 1,
+        },
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(true);
+    });
+
+    it('should return true if the submission count is greater than zero for a MIA', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.MIA,
+        dealType: DEAL_TYPE.BSS_EWCS,
+        details: {
+          ukefDealId: '0030113304',
+          submissionCount: 1,
+        },
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(true);
+    });
+
+    it('should return true if the submission count is greater than zero for a MIN', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.MIN,
+        dealType: DEAL_TYPE.BSS_EWCS,
+        details: {
+          ukefDealId: '0030113304',
+          submissionCount: 2,
+        },
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(true);
+    });
+
+    it('should return false if the submission count is zero for a AIN', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.AIN,
+        dealType: DEAL_TYPE.BSS_EWCS,
+        details: {
+          ukefDealId: '0030113304',
+          submissionCount: 0,
+        },
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(false);
+    });
+
+    it('should return false if the submission count is zero for a MIA', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.MIA,
+        dealType: DEAL_TYPE.BSS_EWCS,
+        details: {
+          ukefDealId: '0030113304',
+          submissionCount: 0,
+        },
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(false);
+    });
+  });
+
+  describe('GEF', () => {
+    it('should return true if the submission count is greater than zero for an AIN', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.AIN,
+        dealType: DEAL_TYPE.GEF,
+        ukefDealId: '0030113304',
+        submissionCount: 1,
+        eligibility: {},
+        exporter: {},
+        portalActivities: [],
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(true);
+    });
+
+    it('should return true if the submission count is greater than zero for a MIA', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.MIA,
+        dealType: DEAL_TYPE.GEF,
+        ukefDealId: '0030113304',
+        submissionCount: 1,
+        eligibility: {},
+        exporter: {},
+        portalActivities: [],
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(true);
+    });
+
+    it('should return true if the submission count is greater than zero for a MIN', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.MIN,
+        dealType: DEAL_TYPE.GEF,
+        ukefDealId: '0030113304',
+        submissionCount: 2,
+        eligibility: {},
+        exporter: {},
+        portalActivities: [],
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(true);
+    });
+
+    it('should return false if the submission count is zero for a AIN', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.AIN,
+        dealType: DEAL_TYPE.GEF,
+        ukefDealId: '0030113304',
+        submissionCount: 0,
+        eligibility: {},
+        exporter: {},
+        portalActivities: [],
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(false);
+    });
+
+    it('should return false if the submission count is zero for a MIA', () => {
+      // Arrange
+      const mockDeal: Deal = {
+        _id: new ObjectId('5ce819935e539c343f141ece'),
+        submissionType: DEAL_SUBMISSION_TYPE.MIA,
+        dealType: DEAL_TYPE.GEF,
+        ukefDealId: '0030113304',
+        submissionCount: 0,
+        eligibility: {},
+        exporter: {},
+        portalActivities: [],
+      };
+
+      // Act
+      const response = hasBeenSubmittedToTfm(mockDeal);
+
+      // Assert
+      expect(response).toBe(false);
+    });
+  });
+});

--- a/libs/common/src/helpers/has-been-submitted-to-tfm.ts
+++ b/libs/common/src/helpers/has-been-submitted-to-tfm.ts
@@ -1,0 +1,23 @@
+import { Deal } from '../types';
+import { DEAL_TYPE } from '../constants';
+
+/**
+ * Determines whether a deal has been submitted to TFM based on its submission count property value.
+ *
+ * For GEF deals, uses the `submissionCount` property directly from the deal.
+ * For other deal types i.e. BSS/EWCS, uses the `submissionCount` from the deal's `details`.
+ * Returns `true` if the submission count is greater than 0, otherwise `false`.
+ *
+ * @param deal - The deal object to check submission status for.
+ * @returns `true` if the deal has been submitted to TFM, otherwise `false`.
+ */
+export const hasBeenSubmittedToTfm = (deal: Deal): boolean => {
+  // Ascertain submission count by deal type
+  const submissionCount = deal.dealType === DEAL_TYPE.GEF ? deal.submissionCount : deal.details.submissionCount;
+
+  /**
+   * If the deal submission count is 0 (with maker or checker).
+   * Then return false otherwise true.
+   */
+  return Boolean(submissionCount);
+};

--- a/libs/common/src/helpers/has-been-submitted-to-tfm.ts
+++ b/libs/common/src/helpers/has-been-submitted-to-tfm.ts
@@ -13,7 +13,8 @@ import { DEAL_TYPE } from '../constants';
  */
 export const hasBeenSubmittedToTfm = (deal: Deal): boolean => {
   // Ascertain submission count by deal type
-  const submissionCount = deal.dealType === DEAL_TYPE.GEF ? deal.submissionCount : deal.details.submissionCount;
+  const isGef = deal.dealType === DEAL_TYPE.GEF;
+  const submissionCount = isGef ? deal.submissionCount : deal.details.submissionCount;
 
   /**
    * If the deal submission count is 0 (with maker or checker).

--- a/libs/common/src/helpers/index.ts
+++ b/libs/common/src/helpers/index.ts
@@ -32,3 +32,4 @@ export * from './strip-html';
 export * from './is-gov-notify-mocked';
 export * from './create-amendment-reference-number';
 export * from './map-facility-fields-to-amendment-fields';
+export * from './has-been-submitted-to-tfm';

--- a/libs/common/src/types/mongo-db-models/deals.ts
+++ b/libs/common/src/types/mongo-db-models/deals.ts
@@ -13,6 +13,7 @@ export interface BssEwcsDeal extends BaseDeal {
   dealType: typeof DEAL_TYPE.BSS_EWCS;
   details: {
     ukefDealId: string;
+    submissionCount: number;
   };
 }
 
@@ -22,6 +23,7 @@ export interface GefDeal extends BaseDeal {
   eligibility: AnyObject;
   exporter: AnyObject;
   portalActivities: PortalActivity[];
+  submissionCount: number;
 }
 
 /**

--- a/portal/tsconfig.json
+++ b/portal/tsconfig.json
@@ -50,7 +50,7 @@
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true,                                   /* Disable emitting files from a compilation. */
     "importHelpers": true /* Allow importing helper functions from tslib once per project, instead of including them per-file. */,
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

`getTfmDeal` was polluting the logs from `gef-ui` and `portal-api` for deals which have not yet been submitted to TFM.

## Resolution :heavy_check_mark:

* Introduced a new central helper function `hasBeenSubmittedToTfm`, which ascertain submission to TFM based on deal's submission count property values.
* Add new unit test cases for `hasBeenSubmittedToTfm` helper function.

## Miscellaneous :heavy_plus_sign:

* Updated test cases.
* Updated various `tsconfig.json` configurations as per warnings.
* Updated central deal type, added `submissionCount` property to both `GEF` and `BSS/EWCS` deal types.
