### PR TITLE
feat(DTFS2-7805): update checker filter - amendment in progress, deal cancelled

### DIFF
--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/dashboard-in-progress-amendment-deal-cancelled.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/dashboard-in-progress-amendment-deal-cancelled.spec.js
@@ -1,0 +1,79 @@
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+import dashboardDeals from '../../../../../../../portal/cypress/e2e/pages/dashboardDeals';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+
+const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
+
+const CHANGED_FACILITY_VALUE = 20000;
+
+context('Amendments - Dashboard - Dashboard page when amendment is in-progress but deal is cancelled', () => {
+  let dealId;
+  let facilityId;
+
+  const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+        cy.login(BANK1_MAKER1);
+        cy.saveSession();
+        cy.visit(relative(`/gef/application-details/${dealId}`));
+
+        applicationPreview.makeAChangeButton(facilityId).click();
+
+        cy.makerSubmitPortalAmendmentForReview({ changedFacilityValue: CHANGED_FACILITY_VALUE, facilityValueExists: true });
+
+        cy.clearSessionCookies();
+
+        cy.visit(TFM_URL);
+
+        cy.tfmLogin(PIM_USER_1);
+
+        const tfmDealPage = `${TFM_URL}/case/${dealId}/deal`;
+        cy.visit(tfmDealPage);
+
+        cy.submitDealCancellation({ dealId });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  describe('Maker', () => {
+    beforeEach(() => {
+      cy.clearSessionCookies();
+      cy.login(BANK1_MAKER1);
+    });
+
+    it('should show the dashboard deals link for the deal', () => {
+      dashboardDeals.row.link(dealId).should('exist');
+    });
+  });
+
+  describe('Checker', () => {
+    beforeEach(() => {
+      cy.clearSessionCookies();
+      cy.login(BANK1_CHECKER1);
+    });
+
+    it('shouldnot  show the dashboard deals link for the deal', () => {
+      dashboardDeals.row.link(dealId).should('not.exist');
+    });
+  });
+});

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/dashboard-in-progress-amendment-deal-pending-cancellation.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/dashboard-in-progress-amendment-deal-pending-cancellation.spec.js
@@ -1,0 +1,82 @@
+import relative from '../../../../relativeURL';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+import dashboardDeals from '../../../../../../../portal/cypress/e2e/pages/dashboardDeals';
+import { tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+
+const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
+
+const CHANGED_FACILITY_VALUE = 20000;
+
+context('Amendments - Dashboard - Dashboard page when amendment is in-progress but deal is pending cancellation', () => {
+  let dealId;
+  let facilityId;
+
+  const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+        cy.login(BANK1_MAKER1);
+        cy.saveSession();
+        cy.visit(relative(`/gef/application-details/${dealId}`));
+
+        applicationPreview.makeAChangeButton(facilityId).click();
+
+        cy.makerSubmitPortalAmendmentForReview({ changedFacilityValue: CHANGED_FACILITY_VALUE, facilityValueExists: true });
+
+        cy.clearSessionCookies();
+
+        cy.visit(TFM_URL);
+
+        cy.tfmLogin(PIM_USER_1);
+
+        const tfmDealPage = `${TFM_URL}/case/${dealId}/deal`;
+        cy.visit(tfmDealPage);
+
+        const effectiveDate = tomorrow.date;
+
+        cy.submitDealCancellation({ dealId, effectiveDate });
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  describe('Maker', () => {
+    beforeEach(() => {
+      cy.clearSessionCookies();
+      cy.login(BANK1_MAKER1);
+    });
+
+    it('should show the dashboard deals link for the deal', () => {
+      dashboardDeals.row.link(dealId).should('exist');
+    });
+  });
+
+  describe('Checker', () => {
+    beforeEach(() => {
+      cy.clearSessionCookies();
+      cy.login(BANK1_CHECKER1);
+    });
+
+    it('shouldnot  show the dashboard deals link for the deal', () => {
+      dashboardDeals.row.link(dealId).should('not.exist');
+    });
+  });
+});

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.ff-test.js
@@ -1,6 +1,6 @@
-import { PORTAL_AMENDMENT_STATUS, ROLES, CHECKERS_AMENDMENTS_DEAL_ID } from '@ukef/dtfs2-common';
+import { PORTAL_AMENDMENT_STATUS, ROLES, CHECKERS_AMENDMENTS_DEAL_ID, DEAL_STATUS } from '@ukef/dtfs2-common';
 import { dashboardDealsFiltersQuery } from './deals-filters-query';
-import { STATUS } from '../../../constants';
+import { STATUS, FIELD_NAMES } from '../../../constants';
 import getCheckersApprovalAmendmentDealIds from '../../../helpers/getCheckersApprovalAmendmentDealIds';
 
 jest.mock('../../../helpers/getCheckersApprovalAmendmentDealIds');
@@ -19,20 +19,24 @@ describe('controllers/dashboard/deals - filters query', () => {
       // Arrange
       const mockFilters = [];
       const mockDealIds = ['deal1', 'deal2'];
-      const expected = {
-        AND: [
-          { 'bank.id': mockUser.bank.id },
-          {
-            OR: [{ status: STATUS.DEAL.READY_FOR_APPROVAL }, { [CHECKERS_AMENDMENTS_DEAL_ID]: mockDealIds }],
-          },
-        ],
-      };
 
       mockUser.roles = [CHECKER];
       getCheckersApprovalAmendmentDealIds.mockResolvedValue(mockDealIds);
 
       // Act
       const result = await dashboardDealsFiltersQuery(mockFilters, mockUser);
+
+      const expected = {
+        AND: [
+          { 'bank.id': mockUser.bank.id },
+          {
+            OR: [
+              { status: STATUS.DEAL.READY_FOR_APPROVAL },
+              { AND: [{ [CHECKERS_AMENDMENTS_DEAL_ID]: mockDealIds }, { [FIELD_NAMES.DEAL.STATUS]: DEAL_STATUS.UKEF_ACKNOWLEDGED }] },
+            ],
+          },
+        ],
+      };
 
       // Assert
       expect(result).toEqual(expected);

--- a/portal/server/controllers/dashboard/deals/deals-filters-query.js
+++ b/portal/server/controllers/dashboard/deals/deals-filters-query.js
@@ -1,4 +1,4 @@
-const { CHECKERS_AMENDMENTS_DEAL_ID, isPortalFacilityAmendmentsFeatureFlagEnabled } = require('@ukef/dtfs2-common');
+const { CHECKERS_AMENDMENTS_DEAL_ID, isPortalFacilityAmendmentsFeatureFlagEnabled, DEAL_STATUS } = require('@ukef/dtfs2-common');
 const CONSTANTS = require('../../../constants');
 const CONTENT_STRINGS = require('../../../content-strings');
 const { getUserRoles, isSuperUser, getCheckersApprovalAmendmentDealIds } = require('../../../helpers');
@@ -36,7 +36,17 @@ const dashboardDealsFiltersQuery = async (filters, user, userToken) => {
       const checkersApprovalAmendmentDealIds = await getCheckersApprovalAmendmentDealIds(userToken);
 
       if (checkersApprovalAmendmentDealIds?.length) {
-        orQuery.OR.push({ [CHECKERS_AMENDMENTS_DEAL_ID]: checkersApprovalAmendmentDealIds });
+        /**
+         * add and query to the orQuery
+         * If there are amendments ready for checkers approval,
+         * AND if the deal status is UKEF_ACKNOWLEDGED,
+         * hence cancelled or pending cancellation deals will not show for checker when there are amendments ready for approval.
+         */
+        const andQuery = {
+          AND: [{ [CHECKERS_AMENDMENTS_DEAL_ID]: checkersApprovalAmendmentDealIds }, { [CONSTANTS.FIELD_NAMES.DEAL.STATUS]: DEAL_STATUS.UKEF_ACKNOWLEDGED }],
+        };
+
+        orQuery.OR.push(andQuery);
       }
     }
 


### PR DESCRIPTION
# Pull Request

## Introduction :pencil2:

This PR updates the filter for dashboard deals when the deal is cancelled and an amendment is in progress - deal should not show for checker

## Resolution :heavy_check_mark:

* Added AND to query for checker when amendment is in progress
* Added deal status to only be acknowledged
* Updated tests
* Added e2e tests

## Miscellaneous :heavy_plus_sign:

List any additional fixes or improvements.

## Screenshot :camera_flash:
