### PR TITLE
feat(DTFS2-8009): added white oak bank

### DIFF
--- a/e2e-tests/portal/cypress/e2e/journeys/homepage/content.spec.js
+++ b/e2e-tests/portal/cypress/e2e/journeys/homepage/content.spec.js
@@ -30,6 +30,7 @@ context('Portal homepage', () => {
     login.banks().contains('Shawbrook Bank');
     login.banks().contains('ICICI');
     login.banks().contains('ABC Bank');
+    login.banks().contains('LDF Operations (trading as White Oak)');
   });
 
   it('Ensure product text is visible on the portal login page', () => {

--- a/portal/templates/_partials/before-you-start.njk
+++ b/portal/templates/_partials/before-you-start.njk
@@ -20,6 +20,7 @@
   <li>Shawbrook Bank</li>
   <li>ICICI</li>
   <li>ABC Bank</li>
+  <li>LDF Operations (trading as White Oak)</li>
 </ul>
 
 <p>Guarantees are provided by UK Export Finance under the terms of the master guarantee agreement (MGA) for either the:</p>


### PR DESCRIPTION
# Introduction :pencil2:

LDF Operations (trading as White Oak) needs to be added to Portal, so they can apply for GEF guarantees.

## Resolution :heavy_check_mark:

* Added `LDF Operations (trading as White Oak)` to the portal and Cypress E2E test.