### PR TITLE
feat(DTFS2-7805): added banner for in progress amendments on pending cancellation deal 

### DIFF
--- a/e2e-tests/gef/cypress/e2e/pages/application-preview.js
+++ b/e2e-tests/gef/cypress/e2e/pages/application-preview.js
@@ -13,6 +13,7 @@ const applicationPreview = {
   amendmentDetailsFurtherMakersInputLink: (index) => cy.get(`[data-cy="amendment-details-further-makers-input-${index}"]`),
 
   amendmentsAbandonedDealCancelledBanner: () => cy.get('[data-cy="amendments-abandoned-deal-cancelled-banner"]'),
+  amendmentsAbandonedDealPendingCancellationBanner: () => cy.get('[data-cy="amendments-abandoned-deal-pending-cancellation-banner"]'),
 
   ukefReview: () => cy.get('[data-cy="ukef-review"]'),
   ukefReviewLink: () => cy.get('[data-cy="ukef-review-link"]'),

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-further-makers-input-pending-cancellation-deal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-further-makers-input-pending-cancellation-deal.spec.js
@@ -4,12 +4,13 @@ import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/ge
 import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
 import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+import { tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
 
 const CHANGED_FACILITY_VALUE = 20000;
 
-context('Amendments - Application details - application preview page when deal status is "Cancelled" and amendment is "Further makers input"', () => {
+context('Amendments - Application details - application preview page when deal status is "Cancelled" and amendment is "Ready for checkers approval"', () => {
   let applicationDetailsUrl;
   let dealId;
   let facilityId;
@@ -50,6 +51,8 @@ context('Amendments - Application details - application preview page when deal s
           cy.clickSubmitButton();
         });
 
+        cy.clearSessionCookies();
+
         cy.visit(TFM_URL);
 
         cy.tfmLogin(PIM_USER_1);
@@ -57,7 +60,9 @@ context('Amendments - Application details - application preview page when deal s
         const tfmDealPage = `${TFM_URL}/case/${dealId}/deal`;
         cy.visit(tfmDealPage);
 
-        cy.submitDealCancellation({ dealId });
+        const effectiveDate = tomorrow.date;
+
+        cy.submitDealCancellation({ dealId, effectiveDate });
       });
     });
   });
@@ -87,16 +92,16 @@ context('Amendments - Application details - application preview page when deal s
       applicationPreview.amendmentInProgress().should('not.exist');
     });
 
-    it('should display the amendments abandoned deal cancelled banner', () => {
-      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('exist');
+    it('should display the amendments abandoned deal pending cancellation banner', () => {
+      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('exist');
       cy.assertText(
-        applicationPreview.amendmentsAbandonedDealCancelledBanner(),
-        'Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.',
+        applicationPreview.amendmentsAbandonedDealPendingCancellationBanner(),
+        'Any amendments in progress have been abandoned by UKEF, as the deal is pending cancellation.',
       );
     });
 
-    it('should not display the amendments abandoned deal pending cancellation banner', () => {
-      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('not.exist');
+    it('should not display the amendments abandoned deal cancelled banner', () => {
+      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('not.exist');
     });
   });
 
@@ -120,16 +125,16 @@ context('Amendments - Application details - application preview page when deal s
       applicationPreview.amendmentInProgress().should('not.exist');
     });
 
-    it('should display the amendments abandoned deal cancelled banner', () => {
-      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('exist');
+    it('should display the amendments abandoned deal pending cancellation banner', () => {
+      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('exist');
       cy.assertText(
-        applicationPreview.amendmentsAbandonedDealCancelledBanner(),
-        'Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.',
+        applicationPreview.amendmentsAbandonedDealPendingCancellationBanner(),
+        'Any amendments in progress have been abandoned by UKEF, as the deal is pending cancellation.',
       );
     });
 
-    it('should not display the amendments abandoned deal pending cancellation banner', () => {
-      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('not.exist');
+    it('should not display the amendments abandoned deal cancelled banner', () => {
+      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('not.exist');
     });
   });
 });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-ready-for-checker-cancelled-deal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-ready-for-checker-cancelled-deal.spec.js
@@ -87,6 +87,10 @@ context('Amendments - Application details - application preview page when deal s
         'Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.',
       );
     });
+
+    it('should not display the amendments abandoned deal pending cancellation banner', () => {
+      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('not.exist');
+    });
   });
 
   describe('Checker', () => {
@@ -115,6 +119,10 @@ context('Amendments - Application details - application preview page when deal s
         applicationPreview.amendmentsAbandonedDealCancelledBanner(),
         'Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.',
       );
+    });
+
+    it('should not display the amendments abandoned deal pending cancellation banner', () => {
+      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('not.exist');
     });
   });
 });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-ready-for-checker-pending-cancellation-deal.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/application-details-amendment-ready-for-checker-pending-cancellation-deal.spec.js
@@ -4,16 +4,16 @@ import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/ge
 import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
 import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
 import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+import { tomorrow } from '../../../../../../../e2e-fixtures/dateConstants';
 
 const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
 
 const CHANGED_FACILITY_VALUE = 20000;
 
-context('Amendments - Application details - application preview page when deal status is "Cancelled" and amendment is "Further makers input"', () => {
+context('Amendments - Application details - application preview page when deal status is "Cancelled" and amendment is "Ready for checkers approval"', () => {
   let applicationDetailsUrl;
   let dealId;
   let facilityId;
-  let amendmentDetailsUrl;
 
   const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
 
@@ -36,19 +36,13 @@ context('Amendments - Application details - application preview page when deal s
 
         applicationPreview.makeAChangeButton(facilityId).click();
 
-        cy.getAmendmentIdFromUrl().then((amendmentId) => {
-          amendmentDetailsUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/amendment-details`;
-          cy.makerMakesPortalAmendmentRequest({
-            facilityValueExists: true,
-            changedFacilityValue: CHANGED_FACILITY_VALUE,
-          });
-          cy.clickSubmitButton();
-
-          cy.login(BANK1_CHECKER1);
-          cy.visit(amendmentDetailsUrl);
-          cy.clickReturnToMakerButton();
-          cy.clickSubmitButton();
+        cy.makerMakesPortalAmendmentRequest({
+          facilityValueExists: true,
+          changedFacilityValue: CHANGED_FACILITY_VALUE,
         });
+        cy.clickSubmitButton();
+
+        cy.clearSessionCookies();
 
         cy.visit(TFM_URL);
 
@@ -57,7 +51,9 @@ context('Amendments - Application details - application preview page when deal s
         const tfmDealPage = `${TFM_URL}/case/${dealId}/deal`;
         cy.visit(tfmDealPage);
 
-        cy.submitDealCancellation({ dealId });
+        const effectiveDate = tomorrow.date;
+
+        cy.submitDealCancellation({ dealId, effectiveDate });
       });
     });
   });
@@ -87,16 +83,16 @@ context('Amendments - Application details - application preview page when deal s
       applicationPreview.amendmentInProgress().should('not.exist');
     });
 
-    it('should display the amendments abandoned deal cancelled banner', () => {
-      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('exist');
+    it('should display the amendments abandoned deal pending cancellation banner', () => {
+      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('exist');
       cy.assertText(
-        applicationPreview.amendmentsAbandonedDealCancelledBanner(),
-        'Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.',
+        applicationPreview.amendmentsAbandonedDealPendingCancellationBanner(),
+        'Any amendments in progress have been abandoned by UKEF, as the deal is pending cancellation.',
       );
     });
 
-    it('should not display the amendments abandoned deal pending cancellation banner', () => {
-      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('not.exist');
+    it('should not display the amendments abandoned deal cancelled banner', () => {
+      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('not.exist');
     });
   });
 
@@ -120,16 +116,16 @@ context('Amendments - Application details - application preview page when deal s
       applicationPreview.amendmentInProgress().should('not.exist');
     });
 
-    it('should display the amendments abandoned deal cancelled banner', () => {
-      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('exist');
+    it('should display the amendments abandoned deal pending cancellation banner', () => {
+      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('exist');
       cy.assertText(
-        applicationPreview.amendmentsAbandonedDealCancelledBanner(),
-        'Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.',
+        applicationPreview.amendmentsAbandonedDealPendingCancellationBanner(),
+        'Any amendments in progress have been abandoned by UKEF, as the deal is pending cancellation.',
       );
     });
 
-    it('should not display the amendments abandoned deal pending cancellation banner', () => {
-      applicationPreview.amendmentsAbandonedDealPendingCancellationBanner().should('not.exist');
+    it('should not display the amendments abandoned deal cancelled banner', () => {
+      applicationPreview.amendmentsAbandonedDealCancelledBanner().should('not.exist');
     });
   });
 });

--- a/gef-ui/component-tests/includes/application-preview/amendments-abandoned-deal-cancelled.component-test.ts
+++ b/gef-ui/component-tests/includes/application-preview/amendments-abandoned-deal-cancelled.component-test.ts
@@ -20,61 +20,124 @@ describe(page, () => {
   let wrapper;
 
   const amendmentsAbandonedDealCancelledBanner = `[data-cy="amendments-abandoned-deal-cancelled-banner"]`;
+  const amendmentsAbandonedDealPendingCancellationBanner = `[data-cy="amendments-abandoned-deal-pending-cancellation-banner"]`;
 
-  describe('cancelledDealWithAmendments does not exist', () => {
-    it(`should NOT render the banner`, () => {
-      wrapper = render({
-        ...params,
+  describe('cancelledDealWithAmendments', () => {
+    describe('cancelledDealWithAmendments does not exist', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
       });
+    });
 
-      wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+    describe('cancelledDealWithAmendments as false', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+          cancelledDealWithAmendments: false,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
+      });
+    });
+
+    describe('cancelledDealWithAmendments as undefined', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+          cancelledDealWithAmendments: undefined,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
+      });
+    });
+
+    describe('cancelledDealWithAmendments as null', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+          cancelledDealWithAmendments: null,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
+      });
+    });
+
+    describe('cancelledDealWithAmendments as true', () => {
+      it(`should render the banner`, () => {
+        wrapper = render({
+          ...params,
+          cancelledDealWithAmendments: true,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).toExist();
+        wrapper
+          .expectText(amendmentsAbandonedDealCancelledBanner)
+          .toRead('Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.');
+
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
+      });
     });
   });
 
-  describe('cancelledDealWithAmendments as false', () => {
-    it(`should NOT render the banner`, () => {
-      wrapper = render({
-        ...params,
-        cancelledDealWithAmendments: false,
-      });
+  describe('pendingCancellationDealWithAmendments', () => {
+    describe('pendingCancellationDealWithAmendments as false', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+          pendingCancellationDealWithAmendments: false,
+        });
 
-      wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
+      });
     });
-  });
 
-  describe('cancelledDealWithAmendments as false', () => {
-    it(`should NOT render the banner`, () => {
-      wrapper = render({
-        ...params,
-        cancelledDealWithAmendments: undefined,
+    describe('pendingCancellationDealWithAmendments as undefined', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+          pendingCancellationDealWithAmendments: undefined,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
       });
-
-      wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
     });
-  });
 
-  describe('cancelledDealWithAmendments as null', () => {
-    it(`should NOT render the banner`, () => {
-      wrapper = render({
-        ...params,
-        cancelledDealWithAmendments: null,
+    describe('pendingCancellationDealWithAmendments as null', () => {
+      it(`should NOT render the banner`, () => {
+        wrapper = render({
+          ...params,
+          pendingCancellationDealWithAmendments: null,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).notToExist();
       });
-
-      wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
     });
-  });
 
-  describe('cancelledDealWithAmendments as true', () => {
-    it(`should render the banner`, () => {
-      wrapper = render({
-        ...params,
-        cancelledDealWithAmendments: true,
+    describe('pendingCancellationDealWithAmendments as true', () => {
+      it(`should render the banner`, () => {
+        wrapper = render({
+          ...params,
+          pendingCancellationDealWithAmendments: true,
+        });
+
+        wrapper.expectElement(amendmentsAbandonedDealPendingCancellationBanner).toExist();
+        wrapper
+          .expectText(amendmentsAbandonedDealPendingCancellationBanner)
+          .toRead('Any amendments in progress have been abandoned by UKEF, as the deal is pending cancellation.');
+
+        wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).notToExist();
       });
-
-      wrapper.expectElement(amendmentsAbandonedDealCancelledBanner).toExist();
-      wrapper
-        .expectText(amendmentsAbandonedDealCancelledBanner)
-        .toRead('Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.');
     });
   });
 });

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -398,9 +398,14 @@ const applicationDetails = async (req, res, next) => {
      */
     const areAmendmentsInProgress = Boolean(amendmentsInProgress?.length);
     const isDealCancelled = application.status === DEAL_STATUS.CANCELLED;
+    const isDealPendingCancellation = application.status === DEAL_STATUS.PENDING_CANCELLATION;
 
     if (areAmendmentsInProgress && isDealCancelled) {
       params.cancelledDealWithAmendments = true;
+    }
+
+    if (areAmendmentsInProgress && isDealPendingCancellation) {
+      params.pendingCancellationDealWithAmendments = true;
     }
 
     /**

--- a/gef-ui/server/controllers/application-details/index.test.js
+++ b/gef-ui/server/controllers/application-details/index.test.js
@@ -792,6 +792,54 @@ describe('controllers/application-details', () => {
         );
       });
 
+      it('should render `application-preview` with pendingCancellationDealWithAmendments as true when amendment is in progress and deal is pending cancellation', async () => {
+        mockGetSubmittedDetailsResponse.portalAmendmentStatus = PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL;
+        mockGetSubmittedDetailsResponse.isPortalAmendmentInProgress = true;
+        mockGetSubmittedDetailsResponse.facilityIdWithAmendmentInProgress = '1234';
+
+        getSubmittedAmendmentDetails.mockResolvedValue(mockGetSubmittedDetailsResponse);
+
+        mockApplicationResponse.status = DEAL_STATUS.PENDING_CANCELLATION;
+        mockApplicationResponse.submissionType = DEAL_SUBMISSION_TYPE.AIN;
+        api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
+
+        api.getPortalAmendmentsOnDeal.mockResolvedValueOnce([
+          { ...aPortalFacilityAmendment({ status: PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL }), facilityId: '1234' },
+        ]);
+
+        await applicationDetails(mockRequest, mockResponse);
+
+        expect(mockResponse.render).toHaveBeenCalledWith(
+          'partials/application-preview.njk',
+          expect.objectContaining({
+            pendingCancellationDealWithAmendments: true,
+          }),
+        );
+      });
+
+      it('should render `application-preview` with cancelledDealWithAmendments as false when amendment is not in progress and deal is pending cancellation', async () => {
+        mockGetSubmittedDetailsResponse.portalAmendmentStatus = PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL;
+        mockGetSubmittedDetailsResponse.isPortalAmendmentInProgress = true;
+        mockGetSubmittedDetailsResponse.facilityIdWithAmendmentInProgress = '1234';
+
+        getSubmittedAmendmentDetails.mockResolvedValue(mockGetSubmittedDetailsResponse);
+
+        api.getPortalAmendmentsOnDeal.mockResolvedValueOnce([]);
+
+        mockApplicationResponse.status = DEAL_STATUS.CANCELLED;
+        mockApplicationResponse.submissionType = DEAL_SUBMISSION_TYPE.AIN;
+        api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
+
+        await applicationDetails(mockRequest, mockResponse);
+
+        expect(mockResponse.render).toHaveBeenCalledWith(
+          'partials/application-preview.njk',
+          expect.not.objectContaining({
+            pendingCancellationDealWithAmendments: expect.any(Boolean),
+          }),
+        );
+      });
+
       it('should render `application-preview` with facilityIdWithAmendmentInProgress as false when amendment is not in progress', async () => {
         mockGetSubmittedDetailsResponse.portalAmendmentStatus = PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL;
         mockGetSubmittedDetailsResponse.isPortalAmendmentInProgress = true;

--- a/gef-ui/server/helpers/map-facility-application-details.test.ts
+++ b/gef-ui/server/helpers/map-facility-application-details.test.ts
@@ -61,6 +61,28 @@ describe('mapFacilityApplicationDetails', () => {
     });
   });
 
+  describe('when the deal is pending cancellation', () => {
+    it('should not populate params and should not populate canIssuedFacilitiesBeAmended', () => {
+      // Arrange
+      const amendmentsInProgress: AmendmentInProgressParams[] = [];
+
+      const cancelledDeal = {
+        ...mockDeal,
+        status: DEAL_STATUS.PENDING_CANCELLATION,
+      };
+
+      // Act
+      const response = mapFacilityApplicationDetails(cancelledDeal, [facility], amendmentsInProgress, params, MOCK_MAKER.roles as Role[]);
+
+      const expected = {
+        mappedFacilities: [facility],
+        facilityParams: params,
+      };
+
+      expect(response).toEqual(expected);
+    });
+  });
+
   describe('when there are no amendments in progress', () => {
     describe('when a facility is issued', () => {
       it('should return mapped facilities with canIssuedFacilitiesBeAmended set to true', () => {

--- a/gef-ui/server/helpers/map-facility-application-details.ts
+++ b/gef-ui/server/helpers/map-facility-application-details.ts
@@ -45,7 +45,7 @@ export const mapFacilityApplicationDetails = (
   const mappedFacilities = facilities.map((facility: FacilityParams) => {
     const facilityToMap = facility;
 
-    const dealIsCancelled = application.status === DEAL_STATUS.CANCELLED;
+    const dealIsCancelled = application.status === DEAL_STATUS.CANCELLED || application.status === DEAL_STATUS.PENDING_CANCELLATION;
 
     /**
      * If the deal is cancelled,

--- a/gef-ui/templates/includes/application-preview/amendments-abandoned-deal-cancelled.njk
+++ b/gef-ui/templates/includes/application-preview/amendments-abandoned-deal-cancelled.njk
@@ -6,3 +6,10 @@
     html: '<p data-cy="amendments-abandoned-deal-cancelled-banner">Any amendments in progress have been abandoned by UKEF, as the deal is now cancelled.</p>'
   }) }}
 {% endif %}
+
+{% if pendingCancellationDealWithAmendments %}
+  {{ mojBanner({
+    type: "information",
+    html: '<p data-cy="amendments-abandoned-deal-pending-cancellation-banner">Any amendments in progress have been abandoned by UKEF, as the deal is pending cancellation.</p>'
+  }) }}
+{% endif %}


### PR DESCRIPTION
# Introduction :pencil2:

This PR adds a missing banner on a pending cancellation deal and hides the amendments in progress links

## Resolution :heavy_check_mark:

* Added PENDING_CANCELLATION to dealCancelled condition to hide links for in progress amendments
* Rendered banner with new pendingCancellationDealWithAmendments with specific banner for pending cancellation deal
* Updated unit tests
* Added conditions to unit tests
* Added e2e tests

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

  ![image](https://github.com/user-attachments/assets/8e39a60f-a0b0-4801-9872-7f434df75ebd)
</details>
