### PR TITLE
feat(DTFS2-7882): in progress portal amendments hide tfm add amendment button

### DIFF
--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/journeys/tfm-create-amendment-portal-amendment-status.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/journeys/tfm-create-amendment-portal-amendment-status.spec.js
@@ -1,0 +1,139 @@
+import { PORTAL_AMENDMENT_STATUS } from '@ukef/dtfs2-common';
+import relative from '../../../../relativeURL';
+import { PIM_USER_1, TFM_URL } from '../../../../../../../e2e-fixtures';
+import MOCK_USERS from '../../../../../../../e2e-fixtures/portal-users.fixture';
+import { MOCK_APPLICATION_AIN_DRAFT } from '../../../../../../../e2e-fixtures/gef/mocks/mock-deals';
+import { anIssuedCashFacility } from '../../../../../../../e2e-fixtures/mock-gef-facilities';
+import facilityPage from '../../../../../../../tfm/cypress/e2e/pages/facilityPage';
+import amendmentsPage from '../../../../../../../tfm/cypress/e2e/pages/amendments/amendmentsPage';
+import { applicationPreview } from '../../../../../../../gef/cypress/e2e/pages';
+import whatDoYouNeedToChange from '../../../../../../../gef/cypress/e2e/pages/amendments/what-do-you-need-to-change';
+
+const { BANK1_MAKER1, BANK1_CHECKER1 } = MOCK_USERS;
+
+const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
+
+const CHANGED_FACILITY_VALUE = '20000';
+
+context('Amendments - TFM - Amendments details page - Creating an amendment while a portal amendment is in progress', () => {
+  let dealId;
+  let facilityId;
+  let applicationDetailsUrl;
+  let facilityUrl;
+  let amendmentDetailsUrl;
+  let confirmSubmissionToUkefUrl;
+  let submittedUrl;
+
+  before(() => {
+    cy.insertOneGefDeal(MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1).then((insertedDeal) => {
+      dealId = insertedDeal._id;
+      applicationDetailsUrl = `/gef/application-details/${dealId}`;
+
+      cy.updateGefDeal(dealId, MOCK_APPLICATION_AIN_DRAFT, BANK1_MAKER1);
+
+      cy.createGefFacilities(dealId, [mockFacility], BANK1_MAKER1).then((createdFacility) => {
+        facilityId = createdFacility.details._id;
+
+        facilityUrl = `${TFM_URL}/case/${dealId}/facility/${facilityId}`;
+
+        cy.makerLoginSubmitGefDealForReview(insertedDeal);
+        cy.checkerLoginSubmitGefDealToUkef(insertedDeal);
+
+        cy.clearSessionCookies();
+      });
+    });
+  });
+
+  after(() => {
+    cy.clearCookies();
+    cy.clearSessionCookies();
+  });
+
+  beforeEach(() => {
+    cy.clearSessionCookies();
+
+    cy.login(BANK1_MAKER1);
+    cy.saveSession();
+  });
+
+  it(`should display the add amendment button when portal amendment is in ${PORTAL_AMENDMENT_STATUS.DRAFT}`, () => {
+    cy.visit(relative(applicationDetailsUrl));
+
+    applicationPreview.makeAChangeButton(facilityId).click();
+
+    whatDoYouNeedToChange.facilityValueCheckbox().click();
+    cy.clickContinueButton();
+
+    // exits amendment to keep it in draft state
+    cy.visit(relative(applicationDetailsUrl));
+
+    cy.visit(TFM_URL);
+
+    cy.tfmLogin(PIM_USER_1);
+
+    cy.visit(facilityUrl);
+    facilityPage.facilityTabAmendments().click();
+
+    amendmentsPage.addAmendmentButton().should('exist');
+  });
+
+  it(`should not display the add amendment button when portal amendment is ${PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL}`, () => {
+    cy.visit(relative(applicationDetailsUrl));
+
+    applicationPreview.makeAChangeButton(facilityId).click();
+
+    cy.getAmendmentIdFromUrl().then((amendmentId) => {
+      amendmentDetailsUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/amendment-details`;
+      confirmSubmissionToUkefUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/submit-amendment-to-ukef`;
+      submittedUrl = `/gef/application-details/${dealId}/facilities/${facilityId}/amendments/${amendmentId}/approved-by-ukef`;
+
+      cy.makerSubmitPortalAmendmentForReview({
+        facilityValueExists: true,
+        changedFacilityValue: CHANGED_FACILITY_VALUE,
+      });
+
+      cy.visit(TFM_URL);
+
+      cy.tfmLogin(PIM_USER_1);
+
+      cy.visit(facilityUrl);
+      facilityPage.facilityTabAmendments().click();
+
+      amendmentsPage.addAmendmentButton().should('not.exist');
+    });
+  });
+
+  it(`should not display the add amendment button when portal amendment is ${PORTAL_AMENDMENT_STATUS.FURTHER_MAKERS_INPUT_REQUIRED}`, () => {
+    // returns the amendment to the maker
+    cy.login(BANK1_CHECKER1);
+    cy.visit(amendmentDetailsUrl);
+    cy.clickReturnToMakerButton();
+    cy.clickSubmitButton();
+
+    cy.visit(TFM_URL);
+
+    cy.tfmLogin(PIM_USER_1);
+
+    cy.visit(facilityUrl);
+    facilityPage.facilityTabAmendments().click();
+
+    amendmentsPage.addAmendmentButton().should('not.exist');
+  });
+
+  it(`should display the add amendment button when portal amendment is ${PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED}`, () => {
+    // submits the amendment to UKEF
+    cy.visit(amendmentDetailsUrl);
+    cy.clickSubmitButton();
+
+    cy.checkerSubmitsPortalAmendmentRequest({ amendmentDetailsUrl, submittedUrl, confirmSubmissionToUkefUrl });
+
+    cy.visit(TFM_URL);
+
+    cy.tfmLogin(PIM_USER_1);
+
+    cy.visit(facilityUrl);
+    facilityPage.facilityTabAmendments().click();
+
+    amendmentsPage.addAmendmentButton().should('exist');
+  });
+});

--- a/libs/common/src/types/mongo-db-models/tfm-facilities.ts
+++ b/libs/common/src/types/mongo-db-models/tfm-facilities.ts
@@ -158,3 +158,10 @@ export type TfmFacility = {
   tfm: object;
   auditRecord?: AuditDatabaseRecord;
 };
+
+export type GetTfmAmendmentInProgressResponse = {
+  amendmentsInProgress: FacilityAmendment[] | TfmFacilityAmendment[];
+  hasAmendmentInProgress: boolean;
+  hasAmendmentInProgressButton: boolean;
+  showContinueAmendmentButton: boolean;
+};

--- a/trade-finance-manager-ui/server/controllers/case/activity/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/activity/index.js
@@ -2,7 +2,7 @@ const { getUnixTime } = require('date-fns');
 const { ACTIVITY_TYPES, FLASH_TYPES } = require('@ukef/dtfs2-common');
 const api = require('../../../api');
 const { generateValidationErrors } = require('../../../helpers/validation');
-const { getAmendmentsInProgress } = require('../../helpers/amendments.helper');
+const { getAmendmentsInProgressSubmittedByPim } = require('../../helpers/amendments.helper');
 const CONSTANTS = require('../../../constants');
 const { mapActivities } = require('./helpers/map-activities');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
@@ -29,7 +29,7 @@ const getActivity = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {
@@ -79,7 +79,7 @@ const filterActivities = async (req, res) => {
     return res.redirect('/not-found');
   }
 
-  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/case/parties/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/parties/index.js
@@ -2,7 +2,7 @@ const { FLASH_TYPES } = require('@ukef/dtfs2-common');
 const api = require('../../../api');
 const { userCanEdit, isEmptyString, partyType } = require('./helpers');
 const validatePartyURN = require('./partyUrnValidation.validate');
-const { getAmendmentsInProgress } = require('../../helpers/amendments.helper');
+const { getAmendmentsInProgressSubmittedByPim } = require('../../helpers/amendments.helper');
 const CONSTANTS = require('../../../constants');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
 
@@ -27,7 +27,7 @@ const getAllParties = async (req, res) => {
       return res.redirect('/not-found');
     }
 
-    const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
+    const amendmentsInProgress = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
     const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
     if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/case/underwriting/index.js
+++ b/trade-finance-manager-ui/server/controllers/case/underwriting/index.js
@@ -12,7 +12,7 @@ const { formattedNumber } = require('../../../helpers/number');
 const { UNDERWRITER_MANAGER_DECISIONS_TAGS } = require('../../../constants/decisions.constant');
 const { BANK_DECISIONS_TAGS } = require('../../../constants/amendments');
 const CONSTANTS = require('../../../constants');
-const { getAmendmentsInProgress } = require('../../helpers/amendments.helper');
+const { getAmendmentsInProgressSubmittedByPim } = require('../../helpers/amendments.helper');
 const { getDealSuccessBannerMessage } = require('../../helpers/get-success-banner-message.helper');
 
 /**
@@ -53,7 +53,7 @@ const getUnderwriterPage = async (req, res) => {
   // filters the amendments submittedByPim and also which are not automatic
   amendments = amendments.filter(({ submittedByPim, requireUkefApproval }) => submittedByPim && requireUkefApproval);
 
-  const amendmentsInProgress = getAmendmentsInProgress({ amendments, deal });
+  const amendmentsInProgress = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
   const hasAmendmentInProgress = amendmentsInProgress.length > 0;
 
   if (hasAmendmentInProgress) {

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.filterAmendmentsByInProgress.test.js
@@ -1,5 +1,5 @@
 const { TFM_DEAL_STAGE, TFM_AMENDMENT_STATUS } = require('@ukef/dtfs2-common');
-const { getAmendmentsInProgress } = require('./amendments.helper');
+const { getAmendmentsInProgressSubmittedByPim } = require('./amendments.helper');
 
 const notStartedAmendment = () => ({
   status: TFM_AMENDMENT_STATUS.NOT_STARTED,
@@ -21,7 +21,7 @@ const completedAmendment = () => ({
   submittedByPim: true,
 });
 
-describe('getAmendmentsInProgress', () => {
+describe('getAmendmentsInProgressSubmittedByPim', () => {
   it(`should return an empty array if the deal stage is ${TFM_DEAL_STAGE.CANCELLED}`, () => {
     // Arrange
     const amendments = [submittedInProgressAmendment()];
@@ -32,7 +32,7 @@ describe('getAmendmentsInProgress', () => {
     };
 
     // Act
-    const result = getAmendmentsInProgress({ amendments, deal });
+    const result = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
 
     // Assert
     expect(result).toEqual([]);
@@ -48,7 +48,7 @@ describe('getAmendmentsInProgress', () => {
     };
 
     // Act
-    const result = getAmendmentsInProgress({ amendments, deal });
+    const result = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
 
     // Assert
     expect(result).toEqual([]);
@@ -64,7 +64,7 @@ describe('getAmendmentsInProgress', () => {
     };
 
     // Act
-    const result = getAmendmentsInProgress({ amendments, deal });
+    const result = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
 
     // Assert
     expect(result).toEqual([]);
@@ -80,7 +80,7 @@ describe('getAmendmentsInProgress', () => {
     };
 
     // Act
-    const result = getAmendmentsInProgress({ amendments, deal });
+    const result = getAmendmentsInProgressSubmittedByPim({ amendments, deal });
 
     // Assert
     expect(result).toEqual([submittedInProgressAmendment()]);

--- a/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.getAmendmentsInProgress.test.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/amendments.helper.getAmendmentsInProgress.test.js
@@ -1,0 +1,223 @@
+import { TFM_DEAL_STAGE, TFM_AMENDMENT_STATUS, PORTAL_AMENDMENT_STATUS, DEAL_SUBMISSION_TYPE } from '@ukef/dtfs2-common';
+import { getAmendmentsInProgress } from './amendments.helper';
+
+const notStartedTFMAmendment = () => ({
+  status: TFM_AMENDMENT_STATUS.NOT_STARTED,
+  submittedByPim: false,
+});
+
+const unsubmittedInProgressTFMAmendment = () => ({
+  status: TFM_AMENDMENT_STATUS.IN_PROGRESS,
+  submittedByPim: false,
+});
+
+const submittedInProgressTFMAmendment = () => ({
+  status: TFM_AMENDMENT_STATUS.IN_PROGRESS,
+  submittedByPim: true,
+});
+
+const completedTFMAmendment = () => ({
+  status: TFM_AMENDMENT_STATUS.COMPLETED,
+  submittedByPim: true,
+});
+
+const notStartedPortalAmendment = () => ({
+  status: PORTAL_AMENDMENT_STATUS.DRAFT,
+});
+
+const inProgressPortalAmendment = () => ({
+  status: PORTAL_AMENDMENT_STATUS.READY_FOR_CHECKERS_APPROVAL,
+});
+
+const returnedToMakerPortalAmendment = () => ({
+  status: PORTAL_AMENDMENT_STATUS.FURTHER_MAKERS_INPUT_REQUIRED,
+});
+
+const completedPortalAmendment = () => ({
+  status: PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED,
+});
+
+const deal = { dealSnapshot: { submissionType: DEAL_SUBMISSION_TYPE.AIN }, tfm: { stage: TFM_DEAL_STAGE.CONFIRMED } };
+const teams = ['PIM'];
+
+describe('getAmendmentsInProgress', () => {
+  describe('when there are no amendments', () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const amendments = [];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [],
+        hasAmendmentInProgress: false,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one TFM amendment that is not started', () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const amendments = [notStartedTFMAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [],
+        hasAmendmentInProgress: false,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one TFM amendment that is in progress and not submitted by PIM', () => {
+    it('should return the amendment in progress', () => {
+      // Arrange
+      const amendments = [unsubmittedInProgressTFMAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [unsubmittedInProgressTFMAmendment()],
+        hasAmendmentInProgress: true,
+        hasAmendmentInProgressButton: true,
+        showContinueAmendmentButton: true,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one TFM amendment that is in progress and submitted by PIM', () => {
+    it('should return the amendment in progress', () => {
+      // Arrange
+      const amendments = [submittedInProgressTFMAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [],
+        hasAmendmentInProgress: false,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one TFM amendment that is completed', () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const amendments = [completedTFMAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [],
+        hasAmendmentInProgress: false,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one portal amendment that is not started', () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const amendments = [notStartedPortalAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [],
+        hasAmendmentInProgress: false,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one portal amendment that is in progress', () => {
+    it('should return the amendment in progress', () => {
+      // Arrange
+      const amendments = [inProgressPortalAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [inProgressPortalAmendment()],
+        hasAmendmentInProgress: true,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one portal amendment that is returned to maker', () => {
+    it('should return the amendment in progress', () => {
+      // Arrange
+      const amendments = [returnedToMakerPortalAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [returnedToMakerPortalAmendment()],
+        hasAmendmentInProgress: true,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when there is one portal amendment that is completed', () => {
+    it('should return an empty array', () => {
+      // Arrange
+      const amendments = [completedPortalAmendment()];
+
+      // Act
+      const result = getAmendmentsInProgress({ amendments, deal, teams });
+
+      // Assert
+      const expected = {
+        amendmentsInProgress: [],
+        hasAmendmentInProgress: false,
+        hasAmendmentInProgressButton: false,
+        showContinueAmendmentButton: false,
+      };
+
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
+++ b/trade-finance-manager-ui/server/controllers/helpers/overrideDealsIfAmendmentsInProgress.helper.js
@@ -1,5 +1,5 @@
 const { cloneDeep } = require('lodash');
-const { getAmendmentsInProgress } = require('./amendments.helper');
+const { getAmendmentsInProgressSubmittedByPim } = require('./amendments.helper');
 const { DEAL } = require('../../constants');
 
 /**
@@ -14,7 +14,7 @@ const overrideDealsIfAmendmentsInProgress = (deals, amendments) => {
       const modifiedDeal = cloneDeep(deal);
 
       const amendmentsForDeal = amendments.filter(({ dealId }) => dealId === deal._id);
-      const amendmentInProgressOnDeal = getAmendmentsInProgress({ amendments: amendmentsForDeal, deal });
+      const amendmentInProgressOnDeal = getAmendmentsInProgressSubmittedByPim({ amendments: amendmentsForDeal, deal });
 
       if (amendmentInProgressOnDeal.length > 0) {
         modifiedDeal.tfm.stage = DEAL.DEAL_STAGE.AMENDMENT_IN_PROGRESS;


### PR DESCRIPTION
# Introduction :pencil2:

This PR adds logic to hide the TFM add amendment button when a portal amendment is Ready for checkers approval or furthers makers input

## Resolution :heavy_check_mark:

* Added logic to getAmendmentsInProgress  to hide amendment button if amendment is in progress on portal
* Added unit tests
* Added e2e test

## Miscellaneous :heavy_plus_sign:

* Redone logic for getAmendmentsInProgress where all variables are set in helper
* Renamed getAmendmentsInProgress  to getAmendmentsInProgressSubmittedByPim 
* Added better documentation

