### PR TITLE
chore(github-actions): actions/checkout@v5

### DIFF
--- a/.github/actions/acr/action.yml
+++ b/.github/actions/acr/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository 🗃️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Step 2: Log in to Azure.
     - name: Azure 🔐

--- a/.github/actions/functions/action.yml
+++ b/.github/actions/functions/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository 🗃️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.branch }}
 

--- a/.github/actions/mssql/action.yml
+++ b/.github/actions/mssql/action.yml
@@ -38,7 +38,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.branch }}
 

--- a/.github/actions/notify/action.yml
+++ b/.github/actions/notify/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository 🗃️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Step 2: Dispatch notification
     - name: Notification 🔔

--- a/.github/actions/webapp/action.yml
+++ b/.github/actions/webapp/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     # Step 1: Check out the repository.
     - name: Repository 🗃️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.branch }}
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/mssql
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/webapp
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/functions

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/mssql
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/webapp
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/functions

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -48,7 +48,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,7 +90,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -118,7 +118,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -146,7 +146,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -174,7 +174,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4
@@ -202,7 +202,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.timezone }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create
         uses: googleapis/release-please-action@v4

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Subscription 🛠️
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/mssql
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/webapp
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Repository 🗂️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy ⚡
         uses: ./.github/actions/functions

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Codacy
         uses: codacy/codacy-analysis-cli-action@master
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         working-directory: ./
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Fossa
         uses: fossas/fossa-action@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.TZ }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         uses: ./.github/actions/rerun
@@ -315,7 +315,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.TZ }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         uses: ./.github/actions/rerun
@@ -420,7 +420,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.TZ }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         uses: ./.github/actions/rerun
@@ -503,7 +503,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.TZ }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         uses: ./.github/actions/rerun
@@ -569,7 +569,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.TZ }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         uses: ./.github/actions/rerun
@@ -642,7 +642,7 @@ jobs:
           timezoneLinux: ${{ needs.setup.outputs.TZ }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependencies
         uses: ./.github/actions/rerun
@@ -731,7 +731,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Timezone
         uses: szenius/set-timezone@v2.0
@@ -834,7 +834,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Timezone
         uses: szenius/set-timezone@v2.0
@@ -958,7 +958,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Timezone
         uses: szenius/set-timezone@v2.0
@@ -1050,7 +1050,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Timezone
         uses: szenius/set-timezone@v2.0
@@ -1237,7 +1237,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Timezone
         uses: szenius/set-timezone@v2.0
@@ -1326,7 +1326,7 @@ jobs:
           node-version: ${{ vars.NODE_VERSION }}
 
       - name: Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Timezone
         uses: szenius/set-timezone@v2.0


### PR DESCRIPTION
# Introduction :pencil2:

Update GitHub actions checkout plugin to latest version.

## Resolution :heavy_check_mark:

* Updated to `actions/checkout@v5`.