### PR TITLE
feat(DTFS2-8060): GEF UI broken CSS link

### DIFF
--- a/gef-ui/component-tests/index/index.component-test.js
+++ b/gef-ui/component-tests/index/index.component-test.js
@@ -15,6 +15,28 @@ describe(page, () => {
     wrapper.expectElement('#main-content').toExist();
   });
 
+  it('should ensure the mask icon link is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('href', '/assets/rebrand/images/govuk-icon-mask.svg');
+  });
+
+  it('should ensure the mask icon colour is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('color', '#1d70b8');
+  });
+
+  it('should ensure the manifest link is correct', () => {
+    wrapper.expectElement('link[rel="manifest"]').toHaveAttribute('href', '/assets/rebrand/manifest.json');
+  });
+
+  it('should ensure the stylesheet link is correct', () => {
+    wrapper.expectElement('link[rel="stylesheet"]').toHaveAttribute('href', '/gef/assets/css/styles.css');
+  });
+
+  it('should have the correct integrity for "/assets/js/jsEnabled.js"', () => {
+    wrapper
+      .expectElement('script[src="/assets/js/jsEnabled.js"]')
+      .toHaveAttribute('integrity', 'sha512-BZmKCksPLPXsFlYmd1MUEDLllt/d7vn1jLdU6FA1Y7hpzaOK7Aj9wwS3alwFEl+tlS5Md3CmwjI98F5Ggsg92Q==');
+  });
+
   it('should have the correct integrity for "/assets/js/main.js"', () => {
     wrapper
       .expectElement('script[src="/assets/js/main.js"]')
@@ -31,6 +53,12 @@ describe(page, () => {
     wrapper
       .expectElement('script[src="/assets/js/mojFrontend.js"]')
       .toHaveAttribute('integrity', 'sha512-oZACuErpjnaaxu4APOJyHBZAk/RW7M5gZ/hVPEBXmbVdcxcdiH89/ey/lqII6wTmpUv87g92RrelMbFXB8qBng==');
+  });
+
+  it('should have the correct integrity for "/assets/js/mojFilters.js"', () => {
+    wrapper
+      .expectElement('script[src="/assets/js/mojFilters.js"]')
+      .toHaveAttribute('integrity', 'sha512-ByfzBGRfJ1AM3hcN4bl0gILRnr3l9IDe8Um0poccVZ5qEfTpNj5r+rbYXQlEk1tL6zTdrIS2U77Kt4Jxi78Usw==');
   });
 
   it('should have the correct integrity for "/assets/js/disableFormSubmitOnSubmission.js"', () => {

--- a/gef-ui/templates/index.njk
+++ b/gef-ui/templates/index.njk
@@ -13,7 +13,7 @@
     <link rel="icon" sizes="any" href="/assets/rebrand/images/favicon.svg" type="image/svg+xml">
     <link rel="mask-icon" href="/assets/rebrand/images/govuk-icon-mask.svg" color="#1d70b8">
     <link rel="apple-touch-icon" href="/assets/rebrand/images/govuk-icon-180.png">
-    <link rel="stylesheet" href="/assets/css/styles.css"/>
+    <link rel="stylesheet" href="/gef/assets/css/styles.css"/>
     <meta property="og:image" content="/assets/rebrand/images/govuk-opengraph-image.png">
     <link rel="manifest" href="/assets/rebrand/manifest.json">
 

--- a/portal/component-tests/index/index.component-test.js
+++ b/portal/component-tests/index/index.component-test.js
@@ -15,6 +15,28 @@ describe(page, () => {
     wrapper.expectElement('#main-content').toExist();
   });
 
+  it('should ensure the mask icon link is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('href', '/assets/rebrand/images/govuk-icon-mask.svg');
+  });
+
+  it('should ensure the mask icon colour is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('color', '#1d70b8');
+  });
+
+  it('should ensure the manifest link is correct', () => {
+    wrapper.expectElement('link[rel="manifest"]').toHaveAttribute('href', '/assets/rebrand/manifest.json');
+  });
+
+  it('should ensure the stylesheet link is correct', () => {
+    wrapper.expectElement('link[rel="stylesheet"]').toHaveAttribute('href', '/assets/css/styles.css');
+  });
+
+  it('should have the correct integrity for "/assets/js/jsEnabled.js"', () => {
+    wrapper
+      .expectElement('script[src="/assets/js/jsEnabled.js"]')
+      .toHaveAttribute('integrity', 'sha512-BZmKCksPLPXsFlYmd1MUEDLllt/d7vn1jLdU6FA1Y7hpzaOK7Aj9wwS3alwFEl+tlS5Md3CmwjI98F5Ggsg92Q==');
+  });
+
   it('should have the correct integrity for "/assets/js/main.js"', () => {
     wrapper
       .expectElement('script[src="/assets/js/main.js"]')


### PR DESCRIPTION
# Introduction :pencil2:

GEF UI container was not referring to the correct `style.css`, rather it was referring to Portal UI stylesheet.

## Resolution :heavy_check_mark:

* Added `/gef` prefix to the stylesheet link.

## Miscellaneous :heavy_plus_sign:

* Updated component test cases for both `gef-ui` and `portal`.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

<img width="1022" height="846" alt="image" src="https://github.com/user-attachments/assets/267f01a4-88bc-4fd3-a77b-fca47bfe606d" />

<img width="1101" height="667" alt="image" src="https://github.com/user-attachments/assets/ef10321d-4b34-4ebb-bfcd-40cf7ff3031c" />

</details>
