### PR TITLE
feat(DTFS2-8060): gef-ui broken CSS link

### DIFF
--- a/gef-ui/component-tests/index/index.component-test.js
+++ b/gef-ui/component-tests/index/index.component-test.js
@@ -15,6 +15,28 @@ describe(page, () => {
     wrapper.expectElement('#main-content').toExist();
   });
 
+  it('should ensure the mask icon link is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('href', '/assets/rebrand/images/govuk-icon-mask.svg');
+  });
+
+  it('should ensure the mask icon colour is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('color', '#1d70b8');
+  });
+
+  it('should ensure the manifest link is correct', () => {
+    wrapper.expectElement('link[rel="manifest"]').toHaveAttribute('href', '/assets/rebrand/manifest.json');
+  });
+
+  it('should ensure the stylesheet link is correct', () => {
+    wrapper.expectElement('link[rel="stylesheet"]').toHaveAttribute('href', '/gef/assets/css/styles.css');
+  });
+
+  it('should have the correct integrity for "/assets/js/jsEnabled.js"', () => {
+    wrapper
+      .expectElement('script[src="/assets/js/jsEnabled.js"]')
+      .toHaveAttribute('integrity', 'sha512-BZmKCksPLPXsFlYmd1MUEDLllt/d7vn1jLdU6FA1Y7hpzaOK7Aj9wwS3alwFEl+tlS5Md3CmwjI98F5Ggsg92Q==');
+  });
+
   it('should have the correct integrity for "/assets/js/main.js"', () => {
     wrapper
       .expectElement('script[src="/assets/js/main.js"]')
@@ -31,6 +53,12 @@ describe(page, () => {
     wrapper
       .expectElement('script[src="/assets/js/mojFrontend.js"]')
       .toHaveAttribute('integrity', 'sha512-oZACuErpjnaaxu4APOJyHBZAk/RW7M5gZ/hVPEBXmbVdcxcdiH89/ey/lqII6wTmpUv87g92RrelMbFXB8qBng==');
+  });
+
+  it('should have the correct integrity for "/assets/js/mojFilters.js"', () => {
+    wrapper
+      .expectElement('script[src="/assets/js/mojFilters.js"]')
+      .toHaveAttribute('integrity', 'sha512-ByfzBGRfJ1AM3hcN4bl0gILRnr3l9IDe8Um0poccVZ5qEfTpNj5r+rbYXQlEk1tL6zTdrIS2U77Kt4Jxi78Usw==');
   });
 
   it('should have the correct integrity for "/assets/js/disableFormSubmitOnSubmission.js"', () => {

--- a/gef-ui/server/controllers/application-details/index.buildBody.test.js
+++ b/gef-ui/server/controllers/application-details/index.buildBody.test.js
@@ -1,0 +1,130 @@
+import { DEAL_SUBMISSION_TYPE, FACILITY_TYPE, isPortalFacilityAmendmentsFeatureFlagEnabled, ACBS_FACILITY_STAGE } from '@ukef/dtfs2-common';
+
+import { applicationDetails } from '.';
+import api from '../../services/api';
+
+import MOCKS from '../mocks';
+import CONSTANTS from '../../constants';
+
+import { getSubmittedAmendmentDetails } from '../../utils/submitted-amendment-details';
+import { mapSummaryList } from '../../utils/helpers';
+
+jest.mock('../../services/api', () => ({
+  getApplication: jest.fn(),
+  getFacilities: jest.fn(),
+  getUserDetails: jest.fn(),
+  getPortalAmendmentsOnDeal: jest.fn(),
+  getTfmDeal: jest.fn(),
+}));
+
+jest.mock('../../utils/submitted-amendment-details', () => ({
+  getSubmittedAmendmentDetails: jest.fn(),
+}));
+
+jest.mock('@ukef/dtfs2-common', () => ({
+  ...jest.requireActual('@ukef/dtfs2-common'),
+  isPortalFacilityAmendmentsFeatureFlagEnabled: jest.fn(),
+}));
+
+jest.mock('../../utils/helpers', () => ({
+  ...jest.requireActual('../../utils/helpers'),
+  mapSummaryList: jest.fn().mockReturnValue({}),
+}));
+
+function mockSuccessfulFlashResponse() {
+  return jest.fn().mockReturnValue([{ message: 'Facility is updated' }]);
+}
+
+describe('controllers/application-details', () => {
+  let mockResponse;
+  let mockRequest;
+  let mockApplicationResponse;
+  let mockFacilityResponse;
+  let mockFacilitiesResponse;
+  let mockUserResponse;
+  const mockGetPortalAmendmentsOnDealResponse = [];
+  const mockGetSubmittedDetailsResponse = {
+    portalAmendmentStatus: null,
+    facilityIdWithAmendmentInProgress: null,
+    isPortalAmendmentInProgress: false,
+  };
+
+  const MockTfmDealResponse = () => {
+    return {
+      dealSnapshot: {},
+      tfm: {
+        facilityGuaranteeDates: { effectiveDate: '2024-08-01', guaranteeCommencementDate: '2024-08-01', guaranteeExpiryDate: '2025-06-01' },
+        feeRecord: null,
+        riskProfile: 'Flat',
+        ukefExposure: 800,
+        ukefExposureCalculationTimestamp: '1722528795105',
+        acbs: {
+          facilities: [
+            {
+              facilityStage: ACBS_FACILITY_STAGE.COMMITMENT,
+            },
+          ],
+        },
+      },
+    };
+  };
+
+  beforeEach(() => {
+    mockResponse = MOCKS.MockResponse();
+    mockRequest = MOCKS.MockRequest();
+    mockApplicationResponse = MOCKS.MockApplicationResponseDraft();
+    mockFacilityResponse = MOCKS.MockFacilityResponse();
+    mockFacilitiesResponse = MOCKS.MockFacilitiesResponse();
+    mockUserResponse = MOCKS.MockUserResponse();
+
+    api.getApplication.mockResolvedValue(mockApplicationResponse);
+    api.getFacilities.mockResolvedValue(mockFacilitiesResponse);
+    api.getUserDetails.mockResolvedValue(mockUserResponse);
+    api.getPortalAmendmentsOnDeal.mockResolvedValue(mockGetPortalAmendmentsOnDealResponse);
+    getSubmittedAmendmentDetails.mockResolvedValue(mockGetSubmittedDetailsResponse);
+    api.getTfmDeal.mockResolvedValue(MockTfmDealResponse);
+    mockRequest.flash = mockSuccessfulFlashResponse();
+    jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(true);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('GET Application Details', () => {
+    describe('template rendering from amendment.status', () => {
+      beforeEach(() => {
+        mockApplicationResponse.submissionType = DEAL_SUBMISSION_TYPE.AIN;
+        mockApplicationResponse.status = CONSTANTS.DEAL_STATUS.UKEF_ACKNOWLEDGED;
+        api.getApplication.mockResolvedValueOnce(mockApplicationResponse);
+
+        jest.mocked(isPortalFacilityAmendmentsFeatureFlagEnabled).mockReturnValueOnce(true);
+      });
+
+      it('should call the mapSummaryList function with correct parameters to render rows', async () => {
+        // Arrange
+        mockFacilityResponse.items = [
+          {
+            details: { type: FACILITY_TYPE.CASH },
+            validation: { required: [] },
+            createdAt: 20,
+          },
+          {
+            details: { type: FACILITY_TYPE.CONTINGENT },
+            validation: { required: [] },
+            createdAt: 10,
+          },
+        ];
+
+        api.getFacilities.mockResolvedValueOnce(mockFacilityResponse);
+
+        // Act
+        await applicationDetails(mockRequest, mockResponse);
+
+        // Assert
+        expect(mapSummaryList).toHaveBeenCalledTimes(3);
+        expect(mapSummaryList).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), expect.any(Object), expect.any(Object), expect.any(Boolean));
+      });
+    });
+  });
+});

--- a/gef-ui/server/controllers/application-details/index.js
+++ b/gef-ui/server/controllers/application-details/index.js
@@ -126,6 +126,7 @@ const buildBody = async (app, latestAmendments, previewMode, user) => {
             correspondenceAddressLink: !app.exporter.correspondenceAddress,
           }),
           mapSummaryParams,
+          latestAmendments,
           previewMode,
         ),
       },

--- a/gef-ui/templates/index.njk
+++ b/gef-ui/templates/index.njk
@@ -13,7 +13,7 @@
     <link rel="icon" sizes="any" href="/assets/rebrand/images/favicon.svg" type="image/svg+xml">
     <link rel="mask-icon" href="/assets/rebrand/images/govuk-icon-mask.svg" color="#1d70b8">
     <link rel="apple-touch-icon" href="/assets/rebrand/images/govuk-icon-180.png">
-    <link rel="stylesheet" href="/assets/css/styles.css"/>
+    <link rel="stylesheet" href="/gef/assets/css/styles.css"/>
     <meta property="og:image" content="/assets/rebrand/images/govuk-opengraph-image.png">
     <link rel="manifest" href="/assets/rebrand/manifest.json">
 

--- a/portal/component-tests/index/index.component-test.js
+++ b/portal/component-tests/index/index.component-test.js
@@ -15,6 +15,28 @@ describe(page, () => {
     wrapper.expectElement('#main-content').toExist();
   });
 
+  it('should ensure the mask icon link is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('href', '/assets/rebrand/images/govuk-icon-mask.svg');
+  });
+
+  it('should ensure the mask icon colour is correct', () => {
+    wrapper.expectElement('link[rel="mask-icon"]').toHaveAttribute('color', '#1d70b8');
+  });
+
+  it('should ensure the manifest link is correct', () => {
+    wrapper.expectElement('link[rel="manifest"]').toHaveAttribute('href', '/assets/rebrand/manifest.json');
+  });
+
+  it('should ensure the stylesheet link is correct', () => {
+    wrapper.expectElement('link[rel="stylesheet"]').toHaveAttribute('href', '/assets/css/styles.css');
+  });
+
+  it('should have the correct integrity for "/assets/js/jsEnabled.js"', () => {
+    wrapper
+      .expectElement('script[src="/assets/js/jsEnabled.js"]')
+      .toHaveAttribute('integrity', 'sha512-BZmKCksPLPXsFlYmd1MUEDLllt/d7vn1jLdU6FA1Y7hpzaOK7Aj9wwS3alwFEl+tlS5Md3CmwjI98F5Ggsg92Q==');
+  });
+
   it('should have the correct integrity for "/assets/js/main.js"', () => {
     wrapper
       .expectElement('script[src="/assets/js/main.js"]')


### PR DESCRIPTION
# Introduction :pencil2:

GEF UI container was not referring to the correct `style.css`, rather it was referring to Portal UI stylesheet.

## Resolution :heavy_check_mark:

* Added `/gef` prefix to the stylesheet link.
* Added missing `latestAmendments` to `mapSummaryList()` function, causing `previewMode` to be false where it should be `true`.


## Miscellaneous :heavy_plus_sign:

* Updated component test cases for both `gef-ui` and `portal`.
* Updated unit test case for `buildBody`.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

<img width="1022" height="846" alt="image" src="https://github.com/user-attachments/assets/267f01a4-88bc-4fd3-a77b-fca47bfe606d" />

<img width="1101" height="667" alt="image" src="https://github.com/user-attachments/assets/ef10321d-4b34-4ebb-bfcd-40cf7ff3031c" />

<img width="973" height="740" alt="image" src="https://github.com/user-attachments/assets/2cd02305-79fd-4f89-9f5e-42296f65a13f" />


</details>
