### PR TITLE
fix(DTFS2-8073): fix checker unauthorised error on portal amendment deal

### DIFF
--- a/portal-api/api-tests/v1/tfm/tfm-facility-get.api-test.ts
+++ b/portal-api/api-tests/v1/tfm/tfm-facility-get.api-test.ts
@@ -4,7 +4,7 @@ import { HttpStatusCode } from 'axios';
 import app from '../../../src/createApp';
 import testUserCache from '../../api-test-users';
 
-import { MAKER } from '../../../src/v1/roles/roles';
+import { CHECKER, MAKER } from '../../../src/v1/roles/roles';
 import createApi from '../../api';
 import { TestUser } from '../../types/test-user';
 import { withRoleAuthorisationTests } from '../../common-tests/role-authorisation-tests';
@@ -58,7 +58,7 @@ describe('/v1/tfm/facility/:facilityId', () => {
     });
 
     withRoleAuthorisationTests({
-      allowedRoles: [MAKER],
+      allowedRoles: [MAKER, CHECKER],
       getUserWithRole: (role: Role) => testUsers().withRole(role).one() as TestUser,
       makeRequestAsUser: (user: TestUser) => as(user).get(url(validFacilityId)),
       successStatusCode: HttpStatusCode.Ok,

--- a/portal-api/src/v1/routes.js
+++ b/portal-api/src/v1/routes.js
@@ -392,10 +392,15 @@ authRouter.route('/tfm/team/:teamId').get(validateUserHasAtLeastOneAllowedRole({
 
 authRouter
   .route('/tfm/deal/:dealId')
-  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), mongoIdValidation('dealId'), handleExpressValidatorResult, tfm.tfmDeal);
+  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER] }), mongoIdValidation('dealId'), handleExpressValidatorResult, tfm.tfmDeal);
 
 authRouter
   .route('/tfm/facility/:facilityId')
-  .get(validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER] }), mongoIdValidation('facilityId'), handleExpressValidatorResult, tfm.tfmFacility);
+  .get(
+    validateUserHasAtLeastOneAllowedRole({ allowedRoles: [MAKER, CHECKER] }),
+    mongoIdValidation('facilityId'),
+    handleExpressValidatorResult,
+    tfm.tfmFacility,
+  );
 
 module.exports = { openRouter, authRouter };


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an error on a deal with portal amendments which is ready for checkers approval.  When the checker opens the deal, there is an error in gef-ui and portal-api

## Resolution :heavy_check_mark:

* Added checker to '/tfm/deal/:dealId' and '/tfm/facility/:facilityId' get calls in portal-api
* Updated test
