### PR TITLE
feat(DTFS2-7812): missing probability of default for BSS/EWCS deals

### DIFF
--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.api-test.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.api-test.js
@@ -89,4 +89,88 @@ describe('mappings - map submitted deal - mapBssEwcsDeal', () => {
 
     expect(result).toEqual(expected);
   });
+
+  it('should return mapped deal when no PoD has been specified', () => {
+    const mockDeal = {
+      dealSnapshot: MOCK_BSS_EWCS_DEAL,
+      tfm: {},
+    };
+
+    const result = mapBssEwcsDeal(mockDeal);
+
+    const {
+      _id,
+      dealType,
+      submissionType,
+      bankInternalRefName,
+      additionalRefName,
+      details,
+      submissionDetails,
+      bondTransactions,
+      loanTransactions,
+      eligibility,
+      exporter,
+      status,
+      maker,
+      supportingInformation,
+    } = mockDeal.dealSnapshot;
+
+    const { submissionCount, submissionDate, ukefDealId } = details;
+
+    const expected = {
+      _id,
+      dealType,
+      submissionType,
+      bankInternalRefName,
+      additionalRefName,
+      submissionCount,
+      submissionDate,
+      status,
+      ukefDealId,
+      maker,
+      exporter: {
+        companyName: exporter.companyName,
+        companiesHouseRegistrationNumber: submissionDetails['supplier-companies-house-registration-number'],
+        probabilityOfDefault: PROBABILITY_OF_DEFAULT.DEFAULT_VALUE,
+        smeType: submissionDetails['sme-type'],
+        registeredAddress: {
+          addressLine1: submissionDetails['supplier-address-line-1'],
+          addressLine2: submissionDetails['supplier-address-line-2'],
+          locality: submissionDetails['supplier-address-town'],
+          postalCode: submissionDetails['supplier-address-postcode'],
+          country: submissionDetails['supplier-address-country'].name,
+        },
+        selectedIndustry: {
+          name: submissionDetails['industry-sector'].name,
+          class: submissionDetails['industry-class'].name,
+          code: submissionDetails['industry-class'].code,
+        },
+      },
+      buyer: {
+        name: submissionDetails['buyer-name'],
+        country: submissionDetails['buyer-address-country'],
+      },
+      indemnifier: {
+        name: submissionDetails['indemnifier-name'],
+      },
+      dealCurrency: submissionDetails.supplyContractCurrency,
+      dealValue: submissionDetails.supplyContractValue,
+      destinationOfGoodsAndServices: submissionDetails.destinationOfGoodsAndServices,
+      eligibility,
+      supportingInformation,
+      facilities: [
+        ...bondTransactions.items.map((facility) => ({
+          ...mapBssEwcsFacility(facility),
+          coverEndDate: expect.any(Object), // date object
+        })),
+        ...loanTransactions.items.map((facility) => ({
+          ...mapBssEwcsFacility(facility),
+          coverEndDate: expect.any(Object), // date object
+        })),
+      ],
+      tfm: {},
+    };
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.js
+++ b/trade-finance-manager-api/src/v1/mappings/map-submitted-deal/map-bss-ewcs-deal.js
@@ -1,3 +1,4 @@
+const { PROBABILITY_OF_DEFAULT } = require('@ukef/dtfs2-common');
 const { mapBssEwcsFacility } = require('./map-bss-ewcs-facility');
 
 /**
@@ -35,6 +36,8 @@ const mapBssEwcsDeal = (deal) => {
 
   const { companyName } = exporter;
 
+  const probabilityOfDefault = tfm?.probabilityOfDefault ?? PROBABILITY_OF_DEFAULT.DEFAULT_VALUE;
+
   const mapped = {
     _id,
     dealType,
@@ -49,7 +52,7 @@ const mapBssEwcsDeal = (deal) => {
     exporter: {
       companyName,
       companiesHouseRegistrationNumber: submissionDetails['supplier-companies-house-registration-number'],
-      probabilityOfDefault: Number(tfm.probabilityOfDefault),
+      probabilityOfDefault,
       smeType: submissionDetails['sme-type'],
       registeredAddress: {
         addressLine1: submissionDetails['supplier-address-line-1'],


### PR DESCRIPTION
# Introduction :pencil2:

During a `BSS/EWCS` deal submission to TFM, party URN for all the required parties are not being added or created. Upon investigation `/customers` MDM endpoint is not being invoked.

## Resolution :heavy_check_mark:

* Since PoD is not provided for `BSS/EWCS`, `tfm.probabilityOfDefault` is null. Have added nullish coalescing with `14.1` value if not available. 

## Miscellaneous :heavy_plus_sign:

* Added an API test case.
* Added try-catch block to `submitDealAfterUkefIds` for graceful error handling.