### PR TITLE
fix(DTFS2-8119): portal amendements - add submittedBy and effectiveDate to tfm amendment details

### DIFF
--- a/dtfs-central-api/server/services/portal/facility-amendment.service.ts
+++ b/dtfs-central-api/server/services/portal/facility-amendment.service.ts
@@ -246,6 +246,7 @@ export class PortalFacilityAmendmentService {
       status: newStatus,
       referenceNumber,
       requestDate,
+      bankName,
     };
 
     const existingAmendment = await TfmFacilitiesRepo.findOneAmendmentByFacilityIdAndAmendmentId(facilityId, amendmentId);

--- a/dtfs-central-api/server/services/portal/facility-amendment.submitPortalFacilityAmendmentToUkef.service.test.ts
+++ b/dtfs-central-api/server/services/portal/facility-amendment.submitPortalFacilityAmendmentToUkef.service.test.ts
@@ -196,6 +196,7 @@ describe('PortalFacilityAmendmentService', () => {
         status: PORTAL_AMENDMENT_STATUS.ACKNOWLEDGED,
         referenceNumber,
         requestDate,
+        bankName,
       };
 
       const today = now();

--- a/e2e-tests/tfm/cypress/e2e/pages/amendments/amendmentsPage.js
+++ b/e2e-tests/tfm/cypress/e2e/pages/amendments/amendmentsPage.js
@@ -78,6 +78,7 @@ const amendmentsPage = {
       return {
         heading: () => cy.get('@row').get(`[data-cy="amendment--heading-${index}"]`),
         effectiveDate: () => cy.get('@row').get(`[data-cy="amendment--details-${index}-effective-date"]`),
+        submittedBy: () => cy.get('@row').get(`[data-cy="amendment--details-${index}-submitted-by"]`),
         requireApproval: () => cy.get('@row').get(`[data-cy="amendment--details-${index}-require-approval"]`),
         bankDecision: () => cy.get('@row').get(`[data-cy="amendment--details-${index}-banks-decision"]`),
 
@@ -90,6 +91,8 @@ const amendmentsPage = {
         newFacilityValue: () => cy.get('@row').get(`[data-cy="amendment--details-${index}-new-facility-value"]`),
 
         bankDecisionTag: () => cy.get('@row').get(`[data-cy="amendment--details-${index}-banks-decision"]`),
+
+        effectiveDateTable: () => cy.get(`[data-cy="amendment--details-${index}-table-effective-date"]`),
 
         eligibilityCriteriaTable: () => cy.get(`[data-cy="amendment-${index}-eligibility-criteria"]`),
 

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/tfm/tfm-display-portal-amendment-on-amendment-details-page.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/tfm/tfm-display-portal-amendment-on-amendment-details-page.spec.js
@@ -15,6 +15,8 @@ const mockFacility = anIssuedCashFacility({ facilityEndDateEnabled: true });
 const CHANGED_FACILITY_VALUE = '20000';
 const CHANGED_FACILITY_VALUE_2 = '30000';
 
+const submittedByString = `${BANK1_MAKER1.firstname} ${BANK1_MAKER1.surname} - ${BANK1_MAKER1.bank.name}`;
+
 context('Amendments - TFM - Amendments details page - TFM should display portal amendments on the amendment details page', () => {
   let dealId;
   let facilityId;
@@ -81,7 +83,7 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
 
   it('should display a row for the first portal amendment', () => {
     cy.assertText(amendmentsPage.amendmentDetails.row(2).heading(), `Amendment ${ukefFacilityId}-001`);
-    cy.assertText(amendmentsPage.amendmentDetails.row(2).effectiveDate(), today.dd_MMMM_yyyy);
+    cy.assertText(amendmentsPage.amendmentDetails.row(2).submittedBy(), submittedByString);
     cy.assertText(amendmentsPage.amendmentDetails.row(2).requireApproval(), 'No');
 
     cy.assertText(amendmentsPage.amendmentDetails.row(2).currentCoverEndDate(), format(new Date(mockFacility.coverEndDate), DD_MMMM_YYYY_FORMAT));
@@ -91,11 +93,13 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
     cy.assertText(amendmentsPage.amendmentDetails.row(2).currentFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(mockFacility.value, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(2).newFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(CHANGED_FACILITY_VALUE, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(2).ukefDecisionFacilityValue(), UNDERWRITER_MANAGER_DECISIONS.AUTOMATIC_APPROVAL);
+
+    cy.assertText(amendmentsPage.amendmentDetails.row(2).effectiveDateTable(), today.dd_MMMM_yyyy);
   });
 
   it('should display a row for the second portal amendment', () => {
     cy.assertText(amendmentsPage.amendmentDetails.row(1).heading(), `Amendment ${ukefFacilityId}-002`);
-    cy.assertText(amendmentsPage.amendmentDetails.row(1).effectiveDate(), today.dd_MMMM_yyyy);
+    cy.assertText(amendmentsPage.amendmentDetails.row(1).submittedBy(), submittedByString);
     cy.assertText(amendmentsPage.amendmentDetails.row(1).requireApproval(), 'No');
 
     cy.assertText(amendmentsPage.amendmentDetails.row(1).currentCoverEndDate(), twoYears.dd_MMMM_yyyy);
@@ -105,5 +109,7 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
     cy.assertText(amendmentsPage.amendmentDetails.row(1).currentFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(CHANGED_FACILITY_VALUE, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(1).newFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(CHANGED_FACILITY_VALUE_2, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(1).ukefDecisionFacilityValue(), UNDERWRITER_MANAGER_DECISIONS.AUTOMATIC_APPROVAL);
+
+    cy.assertText(amendmentsPage.amendmentDetails.row(1).effectiveDateTable(), today.dd_MMMM_yyyy);
   });
 });

--- a/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/tfm/tfm-display-portal-and-tfm-amendments-on-amendment-details-page.spec.js
+++ b/e2e-tests/ukef/cypress/e2e/journeys/portal/amendments/pages/tfm/tfm-display-portal-and-tfm-amendments-on-amendment-details-page.spec.js
@@ -16,6 +16,8 @@ const CHANGED_FACILITY_VALUE = '20000';
 const CHANGED_FACILITY_VALUE_1 = '30000';
 const CHANGED_FACILITY_VALUE_2 = '40000';
 
+const submittedByString = `${BANK1_MAKER1.firstname} ${BANK1_MAKER1.surname} - ${BANK1_MAKER1.bank.name}`;
+
 context('Amendments - TFM - Amendments details page - TFM should display portal and TFM amendments on the amendment details page', () => {
   let dealId;
   let facilityId;
@@ -97,7 +99,7 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
 
   it('should display a row for the first portal amendment', () => {
     cy.assertText(amendmentsPage.amendmentDetails.row(3).heading(), `Amendment ${ukefFacilityId}-001`);
-    cy.assertText(amendmentsPage.amendmentDetails.row(3).effectiveDate(), today.dd_MMMM_yyyy);
+    cy.assertText(amendmentsPage.amendmentDetails.row(3).submittedBy(), submittedByString);
     cy.assertText(amendmentsPage.amendmentDetails.row(3).requireApproval(), 'No');
 
     cy.assertText(amendmentsPage.amendmentDetails.row(3).currentCoverEndDate(), format(new Date(mockFacility.coverEndDate), DD_MMMM_YYYY_FORMAT));
@@ -107,6 +109,11 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
     cy.assertText(amendmentsPage.amendmentDetails.row(3).currentFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(mockFacility.value, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(3).newFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(CHANGED_FACILITY_VALUE, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(3).ukefDecisionFacilityValue(), UNDERWRITER_MANAGER_DECISIONS.AUTOMATIC_APPROVAL);
+  });
+
+  it('should display effective date in the table only for the first portal amendment', () => {
+    amendmentsPage.amendmentDetails.row(3).effectiveDate().should('not.exist');
+    cy.assertText(amendmentsPage.amendmentDetails.row(3).effectiveDateTable(), today.dd_MMMM_yyyy);
   });
 
   it('should display an eligibility criteria table and rows for the portal amendment', () => {
@@ -173,13 +180,18 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
     cy.assertText(amendmentsPage.amendmentDetails.row(2).ukefDecisionFacilityValue(), UNDERWRITER_MANAGER_DECISIONS.AUTOMATIC_APPROVAL);
   });
 
+  it('should not display effective date table row and should not display a submittedBy heading for the TFM amendment', () => {
+    amendmentsPage.amendmentDetails.row(2).effectiveDateTable().should('not.exist');
+    amendmentsPage.amendmentDetails.row(2).submittedBy().should('not.exist');
+  });
+
   it('should not display a eligibility criteria for the TFM table', () => {
     amendmentsPage.amendmentDetails.row(2).eligibilityCriteriaTable().should('not.exist');
   });
 
-  it('should display a row for the portal TFM amendment', () => {
+  it('should display a row for the portal amendment', () => {
     cy.assertText(amendmentsPage.amendmentDetails.row(1).heading(), `Amendment ${ukefFacilityId}-003`);
-    cy.assertText(amendmentsPage.amendmentDetails.row(1).effectiveDate(), today.dd_MMMM_yyyy);
+    cy.assertText(amendmentsPage.amendmentDetails.row(3).submittedBy(), submittedByString);
     cy.assertText(amendmentsPage.amendmentDetails.row(1).requireApproval(), 'No');
 
     cy.assertText(amendmentsPage.amendmentDetails.row(1).currentCoverEndDate(), threeYears.dd_MMMM_yyyy);
@@ -189,6 +201,11 @@ context('Amendments - TFM - Amendments details page - TFM should display portal 
     cy.assertText(amendmentsPage.amendmentDetails.row(1).currentFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(CHANGED_FACILITY_VALUE_1, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(1).newFacilityValue(), `${CURRENCY.GBP} ${getFormattedMonetaryValue(CHANGED_FACILITY_VALUE_2, 2)}`);
     cy.assertText(amendmentsPage.amendmentDetails.row(1).ukefDecisionFacilityValue(), UNDERWRITER_MANAGER_DECISIONS.AUTOMATIC_APPROVAL);
+  });
+
+  it('should display effective date in the table only for the last portal amendment', () => {
+    amendmentsPage.amendmentDetails.row(1).effectiveDate().should('not.exist');
+    cy.assertText(amendmentsPage.amendmentDetails.row(1).effectiveDateTable(), today.dd_MMMM_yyyy);
   });
 
   it('should display an eligibility criteria table and rows for the third portal amendment', () => {

--- a/libs/common/src/types/mongo-db-models/tfm-facilities.ts
+++ b/libs/common/src/types/mongo-db-models/tfm-facilities.ts
@@ -139,6 +139,7 @@ export interface PortalFacilityAmendment extends BaseAmendment {
     criteria: AmendmentsEligibilityCriterionWithAnswer[];
   };
   tfm?: FacilityAmendmentTfmObject;
+  bankName?: string;
 }
 
 /**

--- a/trade-finance-manager-ui/templates/case/facility/_macros/amendment-details.njk
+++ b/trade-finance-manager-ui/templates/case/facility/_macros/amendment-details.njk
@@ -25,8 +25,15 @@
         {% endif %}
 
         <dl class="govuk-grid-row ukef-list">
-          <dt class="govuk-grid-column-one-quarter ukef-heading-xs">Date amendment is effective from</dt>
-          <dd class="govuk-grid-column-three-quarters govuk-body-s" data-cy="amendment--details-{{loop.index}}-effective-date">{{ amendment.effectiveDate | dashIfEmpty}}</dd>
+          {% if not amendment.isPortalAmendment %}
+            <dt class="govuk-grid-column-one-quarter ukef-heading-xs">Date amendment is effective from</dt>
+            <dd class="govuk-grid-column-three-quarters govuk-body-s" data-cy="amendment--details-{{loop.index}}-effective-date">{{ amendment.effectiveDate | dashIfEmpty}}</dd>
+          {% endif %}
+
+          {% if amendment.isPortalAmendment %}
+            <dt class="govuk-grid-column-one-quarter ukef-heading-xs">Submitted by</dt>
+            <dd class="govuk-grid-column-three-quarters govuk-body-s" data-cy="amendment--details-{{loop.index}}-submitted-by">{{ amendment.createdBy.name | dashIfEmpty}} - {{ amendment.bankName | dashIfEmpty}}</dd>
+          {% endif %}
 
           <dt class="govuk-grid-column-one-quarter ukef-heading-xs">Bank requested change</dt>
           <dd class="govuk-grid-column-three-quarters govuk-body-s" data-cy="amendment--details-{{loop.index}}-request-date">{{ amendment.requestDate | dashIfEmpty}}</dd>
@@ -106,6 +113,20 @@
 
           {% set rows = (rows.push(defaultFacilityValue), rows) %}
         {% endif %}
+
+        {% if amendment.isPortalAmendment %}
+          {% set defaultEffectiveDate =
+            [
+              { text: 'Date amendment is effective from' },
+              { text: amendment.effectiveDate, attributes: { "data-cy": "amendment--details-"+loop.index+"-table-effective-date" } },
+              { text: null },
+              { text: null }
+            ]
+          %}
+
+          {% set rows = (rows.push(defaultEffectiveDate), rows) %}
+        {% endif %}
+        
 
 
         {% set head =


### PR DESCRIPTION
# Introduction :pencil2:

This PR fixes an issue where submittedBy was not displayed on the tfm amendment details tab when a portal amendment is submitted.

## Resolution :heavy_check_mark:

* Added bankName to submission to ukef when amendment submitted
* Added row for effective date on portal amendment only
* Added submittedBy on portal amendment only
* Updated unit test
* Updated e2e tests

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

<img width="1543" height="427" alt="image" src="https://github.com/user-attachments/assets/867be3d3-3201-4a97-b529-b849ead17bb5" />

</details>
