### PR TITLE
feat(DTFS2-8115): add swagger endpoints to UI microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,4 +474,19 @@ Each microservice exposes both a **Swagger UI interface** for interactive explor
 - **UI**: [http://localhost:5005/v1/api-docs/](http://localhost:5005/v1/api-docs/)
 - **JSON**: [http://localhost:5005/v1/api-docs/api.json](http://localhost:5005/v1/api-docs/api.json)
 
+### 5️⃣ Portal UI
+
+- **UI**: [http://localhost:5000/v1/api-docs/](http://localhost:5000/v1/api-docs/)
+- **JSON**: [http://localhost:5000/v1/api-docs/api.json](http://localhost:5000/v1/api-docs/api.json)
+
+### 6️⃣ GEF UI
+
+- **UI**: [http://localhost:5006/v1/api-docs/](http://localhost:5006/v1/api-docs/)
+- **JSON**: [http://localhost:5006/v1/api-docs/api.json](http://localhost:5006/v1/api-docs/api.json)
+
+### 7️⃣ TFM UI
+
+- **UI**: [http://localhost:5003/v1/api-docs/](http://localhost:5003/v1/api-docs/)
+- **JSON**: [http://localhost:5003/v1/api-docs/api.json](http://localhost:5003/v1/api-docs/api.json)
+
 ---

--- a/dtfs-central-api/server/v1/routes/swagger-routes.ts
+++ b/dtfs-central-api/server/v1/routes/swagger-routes.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -38,8 +38,8 @@ const definition: swaggerDefinition = {
 };
 
 const apis = [
-  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
-  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.TS),
   path.join(__dirname, '/**/*.js'),
   path.join(__dirname, '/**/*.ts'),
 ];

--- a/external-api/server/helpers/swagger-definitions/acbs.ts
+++ b/external-api/server/helpers/swagger-definitions/acbs.ts
@@ -132,6 +132,6 @@
  *           probabilityOfDefault:
  *             type: integer
  *             example: 14
- *  ACBSAmendFacilityRequestBody:
- *  ACBSAmendFacilityResponseBody:
+ *   ACBSAmendFacilityRequestBody:
+ *   ACBSAmendFacilityResponseBody:
  */

--- a/external-api/server/helpers/swagger-definitions/bank-holidays-division.ts
+++ b/external-api/server/helpers/swagger-definitions/bank-holidays-division.ts
@@ -14,7 +14,7 @@
  *           properties:
  *             title:
  *               type: string
- *               example: 'New Year's Day'
+ *               example: "New Year's Day"
  *             date:
  *               type: string
  *               example: '2022-01-03'

--- a/external-api/server/helpers/swagger-definitions/geospatial-addresses.ts
+++ b/external-api/server/helpers/swagger-definitions/geospatial-addresses.ts
@@ -7,27 +7,27 @@
  *       type: object
  *       properties:
  *         organisationName:
- *            type: string
- *            nullable: true
- *            example: H M TREASURY
- *          addressLine1:
- *            type: string
- *            example: 1 HORSE GUARDS ROAD
- *          addressLine2:
- *            type: string
- *            nullable: true
- *            example: null
- *          addressLine3:,
- *            type: string
- *            nullable: true
- *            example: null
- *          locality:
- *            type: string
- *            example: LONDON
- *          postalCode:
- *            type: string
- *            example: SW1A 2HQ
- *          country:
- *            type: string
- *            example: England
+ *           type: string
+ *           nullable: true
+ *           example: H M TREASURY
+ *         addressLine1:
+ *           type: string
+ *           example: 1 HORSE GUARDS ROAD
+ *         addressLine2:
+ *           type: string
+ *           nullable: true
+ *           example: null
+ *         addressLine3:
+ *           type: string
+ *           nullable: true
+ *           example: null
+ *         locality:
+ *           type: string
+ *           example: LONDON
+ *         postalCode:
+ *           type: string
+ *           example: SW1A 2HQ
+ *         country:
+ *           type: string
+ *           example: England
  */

--- a/external-api/server/v1/routes/swagger.route.ts
+++ b/external-api/server/v1/routes/swagger.route.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -77,8 +77,8 @@ const definition: swaggerDefinition = {
 };
 
 const apis = [
-  path.join(__dirname, '..', '..', '/helpers/swagger-definitions/**/*.js'),
-  path.join(__dirname, '..', '..', '/helpers/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '..', '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', '..', SWAGGER.DEFINITIONS.PATHS.TS),
   path.join(__dirname, '/**/*.js'),
   path.join(__dirname, '/**/*.ts'),
 ];

--- a/gef-ui/server/generateApp.js
+++ b/gef-ui/server/generateApp.js
@@ -9,8 +9,9 @@ const RedisStore = require('connect-redis')(session);
 const dotenv = require('dotenv');
 const cookieParser = require('cookie-parser');
 const csrf = require('csurf');
-const { maintenance } = require('@ukef/dtfs2-common');
+const { SWAGGER, maintenance } = require('@ukef/dtfs2-common');
 const routes = require('./routes');
+const swaggerRouter = require('./routes/swagger.route');
 const supportingInformationUploadRoutes = require('./routes/supporting-information-upload');
 const healthcheck = require('./healthcheck');
 const configureNunjucks = require('./nunjucks-configuration');
@@ -36,6 +37,11 @@ const generateApp = () => {
   };
 
   app.use(seo);
+
+  // Non-authenticated routes
+  app.use(healthcheck);
+  app.use(`/v1/${SWAGGER.ENDPOINTS.UI}`, swaggerRouter.default);
+
   app.use(security);
 
   app.use(compression());
@@ -116,8 +122,6 @@ const generateApp = () => {
   app.use(maintenance);
 
   app.use(createRateLimit());
-
-  app.use(healthcheck);
 
   app.use('/', routes);
 

--- a/gef-ui/server/routes/swagger.route.ts
+++ b/gef-ui/server/routes/swagger.route.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
+
+const definition: swaggerDefinition = {
+  info: {
+    title: SERVICES.GEF_UI,
+    version: '1.0.0',
+    description: 'GEF UI microservice endpoints for GEF UI operations',
+  },
+  tags: [],
+};
+
+const apis = [
+  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
+  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '/**/*.js'),
+  path.join(__dirname, '/**/*.ts'),
+];
+
+export default swaggerRouter(definition, apis);

--- a/gef-ui/server/routes/swagger.route.ts
+++ b/gef-ui/server/routes/swagger.route.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -12,8 +12,8 @@ const definition: swaggerDefinition = {
 };
 
 const apis = [
-  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
-  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.TS),
   path.join(__dirname, '/**/*.js'),
   path.join(__dirname, '/**/*.ts'),
 ];

--- a/libs/common/src/constants/services.ts
+++ b/libs/common/src/constants/services.ts
@@ -19,5 +19,5 @@ export const SERVICES = {
   CENTRAL_API: 'DTFS Central API',
   PORTAL_UI: 'DTFS Portal UI',
   GEF_UI: 'DTFS GEF UI',
-  TFM_UI: 'DTFS Trade finance UI',
+  TFM_UI: 'DTFS Trade finance manager UI',
 };

--- a/libs/common/src/constants/swagger.ts
+++ b/libs/common/src/constants/swagger.ts
@@ -1,19 +1,30 @@
 /**
- * Swagger-related endpoint constants.
+ * Constants used for Swagger API documentation configuration.
  *
  * @remarks
- * This object contains endpoints for accessing the Swagger UI and downloading the Swagger JSON specification.
+ * This object contains endpoints for accessing the Swagger UI and downloading the API definition in JSON format,
+ * as well as file path patterns for locating Swagger definition files in JavaScript and TypeScript.
  *
- * @property ENDPOINTS - Contains endpoint paths for Swagger.
+ * @property ENDPOINTS - Endpoints related to Swagger documentation.
  * @property ENDPOINTS.UI - Path to the Swagger UI.
- * @property ENDPOINTS.DOWNLOAD - Contains endpoints for downloading Swagger specs.
- * @property ENDPOINTS.DOWNLOAD.JSON - Path to download the Swagger JSON specification.
+ * @property ENDPOINTS.DOWNLOAD - Endpoints for downloading Swagger definitions.
+ * @property ENDPOINTS.DOWNLOAD.JSON - Path to download the Swagger definition as a JSON file.
+ * @property DEFINITIONS - File path patterns for Swagger definition files.
+ * @property DEFINITIONS.PATHS - Paths for locating Swagger definition files.
+ * @property DEFINITIONS.PATHS.JS - Glob pattern for JavaScript Swagger definition files.
+ * @property DEFINITIONS.PATHS.TS - Glob pattern for TypeScript Swagger definition files.
  */
 export const SWAGGER = {
   ENDPOINTS: {
     UI: 'api-docs',
     DOWNLOAD: {
       JSON: '/api.json',
+    },
+  },
+  DEFINITIONS: {
+    PATHS: {
+      JS: '/**/swagger-definitions/**/*.js',
+      TS: '/**/swagger-definitions/**/*.ts',
     },
   },
 };

--- a/portal-api/server/v1/routes/swagger.route.ts
+++ b/portal-api/server/v1/routes/swagger.route.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -12,8 +12,8 @@ const definition: swaggerDefinition = {
 };
 
 const apis = [
-  path.join(__dirname, '..', '..', '/helpers/swagger-definitions/**/*.js'),
-  path.join(__dirname, '..', '..', '/helpers/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '..', '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', '..', SWAGGER.DEFINITIONS.PATHS.TS),
   path.join(__dirname, '..', '/**/routes.js'),
   path.join(__dirname, '..', '/**/routes.ts'),
   path.join(__dirname, '/**/*.js'),

--- a/portal-ui/server/generateApp.ts
+++ b/portal-ui/server/generateApp.ts
@@ -8,8 +8,9 @@ import csrf from 'csurf';
 import flash from 'connect-flash';
 import connectRedis from 'connect-redis';
 import { isHttpError } from 'http-errors';
-import { InvalidEnvironmentVariableError, maintenance } from '@ukef/dtfs2-common';
+import { InvalidEnvironmentVariableError, maintenance, SWAGGER } from '@ukef/dtfs2-common';
 import routes from './routes';
+import swaggerRouter from './routes/swagger.route';
 import healthcheck from './healthcheck';
 import configureNunjucks from './nunjucks-configuration';
 import { csrfToken, copyCsrfTokenFromQueryToBody, seo, security, createRateLimit } from './routes/middleware';
@@ -38,6 +39,11 @@ export const generateApp = () => {
   };
 
   app.use(seo);
+
+  // Non-authenticated routes
+  app.use(healthcheck);
+  app.use(`/v1/${SWAGGER.ENDPOINTS.UI}`, swaggerRouter);
+
   app.use(security);
 
   if (!process.env.SESSION_SECRET) {
@@ -124,8 +130,6 @@ export const generateApp = () => {
   app.use(maintenance);
 
   app.use(createRateLimit());
-
-  app.use(healthcheck);
 
   app.use('/', routes);
 

--- a/portal-ui/server/routes/swagger.route.ts
+++ b/portal-ui/server/routes/swagger.route.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
+
+const definition: swaggerDefinition = {
+  info: {
+    title: SERVICES.PORTAL_UI,
+    version: '1.0.0',
+    description: 'Portal UI microservice endpoints for BSS/EWCS UI operations',
+  },
+  tags: [],
+};
+
+const apis = [
+  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
+  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '/**/*.js'),
+  path.join(__dirname, '/**/*.ts'),
+];
+
+export default swaggerRouter(definition, apis);

--- a/portal-ui/server/routes/swagger.route.ts
+++ b/portal-ui/server/routes/swagger.route.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -12,8 +12,8 @@ const definition: swaggerDefinition = {
 };
 
 const apis = [
-  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
-  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.TS),
   path.join(__dirname, '/**/*.js'),
   path.join(__dirname, '/**/*.ts'),
 ];

--- a/trade-finance-manager-api/server/v1/routes/swagger.route.ts
+++ b/trade-finance-manager-api/server/v1/routes/swagger.route.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -25,6 +25,8 @@ const apis = [
   path.join(__dirname, '/**/*.ts'),
   path.join(__dirname, '..', '/**/routes.js'),
   path.join(__dirname, '..', '/**/routes.ts'),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.TS),
 ];
 
 export default swaggerRouter(definition, apis);

--- a/trade-finance-manager-ui/server/generateApp.js
+++ b/trade-finance-manager-ui/server/generateApp.js
@@ -7,8 +7,9 @@ const cookieParser = require('cookie-parser');
 const csrf = require('csurf');
 const flash = require('connect-flash');
 const { HttpStatusCode } = require('axios');
-const { maintenance } = require('@ukef/dtfs2-common');
+const { maintenance, SWAGGER } = require('@ukef/dtfs2-common');
 const routes = require('./routes');
+const swaggerRouter = require('./routes/swagger.route');
 const { unauthenticatedLoginRoutes } = require('./routes/login');
 const feedbackRoutes = require('./routes/feedback');
 const configureNunjucks = require('./nunjucks-configuration');
@@ -38,6 +39,11 @@ const generateApp = () => {
   };
 
   app.use(seo);
+
+  // Non-authenticated routes
+  app.use(healthcheck);
+  app.use(`/v1/${SWAGGER.ENDPOINTS.UI}`, swaggerRouter.default);
+
   app.use(security);
 
   app.use(flash());
@@ -99,7 +105,6 @@ const generateApp = () => {
   app.use(csrfToken());
   app.use(sanitizeXss());
 
-  app.use(healthcheck);
   app.use('/', routes);
 
   app.get('*', (req, res) => res.render('page-not-found.njk', { user: req.session.user }));

--- a/trade-finance-manager-ui/server/routes/swagger.route.ts
+++ b/trade-finance-manager-ui/server/routes/swagger.route.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
+
+const definition: swaggerDefinition = {
+  info: {
+    title: SERVICES.TFM_UI,
+    version: '1.0.0',
+    description: 'TFM UI microservice endpoints for TFM UI operations',
+  },
+  tags: [],
+};
+
+const apis = [
+  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
+  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '/**/*.js'),
+  path.join(__dirname, '/**/*.ts'),
+];
+
+export default swaggerRouter(definition, apis);

--- a/trade-finance-manager-ui/server/routes/swagger.route.ts
+++ b/trade-finance-manager-ui/server/routes/swagger.route.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { swaggerDefinition, SERVICES } from '@ukef/dtfs2-common';
+import { swaggerDefinition, SWAGGER, SERVICES } from '@ukef/dtfs2-common';
 import { swaggerRouter } from '@ukef/dtfs2-common/swagger';
 
 const definition: swaggerDefinition = {
@@ -12,8 +12,8 @@ const definition: swaggerDefinition = {
 };
 
 const apis = [
-  path.join(__dirname, '..', '/swagger-definitions/**/*.js'),
-  path.join(__dirname, '..', '/swagger-definitions/**/*.ts'),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.JS),
+  path.join(__dirname, '..', SWAGGER.DEFINITIONS.PATHS.TS),
   path.join(__dirname, '/**/*.js'),
   path.join(__dirname, '/**/*.ts'),
 ];


### PR DESCRIPTION
# Introduction :pencil2:

This PR introduces swagger UI and JSON download endpoints to following UI microservices.

* Portal UI
* GEF UI
* TFM UI

## Resolution :heavy_check_mark:

* Introduced following URLs:
  * [Portal UI](http://localhost:5000/v1/api-docs/)
  * [GEF UI](http://localhost:5006/v1/api-docs/)
  * [TFM UI](http://localhost:5003/v1/api-docs/)

## Miscellaneous :heavy_plus_sign:

* Dependencies updates.
* Documentation updates.
* Swagger definition indentation fixes.

## Screenshot(s) :camera_flash:

<details>
  <summary>Show/hide</summary>

### Portal UI
<img width="1458" height="784" alt="image" src="https://github.com/user-attachments/assets/b9594171-4fc5-4895-a5cf-1c703061fa33" />


### GEF UI
<img width="1577" height="570" alt="image" src="https://github.com/user-attachments/assets/02f59ad8-3e65-4e82-88f7-a6ccd80ce51e" />


### TFM UI
<img width="2134" height="711" alt="image" src="https://github.com/user-attachments/assets/dba3d15b-9c90-4ce4-b978-a68e0c46e0ed" />


</details>
