### PR TITLE
fix(DTFS2-8016): reverted to guaranteeFee for fixed fee calculation

### DIFF
--- a/libs/common/src/helpers/facility-calculations/index.test.ts
+++ b/libs/common/src/helpers/facility-calculations/index.test.ts
@@ -421,10 +421,10 @@ describe('GEF drawn amount', () => {
       const drawnAmount = 100;
       const daysOfCover = 30;
       const dayCountBasis = 365;
-      const interestPercentage = 1;
+      const guaranteeFee = 1;
 
       // Act
-      const response = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, interestPercentage);
+      const response = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, guaranteeFee);
 
       // Assert
       expect(response).toBe(0.0821917808219178);
@@ -435,10 +435,10 @@ describe('GEF drawn amount', () => {
       const drawnAmount = 1000000;
       const daysOfCover = 365;
       const dayCountBasis = 365;
-      const interestPercentage = 4;
+      const guaranteeFee = 4;
 
       // Act
-      const response = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, interestPercentage);
+      const response = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, guaranteeFee);
 
       // Assert
       expect(response).toBe(40000);
@@ -449,10 +449,10 @@ describe('GEF drawn amount', () => {
       const drawnAmount = 0;
       const daysOfCover = 365;
       const dayCountBasis = 365;
-      const interestPercentage = 2.3;
+      const guaranteeFee = 2.3;
 
       // Act
-      const response = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, interestPercentage);
+      const response = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, guaranteeFee);
 
       // Assert
       expect(response).toBe(0);
@@ -478,12 +478,12 @@ describe('GEF drawn amount', () => {
       },
       value: 100000,
       coverPercentage: 80,
-      interestPercentage: 5,
+      guaranteeFee: 4.5,
       paymentType: 'cash',
       createdAt: new Date().getTime(),
       updatedAt: new Date().getTime(),
       ukefExposure: 80000,
-      guaranteeFee: 10,
+      interestPercentage: 9,
       submittedAsIssuedDate: null,
       ukefFacilityId: '12345678',
       feeType: 'cash',
@@ -514,7 +514,7 @@ describe('GEF drawn amount', () => {
       const response = calculateGefFacilityFeeRecord(facility);
 
       // Assert
-      expect(response).toBe(7004.931506849315);
+      expect(response).toBe(6304.438356164384);
     });
 
     it('should calculate GEF facility fixed fee with only 1 day difference', () => {
@@ -544,7 +544,7 @@ describe('GEF drawn amount', () => {
       const response = calculateGefFacilityFeeRecord(mockFacility);
 
       // Assert
-      expect(response).toBe(0.07004931506849316);
+      expect(response).toBe(0.06304438356164384);
     });
   });
 });

--- a/libs/common/src/helpers/facility-calculations/index.ts
+++ b/libs/common/src/helpers/facility-calculations/index.ts
@@ -75,16 +75,16 @@ export const calculateDaysOfCover = (
 };
 
 /**
- * Calculates the fee amount for a facility based on the drawn amount, duration of cover, day count basis, and interest percentage percentage.
+ * Calculates the fee amount for a facility based on the drawn amount, duration of cover, day count basis, and guarantee fee percentage.
  *
  * @param drawnAmount - The amount that has been drawn from the facility.
  * @param daysOfCover - The number of days the cover is provided for.
  * @param dayCountBasis - The basis for day count calculation (e.g., 360 or 365).
- * @param interestPercentage - The interest percentage percentage to be applied.
+ * @param guaranteeFee - The guarantee fee percentage to be applied.
  * @returns The calculated fee amount.
  */
-export const calculateFeeAmount = (drawnAmount: number, daysOfCover: number, dayCountBasis: number, interestPercentage: number): number =>
-  (drawnAmount * daysOfCover * (interestPercentage / 100)) / dayCountBasis;
+export const calculateFeeAmount = (drawnAmount: number, daysOfCover: number, dayCountBasis: number, guaranteeFee: number): number =>
+  (drawnAmount * daysOfCover * (guaranteeFee / 100)) / dayCountBasis;
 
 /**
  * Calculates the GEF facility fee record for a given facility.
@@ -98,11 +98,11 @@ export const calculateFeeAmount = (drawnAmount: number, daysOfCover: number, day
  */
 export const calculateGefFacilityFeeRecord = (facility: Facility) => {
   if (facility.hasBeenIssued) {
-    const { interestPercentage, dayCountBasis, value, coverPercentage, coverStartDate, coverEndDate, type } = facility;
+    const { guaranteeFee, dayCountBasis, value, coverPercentage, coverStartDate, coverEndDate, type } = facility;
 
     const drawnAmount = calculateDrawnAmount(value, coverPercentage, type);
     const daysOfCover = calculateDaysOfCover(type, coverStartDate, coverEndDate);
-    const feeRecord = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, interestPercentage);
+    const feeRecord = calculateFeeAmount(drawnAmount, daysOfCover, dayCountBasis, guaranteeFee);
 
     return feeRecord;
   }

--- a/trade-finance-manager-api/server/v1/helpers/calculate-gef-facility-fee-record.api-test.js
+++ b/trade-finance-manager-api/server/v1/helpers/calculate-gef-facility-fee-record.api-test.js
@@ -61,7 +61,7 @@ describe('calculate-gef-facility-fee-record', () => {
 
       const drawnAmount = calculateDrawnAmount(mockFacilityValue, mockCoverPercentage, mockType);
       const daysOfCover = calculateDaysOfCover(FACILITY_TYPE.CASH, mockCoverStartDate, mockCoverEndDate);
-      const expected = calculateFeeAmount(drawnAmount, daysOfCover, mockFacility.dayCountBasis, mockInterestPercentage);
+      const expected = calculateFeeAmount(drawnAmount, daysOfCover, mockFacility.dayCountBasis, mockGuaranteeFee);
 
       expect(result).toEqual(expected);
     });


### PR DESCRIPTION
# Introduction :pencil2:

This PR changes the calculation by consuming guarantee fee instead of interest percentage.

## Resolution :heavy_check_mark:

* Changed to `guaranteeFee`.
* Updated test cases.