### PR TITLE
fix(DTFS2-8145): added fix for failing tenor e2e test

### DIFF
--- a/e2e-tests/tfm/cypress/support/utils/facility-tenor.js
+++ b/e2e-tests/tfm/cypress/support/utils/facility-tenor.js
@@ -14,7 +14,6 @@ import { oneMonth, twoYearsAgo } from '@ukef/dtfs2-common/test-helpers';
  * But in some cases for BSS facilities we add one to the difference.
  *
  * Specifically in the case of these tests, the tenor is 25 months except for:
- * - if expiry and commencement dates are the same date of month then you add one
  * - if commencement is end of month and expiry is also end of month you add one
  */
 export const calculateTestFacilityTenorValue = () => {

--- a/e2e-tests/tfm/cypress/support/utils/facility-tenor.js
+++ b/e2e-tests/tfm/cypress/support/utils/facility-tenor.js
@@ -1,4 +1,4 @@
-import { add } from 'date-fns';
+import { add, differenceInMonths } from 'date-fns';
 import { oneMonth, twoYearsAgo } from '@ukef/dtfs2-common/test-helpers';
 
 /**
@@ -18,11 +18,8 @@ import { oneMonth, twoYearsAgo } from '@ukef/dtfs2-common/test-helpers';
  * - if commencement is end of month and expiry is also end of month you add one
  */
 export const calculateTestFacilityTenorValue = () => {
-  let facilityTenor = '25 months';
-
-  if (twoYearsAgo.date.getDate() === oneMonth.date.getDate()) {
-    facilityTenor = '26 months';
-  }
+  const difference = differenceInMonths(oneMonth.date, twoYearsAgo.date).toString();
+  let facilityTenor = `${difference} months`;
 
   const isCommencementDateEndOfMonth = add(twoYearsAgo.date, { days: 1 }).getDate() === 1;
   const isExpiryDateEndOFMonth = add(oneMonth.date, { days: 1 }).getDate() === 1;


### PR DESCRIPTION
# Introduction :pencil2:

This PR adds a fix for the failing tenor e2e test - `e2e-tests/tfm/cypress/e2e/journeys/case-amendments/add-bank-decision/add-bank-decision-proceed.spec.js`

## Resolution :heavy_check_mark:

* Changed tenor calculation to use date-fns difference in months
