### PR TITLE
feat(DTFS2-8078): fixed date in difference formula to JS native

### DIFF
--- a/libs/common/src/helpers/facility-calculations/index.test.ts
+++ b/libs/common/src/helpers/facility-calculations/index.test.ts
@@ -245,7 +245,7 @@ describe('GEF drawn amount', () => {
   });
 
   describe('calculateDaysOfCover', () => {
-    it('should return 1 for a cash facility, when there is no difference in days', () => {
+    it('should return 0 for a cash facility, when there is no difference in days', () => {
       // Arrange
       const coverStartDate = '0';
       const coverEndDate = '0';
@@ -255,10 +255,10 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(1);
+      expect(response).toBe(0);
     });
 
-    it('should return 2 for a contingent facility, when there is no difference in days', () => {
+    it('should return 1 for a contingent facility, when there is no difference in days', () => {
       // Arrange
       const coverStartDate = '0';
       const coverEndDate = '0';
@@ -268,7 +268,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(2);
+      expect(response).toBe(1);
     });
 
     it('should return 1 as the difference in days is only one day for a cash facility', () => {
@@ -307,7 +307,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(30);
+      expect(response).toBe(29);
     });
 
     it('should return difference in cover start and end date in days for a contingent facility', () => {
@@ -320,7 +320,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(31);
+      expect(response).toBe(30);
     });
 
     it('should return difference in cover start and end date in days when cover start date is in string format for a cash facility', () => {
@@ -333,7 +333,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(30);
+      expect(response).toBe(29);
     });
 
     it('should return difference in cover start and end date in days when cover start date is in string format for a contingent facility', () => {
@@ -346,7 +346,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(31);
+      expect(response).toBe(30);
     });
 
     it('should return difference in cover start and end date in days when cover end date is in string format for a cash facility', () => {
@@ -359,7 +359,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(30);
+      expect(response).toBe(29);
     });
 
     it('should return difference in cover start and end date in days when cover end date is in string format for a contingent facility', () => {
@@ -372,7 +372,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(31);
+      expect(response).toBe(30);
     });
 
     it('should return difference in cover start and end date in days when both dates string format for a contingent facility', () => {
@@ -385,7 +385,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(31);
+      expect(response).toBe(30);
     });
 
     it('should return difference in cover start and end date in days when both dates string format for a cash facility', () => {
@@ -398,7 +398,7 @@ describe('GEF drawn amount', () => {
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
 
       // Assert
-      expect(response).toBe(30);
+      expect(response).toBe(29);
     });
 
     it('should return 0 when both cover start and end dates are null', () => {
@@ -406,6 +406,19 @@ describe('GEF drawn amount', () => {
       const coverStartDate = null;
       const coverEndDate = null;
       const type: GefFacilityType = GEF_FACILITY_TYPE.CASH;
+
+      // Act
+      const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
+
+      // Assert
+      expect(response).toBe(0);
+    });
+
+    it('should return 1 when both cover start and end dates are null for contingent', () => {
+      // Arrange
+      const coverStartDate = null;
+      const coverEndDate = null;
+      const type: GefFacilityType = GEF_FACILITY_TYPE.CONTINGENT;
 
       // Act
       const response = calculateDaysOfCover(type, coverStartDate, coverEndDate);
@@ -514,7 +527,7 @@ describe('GEF drawn amount', () => {
       const response = calculateGefFacilityFeeRecord(facility);
 
       // Assert
-      expect(response).toBe(6312.821917808219);
+      expect(response).toBe(6304.438356164384);
     });
 
     it('should calculate GEF facility fixed fee with only 1 day difference', () => {
@@ -544,7 +557,7 @@ describe('GEF drawn amount', () => {
       const response = calculateGefFacilityFeeRecord(mockFacility);
 
       // Assert
-      expect(response).toBe(0.0631282191780822);
+      expect(response).toBe(0.06304438356164384);
     });
   });
 });

--- a/libs/common/src/helpers/facility-calculations/index.ts
+++ b/libs/common/src/helpers/facility-calculations/index.ts
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv';
-import { differenceInDays } from 'date-fns';
 
 import { GEF_FACILITY_TYPE, FACILITY_UTILISATION_PERCENTAGE } from '../../constants';
 import { UnixTimestampString, Facility, FacilityType } from '../../types';
@@ -69,12 +68,13 @@ export const calculateDaysOfCover = (
 ): number => {
   const startDate = coverStartDate?.toString()?.includes('T') ? new Date(String(coverStartDate)).valueOf() : Number(coverStartDate);
   const endDate = coverEndDate?.toString()?.includes('T') ? new Date(String(coverEndDate)).valueOf() : Number(coverEndDate);
+
   /**
-   * We add an additional day for inclusive
-   * subtraction, otherwise differenceInDays will
-   * return number of days in between two days.
+   * Get EPOCH difference by diving with `86,400,000 ms`.
+   * Above is derived from 1000 ms * 60 seconds * 60 minutes * 24 hours
    */
-  const difference = differenceInDays(new Date(endDate), new Date(startDate)) + 1;
+  const differenceMs = endDate - startDate;
+  const difference = differenceMs >= 86400000 ? Math.round(differenceMs / 86400000) : differenceMs;
 
   return type === CONTINGENT ? difference + 1 : difference;
 };


### PR DESCRIPTION
# Introduction :pencil2:

The GEF fixed fee calculation is not correct this was due to `dateInDifference` formula which is calculating the days difference incorrenctly as per the business requirement.

## Resolution :heavy_check_mark:

* Introduced a JS native inclusive subtraction formula in `libs/common`.
* Updated test cases.