### PR TITLE
feat(DTFS2-8042): added effective date to facility amendment

### DIFF
--- a/azure-functions/acbs/mappings/facility/facility-loan-amend.js
+++ b/azure-functions/acbs/mappings/facility/facility-loan-amend.js
@@ -1,5 +1,5 @@
 const CONSTANTS = require('../../constants');
-const { formatDate, now } = require('../../helpers/date');
+const { formatDate } = require('../../helpers/date');
 const helpers = require('./helpers');
 
 const { FACILITY } = CONSTANTS;
@@ -19,7 +19,7 @@ const facilityLoanAmend = (amendment, facility, facilityMasterRecord) => {
     const { facilitySnapshot } = facility;
 
     if (amendment && facilitySnapshot) {
-      const { amount, coverEndDate } = amendment;
+      const { amount, coverEndDate, effectiveDate } = amendment;
       const { type, feeType } = facilitySnapshot;
 
       // 1. UKEF Exposure
@@ -28,7 +28,7 @@ const facilityLoanAmend = (amendment, facility, facilityMasterRecord) => {
         if (type !== FACILITY.FACILITY_TYPE.LOAN) {
           record = {
             ...record,
-            effectiveDate: now(),
+            effectiveDate: formatDate(effectiveDate),
             amountAmendment: helpers.getLoanAmountDifference(amount, type, facilityMasterRecord),
           };
         }

--- a/azure-functions/acbs/src/functions/acbs-amend-facility.js
+++ b/azure-functions/acbs/src/functions/acbs-amend-facility.js
@@ -60,19 +60,21 @@ df.app.orchestration('acbs-amend-facility', function* amendFacility(context) {
       throw new Error('Invalid amendment payload');
     }
 
-    const { facilityIdentifier, amount, coverEndDate } = amendment;
+    const { facilityIdentifier, amount, coverEndDate, effectiveDate } = amendment;
 
     // UKEF Facility ID exists in the payload
     const hasFacilityId = Boolean(facilityIdentifier);
     // At least one of the amendment exists in the payload
     const hasAmendment = Boolean(amount) || Boolean(coverEndDate);
+    // Amendment effective date
+    const hasEffectiveDate = Boolean(effectiveDate);
     // Facility object existence check
     const hasFacility = amendment.facility;
     // Deal properties existence check
     const hasDeal = amendment.deal && amendment.deal.dealSnapshot;
 
     // Payload verification
-    if (!hasFacilityId || !hasAmendment || !hasFacility || !hasDeal) {
+    if (!hasFacilityId || !hasAmendment || !hasFacility || !hasDeal || !hasEffectiveDate) {
       throw new Error('Invalid argument set provided');
     }
 

--- a/external-api/server/v1/controllers/acbs.controller.ts
+++ b/external-api/server/v1/controllers/acbs.controller.ts
@@ -258,6 +258,7 @@ export const amendAcbsFacilityPost = async (req: Request, res: Response) => {
       facilityIdentifier: id,
       amount: amendments.ukefExposure,
       coverEndDate: amendments.coverEndDate,
+      effectiveDate: amendments.effectiveDate,
       facility,
       deal,
     };

--- a/libs/common/src/helpers/date.test.ts
+++ b/libs/common/src/helpers/date.test.ts
@@ -12,6 +12,7 @@ import {
   getLongTimeDateFormat,
   nowZeroSeconds,
   differenceInDays,
+  epochToEpochMs,
 } from './date';
 
 describe('date helpers', () => {
@@ -520,5 +521,26 @@ describe('date helpers', () => {
       // Assert
       expect(result).toBe(2932896);
     });
+  });
+
+  describe('epochToEpochMs', () => {
+    const epochs = [
+      { seconds: 0, milliseconds: 0 },
+      { seconds: 1, milliseconds: 1000 },
+      { seconds: 1000, milliseconds: 1000000 },
+      { seconds: -1000, milliseconds: -1000000 },
+      { seconds: 622249200, milliseconds: 622249200000 },
+    ];
+
+    it.each(epochs)(
+      'should covert given EPOCH in seconds %i to EPOCH in milliseconds %i',
+      ({ seconds, milliseconds }: { seconds: number; milliseconds: number }) => {
+        // Act
+        const result = epochToEpochMs(seconds);
+
+        // Assert
+        expect(result).toBe(milliseconds);
+      },
+    );
   });
 });

--- a/libs/common/src/helpers/date.ts
+++ b/libs/common/src/helpers/date.ts
@@ -117,3 +117,11 @@ export const differenceInDays = (startEpoch: number, endEpoch: number): number =
   // Only divide if EPOCH in microseconds is greater than or equal to 24 hours
   return differenceMs >= EPOCH.MS.ONE_DAY ? Math.round(differenceMs / EPOCH.MS.ONE_DAY) : differenceMs;
 };
+
+/**
+ * Converts a Unix epoch time in seconds to milliseconds.
+ *
+ * @param epoch - The Unix epoch time in seconds.
+ * @returns The corresponding time in milliseconds.
+ */
+export const epochToEpochMs = (epoch: number): number => epoch * 1000;

--- a/trade-finance-manager-api/server/v1/controllers/acbs.controller.js
+++ b/trade-finance-manager-api/server/v1/controllers/acbs.controller.js
@@ -10,7 +10,7 @@ const api = require('../api');
 const { mongoDbClient: db } = require('../../drivers/db-client');
 const tfmController = require('./tfm.controller');
 const CONSTANTS = require('../../constants');
-const { formatCoverEndDate } = require('../helpers/amendment.helpers');
+const { formatAmendmentDates } = require('../helpers/amendment.helpers');
 const { getIsoStringWithOffset } = require('../../utils/date');
 const isUnissuedInACBS = require('../helpers/is-facility-unissued-acbs');
 const { findOneTfmDeal } = require('./deal.controller');
@@ -310,10 +310,7 @@ const issueAcbsFacilities = async (deal) => {
 const amendAcbsFacility = (amendments, facility, deal) => {
   let payload = amendments;
 
-  // TO-DO : EPOCH Convergence
-  if (amendments.coverEndDate) {
-    payload = formatCoverEndDate(amendments);
-  }
+  payload = formatAmendmentDates(amendments);
 
   api
     .amendACBSfacility(payload, facility, deal)

--- a/trade-finance-manager-api/server/v1/controllers/acbs.controller.test.js
+++ b/trade-finance-manager-api/server/v1/controllers/acbs.controller.test.js
@@ -5,7 +5,15 @@ const CONSTANTS = require('../../constants');
 const MOCK_DEAL_ACBS = require('../__mocks__/mock-deal-acbs');
 const { MOCK_ACBS_TASK_LINK, MOCK_ACBS_DEAL_LINK, MOCK_ACBS_FACILITY_LINK } = require('../__mocks__/mock-durable-tasks');
 
-const { createACBS, issueAcbsFacilities, addToACBSLog, updateIssuedFacilityAcbs, updateAmendedFacilityAcbs, updateDealAcbs } = require('./acbs.controller');
+const {
+  createACBS,
+  issueAcbsFacilities,
+  addToACBSLog,
+  updateIssuedFacilityAcbs,
+  updateAmendedFacilityAcbs,
+  updateDealAcbs,
+  amendAcbsFacility,
+} = require('./acbs.controller');
 const { mongoDbClient: db } = require('../../drivers/db-client');
 const { findOneTfmDeal } = require('./deal.controller');
 const { updateFacilityAcbs, updateAcbs } = require('./tfm.controller');
@@ -23,6 +31,10 @@ getCollectionMock.mockResolvedValue({ insertOne: insertOneMock });
 const createAcbsApiMock = jest.fn().mockResolvedValue(123);
 const createACBSMock = jest.spyOn(api, 'createACBS');
 createACBSMock.mockResolvedValue(createAcbsApiMock);
+
+const amendACBSfacilityApiMock = jest.fn().mockReturnValue({});
+const amendACBSfacilityMock = jest.spyOn(api, 'amendACBSfacility');
+amendACBSfacilityMock.mockResolvedValue(amendACBSfacilityApiMock);
 
 /**
  * Mock `deal.controller` imperative functions to
@@ -572,5 +584,29 @@ describe('updateDealAcbs', () => {
     // Assert
     expect(updateAcbs).toHaveBeenCalledTimes(0);
     expect(updateFacilityAcbs).toHaveBeenCalledTimes(0);
+  });
+
+  describe('amendAcbsFacility', () => {
+    it('should call amendACBSfacility with formatted dates', () => {
+      // Arrange
+      const mockFacility = {};
+      const mockDeal = {};
+      const mockAmendment = {
+        effectiveDate: 1760546450,
+        coverEndDate: 1759509731,
+      };
+
+      const mockFormattedAmendment = {
+        effectiveDate: 1760546450000,
+        coverEndDate: 1759509731000,
+      };
+
+      // Act
+      amendAcbsFacility(mockAmendment, mockFacility, mockDeal);
+
+      // Assert
+      expect(api.amendACBSfacility).toHaveBeenCalledTimes(1);
+      expect(api.amendACBSfacility).toHaveBeenCalledWith(mockFormattedAmendment, mockFacility, mockDeal);
+    });
   });
 });

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.js
@@ -1,4 +1,4 @@
-const { TFM_AMENDMENT_STATUS, formatDatesForTenor, createAmendmentFacilityExposure } = require('@ukef/dtfs2-common');
+const { TFM_AMENDMENT_STATUS, formatDatesForTenor, createAmendmentFacilityExposure, epochToEpochMs } = require('@ukef/dtfs2-common');
 const api = require('../api');
 const sendTfmEmail = require('../services/send-tfm-email');
 const { UNDERWRITER_MANAGER_DECISIONS } = require('../../constants/amendments');
@@ -529,17 +529,17 @@ const calculateAcbsUkefExposure = (payload) => {
  * @param {object} payload Amendment payload
  * @returns {object} Computed payload with EPOCH sm compatible `coverEndDate`.
  */
-const formatCoverEndDate = (payload) => {
-  if (payload?.coverEndDate) {
-    // TODO: DTFS2-7047 convert EPOCH to millisecond compatible epoch.
-    const epoch = payload.coverEndDate.toString().length > 10 ? payload.coverEndDate : payload.coverEndDate * 1000;
+const formatAmendmentDates = (payload) => {
+  const formatted = {
+    ...payload,
+    effectiveDate: epochToEpochMs(payload.effectiveDate),
+  };
 
-    return {
-      ...payload,
-      coverEndDate: epoch,
-    };
+  if (formatted?.coverEndDate) {
+    formatted.coverEndDate = epochToEpochMs(formatted.coverEndDate);
   }
-  return payload;
+
+  return formatted;
 };
 
 module.exports = {
@@ -550,7 +550,7 @@ module.exports = {
   sendFirstTaskEmail,
   internalAmendmentEmail,
   canSendToAcbs,
-  formatCoverEndDate,
+  formatAmendmentDates,
   addLatestAmendmentValue,
   addLatestAmendmentCoverEndDate,
   addLatestAmendmentFacilityEndDate,

--- a/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
+++ b/trade-finance-manager-api/server/v1/helpers/amendment.helpers.test.js
@@ -10,6 +10,7 @@ const {
   addLatestAmendmentValue,
   internalAmendmentEmail,
   addLatestAmendmentFacilityEndDate,
+  formatAmendmentDates,
 } = require('./amendment.helpers');
 const CONSTANTS = require('../../constants');
 const { AMENDMENT_UW_DECISION, AMENDMENT_BANK_DECISION } = require('../../constants/deals');
@@ -1007,6 +1008,58 @@ describe('internalAmendmentEmail()', () => {
 
     expect(sendEmailApiSpy).toHaveBeenCalledWith(CONSTANTS.EMAIL_TEMPLATE_IDS.INTERNAL_AMENDMENT_NOTIFICATION, process.env.UKEF_INTERNAL_NOTIFICATION, {
       ukefFacilityId: '1234567890',
+    });
+  });
+});
+
+describe('formatAmendmentDates', () => {
+  it('should convert effective date to EPOCH in MS', () => {
+    // Arrange
+    const mockPayload = {
+      effectiveDate: 1,
+    };
+
+    // Act
+    const response = formatAmendmentDates(mockPayload);
+
+    // Assert
+    expect(response).not.toHaveProperty('coverEndDate');
+    expect(response).toEqual({
+      effectiveDate: 1000,
+    });
+  });
+
+  it('should convert effective and cover end date to EPOCH in MS', () => {
+    // Arrange
+    const mockPayload = {
+      effectiveDate: 1,
+      coverEndDate: 2,
+    };
+
+    // Act
+    const response = formatAmendmentDates(mockPayload);
+
+    // Assert
+    expect(response).toEqual({
+      effectiveDate: 1000,
+      coverEndDate: 2000,
+    });
+  });
+
+  it('should convert realistic effective and cover end date to EPOCH in MS', () => {
+    // Arrange
+    const mockPayload = {
+      effectiveDate: 1760546450,
+      coverEndDate: 1759509638,
+    };
+
+    // Act
+    const response = formatAmendmentDates(mockPayload);
+
+    // Assert
+    expect(response).toEqual({
+      effectiveDate: 1760546450000,
+      coverEndDate: 1759509638000,
     });
   });
 });


### PR DESCRIPTION
# Introduction :pencil2:

When a facility amendment is placed the effective date for the facility loan record is being set to the timestamp of execution. This should be the effective date supplied by the Maker (Portal) or PIM (TFM).

## Resolution :heavy_check_mark:

* Introduced `effectiveDate` to the payload in EPOCH MS.
* Introduced a new date helper `epochToEpochMs` function to convert EPOCH in seconds to EPOCH in MS.
* Added new test cases.
* Updated existing test cases.
