### PR TITLE
fix(DTFS2-7457): set production base image working directory to root

### DIFF
--- a/azure-functions/acbs/Dockerfile
+++ b/azure-functions/acbs/Dockerfile
@@ -78,7 +78,7 @@ ENV AzureFunctionsJobHost__Logging__Console__IsEnabled=$AzureFunctionsJobHost__L
 ENV FUNCTIONS_WORKER_RUNTIME=$FUNCTIONS_WORKER_RUNTIME
 ENV AzureWebJobsFeatureFlags=$AzureWebJobsFeatureFlags
 
-WORKDIR ${AzureWebJobsScriptRoot}
+WORKDIR ${ROOT}
 
 # Copy from `build` to `prod`
 COPY --chown=node:node --from=build ${ROOT}/package.json .


### PR DESCRIPTION
# Introduction :pencil2:

Azure functions was unable to identify the DoF since during the multi-stage build the production working directory was changed to `/home/site/wwwroot/azure-functions/acbs` from `/home/site/wwwroot/`.

## Resolution :heavy_check_mark:

* Updated `acbs` Dockerfile `WORKDIR` command to be set to `/home/site/wwwroot/` for production build.
